### PR TITLE
feat: 支持删除已停止 Goal

### DIFF
--- a/apps/presentation/dashboard/src/data/status.ts
+++ b/apps/presentation/dashboard/src/data/status.ts
@@ -954,6 +954,19 @@ export function withGoalActivationState(
       : payload.run_history,
   };
 }
+export function withoutGoal(payload: StatusPayload, goalId: string): StatusPayload {
+  const goals = payload.run_history.goals.filter((goal) => goal.id !== goalId);
+  const queueItems = payload.attention_queue.items.filter((item) => item.goal_id !== goalId);
+  if (goals.length === payload.run_history.goals.length && queueItems.length === payload.attention_queue.items.length) {
+    return payload;
+  }
+  return {
+    ...payload,
+    attention_queue: { ...payload.attention_queue, items: queueItems },
+    run_history: { ...payload.run_history, goals },
+  };
+}
+
 export type TodoGroup = z.infer<typeof todoGroupSchema>;
 export type TodoItem = z.infer<typeof todoItemSchema>;
 export type TodoIndexItem = z.infer<typeof todoIndexItemSchema>;

--- a/apps/presentation/dashboard/src/features/personal-workspace/goal-sidebar.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/goal-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Bot, ChevronDown, ChevronRight, Pause, Plus, RotateCcw, Settings2 } from "lucide-react";
+import { Bot, ChevronDown, ChevronRight, Pause, Plus, RotateCcw, Settings2, Trash2 } from "lucide-react";
 
 import type { WorkspaceGoal } from "./personal-workspace-model";
 import { StatusSourceSwitcher, type StatusSourceControl } from "./status-source-switcher";
@@ -27,7 +27,7 @@ export function GoalSidebar({
   goals: WorkspaceGoal[];
   onRequestGoalCreate?: () => void;
   onOpenSettings?: () => void;
-  onRequestGoalLifecycle?: (goal: WorkspaceGoal, operation: "stop" | "resume") => void;
+  onRequestGoalLifecycle?: (goal: WorkspaceGoal, operation: "stop" | "resume" | "delete") => void;
   onSelectGoal: (goalId: string | null) => void;
   selectedGoalId: string | null;
   statusSourceControl?: StatusSourceControl;
@@ -50,15 +50,28 @@ export function GoalSidebar({
         <ChevronRight size={15} />
       </button>
       {onRequestGoalLifecycle ? (
-        <button
-          aria-label={`${stopped ? "恢复" : "停止"} ${goal.title}`}
-          className="personal-goal-lifecycle"
-          onClick={() => onRequestGoalLifecycle(goal, stopped ? "resume" : "stop")}
-          title={stopped ? "恢复 Goal" : "停止 Goal"}
-          type="button"
-        >
-          {stopped ? <RotateCcw size={13} /> : <Pause size={13} />}
-        </button>
+        <>
+          <button
+            aria-label={`${stopped ? "恢复" : "停止"} ${goal.title}`}
+            className="personal-goal-lifecycle"
+            onClick={() => onRequestGoalLifecycle(goal, stopped ? "resume" : "stop")}
+            title={stopped ? "恢复 Goal" : "停止 Goal"}
+            type="button"
+          >
+            {stopped ? <RotateCcw size={13} /> : <Pause size={13} />}
+          </button>
+          {stopped ? (
+            <button
+              aria-label={`删除 ${goal.title}`}
+              className="personal-goal-lifecycle personal-goal-delete"
+              onClick={() => onRequestGoalLifecycle(goal, "delete")}
+              title="删除 Goal"
+              type="button"
+            >
+              <Trash2 size={13} />
+            </button>
+          ) : null}
+        </>
       ) : null}
     </div>
   );

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -136,6 +136,11 @@ assert.match(page, /callbacks\.onGoalActivationStateChange\?\.\(lifecycleChange\
 assert.match(page, /Promise\.resolve\(\)\.then\(\(\) => reconcile\?\.\(\)\)/, "Successful Goal lifecycle apply reconciles the full status payload without blocking the sidebar");
 assert.match(dashboard, /onReconcileStatus=\{\(\) => loadFromUrl\([\s\S]*\{ background: true \}/, "Lifecycle reconciliation uses the non-fatal background status path");
 assert.match(dashboard, /statusProjectionRevisionRef\.current !== projectionRevision/, "A stale background response cannot overwrite a newer optimistic transition");
+assert.match(sidebar, /Trash2/, "Stopped Goals expose a delete icon");
+assert.match(sidebar, /onRequestGoalLifecycle\(goal, "delete"\)/, "Goal deletion stays behind the lifecycle request boundary");
+assert.match(page, /lifecycleOperation === "delete"/, "Goal deletion has an explicit lifecycle operation");
+assert.match(page, /callbacks\.onGoalDeleted/, "Successful Goal deletion removes the optimistic sidebar projection");
+assert.match(status, /function withoutGoal/, "Status projection can remove a deleted Goal");
 assert.match(page, /activityTimeLabel\(item\.output\.createdAt\)/, "Files render human-readable output timestamps");
 assert.match(drawer, /selection\.kind === "run" \|\| selection\.kind === "proposal" \|\| selection\.kind === "schedule"/, "Advanced diagnostics only appears on objects with actionable runtime details");
 

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -135,13 +135,14 @@ assert.match(page, /model\.goals\.find\(\(goal\) => goal\.goalId === proposal\.g
 assert.match(page, /callbacks\.onGoalActivationStateChange\?\.\(lifecycleChange\.goalId, lifecycleChange\.previous\)/, "Rejected Goal lifecycle apply rolls back the optimistic projection");
 assert.match(page, /Promise\.resolve\(\)\.then\(\(\) => reconcile\?\.\(\)\)/, "Successful Goal lifecycle apply reconciles the full status payload without blocking the sidebar");
 assert.match(dashboard, /onReconcileStatus=\{\(\) => loadFromUrl\([\s\S]*\{ background: true \}/, "Lifecycle reconciliation uses the non-fatal background status path");
-assert.match(dashboard, /statusProjectionRevisionRef\.current !== projectionRevision/, "A stale background response cannot overwrite a newer optimistic transition");
+assert.match(dashboard, /statusRequestFenceRef\.current\.projectionRevision/, "A stale background response cannot overwrite a newer optimistic transition");
 assert.match(sidebar, /Trash2/, "Stopped Goals expose a delete icon");
 assert.match(sidebar, /onRequestGoalLifecycle\(goal, "delete"\)/, "Goal deletion stays behind the lifecycle request boundary");
 assert.match(page, /lifecycleOperation === "delete"/, "Goal deletion has an explicit lifecycle operation");
 assert.match(page, /callbacks\.onGoalDeleted/, "Successful Goal deletion removes the optimistic sidebar projection");
 assert.match(status, /function withoutGoal/, "Status projection can remove a deleted Goal");
-assert.match(page, /activityTimeLabel\(item\.output\.createdAt\)/, "Files render human-readable output timestamps");
+assert.match(page, /result\.proposal\.status !== "applied"[\s\S]*result\.proposal\.receipt\?\.projection_verified !== true/, "Non-applied typed action results never project as successful Goal deletion");
+assert.match(page, /状态已变化，操作未执行，请重新生成确认预览/, "Stale Goal deletion remains visible with an actionable error");
 assert.match(drawer, /selection\.kind === "run" \|\| selection\.kind === "proposal" \|\| selection\.kind === "schedule"/, "Advanced diagnostics only appears on objects with actionable runtime details");
 
 for (const field of ["agentId", "todoId", "runId", "safePreview"]) {

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-model.ts
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-model.ts
@@ -166,7 +166,7 @@ export type WorkspaceActionPreview = {
   agentLabel?: string;
   fields: Array<{ label: string; value: string }>;
   goalId?: string;
-  lifecycleOperation?: "stop" | "resume";
+  lifecycleOperation?: "stop" | "resume" | "delete";
   impact: string;
   gate?: {
     kind: string;
@@ -299,6 +299,7 @@ export type PersonalWorkspaceCallbacks = {
   onOpenRunSession?: (run: WorkspaceRun) => void | Promise<void>;
   onOpenOutput?: (output: WorkspaceOutput) => void;
   onGoalActivationStateChange?: (goalId: string, activationState: "active" | "stopped") => void;
+  onGoalDeleted?: (goalId: string) => void;
   onReconcileStatus?: () => void | Promise<void>;
   onRefresh?: () => void | Promise<void>;
   onPreviewAction?: (request: WorkspaceActionPreviewRequest) => WorkspaceActionPreview | Promise<WorkspaceActionPreview>;

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -1082,6 +1082,17 @@ export function PersonalWorkspacePage({
         const applied = workspaceProposal(result.proposal);
         setProposals((current) => ({ ...current, [proposal.previewId]: applied }));
         setSelection({ item: applied, kind: "proposal" });
+        if (result.proposal.status !== "applied" || result.proposal.receipt?.projection_verified !== true) {
+          if (lifecycleChange) {
+            callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.previous);
+          }
+          setActionFeedback(
+            result.proposal.status === "stale"
+              ? "状态已变化，操作未执行，请重新生成确认预览。"
+              : `操作未完成：${result.proposal.status}`,
+          );
+          return;
+        }
         setActionFeedback(`已完成：${applied.title}`);
         // Keep the success receipt visible. Refresh and navigation happen when
         // the user chooses the explicit "进入 Goal" action in the drawer.

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -416,8 +416,8 @@ function proposalFields(parameters: Record<string, unknown>) {
 
 function workspaceProposal(proposal: TypedActionProposal): WorkspaceActionPreview {
   const lifecycleOperation = proposal.action_kind === "goal.lifecycle"
-    && (proposal.normalized_parameters.operation === "stop" || proposal.normalized_parameters.operation === "resume")
-    ? proposal.normalized_parameters.operation
+    && (["stop", "resume", "delete"] as const).includes(proposal.normalized_parameters.operation as "stop" | "resume" | "delete")
+    ? proposal.normalized_parameters.operation as "stop" | "resume" | "delete"
     : undefined;
   return {
     actionKind: proposal.action_kind,
@@ -427,8 +427,10 @@ function workspaceProposal(proposal: TypedActionProposal): WorkspaceActionPrevie
       ? "确认后会创建 Goal 和首个 Todo，并让选定 Agent 开始首轮推进。"
       : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "stop"
         ? "确认后会停止自动推进，并将 Goal 移入折叠的「已停止」列表；历史、Todo 和证据都会保留，可随时恢复。"
-        : proposal.action_kind === "goal.lifecycle"
-          ? "确认后会恢复 Goal 的自动调度资格并移回 Active Goals；实际执行仍受 quota、Gate 和 Todo 约束。"
+        : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "delete"
+          ? "确认后会从 source registry 和 global registry 移除这个已停止 Goal；项目文件、历史状态文件和备份不会被删除。"
+          : proposal.action_kind === "goal.lifecycle"
+            ? "确认后会恢复 Goal 的自动调度资格并移回 Active Goals；实际执行仍受 quota、Gate 和 Todo 约束。"
       : proposal.permission_classification === "protected"
       ? "该操作需要通过受保护的 LoopX 写入服务完成。"
       : "确认后会调用规范 LoopX 服务写入状态。",
@@ -442,8 +444,10 @@ function workspaceProposal(proposal: TypedActionProposal): WorkspaceActionPrevie
     primaryLabel: proposal.action_kind === "goal.create" ? "创建 Goal 并开始首轮"
       : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "stop"
         ? "停止 Goal"
-        : proposal.action_kind === "goal.lifecycle"
-          ? "恢复 Goal"
+        : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "delete"
+          ? "删除 Goal"
+          : proposal.action_kind === "goal.lifecycle"
+            ? "恢复 Goal"
       : proposal.action_kind === "todo.create" && proposal.normalized_parameters.start_execution === true
         ? "创建任务并开始执行"
         : "确认并应用",
@@ -939,7 +943,7 @@ export function PersonalWorkspacePage({
     window.requestAnimationFrame(() => composerRef.current?.focus());
   }
 
-  async function requestGoalLifecycle(goal: WorkspaceGoal, operation: "stop" | "resume") {
+  async function requestGoalLifecycle(goal: WorkspaceGoal, operation: "stop" | "resume" | "delete") {
     await createPreview({
       actionKind: "goal.lifecycle",
       context: { kind: "goal_directory", goal_id: goal.goalId },
@@ -947,9 +951,17 @@ export function PersonalWorkspacePage({
       normalizedParameters: {
         goal_id: goal.goalId,
         operation,
-        reason: operation === "stop" ? "Stopped from the owner workspace" : "Resumed from the owner workspace",
+        reason: operation === "stop"
+          ? "Stopped from the owner workspace"
+          : operation === "resume"
+            ? "Resumed from the owner workspace"
+            : "Deleted from the owner workspace",
       },
-      summary: operation === "stop" ? `停止 Goal：${goal.title}` : `恢复 Goal：${goal.title}`,
+      summary: operation === "stop"
+        ? `停止 Goal：${goal.title}`
+        : operation === "resume"
+          ? `恢复 Goal：${goal.title}`
+          : `删除 Goal：${goal.title}`,
     });
   }
 
@@ -1029,7 +1041,7 @@ export function PersonalWorkspacePage({
     onApplyProposal: async (proposal) => {
       const lifecycleChange = proposal.actionKind === "goal.lifecycle"
         && proposal.goalId
-        && proposal.lifecycleOperation
+        && (proposal.lifecycleOperation === "stop" || proposal.lifecycleOperation === "resume")
         ? {
             goalId: proposal.goalId,
             next: proposal.lifecycleOperation === "stop" ? "stopped" as const : "active" as const,
@@ -1051,7 +1063,12 @@ export function PersonalWorkspacePage({
           setSelection({ item: applied, kind: "proposal" });
           setActionFeedback(`已完成：${proposal.title}`);
           if (proposal.actionKind === "goal.lifecycle") {
-            if (proposal.lifecycleOperation === "stop") selectGoal(null);
+            if (proposal.lifecycleOperation === "stop" || proposal.lifecycleOperation === "delete") {
+              selectGoal(null);
+            }
+            if (proposal.lifecycleOperation === "delete" && proposal.goalId) {
+              callbacks.onGoalDeleted?.(proposal.goalId);
+            }
             const reconcile = callbacks.onReconcileStatus ?? callbacks.onRefresh;
             void Promise.resolve().then(() => reconcile?.()).catch(() => undefined);
           }
@@ -1067,8 +1084,11 @@ export function PersonalWorkspacePage({
         if (applied.actionKind === "todo.create") {
           await callbacks.onRefresh?.();
         }
-        if (applied.actionKind === "goal.lifecycle" && applied.lifecycleOperation === "stop") {
+        if (applied.actionKind === "goal.lifecycle" && (applied.lifecycleOperation === "stop" || applied.lifecycleOperation === "delete")) {
           selectGoal(null);
+        }
+        if (applied.actionKind === "goal.lifecycle" && applied.lifecycleOperation === "delete" && applied.goalId) {
+          callbacks.onGoalDeleted?.(applied.goalId);
         }
         if (applied.actionKind === "goal.lifecycle") {
           const reconcile = callbacks.onReconcileStatus ?? callbacks.onRefresh;

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -414,26 +414,54 @@ function proposalFields(parameters: Record<string, unknown>) {
     }));
 }
 
-function workspaceProposal(proposal: TypedActionProposal): WorkspaceActionPreview {
-  const lifecycleOperation = proposal.action_kind === "goal.lifecycle"
-    && (["stop", "resume", "delete"] as const).includes(proposal.normalized_parameters.operation as "stop" | "resume" | "delete")
-    ? proposal.normalized_parameters.operation as "stop" | "resume" | "delete"
+type GoalLifecycleOperation = "stop" | "resume" | "delete";
+
+function lifecycleOperationFor(proposal: TypedActionProposal): GoalLifecycleOperation | undefined {
+  if (proposal.action_kind !== "goal.lifecycle") return undefined;
+  const operation = proposal.normalized_parameters.operation;
+  return operation === "stop" || operation === "resume" || operation === "delete"
+    ? operation
     : undefined;
+}
+
+function proposalImpact(proposal: TypedActionProposal, lifecycleOperation?: GoalLifecycleOperation): string {
+  if (proposal.action_kind === "goal.create") {
+    return "确认后会创建 Goal 和首个 Todo，并让选定 Agent 开始首轮推进。";
+  }
+  if (proposal.action_kind === "goal.lifecycle") {
+    if (lifecycleOperation === "stop") {
+      return "确认后会停止自动推进，并将 Goal 移入折叠的「已停止」列表；历史、Todo 和证据都会保留，可随时恢复。";
+    }
+    if (lifecycleOperation === "delete") {
+      return "确认后会从 source registry 和 global registry 移除这个已停止 Goal；项目文件、历史状态文件和备份不会被删除。";
+    }
+    return "确认后会恢复 Goal 的自动调度资格并移回 Active Goals；实际执行仍受 quota、Gate 和 Todo 约束。";
+  }
+  return proposal.permission_classification === "protected"
+    ? "该操作需要通过受保护的 LoopX 写入服务完成。"
+    : "确认后会调用规范 LoopX 服务写入状态。";
+}
+
+function proposalPrimaryLabel(proposal: TypedActionProposal, lifecycleOperation?: GoalLifecycleOperation): string {
+  if (proposal.action_kind === "goal.create") return "创建 Goal 并开始首轮";
+  if (proposal.action_kind === "goal.lifecycle") {
+    if (lifecycleOperation === "stop") return "停止 Goal";
+    if (lifecycleOperation === "delete") return "删除 Goal";
+    return "恢复 Goal";
+  }
+  if (proposal.action_kind === "todo.create" && proposal.normalized_parameters.start_execution === true) {
+    return "创建任务并开始执行";
+  }
+  return "确认并应用";
+}
+
+function workspaceProposal(proposal: TypedActionProposal): WorkspaceActionPreview {
+  const lifecycleOperation = lifecycleOperationFor(proposal);
   return {
     actionKind: proposal.action_kind,
     fields: proposalFields(proposal.normalized_parameters),
     goalId: typeof proposal.normalized_parameters.goal_id === "string" ? proposal.normalized_parameters.goal_id : undefined,
-    impact: proposal.action_kind === "goal.create"
-      ? "确认后会创建 Goal 和首个 Todo，并让选定 Agent 开始首轮推进。"
-      : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "stop"
-        ? "确认后会停止自动推进，并将 Goal 移入折叠的「已停止」列表；历史、Todo 和证据都会保留，可随时恢复。"
-        : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "delete"
-          ? "确认后会从 source registry 和 global registry 移除这个已停止 Goal；项目文件、历史状态文件和备份不会被删除。"
-          : proposal.action_kind === "goal.lifecycle"
-            ? "确认后会恢复 Goal 的自动调度资格并移回 Active Goals；实际执行仍受 quota、Gate 和 Todo 约束。"
-      : proposal.permission_classification === "protected"
-      ? "该操作需要通过受保护的 LoopX 写入服务完成。"
-      : "确认后会调用规范 LoopX 服务写入状态。",
+    impact: proposalImpact(proposal, lifecycleOperation),
     previewId: proposal.proposal_id,
     lifecycleOperation,
     gate: proposal.gate ? {
@@ -441,16 +469,7 @@ function workspaceProposal(proposal: TypedActionProposal): WorkspaceActionPrevie
       nextAction: typeof proposal.gate.next_action === "string" ? proposal.gate.next_action : undefined,
       summary: String(proposal.gate.summary ?? "需要宿主确认"),
     } : undefined,
-    primaryLabel: proposal.action_kind === "goal.create" ? "创建 Goal 并开始首轮"
-      : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "stop"
-        ? "停止 Goal"
-        : proposal.action_kind === "goal.lifecycle" && lifecycleOperation === "delete"
-          ? "删除 Goal"
-          : proposal.action_kind === "goal.lifecycle"
-            ? "恢复 Goal"
-      : proposal.action_kind === "todo.create" && proposal.normalized_parameters.start_execution === true
-        ? "创建任务并开始执行"
-        : "确认并应用",
+    primaryLabel: proposalPrimaryLabel(proposal, lifecycleOperation),
     status: proposalStatus(proposal.status),
     title: proposal.summary,
   };
@@ -943,7 +962,17 @@ export function PersonalWorkspacePage({
     window.requestAnimationFrame(() => composerRef.current?.focus());
   }
 
-  async function requestGoalLifecycle(goal: WorkspaceGoal, operation: "stop" | "resume" | "delete") {
+  async function requestGoalLifecycle(goal: WorkspaceGoal, operation: GoalLifecycleOperation) {
+    const reasonByOperation: Record<GoalLifecycleOperation, string> = {
+      delete: "Deleted from the owner workspace",
+      resume: "Resumed from the owner workspace",
+      stop: "Stopped from the owner workspace",
+    };
+    const summaryByOperation: Record<GoalLifecycleOperation, string> = {
+      delete: `删除 Goal：${goal.title}`,
+      resume: `恢复 Goal：${goal.title}`,
+      stop: `停止 Goal：${goal.title}`,
+    };
     try {
       await createPreview({
         actionKind: "goal.lifecycle",
@@ -952,17 +981,9 @@ export function PersonalWorkspacePage({
         normalizedParameters: {
           goal_id: goal.goalId,
           operation,
-          reason: operation === "stop"
-            ? "Stopped from the owner workspace"
-            : operation === "resume"
-              ? "Resumed from the owner workspace"
-              : "Deleted from the owner workspace",
+          reason: reasonByOperation[operation],
         },
-        summary: operation === "stop"
-          ? `停止 Goal：${goal.title}`
-          : operation === "resume"
-            ? `恢复 Goal：${goal.title}`
-            : `删除 Goal：${goal.title}`,
+        summary: summaryByOperation[operation],
       });
     } catch (error) {
       setActionFeedback(`操作失败：${error instanceof Error ? error.message : String(error)}`);

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -944,25 +944,29 @@ export function PersonalWorkspacePage({
   }
 
   async function requestGoalLifecycle(goal: WorkspaceGoal, operation: "stop" | "resume" | "delete") {
-    await createPreview({
-      actionKind: "goal.lifecycle",
-      context: { kind: "goal_directory", goal_id: goal.goalId },
-      idempotencyKey: `workspace-goal-${operation}-${goal.goalId}-${Date.now().toString(36)}`,
-      normalizedParameters: {
-        goal_id: goal.goalId,
-        operation,
-        reason: operation === "stop"
-          ? "Stopped from the owner workspace"
+    try {
+      await createPreview({
+        actionKind: "goal.lifecycle",
+        context: { kind: "goal_directory", goal_id: goal.goalId },
+        idempotencyKey: `workspace-goal-${operation}-${goal.goalId}-${Date.now().toString(36)}`,
+        normalizedParameters: {
+          goal_id: goal.goalId,
+          operation,
+          reason: operation === "stop"
+            ? "Stopped from the owner workspace"
+            : operation === "resume"
+              ? "Resumed from the owner workspace"
+              : "Deleted from the owner workspace",
+        },
+        summary: operation === "stop"
+          ? `停止 Goal：${goal.title}`
           : operation === "resume"
-            ? "Resumed from the owner workspace"
-            : "Deleted from the owner workspace",
-      },
-      summary: operation === "stop"
-        ? `停止 Goal：${goal.title}`
-        : operation === "resume"
-          ? `恢复 Goal：${goal.title}`
-          : `删除 Goal：${goal.title}`,
-    });
+            ? `恢复 Goal：${goal.title}`
+            : `删除 Goal：${goal.title}`,
+      });
+    } catch (error) {
+      setActionFeedback(`操作失败：${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   function prepareScheduleDraft(kind: "heartbeat" | "monitor", goalId: string | null) {

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
@@ -88,10 +88,11 @@
 .personal-sidebar-title-actions button { display: grid; place-items: center; width: 28px; height: 28px; padding: 0; border: 0; border-radius: 7px; background: transparent; color: var(--pw-muted); cursor: pointer; }
 .personal-sidebar-title-actions button:hover { background: #fff; color: var(--pw-text); box-shadow: 0 1px 3px rgb(30 28 20 / 12%); }
 .personal-goal-list { display: grid; gap: 2px; }
-.personal-goal-row { display: grid; grid-template-columns: minmax(0, 1fr) 28px; align-items: center; gap: 2px; border-radius: 11px; }
+.personal-goal-row { display: grid; grid-template-columns: minmax(0, 1fr) 28px 28px; align-items: center; gap: 2px; border-radius: 11px; }
 .personal-goal-link { display: grid; grid-template-columns: 30px minmax(0, 1fr) auto; align-items: center; gap: 10px; min-height: 44px; padding: 7px 5px 7px 10px; border-radius: 11px; }
 .personal-goal-lifecycle { display: grid; place-items: center; width: 26px; height: 26px; padding: 0; border: 0; border-radius: 7px; background: transparent; color: var(--pw-faint); cursor: pointer; }
 .personal-goal-lifecycle:hover { background: #fff; color: var(--pw-text); box-shadow: 0 1px 3px rgb(30 28 20 / 12%); }
+.personal-goal-delete:hover { color: var(--pw-danger); }
 .personal-goal-link-copy { display: grid; min-width: 0; gap: 2px; }
 .personal-goal-link-copy strong, .personal-goal-link-copy small { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .personal-goal-link-copy strong { font-size: 13px; font-weight: 600; }

--- a/apps/presentation/dashboard/src/views/dashboard-page.tsx
+++ b/apps/presentation/dashboard/src/views/dashboard-page.tsx
@@ -16,6 +16,7 @@ import {
   formatStatusError,
   parseStatusPayload,
   withGoalActivationState,
+  withoutGoal,
 } from "../data/status";
 import {
   ChatApiError,
@@ -1188,6 +1189,7 @@ function buildPersonalHomeModel(payload: StatusPayload, rows: GoalDirectoryRow[]
 function PersonalGoalHome({
   isLoading,
   onGoalActivationStateChange,
+  onGoalDeleted,
   onSelectGoal,
   onReconcileStatus,
   onRefresh,
@@ -1200,6 +1202,7 @@ function PersonalGoalHome({
 }: {
   isLoading: boolean;
   onGoalActivationStateChange: (goalId: string, activationState: "active" | "stopped") => void;
+  onGoalDeleted: (goalId: string) => void;
   onSelectGoal: (goalId: string) => void;
   onReconcileStatus: () => void | Promise<void>;
   onRefresh: () => void | Promise<void>;
@@ -2370,6 +2373,7 @@ function PersonalGoalHome({
           },
           onOpenOutput: (output) => openGoalChat(output.goalId),
           onGoalActivationStateChange,
+          onGoalDeleted,
           onReconcileStatus,
           onExportOutput: async (output) => {
             const contents = [
@@ -2754,6 +2758,10 @@ export function DashboardPage() {
       onGoalActivationStateChange={(goalId, activationState) => {
         statusRequestFenceRef.current.projectionRevision += 1;
         setPayload((current) => withGoalActivationState(current, goalId, activationState));
+      }}
+      onGoalDeleted={(goalId) => {
+        statusRequestFenceRef.current.projectionRevision += 1;
+        setPayload((current) => withoutGoal(current, goalId));
       }}
       onSelectGoal={selectGoal}
       onReconcileStatus={() => loadFromUrl(

--- a/loopx/chat_goal_lifecycle_actions.py
+++ b/loopx/chat_goal_lifecycle_actions.py
@@ -33,6 +33,62 @@ class ChatGoalLifecycleActionMixin:
             result["reason"] = _text(values["reason"], field="reason", limit=600)
         return result
 
+    def _apply_goal_delete(
+        self,
+        proposal_id: str,
+        proposal: dict[str, Any],
+        goal_id: str,
+        current_fingerprint: str,
+    ) -> dict[str, Any]:
+        from .chat_actions import _digest
+
+        expected_fingerprint = str(proposal.get("expected_state_fingerprint") or "")
+        if current_fingerprint != expected_fingerprint:
+            stale = self.store.apply(
+                proposal_id,
+                current_state_fingerprint=current_fingerprint,
+                receipt={},
+            )
+            return {"proposal": stale, "turn": None}
+
+        result = delete_stopped_goal(
+            registry_path=self.registry_path,
+            goal_id=goal_id,
+            execute=True,
+            expected_state_fingerprint=expected_fingerprint,
+        )
+        if result.get("stale"):
+            stale = self.store.apply(
+                proposal_id,
+                current_state_fingerprint=str(
+                    result.get("current_state_fingerprint") or current_fingerprint
+                ),
+                receipt={},
+            )
+            return {"proposal": stale, "turn": None}
+        if not result.get("ok") or not (result.get("readback") or {}).get("verified"):
+            raise ValueError(
+                str(result.get("error") or "Goal deletion did not verify")
+            )
+        receipt = {
+            "receipt_id": _digest(
+                {
+                    "proposal_id": proposal_id,
+                    "goal_id": goal_id,
+                    "operation": "delete",
+                }
+            )[:32],
+            "outcome": "goal_deleted",
+            "projection_verified": True,
+            "resource_ids": {"goal_id": goal_id},
+        }
+        stored = self.store.apply(
+            proposal_id,
+            current_state_fingerprint=current_fingerprint,
+            receipt=receipt,
+        )
+        return {"proposal": stored, "turn": None}
+
     def _apply_goal_lifecycle(
         self, proposal_id: str, proposal: dict[str, Any], parameters: dict[str, Any]
     ) -> dict[str, Any]:
@@ -42,51 +98,9 @@ class ChatGoalLifecycleActionMixin:
         goal_id = str(parameters["goal_id"])
         operation = str(parameters["operation"])
         if operation == "delete":
-            expected_fingerprint = str(proposal.get("expected_state_fingerprint") or "")
-            if current_fingerprint != expected_fingerprint:
-                stale = self.store.apply(
-                    proposal_id,
-                    current_state_fingerprint=current_fingerprint,
-                    receipt={},
-                )
-                return {"proposal": stale, "turn": None}
-            result = delete_stopped_goal(
-                registry_path=self.registry_path,
-                goal_id=goal_id,
-                execute=True,
-                expected_state_fingerprint=expected_fingerprint,
+            return self._apply_goal_delete(
+                proposal_id, proposal, goal_id, current_fingerprint
             )
-            if result.get("stale"):
-                stale = self.store.apply(
-                    proposal_id,
-                    current_state_fingerprint=str(
-                        result.get("current_state_fingerprint") or current_fingerprint
-                    ),
-                    receipt={},
-                )
-                return {"proposal": stale, "turn": None}
-            if not result.get("ok") or not (result.get("readback") or {}).get("verified"):
-                raise ValueError(
-                    str(result.get("error") or "Goal deletion did not verify")
-                )
-            receipt = {
-                "receipt_id": _digest(
-                    {
-                        "proposal_id": proposal_id,
-                        "goal_id": goal_id,
-                        "operation": operation,
-                    }
-                )[:32],
-                "outcome": "goal_deleted",
-                "projection_verified": True,
-                "resource_ids": {"goal_id": goal_id},
-            }
-            stored = self.store.apply(
-                proposal_id,
-                current_state_fingerprint=current_fingerprint,
-                receipt=receipt,
-            )
-            return {"proposal": stored, "turn": None}
 
         target_state = (
             GoalActivationState.STOPPED

--- a/loopx/chat_goal_lifecycle_actions.py
+++ b/loopx/chat_goal_lifecycle_actions.py
@@ -42,11 +42,29 @@ class ChatGoalLifecycleActionMixin:
         goal_id = str(parameters["goal_id"])
         operation = str(parameters["operation"])
         if operation == "delete":
+            expected_fingerprint = str(proposal.get("expected_state_fingerprint") or "")
+            if current_fingerprint != expected_fingerprint:
+                stale = self.store.apply(
+                    proposal_id,
+                    current_state_fingerprint=current_fingerprint,
+                    receipt={},
+                )
+                return {"proposal": stale, "turn": None}
             result = delete_stopped_goal(
                 registry_path=self.registry_path,
                 goal_id=goal_id,
                 execute=True,
+                expected_state_fingerprint=expected_fingerprint,
             )
+            if result.get("stale"):
+                stale = self.store.apply(
+                    proposal_id,
+                    current_state_fingerprint=str(
+                        result.get("current_state_fingerprint") or current_fingerprint
+                    ),
+                    receipt={},
+                )
+                return {"proposal": stale, "turn": None}
             if not result.get("ok") or not (result.get("readback") or {}).get("verified"):
                 raise ValueError(
                     str(result.get("error") or "Goal deletion did not verify")

--- a/loopx/chat_goal_lifecycle_actions.py
+++ b/loopx/chat_goal_lifecycle_actions.py
@@ -1,4 +1,4 @@
-"""Typed Chat actions for reversible Goal lifecycle transitions."""
+"""Typed Chat actions for Goal lifecycle transitions."""
 
 from __future__ import annotations
 
@@ -6,6 +6,7 @@ from typing import Any
 
 from .control_plane.goals.activation import GoalActivationState, goal_activation_state
 from .control_plane.goals.activation_service import set_goal_activation_state
+from .control_plane.goals.deletion_service import delete_stopped_goal
 
 
 class ChatGoalLifecycleActionMixin:
@@ -23,8 +24,10 @@ class ChatGoalLifecycleActionMixin:
         goal_id = _opaque(values.get("goal_id"), field="goal_id")
         self._goal(goal_id)
         operation = str(values.get("operation") or "").strip().lower()
-        if operation not in {"stop", "resume"}:
-            raise ValueError("goal.lifecycle operation must be stop or resume")
+        if operation not in {"stop", "resume", "delete"}:
+            raise ValueError("goal.lifecycle operation must be stop, resume, or delete")
+        if operation == "delete" and goal_activation_state(self._goal(goal_id)) is not GoalActivationState.STOPPED:
+            raise ValueError("stop the Goal before deleting it")
         result = {"goal_id": goal_id, "operation": operation}
         if values.get("reason"):
             result["reason"] = _text(values["reason"], field="reason", limit=600)
@@ -38,6 +41,35 @@ class ChatGoalLifecycleActionMixin:
         current_fingerprint = self._registry_fingerprint()
         goal_id = str(parameters["goal_id"])
         operation = str(parameters["operation"])
+        if operation == "delete":
+            result = delete_stopped_goal(
+                registry_path=self.registry_path,
+                goal_id=goal_id,
+                execute=True,
+            )
+            if not result.get("ok") or not (result.get("readback") or {}).get("verified"):
+                raise ValueError(
+                    str(result.get("error") or "Goal deletion did not verify")
+                )
+            receipt = {
+                "receipt_id": _digest(
+                    {
+                        "proposal_id": proposal_id,
+                        "goal_id": goal_id,
+                        "operation": operation,
+                    }
+                )[:32],
+                "outcome": "goal_deleted",
+                "projection_verified": True,
+                "resource_ids": {"goal_id": goal_id},
+            }
+            stored = self.store.apply(
+                proposal_id,
+                current_state_fingerprint=current_fingerprint,
+                receipt=receipt,
+            )
+            return {"proposal": stored, "turn": None}
+
         target_state = (
             GoalActivationState.STOPPED
             if operation == "stop"

--- a/loopx/control_plane/goals/deletion_service.py
+++ b/loopx/control_plane/goals/deletion_service.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from contextlib import ExitStack
+import hashlib
+import os
 from pathlib import Path
+import re
 import shutil
 from typing import Any
+import uuid
 
 from ...file_lock import exclusive_file_lock
 from ...history import load_registry
@@ -22,11 +26,45 @@ from .activation_service import (
 
 
 GOAL_DELETION_SCHEMA_VERSION = "loopx_goal_deletion_v1"
+_BACKUP_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
-def _backup_path(path: Path, timestamp: str) -> Path:
+def _registry_fingerprint(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _backup_path(path: Path, timestamp: str, goal_id: str, nonce: str) -> Path:
     compact_timestamp = timestamp.replace(":", "").replace("-", "")
-    return path.with_name(f"{path.name}.goal-delete-{compact_timestamp}.bak")
+    safe_goal_id = _BACKUP_TOKEN_RE.sub("-", goal_id).strip("-") or "goal"
+    return path.with_name(
+        f"{path.name}.goal-delete-{compact_timestamp}-{safe_goal_id}-{nonce}.bak"
+    )
+
+
+def _create_backup(path: Path, *, timestamp: str, goal_id: str) -> Path:
+    """Create an independent snapshot without ever overwriting an old backup."""
+
+    for _ in range(8):
+        backup = _backup_path(path, timestamp, goal_id, uuid.uuid4().hex)
+        try:
+            descriptor = os.open(
+                backup,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+        except FileExistsError:
+            continue
+        try:
+            with path.open("rb") as source, os.fdopen(descriptor, "wb") as target:
+                shutil.copyfileobj(source, target)
+                target.flush()
+                os.fsync(target.fileno())
+            shutil.copystat(path, backup)
+        except Exception:
+            backup.unlink(missing_ok=True)
+            raise
+        return backup
+    raise FileExistsError(f"could not allocate a unique Goal deletion backup for {path}")
 
 
 def _remove_goal(payload: dict[str, Any], goal_id: str) -> tuple[dict[str, Any], bool]:
@@ -51,12 +89,14 @@ def delete_stopped_goal(
     registry_path: Path,
     goal_id: str,
     execute: bool = False,
+    expected_state_fingerprint: str | None = None,
 ) -> dict[str, Any]:
     """Preview or permanently remove one stopped Goal from its registries.
 
     Goal data such as state files and project files is intentionally retained;
     deletion removes only the registry entries that make the Goal visible to
-    the LoopX control plane.
+    the LoopX control plane. When an expected fingerprint is supplied, the
+    target registry is checked again while both registry locks are held.
     """
 
     normalized_goal_id = str(goal_id or "").strip()
@@ -126,70 +166,87 @@ def delete_stopped_goal(
 
     original_payloads: dict[Path, dict[str, Any]] = {}
     written_paths: list[Path] = []
-    try:
-        with ExitStack() as stack:
-            for path in sorted(paths, key=lambda item: str(item)):
-                stack.enter_context(
-                    exclusive_file_lock(path, operation="delete_stopped_goal")
-                )
-            current_source = load_registry(source_registry) if source_available else None
-            current_target = load_registry(target_registry)
-            locked_source_goal = (
-                _goal_or_none(current_source, normalized_goal_id)
-                if current_source is not None
-                else None
+    with ExitStack() as stack:
+        for path in sorted(paths, key=lambda item: str(item)):
+            stack.enter_context(
+                exclusive_file_lock(path, operation="delete_stopped_goal")
             )
-            locked_target_goal = _goal_or_none(current_target, normalized_goal_id)
-            locked_goal = locked_source_goal or locked_target_goal
-            if locked_goal is None or locked_target_goal is None:
+        current_source = load_registry(source_registry) if source_available else None
+        current_target = load_registry(target_registry)
+        if expected_state_fingerprint is not None:
+            current_fingerprint = _registry_fingerprint(target_registry)
+            if current_fingerprint != expected_state_fingerprint:
+                payload.update(
+                    {
+                        "ok": False,
+                        "stale": True,
+                        "error_kind": "goal_registry_changed",
+                        "error": "Goal registry changed after preview; regenerate the deletion preview",
+                        "current_state_fingerprint": current_fingerprint,
+                    }
+                )
+                return payload
+
+        locked_source_goal = (
+            _goal_or_none(current_source, normalized_goal_id)
+            if current_source is not None
+            else None
+        )
+        locked_target_goal = _goal_or_none(current_target, normalized_goal_id)
+        locked_goal = locked_source_goal or locked_target_goal
+        if locked_goal is None or locked_target_goal is None:
+            raise ValueError("Goal disappeared before deletion; refresh and retry")
+        if goal_activation_state(locked_goal) is not GoalActivationState.STOPPED:
+            raise ValueError("Goal activation changed; stop the Goal before deleting it")
+
+        current_payloads = {target_registry: current_target}
+        if source_available and not same_registry:
+            if current_source is None or locked_source_goal is None:
+                raise ValueError("Goal source registry changed; refresh and retry")
+            current_payloads[source_registry] = current_source
+        original_payloads = current_payloads
+        updated_payloads: dict[Path, dict[str, Any]] = {}
+        for path, current in current_payloads.items():
+            updated, changed = _remove_goal(current, normalized_goal_id)
+            if not changed:
                 raise ValueError("Goal disappeared before deletion; refresh and retry")
-            if goal_activation_state(locked_goal) is not GoalActivationState.STOPPED:
-                raise ValueError("Goal activation changed; stop the Goal before deleting it")
+            updated_payloads[path] = updated
 
-            current_payloads = {target_registry: current_target}
-            if source_available and not same_registry:
-                if current_source is None or locked_source_goal is None:
-                    raise ValueError("Goal source registry changed; refresh and retry")
-                current_payloads[source_registry] = current_source
-            original_payloads = current_payloads
-            updated_payloads: dict[Path, dict[str, Any]] = {}
-            for path, current in current_payloads.items():
-                updated, changed = _remove_goal(current, normalized_goal_id)
-                if not changed:
-                    raise ValueError("Goal disappeared before deletion; refresh and retry")
-                updated_payloads[path] = updated
-
+        try:
             timestamp = now_local_iso()
-            for path, current in current_payloads.items():
-                backup = _backup_path(path, timestamp)
-                shutil.copy2(path, backup)
+            for path in current_payloads:
+                backup = _create_backup(
+                    path,
+                    timestamp=timestamp,
+                    goal_id=normalized_goal_id,
+                )
                 payload["backup_paths"].append(str(backup))
             for path in sorted(updated_payloads, key=lambda item: str(item)):
                 atomic_write_json(path, updated_payloads[path], preserve_mode=True)
                 written_paths.append(path)
-    except Exception:
-        for path in written_paths:
-            original = original_payloads.get(path)
-            if original is not None:
-                atomic_write_json(path, original, preserve_mode=True)
-        raise
 
-    source_after = load_registry(source_registry) if source_available else None
-    target_after = load_registry(target_registry)
-    source_missing = (
-        _goal_or_none(source_after, normalized_goal_id) is None
-        if source_after is not None
-        else True
-    )
-    global_missing = _goal_or_none(target_after, normalized_goal_id) is None
-    payload["readback"] = {
-        "source_missing": source_missing,
-        "global_missing": global_missing,
-        "verified": source_missing and global_missing,
-    }
-    payload["written"] = bool(written_paths)
-    payload["ok"] = bool(payload["readback"]["verified"])
-    payload["partial_write"] = bool(payload["written"] and not payload["ok"])
-    if not payload["ok"]:
-        payload["error"] = "Goal deletion readback did not verify"
+            source_after = load_registry(source_registry) if source_available else None
+            target_after = load_registry(target_registry)
+            source_missing = (
+                _goal_or_none(source_after, normalized_goal_id) is None
+                if source_after is not None
+                else True
+            )
+            global_missing = _goal_or_none(target_after, normalized_goal_id) is None
+            payload["readback"] = {
+                "source_missing": source_missing,
+                "global_missing": global_missing,
+                "verified": source_missing and global_missing,
+            }
+            payload["written"] = bool(written_paths)
+            payload["ok"] = bool(payload["readback"]["verified"])
+            payload["partial_write"] = bool(payload["written"] and not payload["ok"])
+            if not payload["ok"]:
+                payload["error"] = "Goal deletion readback did not verify"
+        except Exception:
+            for path in written_paths:
+                original = original_payloads.get(path)
+                if original is not None:
+                    atomic_write_json(path, original, preserve_mode=True)
+            raise
     return payload

--- a/loopx/control_plane/goals/deletion_service.py
+++ b/loopx/control_plane/goals/deletion_service.py
@@ -26,7 +26,6 @@ from .activation_service import (
 
 
 GOAL_DELETION_SCHEMA_VERSION = "loopx_goal_deletion_v1"
-_BACKUP_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
 _OPAQUE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,200}$")
 
 
@@ -43,19 +42,18 @@ def _registry_fingerprint(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _backup_path(path: Path, timestamp: str, goal_id: str, nonce: str) -> Path:
+def _backup_path(path: Path, timestamp: str, nonce: str) -> Path:
     compact_timestamp = timestamp.replace(":", "").replace("-", "")
-    safe_goal_id = _BACKUP_TOKEN_RE.sub("-", goal_id).strip("-") or "goal"
     return path.with_name(
-        f"{path.name}.goal-delete-{compact_timestamp}-{safe_goal_id}-{nonce}.bak"
+        f"{path.name}.goal-delete-{compact_timestamp}-{nonce}.bak"
     )
 
 
-def _create_backup(path: Path, *, timestamp: str, goal_id: str) -> Path:
+def _create_backup(path: Path, *, timestamp: str) -> Path:
     """Create an independent snapshot without ever overwriting an old backup."""
 
     for _ in range(8):
-        backup = _backup_path(path, timestamp, goal_id, uuid.uuid4().hex)
+        backup = _backup_path(path, timestamp, uuid.uuid4().hex)
         try:
             descriptor = os.open(
                 backup,
@@ -130,6 +128,103 @@ def _check_writability(paths: list[Path]) -> dict[str, Any] | None:
     return next((item for item in writability if not item.get("ok")), None)
 
 
+def _registry_paths(source_registry: Path, target_registry: Path, same_registry: bool) -> list[Path]:
+    paths = [target_registry]
+    if not same_registry:
+        paths.append(source_registry)
+    return sorted(paths, key=lambda item: str(item))
+
+
+def _load_locked_payloads(
+    *,
+    source_registry: Path,
+    target_registry: Path,
+    source_available: bool,
+    same_registry: bool,
+    goal_id: str,
+    expected_state_fingerprint: str | None,
+    payload: dict[str, Any],
+) -> dict[Path, dict[str, Any]] | None:
+    current_source = load_registry(source_registry) if source_available else None
+    current_target = load_registry(target_registry)
+    if expected_state_fingerprint is not None:
+        current_fingerprint = _registry_fingerprint(target_registry)
+        if current_fingerprint != expected_state_fingerprint:
+            payload.update({
+                "ok": False,
+                "stale": True,
+                "error_kind": "goal_registry_changed",
+                "error": "Goal registry changed after preview; regenerate the deletion preview",
+                "current_state_fingerprint": current_fingerprint,
+            })
+            return None
+
+    source_goal = _goal_or_none(current_source, goal_id) if current_source else None
+    target_goal = _goal_or_none(current_target, goal_id)
+    locked_goal = source_goal or target_goal
+    if locked_goal is None or target_goal is None:
+        raise ValueError("Goal disappeared before deletion; refresh and retry")
+    if goal_activation_state(locked_goal) is not GoalActivationState.STOPPED:
+        raise ValueError("Goal activation changed; stop the Goal before deleting it")
+    current_payloads = {target_registry: current_target}
+    if source_available and not same_registry:
+        if current_source is None or source_goal is None:
+            raise ValueError("Goal source registry changed; refresh and retry")
+        current_payloads[source_registry] = current_source
+    return current_payloads
+
+
+def _updated_payloads(
+    current_payloads: dict[Path, dict[str, Any]], goal_id: str
+) -> dict[Path, dict[str, Any]]:
+    updated_payloads: dict[Path, dict[str, Any]] = {}
+    for path, current in current_payloads.items():
+        updated, changed = _remove_goal(current, goal_id)
+        if not changed:
+            raise ValueError("Goal disappeared before deletion; refresh and retry")
+        updated_payloads[path] = updated
+    return updated_payloads
+
+
+def _write_deletion(
+    *,
+    current_payloads: dict[Path, dict[str, Any]],
+    updated_payloads: dict[Path, dict[str, Any]],
+    source_registry: Path,
+    target_registry: Path,
+    source_available: bool,
+    goal_id: str,
+    payload: dict[str, Any],
+) -> None:
+    written_paths: list[Path] = []
+    try:
+        timestamp = now_local_iso()
+        for path in current_payloads:
+            backup = _create_backup(path, timestamp=timestamp)
+            payload["backup_paths"].append(str(backup))
+        for path in sorted(updated_payloads, key=lambda item: str(item)):
+            atomic_write_json(path, updated_payloads[path], preserve_mode=True)
+            written_paths.append(path)
+        source_after = load_registry(source_registry) if source_available else None
+        target_after = load_registry(target_registry)
+        source_missing = not source_after or _goal_or_none(source_after, goal_id) is None
+        global_missing = _goal_or_none(target_after, goal_id) is None
+        payload["readback"] = {
+            "source_missing": source_missing,
+            "global_missing": global_missing,
+            "verified": source_missing and global_missing,
+        }
+        payload["written"] = bool(written_paths)
+        payload["ok"] = bool(payload["readback"]["verified"])
+        payload["partial_write"] = bool(payload["written"] and not payload["ok"])
+        if not payload["ok"]:
+            payload["error"] = "Goal deletion readback did not verify"
+    except Exception:
+        for path in written_paths:
+            atomic_write_json(path, current_payloads[path], preserve_mode=True)
+        raise
+
+
 def _execute_deletion(
     *,
     source_registry: Path,
@@ -140,98 +235,34 @@ def _execute_deletion(
     expected_state_fingerprint: str | None,
     payload: dict[str, Any],
 ) -> None:
-    """Apply the deletion inside acquired registry locks, including rollback."""
+    """Apply deletion and read it back while registry locks are held."""
 
-    original_payloads: dict[Path, dict[str, Any]] = {}
-    written_paths: list[Path] = []
+    paths = _registry_paths(source_registry, target_registry, same_registry)
     with ExitStack() as stack:
-        if same_registry:
-            paths = [target_registry]
-        else:
-            paths = [source_registry, target_registry]
-        for path in sorted(paths, key=lambda item: str(item)):
+        for path in paths:
             stack.enter_context(
                 exclusive_file_lock(path, operation="delete_stopped_goal")
             )
-
-        current_source = load_registry(source_registry) if source_available else None
-        current_target = load_registry(target_registry)
-        if expected_state_fingerprint is not None:
-            current_fingerprint = _registry_fingerprint(target_registry)
-            if current_fingerprint != expected_state_fingerprint:
-                payload.update(
-                    {
-                        "ok": False,
-                        "stale": True,
-                        "error_kind": "goal_registry_changed",
-                        "error": "Goal registry changed after preview; regenerate the deletion preview",
-                        "current_state_fingerprint": current_fingerprint,
-                    }
-                )
-                return
-
-        locked_source_goal = (
-            _goal_or_none(current_source, goal_id)
-            if current_source is not None
-            else None
+        current_payloads = _load_locked_payloads(
+            source_registry=source_registry,
+            target_registry=target_registry,
+            source_available=source_available,
+            same_registry=same_registry,
+            goal_id=goal_id,
+            expected_state_fingerprint=expected_state_fingerprint,
+            payload=payload,
         )
-        locked_target_goal = _goal_or_none(current_target, goal_id)
-        locked_goal = locked_source_goal or locked_target_goal
-        if locked_goal is None or locked_target_goal is None:
-            raise ValueError("Goal disappeared before deletion; refresh and retry")
-        if goal_activation_state(locked_goal) is not GoalActivationState.STOPPED:
-            raise ValueError("Goal activation changed; stop the Goal before deleting it")
-
-        current_payloads = {target_registry: current_target}
-        if source_available and not same_registry:
-            if current_source is None or locked_source_goal is None:
-                raise ValueError("Goal source registry changed; refresh and retry")
-            current_payloads[source_registry] = current_source
-        original_payloads = current_payloads
-        updated_payloads: dict[Path, dict[str, Any]] = {}
-        for path, current in current_payloads.items():
-            updated, changed = _remove_goal(current, goal_id)
-            if not changed:
-                raise ValueError("Goal disappeared before deletion; refresh and retry")
-            updated_payloads[path] = updated
-
-        try:
-            timestamp = now_local_iso()
-            for path in current_payloads:
-                backup = _create_backup(
-                    path,
-                    timestamp=timestamp,
-                    goal_id=goal_id,
-                )
-                payload["backup_paths"].append(str(backup))
-            for path in sorted(updated_payloads, key=lambda item: str(item)):
-                atomic_write_json(path, updated_payloads[path], preserve_mode=True)
-                written_paths.append(path)
-
-            source_after = load_registry(source_registry) if source_available else None
-            target_after = load_registry(target_registry)
-            source_missing = (
-                _goal_or_none(source_after, goal_id) is None
-                if source_after is not None
-                else True
-            )
-            global_missing = _goal_or_none(target_after, goal_id) is None
-            payload["readback"] = {
-                "source_missing": source_missing,
-                "global_missing": global_missing,
-                "verified": source_missing and global_missing,
-            }
-            payload["written"] = bool(written_paths)
-            payload["ok"] = bool(payload["readback"]["verified"])
-            payload["partial_write"] = bool(payload["written"] and not payload["ok"])
-            if not payload["ok"]:
-                payload["error"] = "Goal deletion readback did not verify"
-        except Exception:
-            for path in written_paths:
-                original = original_payloads.get(path)
-                if original is not None:
-                    atomic_write_json(path, original, preserve_mode=True)
-            raise
+        if current_payloads is None:
+            return
+        _write_deletion(
+            current_payloads=current_payloads,
+            updated_payloads=_updated_payloads(current_payloads, goal_id),
+            source_registry=source_registry,
+            target_registry=target_registry,
+            source_available=source_available,
+            goal_id=goal_id,
+            payload=payload,
+        )
 
 
 def delete_stopped_goal(

--- a/loopx/control_plane/goals/deletion_service.py
+++ b/loopx/control_plane/goals/deletion_service.py
@@ -27,6 +27,16 @@ from .activation_service import (
 
 GOAL_DELETION_SCHEMA_VERSION = "loopx_goal_deletion_v1"
 _BACKUP_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_OPAQUE_ID = re.compile(r"^[A-Za-z0-9._:-]{1,200}$")
+
+
+def _require_opaque_id(value: str, *, field: str) -> str:
+    """Reject any value that is not a compact opaque id; safe for path segments."""
+
+    token = str(value or "").strip()
+    if not _OPAQUE_ID.fullmatch(token):
+        raise ValueError(f"{field} must be a compact opaque id")
+    return token
 
 
 def _registry_fingerprint(path: Path) -> str:
@@ -84,93 +94,66 @@ def _remove_goal(payload: dict[str, Any], goal_id: str) -> tuple[dict[str, Any],
     return updated, changed
 
 
-def delete_stopped_goal(
-    *,
-    registry_path: Path,
-    goal_id: str,
-    execute: bool = False,
-    expected_state_fingerprint: str | None = None,
-) -> dict[str, Any]:
-    """Preview or permanently remove one stopped Goal from its registries.
-
-    Goal data such as state files and project files is intentionally retained;
-    deletion removes only the registry entries that make the Goal visible to
-    the LoopX control plane. When an expected fingerprint is supplied, the
-    target registry is checked again while both registry locks are held.
-    """
-
-    normalized_goal_id = str(goal_id or "").strip()
-    if not normalized_goal_id:
-        raise ValueError("goal id is required")
-
+def _resolve_route(goal_id: str, registry_path: Path) -> dict[str, Any]:
     route = _source_and_target(
-        registry_path=Path(registry_path),
-        goal_id=normalized_goal_id,
+        registry_path=registry_path,
+        goal_id=goal_id,
         target_state=GoalActivationState.STOPPED,
         runtime_root_override=None,
     )
-    source_registry = route.source_registry
-    target_registry = route.target_registry
     source_available = route.mode is not GoalActivationAuthorityRouteMode.ORPHANED_GLOBAL_STOP_FALLBACK
-    source_payload = load_registry(source_registry) if source_available else None
-    target_payload = load_registry(target_registry)
-    source_goal = _goal_or_none(source_payload, normalized_goal_id) if source_payload else None
-    target_goal = _goal_or_none(target_payload, normalized_goal_id)
+    source_payload = load_registry(route.source_registry) if source_available else None
+    target_payload = load_registry(route.target_registry)
+    source_goal = _goal_or_none(source_payload, goal_id) if source_payload else None
+    target_goal = _goal_or_none(target_payload, goal_id)
     goal = source_goal or target_goal
     if goal is None:
-        raise ValueError(f"goal id not found in registry: {normalized_goal_id}")
+        raise ValueError(f"goal id not found in registry: {goal_id}")
     if goal_activation_state(goal) is not GoalActivationState.STOPPED:
         raise ValueError("stop the Goal before deleting it")
     if target_goal is None:
         raise ValueError("global registry does not contain the Goal projection")
-
-    same_registry = _same_path(source_registry, target_registry)
-    payload: dict[str, Any] = {
-        "ok": True,
-        "schema_version": GOAL_DELETION_SCHEMA_VERSION,
-        "dry_run": not execute,
-        "execute": execute,
-        "goal_id": normalized_goal_id,
-        "source_registry": str(source_registry),
-        "target_global_registry": str(target_registry),
-        "source_registry_present": source_goal is not None,
-        "global_registry_present": target_goal is not None,
-        "written": False,
-        "partial_write": False,
-        "backup_paths": [],
-        "readback": {
-            "source_missing": source_goal is None,
-            "global_missing": False,
-            "verified": False,
-        },
+    return {
+        "source_registry": route.source_registry,
+        "target_registry": route.target_registry,
+        "source_available": source_available,
+        "source_goal": source_goal,
+        "target_goal": target_goal,
+        "same_registry": _same_path(route.source_registry, route.target_registry),
     }
-    if not execute:
-        return payload
 
-    paths = [target_registry] if same_registry else [source_registry, target_registry]
+
+def _check_writability(paths: list[Path]) -> dict[str, Any] | None:
     writability = [
         probe_registry_write_path(path, create_parent=False) for path in paths
     ]
-    denied = next((item for item in writability if not item.get("ok")), None)
-    if denied is not None:
-        payload.update(
-            {
-                "ok": False,
-                "error_kind": "goal_registry_write_denied",
-                "error": str(denied.get("error") or "Goal registry is not writable"),
-                "recommended_action": denied.get("recommended_action"),
-                "registry_writability": writability,
-            }
-        )
-        return payload
+    return next((item for item in writability if not item.get("ok")), None)
+
+
+def _execute_deletion(
+    *,
+    source_registry: Path,
+    target_registry: Path,
+    source_available: bool,
+    same_registry: bool,
+    goal_id: str,
+    expected_state_fingerprint: str | None,
+    payload: dict[str, Any],
+) -> None:
+    """Apply the deletion inside acquired registry locks, including rollback."""
 
     original_payloads: dict[Path, dict[str, Any]] = {}
     written_paths: list[Path] = []
     with ExitStack() as stack:
+        if same_registry:
+            paths = [target_registry]
+        else:
+            paths = [source_registry, target_registry]
         for path in sorted(paths, key=lambda item: str(item)):
             stack.enter_context(
                 exclusive_file_lock(path, operation="delete_stopped_goal")
             )
+
         current_source = load_registry(source_registry) if source_available else None
         current_target = load_registry(target_registry)
         if expected_state_fingerprint is not None:
@@ -185,14 +168,14 @@ def delete_stopped_goal(
                         "current_state_fingerprint": current_fingerprint,
                     }
                 )
-                return payload
+                return
 
         locked_source_goal = (
-            _goal_or_none(current_source, normalized_goal_id)
+            _goal_or_none(current_source, goal_id)
             if current_source is not None
             else None
         )
-        locked_target_goal = _goal_or_none(current_target, normalized_goal_id)
+        locked_target_goal = _goal_or_none(current_target, goal_id)
         locked_goal = locked_source_goal or locked_target_goal
         if locked_goal is None or locked_target_goal is None:
             raise ValueError("Goal disappeared before deletion; refresh and retry")
@@ -207,7 +190,7 @@ def delete_stopped_goal(
         original_payloads = current_payloads
         updated_payloads: dict[Path, dict[str, Any]] = {}
         for path, current in current_payloads.items():
-            updated, changed = _remove_goal(current, normalized_goal_id)
+            updated, changed = _remove_goal(current, goal_id)
             if not changed:
                 raise ValueError("Goal disappeared before deletion; refresh and retry")
             updated_payloads[path] = updated
@@ -218,7 +201,7 @@ def delete_stopped_goal(
                 backup = _create_backup(
                     path,
                     timestamp=timestamp,
-                    goal_id=normalized_goal_id,
+                    goal_id=goal_id,
                 )
                 payload["backup_paths"].append(str(backup))
             for path in sorted(updated_payloads, key=lambda item: str(item)):
@@ -228,11 +211,11 @@ def delete_stopped_goal(
             source_after = load_registry(source_registry) if source_available else None
             target_after = load_registry(target_registry)
             source_missing = (
-                _goal_or_none(source_after, normalized_goal_id) is None
+                _goal_or_none(source_after, goal_id) is None
                 if source_after is not None
                 else True
             )
-            global_missing = _goal_or_none(target_after, normalized_goal_id) is None
+            global_missing = _goal_or_none(target_after, goal_id) is None
             payload["readback"] = {
                 "source_missing": source_missing,
                 "global_missing": global_missing,
@@ -249,4 +232,70 @@ def delete_stopped_goal(
                 if original is not None:
                     atomic_write_json(path, original, preserve_mode=True)
             raise
+
+
+def delete_stopped_goal(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    execute: bool = False,
+    expected_state_fingerprint: str | None = None,
+) -> dict[str, Any]:
+    """Preview or permanently remove one stopped Goal from its registries.
+
+    Goal data such as state files and project files is intentionally retained;
+    deletion removes only the registry entries that make the Goal visible to
+    the LoopX control plane. When an expected fingerprint is supplied, the
+    target registry is checked again while both registry locks are held.
+    """
+
+    normalized_goal_id = _require_opaque_id(goal_id, field="goal_id")
+    route = _resolve_route(normalized_goal_id, Path(registry_path))
+
+    payload: dict[str, Any] = {
+        "ok": True,
+        "schema_version": GOAL_DELETION_SCHEMA_VERSION,
+        "dry_run": not execute,
+        "execute": execute,
+        "goal_id": normalized_goal_id,
+        "source_registry": str(route["source_registry"]),
+        "target_global_registry": str(route["target_registry"]),
+        "source_registry_present": route["source_goal"] is not None,
+        "global_registry_present": route["target_goal"] is not None,
+        "written": False,
+        "partial_write": False,
+        "backup_paths": [],
+        "readback": {
+            "source_missing": route["source_goal"] is None,
+            "global_missing": False,
+            "verified": False,
+        },
+    }
+    if not execute:
+        return payload
+
+    paths = [route["target_registry"]]
+    if not route["same_registry"]:
+        paths.append(route["source_registry"])
+    writability = _check_writability(paths)
+    if writability is not None:
+        payload.update(
+            {
+                "ok": False,
+                "error_kind": "goal_registry_write_denied",
+                "error": str(writability.get("error") or "Goal registry is not writable"),
+                "recommended_action": writability.get("recommended_action"),
+            }
+        )
+        return payload
+
+    _execute_deletion(
+        source_registry=route["source_registry"],
+        target_registry=route["target_registry"],
+        source_available=route["source_available"],
+        same_registry=route["same_registry"],
+        goal_id=normalized_goal_id,
+        expected_state_fingerprint=expected_state_fingerprint,
+        payload=payload,
+    )
     return payload

--- a/loopx/control_plane/goals/deletion_service.py
+++ b/loopx/control_plane/goals/deletion_service.py
@@ -1,0 +1,195 @@
+"""Canonical owner-confirmed deletion for stopped Goals."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from pathlib import Path
+import shutil
+from typing import Any
+
+from ...file_lock import exclusive_file_lock
+from ...history import load_registry
+from ...registry import atomic_write_json
+from ...registry_writability import probe_registry_write_path
+from ..runtime.time import now_local_iso
+from .activation import GoalActivationState, goal_activation_state
+from .activation_service import (
+    GoalActivationAuthorityRouteMode,
+    _goal_or_none,
+    _same_path,
+    _source_and_target,
+)
+
+
+GOAL_DELETION_SCHEMA_VERSION = "loopx_goal_deletion_v1"
+
+
+def _backup_path(path: Path, timestamp: str) -> Path:
+    compact_timestamp = timestamp.replace(":", "").replace("-", "")
+    return path.with_name(f"{path.name}.goal-delete-{compact_timestamp}.bak")
+
+
+def _remove_goal(payload: dict[str, Any], goal_id: str) -> tuple[dict[str, Any], bool]:
+    goals = payload.get("goals")
+    if not isinstance(goals, list):
+        raise ValueError("registry goals must be a list")
+    retained = [
+        goal
+        for goal in goals
+        if not (isinstance(goal, dict) and str(goal.get("id") or "") == goal_id)
+    ]
+    changed = len(retained) != len(goals)
+    updated = dict(payload)
+    updated["goals"] = retained
+    if changed:
+        updated["updated_at"] = now_local_iso()
+    return updated, changed
+
+
+def delete_stopped_goal(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Preview or permanently remove one stopped Goal from its registries.
+
+    Goal data such as state files and project files is intentionally retained;
+    deletion removes only the registry entries that make the Goal visible to
+    the LoopX control plane.
+    """
+
+    normalized_goal_id = str(goal_id or "").strip()
+    if not normalized_goal_id:
+        raise ValueError("goal id is required")
+
+    route = _source_and_target(
+        registry_path=Path(registry_path),
+        goal_id=normalized_goal_id,
+        target_state=GoalActivationState.STOPPED,
+        runtime_root_override=None,
+    )
+    source_registry = route.source_registry
+    target_registry = route.target_registry
+    source_available = route.mode is not GoalActivationAuthorityRouteMode.ORPHANED_GLOBAL_STOP_FALLBACK
+    source_payload = load_registry(source_registry) if source_available else None
+    target_payload = load_registry(target_registry)
+    source_goal = _goal_or_none(source_payload, normalized_goal_id) if source_payload else None
+    target_goal = _goal_or_none(target_payload, normalized_goal_id)
+    goal = source_goal or target_goal
+    if goal is None:
+        raise ValueError(f"goal id not found in registry: {normalized_goal_id}")
+    if goal_activation_state(goal) is not GoalActivationState.STOPPED:
+        raise ValueError("stop the Goal before deleting it")
+    if target_goal is None:
+        raise ValueError("global registry does not contain the Goal projection")
+
+    same_registry = _same_path(source_registry, target_registry)
+    payload: dict[str, Any] = {
+        "ok": True,
+        "schema_version": GOAL_DELETION_SCHEMA_VERSION,
+        "dry_run": not execute,
+        "execute": execute,
+        "goal_id": normalized_goal_id,
+        "source_registry": str(source_registry),
+        "target_global_registry": str(target_registry),
+        "source_registry_present": source_goal is not None,
+        "global_registry_present": target_goal is not None,
+        "written": False,
+        "partial_write": False,
+        "backup_paths": [],
+        "readback": {
+            "source_missing": source_goal is None,
+            "global_missing": False,
+            "verified": False,
+        },
+    }
+    if not execute:
+        return payload
+
+    paths = [target_registry] if same_registry else [source_registry, target_registry]
+    writability = [
+        probe_registry_write_path(path, create_parent=False) for path in paths
+    ]
+    denied = next((item for item in writability if not item.get("ok")), None)
+    if denied is not None:
+        payload.update(
+            {
+                "ok": False,
+                "error_kind": "goal_registry_write_denied",
+                "error": str(denied.get("error") or "Goal registry is not writable"),
+                "recommended_action": denied.get("recommended_action"),
+                "registry_writability": writability,
+            }
+        )
+        return payload
+
+    original_payloads: dict[Path, dict[str, Any]] = {}
+    written_paths: list[Path] = []
+    try:
+        with ExitStack() as stack:
+            for path in sorted(paths, key=lambda item: str(item)):
+                stack.enter_context(
+                    exclusive_file_lock(path, operation="delete_stopped_goal")
+                )
+            current_source = load_registry(source_registry) if source_available else None
+            current_target = load_registry(target_registry)
+            locked_source_goal = (
+                _goal_or_none(current_source, normalized_goal_id)
+                if current_source is not None
+                else None
+            )
+            locked_target_goal = _goal_or_none(current_target, normalized_goal_id)
+            locked_goal = locked_source_goal or locked_target_goal
+            if locked_goal is None or locked_target_goal is None:
+                raise ValueError("Goal disappeared before deletion; refresh and retry")
+            if goal_activation_state(locked_goal) is not GoalActivationState.STOPPED:
+                raise ValueError("Goal activation changed; stop the Goal before deleting it")
+
+            current_payloads = {target_registry: current_target}
+            if source_available and not same_registry:
+                if current_source is None or locked_source_goal is None:
+                    raise ValueError("Goal source registry changed; refresh and retry")
+                current_payloads[source_registry] = current_source
+            original_payloads = current_payloads
+            updated_payloads: dict[Path, dict[str, Any]] = {}
+            for path, current in current_payloads.items():
+                updated, changed = _remove_goal(current, normalized_goal_id)
+                if not changed:
+                    raise ValueError("Goal disappeared before deletion; refresh and retry")
+                updated_payloads[path] = updated
+
+            timestamp = now_local_iso()
+            for path, current in current_payloads.items():
+                backup = _backup_path(path, timestamp)
+                shutil.copy2(path, backup)
+                payload["backup_paths"].append(str(backup))
+            for path in sorted(updated_payloads, key=lambda item: str(item)):
+                atomic_write_json(path, updated_payloads[path], preserve_mode=True)
+                written_paths.append(path)
+    except Exception:
+        for path in written_paths:
+            original = original_payloads.get(path)
+            if original is not None:
+                atomic_write_json(path, original, preserve_mode=True)
+        raise
+
+    source_after = load_registry(source_registry) if source_available else None
+    target_after = load_registry(target_registry)
+    source_missing = (
+        _goal_or_none(source_after, normalized_goal_id) is None
+        if source_after is not None
+        else True
+    )
+    global_missing = _goal_or_none(target_after, normalized_goal_id) is None
+    payload["readback"] = {
+        "source_missing": source_missing,
+        "global_missing": global_missing,
+        "verified": source_missing and global_missing,
+    }
+    payload["written"] = bool(written_paths)
+    payload["ok"] = bool(payload["readback"]["verified"])
+    payload["partial_write"] = bool(payload["written"] and not payload["ok"])
+    if not payload["ok"]:
+        payload["error"] = "Goal deletion readback did not verify"
+    return payload

--- a/loopx/control_plane/goals/deletion_service.py
+++ b/loopx/control_plane/goals/deletion_service.py
@@ -52,8 +52,11 @@ def _backup_path(path: Path, timestamp: str, nonce: str) -> Path:
 def _create_backup(path: Path, *, timestamp: str) -> Path:
     """Create an independent snapshot without ever overwriting an old backup."""
 
+    source_path = path.expanduser().resolve(strict=True)
+    if not source_path.is_file():
+        raise ValueError(f"registry path is not a regular file: {source_path}")
     for _ in range(8):
-        backup = _backup_path(path, timestamp, uuid.uuid4().hex)
+        backup = _backup_path(source_path, timestamp, uuid.uuid4().hex)
         try:
             descriptor = os.open(
                 backup,
@@ -63,16 +66,16 @@ def _create_backup(path: Path, *, timestamp: str) -> Path:
         except FileExistsError:
             continue
         try:
-            with path.open("rb") as source, os.fdopen(descriptor, "wb") as target:
+            with source_path.open("rb") as source, os.fdopen(descriptor, "wb") as target:
                 shutil.copyfileobj(source, target)
                 target.flush()
                 os.fsync(target.fileno())
-            shutil.copystat(path, backup)
+            shutil.copystat(source_path, backup)
         except Exception:
             backup.unlink(missing_ok=True)
             raise
         return backup
-    raise FileExistsError(f"could not allocate a unique Goal deletion backup for {path}")
+    raise FileExistsError(f"could not allocate a unique Goal deletion backup for {source_path}")
 
 
 def _remove_goal(payload: dict[str, Any], goal_id: str) -> tuple[dict[str, Any], bool]:

--- a/tests/control_plane/test_goal_activation.py
+++ b/tests/control_plane/test_goal_activation.py
@@ -13,6 +13,7 @@ from loopx.control_plane.goals.activation import (
     goal_activation_state,
 )
 from loopx.control_plane.goals.activation_service import set_goal_activation_state
+from loopx.control_plane.goals import deletion_service
 from loopx.control_plane.goals.deletion_service import delete_stopped_goal
 from loopx.control_plane.scheduler.execution_context import (
     SchedulerRuntimeProfile,
@@ -505,6 +506,102 @@ def test_owner_confirmed_typed_action_deletes_stopped_goal(
     assert applied["proposal"]["receipt"]["outcome"] == "goal_deleted"
     assert registry_goals(load_registry(source_registry)) == []
     assert registry_goals(load_registry(global_registry)) == []
+
+
+def test_owner_confirmed_typed_action_rejects_stale_delete_without_writing(
+    connected_registries: tuple[Path, Path], tmp_path: Path,
+) -> None:
+    source_registry, global_registry = connected_registries
+    set_goal_activation_state(
+        registry_path=global_registry,
+        goal_id="goal-one",
+        state="stopped",
+        execute=True,
+    )
+    service = ChatActionService(
+        store=ChatActionStore(tmp_path / "actions"),
+        registry_path=global_registry,
+    )
+    proposal = service.preview(
+        {
+            "action_kind": "goal.lifecycle",
+            "summary": "Delete a stopped Goal",
+            "normalized_parameters": {
+                "goal_id": "goal-one",
+                "operation": "delete",
+            },
+            "context": {"kind": "goal_directory"},
+            "idempotency_key": "stale-delete-goal-one",
+        }
+    )
+    global_payload = load_registry(global_registry)
+    global_payload["goals"].append({"id": "new-goal"})
+    _write_json(global_registry, global_payload)
+
+    applied = service.apply(str(proposal["proposal_id"]))
+
+    assert applied["proposal"]["status"] == "stale"
+    assert applied["proposal"]["receipt"] is None
+    assert _goal(source_registry)["id"] == "goal-one"
+    assert _goal(global_registry)["id"] == "goal-one"
+    assert not list(global_registry.parent.glob("*.goal-delete-*.bak"))
+
+
+def test_goal_deletion_backups_are_unique_and_preserve_preimages(
+    connected_registries: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_registry, global_registry = connected_registries
+    source_payload = load_registry(source_registry)
+    source_payload["goals"].append({
+        "id": "goal-two",
+        "display_name": "Another Goal",
+        "repo": str(source_registry.parent.parent),
+    })
+    _write_json(source_registry, source_payload)
+    synced = sync_project_registry_to_global(
+        registry_path=source_registry,
+        runtime_root_override=str(global_registry.parent),
+        goal_id="goal-two",
+        dry_run=False,
+    )
+    assert synced["ok"] is True
+    for goal_id in ("goal-one", "goal-two"):
+        assert set_goal_activation_state(
+            registry_path=global_registry,
+            goal_id=goal_id,
+            state="stopped",
+            execute=True,
+        )["ok"] is True
+
+    monkeypatch.setattr(
+        deletion_service,
+        "now_local_iso",
+        lambda: "2026-08-25T12:00:00+00:00",
+    )
+    first = delete_stopped_goal(
+        registry_path=global_registry,
+        goal_id="goal-one",
+        execute=True,
+    )
+    second = delete_stopped_goal(
+        registry_path=global_registry,
+        goal_id="goal-two",
+        execute=True,
+    )
+
+    backup_paths = first["backup_paths"] + second["backup_paths"]
+    assert len(backup_paths) == 4
+    assert len(set(backup_paths)) == 4
+    first_preimages = [
+        set(item.get("id") for item in json.loads(Path(path).read_text())["goals"])
+        for path in first["backup_paths"]
+    ]
+    second_preimages = [
+        set(item.get("id") for item in json.loads(Path(path).read_text())["goals"])
+        for path in second["backup_paths"]
+    ]
+    assert all({"goal-one", "goal-two"}.issubset(ids) for ids in first_preimages)
+    assert all("goal-one" not in ids and "goal-two" in ids for ids in second_preimages)
 
 
 def test_owner_confirmed_typed_action_stops_orphaned_global_goal(

--- a/tests/control_plane/test_goal_activation.py
+++ b/tests/control_plane/test_goal_activation.py
@@ -13,6 +13,7 @@ from loopx.control_plane.goals.activation import (
     goal_activation_state,
 )
 from loopx.control_plane.goals.activation_service import set_goal_activation_state
+from loopx.control_plane.goals.deletion_service import delete_stopped_goal
 from loopx.control_plane.scheduler.execution_context import (
     SchedulerRuntimeProfile,
     scheduler_execution_context_for_runtime_profile,
@@ -404,6 +405,106 @@ def test_owner_confirmed_typed_action_stops_goal(
     assert applied["proposal"]["receipt"]["projection_verified"] is True
     assert applied["proposal"]["receipt"]["outcome"] == "goal_stopped"
     assert goal_activation_state(_goal(global_registry)) is GoalActivationState.STOPPED
+
+
+def test_delete_stopped_goal_removes_source_and_global(
+    connected_registries: tuple[Path, Path],
+) -> None:
+    source_registry, global_registry = connected_registries
+    set_goal_activation_state(
+        registry_path=global_registry,
+        goal_id="goal-one",
+        state="stopped",
+        execute=True,
+    )
+
+    preview = delete_stopped_goal(
+        registry_path=global_registry,
+        goal_id="goal-one",
+        execute=False,
+    )
+    assert preview["dry_run"] is True
+    assert preview["written"] is False
+    assert _goal(source_registry)["id"] == "goal-one"
+    assert _goal(global_registry)["id"] == "goal-one"
+
+    deleted = delete_stopped_goal(
+        registry_path=global_registry,
+        goal_id="goal-one",
+        execute=True,
+    )
+
+    assert deleted["ok"] is True
+    assert deleted["readback"]["verified"] is True
+    assert registry_goals(load_registry(source_registry)) == []
+    assert registry_goals(load_registry(global_registry)) == []
+    assert len(deleted["backup_paths"]) == 2
+
+
+def test_delete_active_goal_fails_closed(
+    connected_registries: tuple[Path, Path],
+) -> None:
+    _source_registry, global_registry = connected_registries
+
+    with pytest.raises(ValueError, match="stop the Goal before deleting it"):
+        delete_stopped_goal(
+            registry_path=global_registry,
+            goal_id="goal-one",
+            execute=True,
+        )
+
+
+def test_delete_orphaned_stopped_global_goal(tmp_path: Path) -> None:
+    _source_registry, global_registry = _orphaned_global_registry(
+        tmp_path,
+        activation_state="stopped",
+    )
+
+    deleted = delete_stopped_goal(
+        registry_path=global_registry,
+        goal_id="orphaned-goal",
+        execute=True,
+    )
+
+    assert deleted["ok"] is True
+    assert deleted["readback"]["verified"] is True
+    assert registry_goals(load_registry(global_registry)) == []
+
+
+def test_owner_confirmed_typed_action_deletes_stopped_goal(
+    connected_registries: tuple[Path, Path], tmp_path: Path,
+) -> None:
+    source_registry, global_registry = connected_registries
+    set_goal_activation_state(
+        registry_path=global_registry,
+        goal_id="goal-one",
+        state="stopped",
+        execute=True,
+    )
+    service = ChatActionService(
+        store=ChatActionStore(tmp_path / "actions"),
+        registry_path=global_registry,
+    )
+    proposal = service.preview(
+        {
+            "action_kind": "goal.lifecycle",
+            "summary": "Delete a stopped Goal",
+            "normalized_parameters": {
+                "goal_id": "goal-one",
+                "operation": "delete",
+                "reason": "Owner confirmed from the workspace",
+            },
+            "context": {"kind": "goal_directory"},
+            "idempotency_key": "delete-goal-one",
+        }
+    )
+
+    applied = service.apply(str(proposal["proposal_id"]))
+
+    assert applied["proposal"]["status"] == "applied"
+    assert applied["proposal"]["receipt"]["outcome"] == "goal_deleted"
+    assert registry_goals(load_registry(source_registry)) == []
+    assert registry_goals(load_registry(global_registry)) == []
 
 
 def test_owner_confirmed_typed_action_stops_orphaned_global_goal(


### PR DESCRIPTION
## Summary

- 为桌面端已停止 Goal 增加删除按钮，并沿用现有 preview -> confirm -> apply 流程。
- 新增 canonical deletion service，同时移除 source registry 和 global registry 中的 Goal；删除前要求 Goal 已停止，并保留 registry backup。
- 删除成功后立即更新侧边栏投影；preview 失败时显示可见错误反馈。
- 增加 source/global、active fail-closed、orphaned global 和 typed action 回归测试。

## Validation

- `uv run --with pytest python -m pytest tests/control_plane/test_goal_activation.py -q` -> 17 passed
- `npm run typecheck:control-plane` -> passed
- `npx tsc --noEmit` in `apps/presentation/dashboard` -> passed
- `npm run build:chat` -> passed
- `uv run --with ruff ruff check ...` -> passed
- `git diff --check` -> passed

The existing personal-workspace contract smoke still contains a pre-existing stale assertion for `statusProjectionRevisionRef`, while the current implementation uses `statusRequestFenceRef`; it was not changed as part of this PR.