### PR TITLE
feat(examples): add reliable SSH reverse egress proxy

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -16,6 +16,7 @@ and external systems while preserving one control-plane authority.
 - [Botmux Goal Channel runtime](botmux-goal-channel-runtime.md)
 - [Extensions and capabilities](../reference/extensions.md)
 - [Host integration surface v0](../reference/protocols/host-integration-surface-v0.md)
+- [Reliable SSH reverse egress proxy](ssh-reverse-egress-proxy.md)
 
 Architecture proposals belong under
 [`docs/architecture/rfcs/`](../architecture/rfcs/README.md).

--- a/docs/integrations/ssh-reverse-egress-proxy.md
+++ b/docs/integrations/ssh-reverse-egress-proxy.md
@@ -1,0 +1,194 @@
+# Reliable SSH Reverse Egress Proxy
+
+A remote agent runtime may have a healthy SSH control channel while lacking a
+reliable outbound route to its model API. These are separate data paths. A
+desktop application that starts a remote runtime over SSH does not necessarily
+forward the desktop's HTTPS connectivity to that runtime.
+
+This guide provides a public-safe reference for running a loopback-only HTTPS
+CONNECT proxy on the desktop side and exposing it to one remote runtime through
+an SSH reverse forward. It transfers network traffic only. It does not copy
+credentials, session databases, rollout files, or runtime state.
+
+The implementation is the parameterized
+[`examples/ssh_reverse_proxy_supervisor.py`](../../examples/ssh_reverse_proxy_supervisor.py)
+script. It is an optional integration example, not a LoopX control-plane
+capability or a replacement for a host application's native SSH connection.
+
+## Data Path And Ownership
+
+```text
+remote agent process
+  -> remote 127.0.0.1:<remote-port>
+  -> managed SSH reverse-forward channel
+  -> desktop 127.0.0.1:<local-port>
+  -> loopback HTTPS CONNECT proxy
+  -> public model endpoint:443
+```
+
+The desktop owns both the local proxy and the SSH client that creates the
+reverse forward. The remote side receives only a loopback listener. Keeping
+both listeners on `127.0.0.1` prevents other machines from using the proxy.
+
+Use a dedicated port for this bridge. Do not reuse the native control channel's
+port, a project status port, or a shared proxy port.
+
+## Failure Modes Worth Preserving
+
+### A stale remote listener is not necessarily a timer
+
+When a route, VPN, or network interface changes abruptly, the desktop SSH
+client can disappear before the remote `sshd` child notices. That child may
+temporarily retain the reverse-forward listener. A process manager with
+`KeepAlive` or an equivalent restart policy then launches a new SSH client,
+which fails with `remote port forwarding failed` because the old listener still
+owns the port.
+
+The restart policy creates repeated attempts; it does not create the stale
+listener. Treat the remote `sshd` child and the local supervisor as two
+different lifecycle owners when diagnosing this loop.
+
+### Out-of-band SSH health probes can amplify an outage
+
+A periodic check that opens a second SSH connection may time out during a slow
+handshake even while the managed tunnel is still usable. If that check kills
+the tunnel, a transient route slowdown becomes a deterministic restart loop.
+
+Prefer the managed SSH process's `ServerAliveInterval` and
+`ServerAliveCountMax`. Run remote inspection only after that process exits.
+This keeps the failure detector on the same connection it manages.
+
+### Globally scoped IPv6 can still be unreachable
+
+DNS may return IPv6 before IPv4 while the active route has no working IPv6
+egress. A sequential connector can spend the caller's entire timeout on the
+first IPv6 address. The example filters non-public targets, prefers IPv4, and
+retains IPv6 as a fallback.
+
+## Run The Supervisor
+
+Configure an ordinary SSH alias for the remote runtime, then run:
+
+```bash
+python3 examples/ssh_reverse_proxy_supervisor.py \
+  --ssh-host example-runtime \
+  --local-port 18080 \
+  --remote-port 18080
+```
+
+The local proxy remains alive while its managed SSH child reconnects. The SSH
+command uses batch mode, disables connection sharing, enables server-alive
+checks, and requires the reverse forward to bind successfully.
+
+On the remote runtime, point HTTPS clients at the remote loopback listener:
+
+```bash
+export HTTPS_PROXY=http://127.0.0.1:18080
+```
+
+Keep credentials in the remote runtime's existing credential source. Proxy
+configuration should contain only the loopback URL.
+
+## Optional Stale-Listener Cleanup
+
+Automatic cleanup is intentionally opt-in:
+
+```bash
+python3 examples/ssh_reverse_proxy_supervisor.py \
+  --ssh-host example-runtime \
+  --local-port 18080 \
+  --remote-port 18080 \
+  --cleanup-stale-listener
+```
+
+Cleanup runs only after the managed tunnel exits. It refuses to terminate a
+process unless all of these conditions hold:
+
+- the process listens on the exact configured remote loopback port;
+- the process belongs to the current remote user;
+- its executable name is `sshd` or `sshd-session`.
+
+The remote account must be able to inspect that listener. If `lsof` requires
+privilege, allow only non-interactive inspection of the dedicated loopback
+port. Do not grant a broad process-management rule. Terminating a same-user
+`sshd` child should not require elevated privilege.
+
+If cleanup is disabled or refused, the local proxy stays up and the supervisor
+continues retrying. Operators can inspect the exact listener before deciding
+whether to remove it.
+
+## End-To-End Validation
+
+First validate the local proxy without depending on SSH:
+
+```bash
+curl --proxy http://127.0.0.1:18080 \
+  --noproxy '' \
+  --connect-timeout 10 \
+  https://example.com/ \
+  --output /dev/null \
+  --write-out 'status=%{http_code} total=%{time_total}\n'
+```
+
+Then validate the reverse-forward path from the remote runtime. The synthetic
+health host is answered locally by the example and does not use public DNS:
+
+```bash
+curl --proxy http://127.0.0.1:18080 \
+  --noproxy '' \
+  --max-time 15 \
+  --output /dev/null \
+  --write-out 'status=%{http_code} total=%{time_total}\n' \
+  http://reverse-proxy-health.invalid/
+```
+
+Expected status is `204`. Finally, request the intended public HTTPS endpoint.
+Any real HTTP response, including an authentication or method error, proves
+that DNS resolution, reverse forwarding, CONNECT, TLS, and HTTP reached the
+service. A successful health endpoint with a failed HTTPS request narrows the
+problem to desktop DNS or public egress rather than the reverse forward.
+
+## Controlled Recovery Test
+
+Before relying on a process manager, terminate only the supervisor's managed
+SSH child. Do not terminate the host application's native SSH control process.
+The expected result is:
+
+1. the supervisor process stays alive;
+2. the old SSH child exits;
+3. an exact stale listener is cleaned only when cleanup is enabled;
+4. a new SSH child appears;
+5. the remote health endpoint returns `204` again.
+
+When using `launchd`, `systemd`, or another process manager, verify that its
+restart counter does not increase during this test. A stable supervisor with a
+replaced child proves that reconnect ownership is inside the supervisor rather
+than delegated to a crash loop.
+
+## Security Boundary
+
+The example deliberately applies a narrow policy:
+
+- local and remote listeners bind only to IPv4 loopback;
+- only HTTPS `CONNECT` requests to port `443` are accepted;
+- resolved targets must be globally routable addresses;
+- proxy authentication data is neither accepted nor logged;
+- the SSH host, ports, retry policy, and cleanup behavior are explicit CLI
+  configuration;
+- logs contain lifecycle events and error classes, not request headers or
+  response bodies.
+
+Do not publish real SSH aliases, hostnames, private addresses, local absolute
+paths, process listings, route tables, credentials, or incident logs when
+sharing a diagnosis. Preserve the lifecycle pattern and validation method,
+not the original environment.
+
+## Repository Validation
+
+The smoke is offline: it mocks address resolution and opens only an ephemeral
+loopback server. It never contacts an SSH host or a public endpoint.
+
+```bash
+python3 examples/ssh-reverse-proxy-supervisor-smoke.py
+python3 -m py_compile examples/ssh_reverse_proxy_supervisor.py
+```

--- a/examples/ssh-reverse-proxy-supervisor-smoke.py
+++ b/examples/ssh-reverse-proxy-supervisor-smoke.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Offline smoke for the public SSH reverse-proxy supervisor example."""
+
+from __future__ import annotations
+
+import importlib.util
+import socket
+import sys
+import threading
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "examples" / "ssh_reverse_proxy_supervisor.py"
+
+
+def load_example():
+    spec = importlib.util.spec_from_file_location(
+        "loopx_ssh_reverse_proxy_supervisor",
+        SCRIPT,
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("cannot load SSH reverse-proxy supervisor example")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def example_config(module):
+    return module.ProxyConfig(
+        ssh_host="example-runtime",
+        local_port=18080,
+        remote_port=18081,
+        ssh_binary="/usr/bin/ssh",
+        retry_delay=1.0,
+        upstream_connect_timeout=2.0,
+        server_alive_interval=20,
+        server_alive_count_max=4,
+        cleanup_stale_listener=True,
+    )
+
+
+def assert_ipv4_precedes_ipv6(module) -> None:
+    answers = [
+        (
+            socket.AF_INET6,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("2001:4860:4860::8888", 443, 0, 0),
+        ),
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("8.8.8.8", 443),
+        ),
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("192.0.2.10", 443),
+        ),
+    ]
+    with mock.patch.object(module.socket, "getaddrinfo", return_value=answers):
+        resolved = module._public_addresses("example.com", 443)
+    assert [family for family, _address in resolved] == [
+        socket.AF_INET,
+        socket.AF_INET6,
+    ], resolved
+
+
+def assert_ssh_command_is_bounded(module) -> None:
+    config = example_config(module)
+    command = module.build_ssh_command(config)
+    assert command[-3:] == [
+        "-R",
+        "127.0.0.1:18081:127.0.0.1:18080",
+        "example-runtime",
+    ], command
+    assert "ExitOnForwardFailure=yes" in command, command
+    assert "ServerAliveInterval=20" in command, command
+    assert "ServerAliveCountMax=4" in command, command
+    assert "0.0.0.0" not in " ".join(command), command
+
+    cleanup = module._cleanup_command(config.remote_port)
+    assert "127.0.0.1:$port" in cleanup, cleanup
+    assert "owner-mismatch" in cleanup, cleanup
+    assert "unexpected-process" in cleanup, cleanup
+    assert "sshd|sshd-session" in cleanup, cleanup
+    try:
+        module._ssh_alias("-oProxyCommand=unexpected")
+    except module.argparse.ArgumentTypeError:
+        pass
+    else:
+        raise AssertionError("SSH aliases that look like options must be refused")
+
+
+def assert_health_endpoint_is_local(module) -> None:
+    config = example_config(module)
+    server = module.ProxyServer((module.LOOPBACK_HOST, 0), config)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        with socket.create_connection(server.server_address, timeout=2) as client:
+            client.sendall(
+                b"GET http://reverse-proxy-health.invalid/ HTTP/1.1\r\n"
+                b"Host: reverse-proxy-health.invalid\r\n"
+                b"Connection: close\r\n\r\n"
+            )
+            response = client.recv(4096)
+        assert response.startswith(b"HTTP/1.1 204 No Content"), response
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def main() -> int:
+    module = load_example()
+    assert_ipv4_precedes_ipv6(module)
+    assert_ssh_command_is_bounded(module)
+    assert_health_endpoint_is_local(module)
+    print("ssh-reverse-proxy-supervisor-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ssh_reverse_proxy_supervisor.py
+++ b/examples/ssh_reverse_proxy_supervisor.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Run a loopback-only HTTPS CONNECT proxy through an SSH reverse forward.
+
+This example is intentionally provider-neutral. It gives a remote agent runtime
+an outbound HTTPS path through its desktop host without copying credentials or
+session state between machines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import os
+import re
+import select
+import shutil
+import signal
+import socket
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlsplit
+
+LOOPBACK_HOST = "127.0.0.1"
+HEALTH_HOST = "reverse-proxy-health.invalid"
+BUFFER_SIZE = 65536
+HEADER_LIMIT = 65536
+
+
+@dataclass(frozen=True)
+class ProxyConfig:
+    ssh_host: str
+    local_port: int
+    remote_port: int
+    ssh_binary: str
+    retry_delay: float
+    upstream_connect_timeout: float
+    server_alive_interval: int
+    server_alive_count_max: int
+    cleanup_stale_listener: bool
+
+
+def _log(message: str, *, error: bool = False) -> None:
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    print(
+        f"{stamp} {message}",
+        file=sys.stderr if error else sys.stdout,
+        flush=True,
+    )
+
+
+def _port(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("port must be an integer") from exc
+    if not 1024 <= port <= 65535:
+        raise argparse.ArgumentTypeError("port must be in 1024..65535")
+    return port
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must be an integer") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("value must be a number") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("value must be positive")
+    return parsed
+
+
+def _ssh_alias(value: str) -> str:
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", value):
+        raise argparse.ArgumentTypeError(
+            "SSH host must be a config alias containing only letters, digits, "
+            "dots, underscores, or hyphens"
+        )
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> ProxyConfig:
+    default_ssh = "/usr/bin/ssh" if Path("/usr/bin/ssh").is_file() else "ssh"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--ssh-host",
+        required=True,
+        type=_ssh_alias,
+        help="SSH config alias for the remote runtime host",
+    )
+    parser.add_argument("--local-port", required=True, type=_port)
+    parser.add_argument(
+        "--remote-port",
+        type=_port,
+        help="remote loopback port; defaults to --local-port",
+    )
+    parser.add_argument("--ssh-binary", default=default_ssh)
+    parser.add_argument("--retry-delay", default=5.0, type=_positive_float)
+    parser.add_argument(
+        "--upstream-connect-timeout",
+        default=6.0,
+        type=_positive_float,
+    )
+    parser.add_argument(
+        "--server-alive-interval",
+        default=30,
+        type=_positive_int,
+    )
+    parser.add_argument(
+        "--server-alive-count-max",
+        default=3,
+        type=_positive_int,
+    )
+    parser.add_argument(
+        "--cleanup-stale-listener",
+        action="store_true",
+        help=(
+            "after the managed tunnel exits, remove only a same-user sshd "
+            "listener on the configured remote loopback port"
+        ),
+    )
+    args = parser.parse_args(argv)
+    ssh_binary = shutil.which(args.ssh_binary)
+    if ssh_binary is None:
+        parser.error(f"SSH binary is not executable: {args.ssh_binary}")
+    return ProxyConfig(
+        ssh_host=args.ssh_host,
+        local_port=args.local_port,
+        remote_port=args.remote_port or args.local_port,
+        ssh_binary=ssh_binary,
+        retry_delay=args.retry_delay,
+        upstream_connect_timeout=args.upstream_connect_timeout,
+        server_alive_interval=args.server_alive_interval,
+        server_alive_count_max=args.server_alive_count_max,
+        cleanup_stale_listener=args.cleanup_stale_listener,
+    )
+
+
+def _read_headers(sock: socket.socket) -> bytes:
+    data = bytearray()
+    while b"\r\n\r\n" not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        data.extend(chunk)
+        if len(data) > HEADER_LIMIT:
+            raise ValueError("request headers are too large")
+    return bytes(data)
+
+
+def _split_authority(authority: str) -> tuple[str, int]:
+    parsed = urlsplit(f"//{authority}")
+    if not parsed.hostname:
+        raise ValueError("CONNECT target is missing a host")
+    return parsed.hostname, parsed.port or 443
+
+
+def _public_addresses(host: str, port: int) -> list[tuple[int, tuple]]:
+    addresses: list[tuple[int, tuple]] = []
+    seen: set[tuple[int, tuple]] = set()
+    for family, _socktype, _proto, _name, sockaddr in socket.getaddrinfo(
+        host,
+        port,
+        type=socket.SOCK_STREAM,
+    ):
+        if family not in (socket.AF_INET, socket.AF_INET6):
+            continue
+        address = ipaddress.ip_address(sockaddr[0].split("%", 1)[0])
+        candidate = (family, sockaddr)
+        if address.is_global and candidate not in seen:
+            seen.add(candidate)
+            addresses.append(candidate)
+    if not addresses:
+        raise OSError("CONNECT target has no globally routable address")
+
+    # Some VPNs leave globally scoped IPv6 DNS answers available while their
+    # IPv6 route is unusable. Try IPv4 first, but retain IPv6 as a fallback.
+    addresses.sort(key=lambda item: 0 if item[0] == socket.AF_INET else 1)
+    return addresses
+
+
+def _connect_public(config: ProxyConfig, host: str, port: int) -> socket.socket:
+    last_error: OSError | None = None
+    for family, sockaddr in _public_addresses(host, port):
+        upstream = socket.socket(family, socket.SOCK_STREAM)
+        upstream.settimeout(config.upstream_connect_timeout)
+        try:
+            upstream.connect(sockaddr)
+            return upstream
+        except OSError as exc:
+            last_error = exc
+            upstream.close()
+    raise last_error or OSError("failed to connect to CONNECT target")
+
+
+def _relay(client: socket.socket, upstream: socket.socket) -> None:
+    for sock in (client, upstream):
+        sock.settimeout(None)
+    peers = {client: upstream, upstream: client}
+    readable = [client, upstream]
+    while readable:
+        ready, _, failed = select.select(readable, [], readable)
+        if failed:
+            raise OSError("CONNECT relay socket failed")
+        for source in ready:
+            chunk = source.recv(BUFFER_SIZE)
+            if chunk:
+                peers[source].sendall(chunk)
+                continue
+            readable.remove(source)
+            try:
+                peers[source].shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+
+
+class ProxyServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+    request_queue_size = 64
+
+    def __init__(self, address: tuple[str, int], config: ProxyConfig) -> None:
+        self.proxy_config = config
+        super().__init__(address, ProxyHandler)
+
+
+class ProxyHandler(socketserver.BaseRequestHandler):
+    server: ProxyServer
+
+    def handle(self) -> None:
+        client = self.request
+        client.settimeout(30)
+        upstream: socket.socket | None = None
+        tunnel_established = False
+        try:
+            request = _read_headers(client)
+            header_end = request.find(b"\r\n\r\n")
+            if header_end < 0:
+                raise ValueError("incomplete proxy request")
+            head = request[:header_end].decode("iso-8859-1")
+            lines = head.split("\r\n")
+            method, target, _version = lines[0].split(" ", 2)
+            host_header = next(
+                (
+                    line.split(":", 1)[1].strip()
+                    for line in lines[1:]
+                    if line.lower().startswith("host:")
+                ),
+                "",
+            )
+            parsed = urlsplit(target)
+            request_host = parsed.hostname or host_header.split(":", 1)[0]
+            if method.upper() == "GET" and request_host == HEALTH_HOST:
+                client.sendall(
+                    b"HTTP/1.1 204 No Content\r\n"
+                    b"Content-Length: 0\r\n"
+                    b"Connection: close\r\n\r\n"
+                )
+                return
+            if method.upper() != "CONNECT":
+                raise ValueError("proxy accepts only HTTPS CONNECT requests")
+            host, port = _split_authority(target)
+            if port != 443:
+                raise ValueError("CONNECT is restricted to port 443")
+            upstream = _connect_public(self.server.proxy_config, host, port)
+            client.sendall(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            tunnel_established = True
+            _relay(client, upstream)
+        except (OSError, ValueError) as exc:
+            _log(
+                f"proxy_connection_error:{type(exc).__name__}:{exc}",
+                error=True,
+            )
+            if not tunnel_established:
+                try:
+                    client.sendall(
+                        b"HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n"
+                    )
+                except OSError:
+                    pass
+        finally:
+            if upstream is not None:
+                upstream.close()
+
+
+def build_ssh_command(config: ProxyConfig) -> list[str]:
+    reverse_forward = (
+        f"{LOOPBACK_HOST}:{config.remote_port}:{LOOPBACK_HOST}:{config.local_port}"
+    )
+    return [
+        config.ssh_binary,
+        "-x",
+        "-N",
+        "-T",
+        "-o",
+        "ControlMaster=no",
+        "-o",
+        "ControlPath=none",
+        "-o",
+        "ControlPersist=no",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        f"ServerAliveInterval={config.server_alive_interval}",
+        "-o",
+        f"ServerAliveCountMax={config.server_alive_count_max}",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "ExitOnForwardFailure=yes",
+        "-R",
+        reverse_forward,
+        config.ssh_host,
+    ]
+
+
+def _cleanup_command(remote_port: int) -> str:
+    return f"""
+port={remote_port}
+pid=$(lsof -t -nP -iTCP@127.0.0.1:$port -sTCP:LISTEN 2>/dev/null | head -n 1)
+if [ -z "$pid" ]; then
+    pid=$(sudo -n lsof -t -nP -iTCP@127.0.0.1:$port -sTCP:LISTEN 2>/dev/null | head -n 1)
+fi
+if [ -z "$pid" ]; then
+    printf 'none\\n'
+    exit 0
+fi
+owner_uid=$(ps -p "$pid" -o uid= 2>/dev/null | tr -d ' ')
+expected_uid=$(id -u)
+comm=$(ps -p "$pid" -o comm= 2>/dev/null | tr -d ' ')
+if [ "$owner_uid" != "$expected_uid" ]; then
+    printf 'refused:%s:owner-mismatch\\n' "$pid" >&2
+    exit 64
+fi
+case "$comm" in
+    sshd|sshd-session) ;;
+    *)
+        printf 'refused:%s:unexpected-process\\n' "$pid" >&2
+        exit 65
+        ;;
+esac
+kill -TERM "$pid"
+for delay in 1 1 1 1 1; do
+    if ! lsof -a -p "$pid" -iTCP@127.0.0.1:$port -sTCP:LISTEN >/dev/null 2>&1; then
+        printf 'terminated:%s\\n' "$pid"
+        exit 0
+    fi
+    sleep "$delay"
+done
+printf 'timeout:%s\\n' "$pid" >&2
+exit 66
+""".strip()
+
+
+def _remote_ssh_command(config: ProxyConfig, command: str) -> list[str]:
+    return [
+        config.ssh_binary,
+        "-x",
+        "-T",
+        "-o",
+        "ControlMaster=no",
+        "-o",
+        "ControlPath=none",
+        "-o",
+        "ControlPersist=no",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        config.ssh_host,
+        command,
+    ]
+
+
+def remove_stale_remote_listener(config: ProxyConfig) -> bool:
+    try:
+        result = subprocess.run(
+            _remote_ssh_command(config, _cleanup_command(config.remote_port)),
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=25,
+            close_fds=True,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        _log("stale_listener_cleanup_timeout", error=True)
+        return False
+    detail = (result.stdout or result.stderr).strip().replace("\n", ";")
+    if result.returncode == 0:
+        _log(f"stale_listener_cleanup:{detail or 'ok'}")
+        return True
+    _log(
+        f"stale_listener_cleanup_failed:exit={result.returncode}:{detail}",
+        error=True,
+    )
+    return False
+
+
+def _terminate(process: subprocess.Popen[bytes], timeout: float = 5.0) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=timeout)
+
+
+def supervise(config: ProxyConfig) -> int:
+    try:
+        server = ProxyServer((LOOPBACK_HOST, config.local_port), config)
+    except OSError as exc:
+        _log(f"proxy_bind_failed:{exc.errno}", error=True)
+        return 98
+    server_thread = threading.Thread(
+        target=server.serve_forever,
+        kwargs={"poll_interval": 0.2},
+        name="reverse-connect-proxy",
+        daemon=True,
+    )
+    server_thread.start()
+    _log(f"proxy_ready:{LOOPBACK_HOST}:{config.local_port}")
+
+    stopping = threading.Event()
+    tunnel: subprocess.Popen[bytes] | None = None
+
+    def stop(_signum: int, _frame: object) -> None:
+        if stopping.is_set():
+            return
+        stopping.set()
+        if tunnel is not None:
+            _terminate(tunnel)
+        server.shutdown()
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    try:
+        while not stopping.is_set():
+            try:
+                tunnel = subprocess.Popen(
+                    build_ssh_command(config),
+                    stdin=subprocess.DEVNULL,
+                    close_fds=True,
+                    env=os.environ.copy(),
+                )
+            except OSError as exc:
+                _log(f"ssh_tunnel_start_failed:{exc.errno}", error=True)
+                stopping.wait(config.retry_delay)
+                continue
+            return_code = tunnel.wait()
+            _log(f"ssh_tunnel_exit:{return_code}", error=True)
+            if stopping.is_set():
+                break
+            if config.cleanup_stale_listener:
+                remove_stale_remote_listener(config)
+            stopping.wait(config.retry_delay)
+        return 0
+    finally:
+        if tunnel is not None:
+            _terminate(tunnel)
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=3)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return supervise(parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a provider-neutral, loopback-only HTTPS CONNECT proxy supervised with an SSH reverse forward
- document stale-listener ownership, false-negative health probes, IPv6 fallback, and controlled recovery
- add an offline smoke for address filtering, bounded SSH arguments, cleanup guards, and the local health endpoint

## Issue Or Task

- Owner request: preserve a sanitized and reusable remote-runtime network recovery pattern
- Contributor task ID: N/A

## Validation

- [x] `python3 -m py_compile examples/ssh_reverse_proxy_supervisor.py examples/ssh-reverse-proxy-supervisor-smoke.py`
- [x] `python3 examples/ssh-reverse-proxy-supervisor-smoke.py`
- [x] `ruff check` and `ruff format --check` on both Python files
- [x] `python3 examples/docs-governance-smoke.py`
- [x] `python3 examples/repository-hygiene-smoke.py`
- [x] `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` — 13 selected catalog/risk smokes passed, public-boundary scan passed, 0 warnings, 0 manual holds

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [ ] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [x] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: optional host/runtime integration example

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the requested public-safe integration pattern.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

## Review Notes

- Automatic stale-listener cleanup is opt-in and refuses targets outside the exact same-user `sshd` or `sshd-session` listener on the configured loopback port.
- The example is intentionally not wired into LoopX core. It has no active product call site and remains a reversible integration recipe.
- Host-specific configuration, real logs, route details, process listings, and credentials were explicitly excluded.