### PR TITLE
fix(scheduler): materialize cadence monitor schedules

### DIFF
--- a/examples/control_plane/monitor-todo-policy-seam-smoke.py
+++ b/examples/control_plane/monitor-todo-policy-seam-smoke.py
@@ -91,6 +91,10 @@ def main() -> int:
     unscheduled.pop("next_due_at")
     assert_policy_matches_wrappers(unscheduled, due=False, expired=False)
     assert monitor_todo_missing_schedule(unscheduled, now=NOW) is True, unscheduled
+    cadence_only = monitor_item(cadence="30m")
+    cadence_only.pop("next_due_at")
+    assert_policy_matches_wrappers(cadence_only, due=False, expired=False)
+    assert monitor_todo_missing_schedule(cadence_only, now=NOW) is True, cadence_only
     assert monitor_todo_next_due_at({"next_due_at": "2026-01-01T00:00:00"}) == NOW
     assert parse_monitor_counter("3") == 3
     assert parse_monitor_counter("not-a-number") == 0

--- a/loopx/control_plane/scheduler/monitor_todo.py
+++ b/loopx/control_plane/scheduler/monitor_todo.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -13,12 +12,7 @@ from ..todos.contract import (
     normalize_todo_task_class,
 )
 from .time import parse_scheduler_timestamp
-
-MONITOR_CADENCE_PATTERN = re.compile(
-    r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
-    r"(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
-    re.IGNORECASE,
-)
+from .state_transition_rules import project_monitor_todo_schedule
 
 
 parse_monitor_timestamp = parse_scheduler_timestamp
@@ -32,21 +26,13 @@ def parse_monitor_counter(value: Any) -> int:
 
 
 def monitor_cadence_delta(value: Any) -> timedelta | None:
-    candidate = str(value or "").strip()
-    if not candidate:
+    projected = project_monitor_todo_schedule(
+        generated_at="1970-01-01T00:00:00Z",
+        cadence=value,
+    )
+    if projected.cadence_seconds is None:
         return None
-    match = MONITOR_CADENCE_PATTERN.match(candidate)
-    if not match:
-        return None
-    count = int(match.group("count"))
-    unit = match.group("unit").lower()
-    if unit.startswith("s"):
-        return timedelta(seconds=count)
-    if unit.startswith("m"):
-        return timedelta(minutes=count)
-    if unit.startswith("h"):
-        return timedelta(hours=count)
-    return timedelta(days=count)
+    return timedelta(seconds=projected.cadence_seconds)
 
 
 def monitor_next_due_at(
@@ -55,18 +41,11 @@ def monitor_next_due_at(
     cadence: Any = None,
     explicit_next_due_at: Any = None,
 ) -> str | None:
-    explicit = str(explicit_next_due_at or "").strip()
-    if explicit:
-        if parse_monitor_timestamp(explicit) is None:
-            raise ValueError("--next-due-at must be an ISO timestamp")
-        return explicit
-    delta = monitor_cadence_delta(cadence)
-    if delta is None:
-        return None
-    checked_at = parse_monitor_timestamp(generated_at)
-    if checked_at is None:
-        checked_at = now_utc()
-    return (checked_at + delta).astimezone().replace(microsecond=0).isoformat()
+    return project_monitor_todo_schedule(
+        generated_at=generated_at,
+        cadence=cadence,
+        explicit_next_due_at=explicit_next_due_at,
+    ).next_due_at
 
 
 def monitor_todo_task_class(item: dict[str, Any], *, task_text: str | None = None) -> str:
@@ -94,10 +73,7 @@ def monitor_todo_next_due_at(item: dict[str, Any]) -> datetime | None:
 
 
 def monitor_todo_has_schedule(item: dict[str, Any]) -> bool:
-    return bool(
-        str(item.get("cadence") or "").strip()
-        or str(item.get("next_due_at") or "").strip()
-    )
+    return monitor_todo_next_due_at(item) is not None
 
 
 def monitor_todo_expires_at(item: dict[str, Any]) -> datetime | None:

--- a/loopx/control_plane/scheduler/state_transition_rules.py
+++ b/loopx/control_plane/scheduler/state_transition_rules.py
@@ -35,6 +35,58 @@ class SchedulerCadenceDecision:
     current_cadence_acknowledged: bool
 
 
+@dataclass(frozen=True)
+class MonitorScheduleProjection:
+    next_due_at: str | None
+    schedule_source: str
+    cadence_seconds: int | None
+
+
+def project_monitor_todo_schedule(
+    *,
+    generated_at: str,
+    cadence: Any = None,
+    explicit_next_due_at: Any = None,
+) -> MonitorScheduleProjection:
+    """Project monitor schedule facts through the TypeScript scheduler owner."""
+
+    result = _runtime_result(
+        {
+            "schema_version": SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,
+            "operation": "monitor_schedule",
+            "generated_at": generated_at,
+            "cadence": None if cadence is None else str(cadence),
+            "explicit_next_due_at": (
+                None
+                if explicit_next_due_at is None
+                else str(explicit_next_due_at)
+            ),
+        }
+    )
+    next_due_at = result.get("next_due_at")
+    schedule_source = result.get("schedule_source")
+    cadence_seconds = result.get("cadence_seconds")
+    if (
+        result.get("operation") != "monitor_schedule"
+        or (next_due_at is not None and not isinstance(next_due_at, str))
+        or schedule_source not in {"explicit", "cadence", "none"}
+        or (
+            cadence_seconds is not None
+            and (
+                isinstance(cadence_seconds, bool)
+                or not isinstance(cadence_seconds, int)
+                or cadence_seconds <= 0
+            )
+        )
+    ):
+        raise RuntimeError("TypeScript monitor schedule result shape mismatch")
+    return MonitorScheduleProjection(
+        next_due_at=next_due_at,
+        schedule_source=str(schedule_source),
+        cadence_seconds=cadence_seconds,
+    )
+
+
 def _runtime_result(params: dict[str, Any]) -> Mapping[str, Any]:
     try:
         result = effect_runtime_result("scheduler.state_transition.evaluate", params)

--- a/loopx/control_plane/scheduler/state_transition_rules.ts
+++ b/loopx/control_plane/scheduler/state_transition_rules.ts
@@ -79,10 +79,97 @@ export interface SchedulerBackoffTransitionResult extends JsonObject {
   repeated_failed_pair: boolean;
 }
 
+export interface SchedulerMonitorScheduleResult extends JsonObject {
+  schema_version: typeof SCHEDULER_STATE_TRANSITION_RESULT_SCHEMA;
+  operation: "monitor_schedule";
+  next_due_at: string | null;
+  schedule_source: "explicit" | "cadence" | "none";
+  cadence_seconds: number | null;
+}
+
 export type SchedulerStateTransitionResult =
   | SchedulerCadenceTransitionResult
   | SchedulerHostTransitionResult
-  | SchedulerBackoffTransitionResult;
+  | SchedulerBackoffTransitionResult
+  | SchedulerMonitorScheduleResult;
+
+const MONITOR_CADENCE_PATTERN =
+  /^\s*(?<count>[1-9][0-9]{0,4})\s*(?<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$/i;
+
+function optionalRequestString(value: unknown, label: string): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value !== "string") {
+    throw new EffectRuntimeRequestError(`${label} must be a string when present`);
+  }
+  return value.trim();
+}
+
+function monitorCadenceSeconds(value: unknown): number | null {
+  const cadence = optionalRequestString(value, "monitor cadence");
+  if (!cadence) return null;
+  const match = MONITOR_CADENCE_PATTERN.exec(cadence);
+  if (!match?.groups) return null;
+  const count = Number.parseInt(match.groups.count, 10);
+  const unit = match.groups.unit.toLowerCase();
+  const multiplier = unit.startsWith("s")
+    ? 1
+    : unit.startsWith("m")
+    ? 60
+    : unit.startsWith("h")
+    ? 60 * 60
+    : 24 * 60 * 60;
+  return count * multiplier;
+}
+
+function monitorScheduleTimestamp(milliseconds: number): string {
+  return new Date(milliseconds).toISOString().replace(".000Z", "Z");
+}
+
+function evaluateMonitorSchedule(
+  request: JsonObject,
+): SchedulerMonitorScheduleResult {
+  const explicitNextDueAt = optionalRequestString(
+    request.explicit_next_due_at,
+    "explicit_next_due_at",
+  );
+  if (explicitNextDueAt) {
+    if (schedulerTimestampMilliseconds(explicitNextDueAt) === null) {
+      throw new EffectRuntimeRequestError("explicit_next_due_at must be an ISO timestamp");
+    }
+    return {
+      schema_version: SCHEDULER_STATE_TRANSITION_RESULT_SCHEMA,
+      operation: "monitor_schedule",
+      next_due_at: explicitNextDueAt,
+      schedule_source: "explicit",
+      cadence_seconds: monitorCadenceSeconds(request.cadence),
+    };
+  }
+
+  const cadenceSeconds = monitorCadenceSeconds(request.cadence);
+  if (cadenceSeconds === null) {
+    return {
+      schema_version: SCHEDULER_STATE_TRANSITION_RESULT_SCHEMA,
+      operation: "monitor_schedule",
+      next_due_at: null,
+      schedule_source: "none",
+      cadence_seconds: null,
+    };
+  }
+  const generatedAt = requiredString(request.generated_at, "generated_at");
+  const generatedAtMilliseconds = schedulerTimestampMilliseconds(generatedAt);
+  if (generatedAtMilliseconds === null) {
+    throw new EffectRuntimeRequestError("generated_at must be an ISO timestamp");
+  }
+  return {
+    schema_version: SCHEDULER_STATE_TRANSITION_RESULT_SCHEMA,
+    operation: "monitor_schedule",
+    next_due_at: monitorScheduleTimestamp(
+      generatedAtMilliseconds + cadenceSeconds * 1_000,
+    ),
+    schedule_source: "cadence",
+    cadence_seconds: cadenceSeconds,
+  };
+}
 
 function requiredPositiveIntegerList(value: unknown, label: string): number[] {
   if (
@@ -392,5 +479,8 @@ export function evaluateSchedulerStateTransition(
   if (request.operation === "cadence") return evaluateCadence(request);
   if (request.operation === "host") return evaluateHost(request);
   if (request.operation === "backoff") return evaluateBackoff(request);
+  if (request.operation === "monitor_schedule") {
+    return evaluateMonitorSchedule(request);
+  }
   throw new EffectRuntimeRequestError("Scheduler state transition operation is unsupported");
 }

--- a/loopx/control_plane/todos/monitor_metadata.py
+++ b/loopx/control_plane/todos/monitor_metadata.py
@@ -1,22 +1,14 @@
 from __future__ import annotations
 
-import re
 from typing import Any
 
 from ..runtime.time import parse_timestamp
+from ..scheduler.monitor_todo import monitor_cadence_delta, monitor_next_due_at
 from .contract import (
     TODO_MONITOR_METADATA_FIELDS,
     TODO_TASK_CLASS_MONITOR,
     normalize_todo_watch_only,
 )
-
-
-MONITOR_CADENCE_PATTERN = re.compile(
-    r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
-    r"(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
-    re.IGNORECASE,
-)
-
 
 def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
     normalized: dict[str, Any] = {}
@@ -29,7 +21,10 @@ def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, Any
         candidate = str(value or "").strip()
         if candidate:
             normalized[key] = candidate
-    if normalized.get("cadence") is not None and not MONITOR_CADENCE_PATTERN.match(normalized["cadence"]):
+    if (
+        normalized.get("cadence") is not None
+        and monitor_cadence_delta(normalized["cadence"]) is None
+    ):
         raise ValueError("--cadence must look like 30m, 2h, or 1d")
     if normalized.get("next_due_at") is not None and parse_timestamp(normalized["next_due_at"]) is None:
         raise ValueError("--next-due-at must be an ISO timestamp")
@@ -49,6 +44,30 @@ def normalize_monitor_metadata(metadata: dict[str, Any] | None) -> dict[str, Any
     ) is None:
         raise ValueError("--watch-only metadata must be true or false")
     return normalized
+
+
+def materialize_monitor_schedule(
+    *,
+    task_class: str | None,
+    monitor_metadata: dict[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    """Materialize the first due time for a cadence-only monitor mutation."""
+
+    if task_class != TODO_TASK_CLASS_MONITOR:
+        return monitor_metadata
+    if monitor_metadata.get("next_due_at") is not None:
+        return monitor_metadata
+    cadence = monitor_metadata.get("cadence")
+    if cadence is None:
+        return monitor_metadata
+    next_due_at = monitor_next_due_at(
+        generated_at=generated_at,
+        cadence=cadence,
+    )
+    if next_due_at is None:
+        return monitor_metadata
+    return {**monitor_metadata, "next_due_at": next_due_at}
 
 
 def require_continuous_monitor_boundedness(
@@ -77,6 +96,7 @@ def require_monitor_metadata_scope(
     monitor_metadata: dict[str, Any] | None,
     role: str,
     task_class: str | None,
+    generated_at: str | None = None,
 ) -> dict[str, Any]:
     normalized = normalize_monitor_metadata(monitor_metadata)
     if not normalized:
@@ -88,4 +108,10 @@ def require_monitor_metadata_scope(
         )
     if normalized.get("target_key") is not None and role != "agent":
         raise ValueError("target_key requires --role agent")
-    return normalized
+    if generated_at is None:
+        return normalized
+    return materialize_monitor_schedule(
+        task_class=task_class,
+        monitor_metadata=normalized,
+        generated_at=generated_at,
+    )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -674,7 +674,7 @@ def add_todo_to_lines(
     normalized_monitor_metadata = todo_monitor_metadata.require_monitor_metadata_scope(
         monitor_metadata=monitor_metadata,
         role=role,
-        task_class=task_class,
+        task_class=task_class, generated_at=updated_at,
     )
     bounds = section_bounds(lines, role)
     section = bounds[2] if bounds else TODO_SECTION_HEADINGS[role]
@@ -1079,7 +1079,7 @@ def add_goal_todo(
         normalized_monitor_metadata = todo_monitor_metadata.require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
             role=role,
-            task_class=task_class,
+            task_class=task_class, generated_at=updated_at,
         )
         todo_monitor_metadata.require_continuous_monitor_boundedness(
             task_class=task_class,
@@ -1535,7 +1535,7 @@ def update_goal_todo(
         normalized_monitor_metadata = todo_monitor_metadata.require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
             role=target_role,
-            task_class=target_task_class,
+            task_class=target_task_class, generated_at=updated_at,
         )
         effective_monitor_metadata = {
             k: v

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -196,6 +196,13 @@ def test_monitor_resume_when_is_a_supported_bounded_policy(
         monitor_metadata={"target_key": "public-pr:42", "cadence": "1h"},
     )
     assert bounded["resume_when"] == "pr_merged:owner/repo#42"
+    assert bounded["next_due_at"]
+    persisted = resolve_monitor_todo_item(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=bounded["todo_id"],
+    )
+    assert persisted["next_due_at"] == bounded["next_due_at"]
 
     monitor = _add_monitor(
         registry,
@@ -219,6 +226,46 @@ def test_monitor_resume_when_is_a_supported_bounded_policy(
             "resume_ready": False,
         }
     ) is False
+
+
+def test_todo_add_cli_materializes_cadence_only_monitor_due_time(
+    tmp_path: Path,
+) -> None:
+    registry, runtime, _state = _write_fixture(tmp_path)
+
+    added = run_json_cli(
+        "todo",
+        "add",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--text",
+        "Poll a public dependency on cadence.",
+        "--task-class",
+        "continuous_monitor",
+        "--action-kind",
+        "monitor",
+        "--claimed-by",
+        AGENT_ID,
+        "--target-key",
+        "public-dependency:cadence-only",
+        "--cadence",
+        "30m",
+        "--watch-only",
+        registry_path=registry,
+        runtime_root=runtime,
+    )
+
+    assert added["cadence"] == "30m"
+    assert added["next_due_at"]
+    persisted = resolve_monitor_todo_item(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        todo_id=added["todo_id"],
+    )
+    assert persisted["next_due_at"] == added["next_due_at"]
+    assert persisted["target_key"] == "public-dependency:cadence-only"
 
 
 def test_runtime_writeback_can_read_legacy_unbounded_monitor(tmp_path: Path) -> None:

--- a/tests/control_plane/test_scheduler_execution_context.py
+++ b/tests/control_plane/test_scheduler_execution_context.py
@@ -637,22 +637,24 @@ def test_quota_payload_compaction_preserves_earliest_frontier_deadline() -> None
             "deferred_count": 0,
             "monitor_open_items": [
                 {
-                    "todo_id": "todo_unscheduled_monitor_a",
+                        "todo_id": "todo_later_monitor_a",
                     "index": 0,
                     "status": "open",
                     "task_class": "continuous_monitor",
-                    "text": "[P1] Unscheduled monitor A",
-                    "target_key": "unscheduled-monitor-a",
-                    "cadence": "60m",
+                        "text": "[P1] Later monitor A",
+                        "target_key": "later-monitor-a",
+                        "cadence": "60m",
+                        "next_due_at": (now + timedelta(minutes=60)).isoformat(),
                 },
                 {
-                    "todo_id": "todo_unscheduled_monitor_b",
+                        "todo_id": "todo_later_monitor_b",
                     "index": 1,
                     "status": "open",
                     "task_class": "continuous_monitor",
-                    "text": "[P1] Unscheduled monitor B",
-                    "target_key": "unscheduled-monitor-b",
-                    "cadence": "60m",
+                        "text": "[P1] Later monitor B",
+                        "target_key": "later-monitor-b",
+                        "cadence": "60m",
+                        "next_due_at": (now + timedelta(minutes=60)).isoformat(),
                 },
                 {
                     "todo_id": "todo_earliest_monitor",
@@ -697,8 +699,8 @@ def test_quota_payload_compaction_preserves_earliest_frontier_deadline() -> None
     compacted_summary = quota["agent_todo_summary"]
     compacted_monitors = compacted_summary["monitor_open_items"]
     assert [item["todo_id"] for item in compacted_monitors] == [
-        "todo_unscheduled_monitor_a",
-        "todo_unscheduled_monitor_b",
+            "todo_later_monitor_a",
+            "todo_later_monitor_b",
     ]
     assert compacted_summary["frontier_deadline"]["identity"] == (
         "todo_earliest_monitor"

--- a/tests/control_plane_ts/scheduler_state_transition_rules.test.ts
+++ b/tests/control_plane_ts/scheduler_state_transition_rules.test.ts
@@ -87,6 +87,64 @@ test("transition decisions do not mutate caller input", () => {
   assert.deepEqual(request, before);
 });
 
+test("monitor schedule materializes cadence and preserves explicit due time", () => {
+  const cadence = evaluateSchedulerStateTransition({
+    schema_version: SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,
+    operation: "monitor_schedule",
+    generated_at: "2026-08-25T10:00:00+08:00",
+    cadence: "30 minutes",
+    explicit_next_due_at: null,
+  });
+  assert.deepEqual(cadence, {
+    schema_version: SCHEDULER_STATE_TRANSITION_RESULT_SCHEMA,
+    operation: "monitor_schedule",
+    next_due_at: "2026-08-25T02:30:00Z",
+    schedule_source: "cadence",
+    cadence_seconds: 1800,
+  });
+
+  const explicit = evaluateSchedulerStateTransition({
+    schema_version: SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,
+    operation: "monitor_schedule",
+    generated_at: "ignored-for-explicit-schedule",
+    cadence: "1h",
+    explicit_next_due_at: "2026-08-26T09:00:00+08:00",
+  });
+  assert.equal(explicit.next_due_at, "2026-08-26T09:00:00+08:00");
+  assert.equal(explicit.schedule_source, "explicit");
+  assert.equal(explicit.cadence_seconds, 3600);
+
+  const missing = evaluateSchedulerStateTransition({
+    schema_version: SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,
+    operation: "monitor_schedule",
+    generated_at: "2026-08-25T10:00:00+08:00",
+    cadence: "not-a-cadence",
+  });
+  assert.equal(missing.next_due_at, null);
+  assert.equal(missing.schedule_source, "none");
+});
+
+test("monitor schedule rejects malformed timestamps without wall-clock fallback", () => {
+  assert.throws(
+    () => evaluateSchedulerStateTransition({
+      schema_version: SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,
+      operation: "monitor_schedule",
+      generated_at: "not-a-timestamp",
+      cadence: "30m",
+    }),
+    /generated_at must be an ISO timestamp/,
+  );
+  assert.throws(
+    () => evaluateSchedulerStateTransition({
+      schema_version: SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,
+      operation: "monitor_schedule",
+      generated_at: "2026-08-25T10:00:00Z",
+      explicit_next_due_at: "not-a-timestamp",
+    }),
+    /explicit_next_due_at must be an ISO timestamp/,
+  );
+});
+
 function backoffRequest(extra: Record<string, unknown> = {}) {
   return {
     schema_version: SCHEDULER_STATE_TRANSITION_REQUEST_SCHEMA,


### PR DESCRIPTION
## Summary

- make cadence-only continuous monitors schedulable instead of leaving them neither due nor repairable
- move cadence parsing and due-time materialization into the typed TypeScript scheduler transition owner
- materialize `next_due_at` during Todo add/update and classify legacy cadence-only rows as schedule gaps for repair
- remove the duplicate Python cadence parser and wall-clock fallback

Relates to #3539 (C3).

## Changed surfaces

- scheduler transition rules and Python adapter
- monitor metadata validation/materialization
- Todo add/update lifecycle
- scheduler and CLI regression coverage

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 136 passed
- focused Python scheduler/Todo set — 207 passed
- cadence-only Todo add/update CLI regressions — 2 passed
- `mypy` — repository strict set passed
- `ruff check` — changed Python surfaces passed
- maintainability ratchet — no unreviewed or magnitude regressions
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18 selected checks passed
- public/private boundary scan — 9 files clean
- change-quality receipt: `cqr_487b037aa9bee97c7eca`

The CLI differential check creates a read-only detached fixture worktree. The installed local change-window reference hook currently rejects that unborn-worktree phase, so this validation-only subprocess disabled repository hooks; no commit, push, or delivery gate was bypassed.

## Review notes

- No failures, skips, or manual holds remain.
- Future-facing pass applied: scheduler semantics stay TypeScript-owned, Python is a narrow adapter, and the safe-fix avoided growing the existing `todos.py` orchestration facade.
- This does not change monitor cadence after a successful poll; it only establishes and repairs the initial due-time contract.
