### PR TITLE
fix(quota): bind SSH guided start to one turn

### DIFF
--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -429,6 +429,7 @@ def main() -> int:
         assert "--runtime-profile codex_app_ssh_goal" in (
             app_ssh_prompt["quota_guard_command"]
         ), app_ssh_prompt
+        assert "--begin-turn" not in app_ssh_prompt["quota_guard_command"], app_ssh_prompt
         assert "--turn-instance-id" not in app_ssh_prompt["quota_guard_command"], app_ssh_prompt
         assert "--source visible-goal" in app_ssh_prompt["quota_spend_command"], app_ssh_prompt
         spend_args = build_parser().parse_args(

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -18,6 +18,9 @@ from .control_plane.goals.start_contract import (
     build_goal_start_contract,
     build_goal_start_prompt,
 )
+from .control_plane.scheduler.execution_context import (
+    GUIDED_START_TURN_RUNTIME_PROFILES,
+)
 from .host_loop_activation import (
     agent_type_for_host_surface,
     build_host_loop_activation_packet,
@@ -808,7 +811,7 @@ def build_loopx_bootstrap_command_pack(
         explicit_goal_start
         and selected_agent_id
         and scheduler_command_binding.get("runtime_profile")
-        == "codex_app_heartbeat"
+        in {profile.value for profile in GUIDED_START_TURN_RUNTIME_PROFILES}
     )
     quota_guard_command = (
         render_quota_guard_command(

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -5,16 +5,17 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..capabilities.repository_change_window import (
-    repository_delivery_interaction_hook,
-)
 from ..capabilities.explore.composition_frontier import (
     project_live_explore_composition_frontier,
+)
+from ..capabilities.repository_change_window import (
+    repository_delivery_interaction_hook,
 )
 from ..control_plane.quota.cli_projection import (
     compact_quota_monitor_poll_cli_payload,
     compact_quota_should_run_cli_payload,
 )
+from ..control_plane.quota.effect_program import SettlementIdentity
 from ..control_plane.quota.error_codes import (
     HeartbeatReceiptIdentityConflictError,
     QuotaCommandValidationError,
@@ -38,10 +39,9 @@ from ..control_plane.quota.settlement_cli import (
     quota_rollout_details,
     quota_rollout_replan_obligation_id,
     quota_rollout_todo_id,
-    render_existing_heartbeat_receipt_payload,
     reconcile_existing_heartbeat_receipt_for_turn,
+    render_existing_heartbeat_receipt_payload,
 )
-from ..control_plane.quota.effect_program import SettlementIdentity
 from ..control_plane.quota.turn_envelope import build_turn_envelope
 from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,
@@ -49,6 +49,7 @@ from ..control_plane.runtime.status_projection_cache import (
     write_status_projection_cache,
 )
 from ..control_plane.scheduler.execution_context import (
+    GUIDED_START_TURN_RUNTIME_PROFILES,
     SchedulerExecutionContextResolution,
     SchedulerRuntimeProfile,
     scheduler_execution_context_for_runtime_profile,
@@ -82,15 +83,16 @@ from ..turn_identity import mint_turn_instance_id, normalize_turn_instance_id
 from ..upgrade import resolve_codex_app_automation_rrule
 from .lark_inbox import build_lark_operator_inbox_urgency_projector
 from .quota_host_poll import attach_host_poll_receipt
+from .quota_monitor_poll import record_quota_monitor_poll_for_cli
+from .quota_registration import (
+    register_quota_command as register_quota_command,  # noqa: PLC0414
+)
 from .quota_request import (
     QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
     QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
     quota_detail_sections_from_args,
     validate_quota_command_request,
 )
-from .quota_monitor_poll import record_quota_monitor_poll_for_cli
-from .quota_registration import register_quota_command as register_quota_command
-
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -253,9 +255,10 @@ def _prepare_quota_command_context(
     validate_quota_command_request(args)
     if begin_turn:
         profile = scheduler_runtime_profile_for_execution_context(scheduler_context)
-        if profile is not SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT:
+        if profile not in GUIDED_START_TURN_RUNTIME_PROFILES:
             raise QuotaCommandValidationError(
-                "--begin-turn requires runtime-profile codex_app_heartbeat"
+                "--begin-turn requires runtime-profile codex_app_heartbeat "
+                "or codex_app_ssh_goal"
             )
         heartbeat_turn_id = mint_turn_instance_id(prefix="guided-start")
     if heartbeat_turn_id and command == "should-run" and bool(args.dry_run):
@@ -556,7 +559,8 @@ def _requested_quota_action_todo_id(
 ) -> str | None:
     if not (
         bool(args.codex_app)
-        or args.runtime_profile == "codex_app_heartbeat"
+        or args.runtime_profile
+        in {profile.value for profile in GUIDED_START_TURN_RUNTIME_PROFILES}
     ):
         return None
     return normalize_todo_id(args.todo_id)

--- a/loopx/control_plane/scheduler/execution_context.py
+++ b/loopx/control_plane/scheduler/execution_context.py
@@ -73,6 +73,13 @@ NATIVE_GOAL_RUNTIME_PROFILES = frozenset(
     }
 )
 
+GUIDED_START_TURN_RUNTIME_PROFILES = frozenset(
+    {
+        SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT,
+        SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE,
+    }
+)
+
 
 _SCHEDULER_RUNTIME_PROFILE_CONTEXTS = {
     SchedulerRuntimeProfile.ARK_MANAGED_AGENT_GOAL: (

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from loopx.bootstrap_command_pack import build_start_goal_guided_packet
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -1256,8 +1258,10 @@ def test_agent_selects_one_bounded_action_before_delivery_receipt_binding(
     assert _heartbeat_receipt_count(runtime, turn_instance_id) == 2
 
 
+@pytest.mark.parametrize("host_surface", ["codex-app", "codex-app-ssh"])
 def test_guided_start_begins_one_turn_and_executes_returned_selection(
     tmp_path: Path,
+    host_surface: str,
 ) -> None:
     project, runtime, registry_path = _write_fixture(tmp_path)
     _configure_selectable_alternative(project)
@@ -1266,7 +1270,7 @@ def test_guided_start_begins_one_turn_and_executes_returned_selection(
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         cli_bin="loopx",
-        host_surface="codex-app",
+        host_surface=host_surface,
         goal_text="Start one accountable delivery turn.",
     )
     guard_command = next(
@@ -1306,18 +1310,27 @@ def test_guided_start_begins_one_turn_and_executes_returned_selection(
 
     assert selected_rc == 0, selected
     assert selected["selected_todo"]["todo_id"] == ALTERNATIVE_TODO_ID
+    assert selected["selected_todo"]["selection_binding"] == "heartbeat_receipt"
     receipt_identity = selected["heartbeat_receipt"]["settlement_identity"]
     assert receipt_identity["turn_instance_id"] == turn_instance_id
-    settlement_plan = selected["interaction_contract"]["cli_channel"][
-        "settlement_plan"
-    ]
-    assert settlement_plan["identity"] == receipt_identity
-    assert f"--turn-instance-id {turn_instance_id}" in json.dumps(settlement_plan)
+    cli_channel = selected["interaction_contract"]["cli_channel"]
+    if host_surface == "codex-app":
+        settlement_plan = cli_channel["settlement_plan"]
+        assert settlement_plan["identity"] == receipt_identity
+        assert f"--turn-instance-id {turn_instance_id}" in json.dumps(settlement_plan)
+    else:
+        assert "settlement_plan" not in cli_channel
+        assert any(
+            "--source visible-goal" in action
+            for action in cli_channel["next_cli_actions"]
+        )
     assert _heartbeat_receipt_count(runtime, turn_instance_id) == 2
 
 
+@pytest.mark.parametrize("host_surface", ["codex-app", "codex-app-ssh"])
 def test_single_todo_guided_start_keeps_direct_delivery_semantics(
     tmp_path: Path,
+    host_surface: str,
 ) -> None:
     project, _runtime, registry_path = _write_fixture(tmp_path)
     packet = build_start_goal_guided_packet(
@@ -1325,7 +1338,7 @@ def test_single_todo_guided_start_keeps_direct_delivery_semantics(
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         cli_bin="loopx",
-        host_surface="codex-app",
+        host_surface=host_surface,
         goal_text="Start one accountable delivery turn.",
     )
     guard_command = next(
@@ -1371,7 +1384,8 @@ def test_begin_turn_rejects_a_non_receipt_runtime_profile(tmp_path: Path) -> Non
     assert guard_rc == 1, guard
     assert guard["error_code"] == "QUOTA_VALIDATION_FAILED"
     assert guard["reason"] == (
-        "--begin-turn requires runtime-profile codex_app_heartbeat"
+        "--begin-turn requires runtime-profile codex_app_heartbeat "
+        "or codex_app_ssh_goal"
     )
 
 


### PR DESCRIPTION
## Summary

- let direct `codex-app-ssh` guided starts mint a stable Turn identity at quota admission
- propagate that identity through the generated multi-Todo selection command
- honor the selected Todo for both supported Codex App guided runtime profiles
- keep ordinary visible-Goal polling unchanged and keep generic profiles fail-closed

Closes #3569.

## Root cause

The guided-start generator and quota validator shared a heartbeat-only allow rule, while `codex-app-ssh` uses the distinct `codex_app_ssh_goal` runtime profile. Even after admitting that profile, explicit Todo selection was still classified as heartbeat-only, so the receipt identity and projected selected Todo could diverge.

## Validation

- 182 adjacent quota, start-goal, and host activation tests passed
- focused post-rebase regression: 5 passed
- onboarding host-loop activation smoke passed
- Ruff passed on every changed Python file
- premerge canary passed 17/17 selected checks with no failures, warnings, skips, or manual holds
- mypy 2.3.0 hit its own `INTERNAL ERROR` before emitting any type diagnostic; recorded as an infrastructure failure, not a passing check

## Public/private boundary

The diff contains only product runtime code and synthetic public regression fixtures. Added lines were scanned for credentials, private paths, internal links, raw benchmark evidence, and provider-specific context; none were present.

## Merge decision

The change is a narrow runtime repair with executable end-to-end regression coverage. It does not change benchmark scoring, task semantics, permissions, or ordinary non-guided quota calls.