### PR TITLE
fix(goal): preserve thin prompt budget

### DIFF
--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -569,7 +569,7 @@ def _render_goal_task_body(
 {prequota_block}{HOST_LOOP_QUOTA_DISPATCH_RULE}
 Guard: `{quota_guard_command}`.
 
-`should_run=false`: no delivery/spend; NOTIFY surfaces Chinese action/gate;
+`should_run=false`: no delivery/spend; NOTIFY: Chinese action/gate;
 otherwise wait.{host_wait_rule}
 
 `should_run=true`: take highest-priority unblocked in-scope todo by default; choose any


### PR DESCRIPTION
## Summary

- compact one duplicated native Goal boundary sentence without changing its obligation
- keep the visible Goal prompt below the existing 2,800-character interface budget after CLI-owned Turn minting
- close the complete-suite regression observed after #3589

## Validation

- `python -m pytest tests/test_host_loop_activation.py::test_goal_hosts_reuse_thin_dispatch_and_stay_compact tests/test_host_loop_activation.py::test_goal_hosts_share_narrow_runtime_skill_routing -q` (3 passed)
- generated prompt lengths: SSH Goal 2783, Codex CLI 2761, managed Goal 2510, generic CLI 2439
- `python -m loopx.cli canary premerge --from-git-diff --format json` (12/12 selected canaries passed; no failures, warnings, skips, or manual holds)

## Boundary

No scoring, benchmark task semantics, permission boundary, runtime behavior, or private evidence changes.