### PR TITLE
fix(goal): bind visible continuations to CLI turns

### DIFF
--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -83,8 +83,11 @@ all hosts have the same transport or lifecycle API.
 
 The `codex-app-ssh` task body is an interactive Goal contract, not a scheduled
 heartbeat. It must fit the Codex `/goal` text limit, call `quota should-run`
-without a heartbeat turn receipt, and must not instruct the host to invoke
-`automation_update`, apply an RRULE, or synthesize `LOOPX_TURN`.
+with `--begin-turn` so the CLI mints the identity required for exact Todo
+selection, and must not instruct the host to invoke `automation_update`, apply
+an RRULE, or synthesize `LOOPX_TURN`. This CLI-owned selection receipt does not
+turn the Goal into heartbeat automation or a Turn-bound settlement flow; after
+validated writeback, the Goal still spends once with `--source visible-goal`.
 
 Visible Goal activation captures the capabilities observed when the task body
 is generated, but that initial list is not exhaustive for a long-running

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -429,7 +429,7 @@ def main() -> int:
         assert "--runtime-profile codex_app_ssh_goal" in (
             app_ssh_prompt["quota_guard_command"]
         ), app_ssh_prompt
-        assert "--begin-turn" not in app_ssh_prompt["quota_guard_command"], app_ssh_prompt
+        assert "--begin-turn" in app_ssh_prompt["quota_guard_command"], app_ssh_prompt
         assert "--turn-instance-id" not in app_ssh_prompt["quota_guard_command"], app_ssh_prompt
         assert "--source visible-goal" in app_ssh_prompt["quota_spend_command"], app_ssh_prompt
         spend_args = build_parser().parse_args(

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -7,7 +7,9 @@ from typing import Any
 from .bootstrap import default_goal_id
 from .control_plane.scheduler.execution_context import (
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
+    SchedulerRuntimeProfile,
     render_scheduler_execution_args,
+    scheduler_runtime_profile_for_execution_context,
 )
 from .control_plane.todos.contract import normalize_required_capabilities
 from .install_contract import NO_CLONE_INSTALL_URL
@@ -102,6 +104,17 @@ def render_quota_guard_command(
     begin_turn: bool = False,
     include_shared_registry: bool = True,
 ) -> str:
+    if not heartbeat_turn_receipt and agent_id and (
+        runtime_profile == SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE.value
+        or (
+            runtime_profile is None
+            and scheduler_runtime_profile_for_execution_context(
+                scheduler_execution_context
+            )
+            is SchedulerRuntimeProfile.CODEX_APP_SSH_VISIBLE
+        )
+    ):
+        begin_turn = True
     if heartbeat_turn_receipt and begin_turn:
         raise ValueError(
             "quota guard cannot both begin a Turn and reuse a heartbeat Turn identity"

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from loopx.bootstrap_command_pack import build_start_goal_guided_packet
+from loopx.heartbeat_prompt import build_heartbeat_prompt
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GOAL_ID = "settlement-cli-fixture"
@@ -1324,6 +1325,66 @@ def test_guided_start_begins_one_turn_and_executes_returned_selection(
             "--source visible-goal" in action
             for action in cli_channel["next_cli_actions"]
         )
+    assert _heartbeat_receipt_count(runtime, turn_instance_id) == 2
+
+
+def test_visible_goal_continuation_begins_turn_and_executes_returned_selection(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_selectable_alternative(project)
+    prompt = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        runtime_profile="codex_app_ssh_goal",
+        thin=True,
+    )
+    guard_command = prompt["quota_guard_command"].replace(
+        "$HOME/.codex/loopx/registry.global.json",
+        str(registry_path),
+    )
+
+    assert "--begin-turn" in guard_command
+    assert "--turn-instance-id" not in guard_command
+    first_rc, first = _run_generated_cli(
+        guard_command,
+        registry_path=registry_path,
+    )
+
+    assert first_rc == 0, first
+    assert first["interaction_contract"]["cli_channel"][
+        "selection_required"
+    ] is True
+    turn_instance_id = first["heartbeat_receipt"]["turn_instance_id"]
+    assert turn_instance_id.startswith("guided-start:")
+    selection = first["interaction_contract"]["cli_channel"]["selection_command"]
+    assert f"--turn-instance-id {turn_instance_id}" in selection[
+        "command_args_template"
+    ]
+    selection_command = (
+        f"{selection['route_prefix']} "
+        + selection["command_args_template"].replace(
+            "{todo_id}", ALTERNATIVE_TODO_ID
+        )
+    )
+
+    selected_rc, selected = _run_generated_cli(
+        selection_command,
+        registry_path=registry_path,
+    )
+
+    assert selected_rc == 0, selected
+    assert selected["selected_todo"]["todo_id"] == ALTERNATIVE_TODO_ID
+    assert selected["selected_todo"]["selection_binding"] == "heartbeat_receipt"
+    assert selected["heartbeat_receipt"]["settlement_identity"][
+        "turn_instance_id"
+    ] == turn_instance_id
+    cli_channel = selected["interaction_contract"]["cli_channel"]
+    assert "settlement_plan" not in cli_channel
+    assert any(
+        "--source visible-goal" in action
+        for action in cli_channel["next_cli_actions"]
+    )
     assert _heartbeat_receipt_count(runtime, turn_instance_id) == 2
 
 


### PR DESCRIPTION
## Summary

- make every agent-scoped `codex-app-ssh` visible Goal quota guard start a CLI-owned Turn
- preserve exact same-Turn Todo selection on later Goal continuations, not only on the initial guided start
- keep native visible-Goal settlement unchanged (`--source visible-goal`, no heartbeat settlement plan)
- document the distinction between the CLI-owned selection receipt and heartbeat automation

## Motivation

The guided-start repair closed the first activation path, but the durable `/goal` task body still rendered its per-continuation guard without `--begin-turn`. With multiple eligible Todos, that guard returned a `selection_command` containing `--todo-id` but no `--turn-instance-id`; executing the generated command then failed closed. This PR moves the invariant into the shared quota-command renderer so onboarding packets and later visible Goal continuations agree.

## Validation

- `python -m pytest tests/control_plane/test_quota_settlement_cli.py -q` (30 passed)
- `python examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `python -m pytest tests/control_plane/test_heartbeat_prompt_support.py tests/control_plane/test_cli_output_budget.py -q` (38 passed)
- `python -m loopx.cli canary premerge --from-git-diff --format json`
  - 4 direct checks passed
  - 14/14 selected canaries passed
  - public/private boundary scan passed
  - no failures, skips, warnings, or manual holds
  - self-merge gate passed

## Boundaries

No scoring, benchmark task semantics, permissions, automation scheduling, or native visible-Goal spend behavior changes. The generated prompt still does not synthesize `LOOPX_TURN` or invoke automation APIs.

Follow-up to #3569 and #3583.
