### PR TITLE
fix(coordination): close the forked-oracle, typed-unavailable, and bool-integer promotion gaps

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md
@@ -35,7 +35,10 @@
 python3 examples/nokv-shadow-provider/probes.py contract
 ```
 
-命令退出码为 `0`，并逐项报告以下九个通过的合同探针：
+命令退出码为 `0`，并逐项报告以下九个通过的合同探针。自 Stage 2 切片合并
+后，claim/CAS 探针全部由生产 `CoordinationAuthorityExecutor` 与生产 head
+编解码驱动（不再存在第二套参考 authority），且每个探针的持久 head 都经
+生产 `validated_head` 回环校验：
 
 - `contract.bootstrap_and_preconditions`；
 - `contract.a_success_b_advance_replay_a`；
@@ -43,9 +46,10 @@ python3 examples/nokv-shadow-provider/probes.py contract
 - `contract.competing_claims`；
 - `contract.crash_windows_and_ambiguity`；
 - `contract.version_domains_and_retain_all`；
-- `contract.nokv_adapter_exception_mapping`（NoKV adapter 把 0.11.0 SDK 的
-  `FileNotFoundError` / `FileExistsError` / `RuntimeError` 全部映射为类型化
-  provider 结果，不向 authority 泄露异常）；
+- `contract.nokv_adapter_exception_mapping`（NoKV adapter 仅按异常类分类：
+  `FileNotFoundError` 是唯一的 missing 信号；其余客户端失败在读路径抛类型化
+  `ProviderUnavailableError`、在 CAS 前置为类型化 `failed`，携带 not-found
+  文案的路由故障不再被误判为未初始化）；
 - `contract.durable_completion_projection`；
 - `contract.durable_completion_fail_closed`（含显式 `completion_continuation`
   缺失或矛盾时的 fail-closed）。

--- a/examples/nokv-shadow-provider/README.md
+++ b/examples/nokv-shadow-provider/README.md
@@ -74,18 +74,23 @@ aggregate's `authority_revision` and from each todo's lease epoch; none of these
 three version domains is derived from another.
 
 The storage provider deterministically serializes and stores the opaque
-aggregate and returns CAS outcomes.
-`CoordinationAuthority` remains responsible for request validation, authority
-revision, claim/lease transitions, request-digest binding, and the original
-domain receipt. The provider must not inspect an operation receipt or invent
+aggregate and returns CAS outcomes. The production
+`loopx.control_plane.coordination` modules (`head` codec plus the
+`CoordinationAuthorityExecutor`) are responsible for request validation,
+authority revision, claim/lease transitions, request-digest binding, and the
+original domain receipt; this directory no longer carries a second reference
+authority. The provider must not inspect an operation receipt or invent
 lease, gate, quota, or scheduling decisions.
 
 ## Files
 
 - `provider.py`: `NoKVCoordinationProvider`, which maps an opaque per-goal
-  aggregate to NoKV path generation CAS, plus `CoordinationAuthority`, which
-  constructs the aggregate and its receipt index.
-- `probes.py`: deterministic contract regressions. Only the checks in the
+  aggregate to NoKV path generation CAS. It serializes through the
+  production canonical head codec, so the adapter cannot fork the
+  digest/parity basis.
+- `probes.py`: deterministic contract regressions driven by the production
+  executor and head codec; every claim/CAS probe round-trips its persisted
+  head through the production `validated_head`. Only the checks in the
   [evidence note](../../docs/architecture/rfcs/shared-goal-authority-state-provider-v0-evidence.zh-CN.md)
   are merge evidence for the revised receipt contract.
 
@@ -98,11 +103,18 @@ The provider mapping is pinned to NoKV
 publication `operation_id` and `artifact_revision_id` inputs; `read` and
 `stat` return the path `generation` the adapter treats as
 `provider_generation`. Since NoKV 0.11.0 the SDK raises `FileNotFoundError`
-for a missing path and `FileExistsError` for a create-only collision (earlier
-SDKs raised `RuntimeError` for both); the adapter classifies both generations
-by exception class first and by message token second, and
-`contract.nokv_adapter_exception_mapping` pins that classification offline
-with a fake client that raises the 0.11.0 exception classes.
+for a missing path and `FileExistsError` for a create-only collision; every
+other client failure is a `RuntimeError`. The adapter classifies by
+exception class only: `FileNotFoundError` is the one missing signal, and any
+other client failure on a read path raises the typed
+`ProviderUnavailableError` instead of masquerading as an uninitialized goal
+or escaping as a bare `RuntimeError`. Error prose is never a channel - real
+non-missing failures carry messages such as `invalid root route: root
+placement does not exist` - and pre-0.11 SDKs, which signalled missing with
+such prose, cannot route the post-#465 control plane and are outside the
+pinned baseline. `contract.nokv_adapter_exception_mapping` pins the
+classification offline with fake clients that raise the 0.11.0 exception
+classes and the real outage message shapes.
 
 The mapping was exercised once by hand against a live NoKV stack at that
 pin (etcd, an S3-compatible object store, `nokv serve`, and `nokv-python`

--- a/examples/nokv-shadow-provider/probes.py
+++ b/examples/nokv-shadow-provider/probes.py
@@ -1008,6 +1008,76 @@ def probe_nokv_adapter_exception_mapping() -> None:
     assert unserializable["result"] == "failed", unserializable
     assert "serializable" in unserializable["error"]
 
+    # The authoritative CAS token is typed state at both ends of the seam.
+    # A bool or otherwise invalid caller expectation is a typed failed
+    # verdict before any client I/O, and a malformed SDK response carrying
+    # generation true / a negative / a string must never be repaired into a
+    # legitimate generation.
+    class ExplodingClient:
+        def __getattr__(self, name):
+            raise AssertionError("no client I/O may happen for invalid input")
+
+    untouchable = NoKVCoordinationProvider(ExplodingClient(), "wb-typed", goal_id)
+    for invalid_expected in (True, False, -1, "1"):
+        verdict = untouchable.compare_and_put(invalid_expected, head)
+        assert verdict["result"] == "failed", (invalid_expected, verdict)
+        assert "non-negative integer" in verdict["error"]
+
+    class MalformedClient(FakeNoKVClient):
+        def __init__(self, generation_value):
+            super().__init__()
+            self.generation_value = generation_value
+
+        def stat(self, workbench, path):
+            return {"generation": self.generation_value}
+
+        def read(self, workbench, path):
+            return {
+                "bytes": b"{}",
+                "metadata": {"generation": self.generation_value},
+            }
+
+    for bad_generation in (True, -3, "7", None):
+        malformed = NoKVCoordinationProvider(
+            MalformedClient(bad_generation), "wb-malformed", goal_id
+        )
+        try:
+            malformed.load()
+        except ProviderProtocolError:
+            pass
+        else:
+            raise AssertionError(f"generation {bad_generation!r} was repaired")
+        try:
+            malformed._generation()
+        except ProviderProtocolError:
+            pass
+        else:
+            raise AssertionError(f"stat generation {bad_generation!r} was repaired")
+
+    class ShapelessClient(FakeNoKVClient):
+        def read(self, workbench, path):
+            return {"metadata": {"generation": 1}}
+
+    shapeless = NoKVCoordinationProvider(ShapelessClient(), "wb-shapeless", goal_id)
+    try:
+        shapeless.load()
+    except ProviderProtocolError as exc:
+        assert "bytes" in str(exc)
+    else:
+        raise AssertionError("missing read bytes escaped untyped")
+
+    class BoolPublishClient(FakeNoKVClient):
+        def publish_bytes(self, workbench, path, data, **options):
+            return {"generation": True}
+
+    bool_publish = NoKVCoordinationProvider(BoolPublishClient(), "wb-boolpub", goal_id)
+    try:
+        bool_publish.compare_and_put(0, head)
+    except ProviderProtocolError:
+        pass
+    else:
+        raise AssertionError("publish generation true was repaired to applied")
+
     out(
         "contract.nokv_adapter_exception_mapping",
         ok=True,
@@ -1020,6 +1090,9 @@ def probe_nokv_adapter_exception_mapping() -> None:
         legacy_prose_unsupported=True,
         corrupt_bytes_typed=True,
         unserializable_head_typed_failed=True,
+        invalid_expected_generation_typed=True,
+        malformed_generation_never_repaired=True,
+        malformed_result_shape_typed=True,
     )
 
 

--- a/examples/nokv-shadow-provider/probes.py
+++ b/examples/nokv-shadow-provider/probes.py
@@ -1,14 +1,21 @@
 """Deterministic probes for the coordination authority proof.
 
-Run ``python probes.py contract`` without NoKV or external services.  The
-claim/CAS probes do not qualify NoKV restart, recovery, GC, HA, or a live
-deployment.  The durable-completion probes are the read-side comparison
-registered by RFC shared-goal-authority-state-provider-v0 (later runtime
-qualification slice): they prove the provider byte-CAS can hold and read back
-a post-completion head whose durable records project to the same typed
-continuation outcomes (``successor | no_followup | active_goal``, fail-closed
-on contradiction/dangling) as the LoopX projection seam.  They do not
-implement or qualify the atomic ``complete_todo_with_successor`` write side.
+Run ``python probes.py contract`` without NoKV or external services.  Every
+claim/CAS probe drives the production Stage 2 modules
+(``loopx.control_plane.coordination.head`` and ``.executor``) - there is no
+second reference authority - and finishes by round-tripping its persisted
+head through the production ``validated_head``, so a probe that passes is
+evidence about the exact code the runtime ships.  The claim/CAS probes do
+not qualify NoKV restart, recovery, GC, HA, or a live deployment.  The
+durable-completion probes are the read-side comparison registered by RFC
+shared-goal-authority-state-provider-v0 (later runtime qualification slice):
+they prove the provider byte-CAS can hold and read back a post-completion
+head whose durable records project to the same typed continuation outcomes
+(``successor | no_followup | active_goal``, fail-closed on
+contradiction/dangling) as the LoopX projection seam.  Because completion is
+a later slice, those evolved heads deliberately carry fields outside the v0
+closed set and are not v0-validated.  They do not implement or qualify the
+atomic ``complete_todo_with_successor`` write side.
 """
 
 from __future__ import annotations
@@ -28,6 +35,15 @@ sys.path.insert(
     ),
 )
 
+from loopx.control_plane.coordination.executor import (  # noqa: E402
+    CoordinationAuthorityExecutor,
+    EnvelopeError,
+    sample_claim_envelope,
+)
+from loopx.control_plane.coordination.head import (  # noqa: E402
+    bootstrap_head,
+    validated_head,
+)
 from loopx.control_plane.todos.completion_state import (  # noqa: E402
     completion_continuation_for_write,
 )
@@ -36,10 +52,9 @@ from loopx.control_plane.todos.durable_completion import (  # noqa: E402
 )
 
 from provider import (  # noqa: E402
-    CoordinationAuthority,
     NoKVCoordinationProvider,
-    bootstrap_aggregate,
-    sample_envelope,
+    ProviderProtocolError,
+    ProviderUnavailableError,
 )
 
 
@@ -141,10 +156,6 @@ class DeterministicProvider:
             return {"result": "applied", "provider_generation": generation}
 
 
-def fixed_clock(value: float):
-    return lambda: value
-
-
 def initial_todo(
     allowed_agents=None,
     dependencies_satisfied: bool = True,
@@ -170,14 +181,11 @@ def initial_todo(
 
 
 def bootstrap(provider, goal_id: str, todo_ids) -> int:
-    head = bootstrap_aggregate(
+    head = bootstrap_head(
         goal_id,
         {todo_id: initial_todo() for todo_id in todo_ids},
     )
-    result = provider.compare_and_put(
-        0,
-        head,
-    )
+    result = provider.compare_and_put(0, head)
     assert result["result"] == "applied", result
     return result["provider_generation"]
 
@@ -187,6 +195,17 @@ def load_head(provider, goal_id: str):
     return provider.load()
 
 
+def authority(provider, goal_id: str, when: float) -> CoordinationAuthorityExecutor:
+    return CoordinationAuthorityExecutor(provider, goal_id=goal_id, now=lambda: when)
+
+
+def assert_production_valid(provider, goal_id: str) -> None:
+    """The persisted probe artifact must pass the production validator."""
+
+    head, _generation = provider.load()
+    validated_head(head, goal_id=goal_id)
+
+
 def assert_exact_replay(first: dict, replay: dict) -> None:
     assert first["result"] == "applied", first
     assert replay["result"] == "already_applied", replay
@@ -194,17 +213,33 @@ def assert_exact_replay(first: dict, replay: dict) -> None:
 
 
 def claim(operation_id: str, goal_id: str, todo_id: str, **values) -> dict:
-    return sample_envelope(
-        operation_id=operation_id,
+    expected_preconditions = values.pop("expected_preconditions", None)
+    if expected_preconditions is None:
+        expected_preconditions = {
+            "authorization_projection_revision": 3,
+            "authorization_projection_digest": "sha256:bootstrap-auth",
+            "dependency_revision": 12,
+            "gate_revision": 5,
+        }
+    envelope = sample_claim_envelope(
         goal_id=goal_id,
+        operation_id=operation_id,
+        agent_id=values.pop("agent_id", "agent-a"),
+        device_id=values.pop("device_id", "dev-laptop"),
         todo_id=todo_id,
-        **values,
+        expected_todo_revision=values.pop("expected_todo_revision", 7),
+        expected_preconditions=expected_preconditions,
+        lease_ttl_seconds=values.pop("lease_ttl_seconds", 600),
+        transport=values.pop("transport", None),
     )
+    if values:
+        raise TypeError(f"unknown claim kwargs: {sorted(values)}")
+    return envelope
 
 
 def assert_bootstrap_rejected(todo: dict, message: str | None = None) -> None:
     try:
-        bootstrap_aggregate("goal-private", {"todo-private": todo})
+        bootstrap_head("goal-private", {"todo-private": todo})
     except ValueError as exc:
         if message is not None:
             assert message in str(exc)
@@ -214,14 +249,13 @@ def assert_bootstrap_rejected(todo: dict, message: str | None = None) -> None:
 
 def probe_bootstrap_and_preconditions() -> None:
     provider = DeterministicProvider()
-    authority = CoordinationAuthority(provider, "goal-preconditions", fixed_clock(1000))
-    uninitialized = authority.apply(
+    uninitialized = authority(provider, "goal-preconditions", 1000).apply(
         claim("op-uninitialized", "goal-preconditions", "todo-known")
     )
     assert uninitialized["result"] == "failed"
     assert uninitialized["reason"] == "coordination_head_uninitialized"
 
-    initial_head = bootstrap_aggregate(
+    initial_head = bootstrap_head(
         "goal-preconditions",
         {
             "todo-known": initial_todo(),
@@ -232,19 +266,16 @@ def probe_bootstrap_and_preconditions() -> None:
     bootstrap_result = provider.compare_and_put(0, initial_head)
     assert bootstrap_result["result"] == "applied"
     initial_generation = bootstrap_result["provider_generation"]
-    missing = authority.apply(claim("op-missing", "goal-preconditions", "todo-missing"))
-    stale = authority.apply(
+    executor = authority(provider, "goal-preconditions", 1000)
+    missing = executor.apply(claim("op-missing", "goal-preconditions", "todo-missing"))
+    stale = executor.apply(
         claim("op-stale", "goal-preconditions", "todo-known", expected_todo_revision=6)
     )
-    expected_preconditions = initial_todo()["eligibility"]
     expected_preconditions = {
-        field: expected_preconditions[field]
-        for field in (
-            "authorization_projection_revision",
-            "authorization_projection_digest",
-            "dependency_revision",
-            "gate_revision",
-        )
+        "authorization_projection_revision": 3,
+        "authorization_projection_digest": "sha256:bootstrap-auth",
+        "dependency_revision": 12,
+        "gate_revision": 5,
     }
     stale_values = {
         "authorization_projection_revision": 2,
@@ -256,22 +287,22 @@ def probe_bootstrap_and_preconditions() -> None:
     for field, stale_value in stale_values.items():
         preconditions = copy.deepcopy(expected_preconditions)
         preconditions[field] = stale_value
-        changed_preconditions.append(authority.apply(claim(
+        changed_preconditions.append(executor.apply(claim(
             f"op-stale-{field}",
             "goal-preconditions",
             "todo-known",
             expected_preconditions=preconditions,
         )))
-    ineligible = authority.apply(claim(
+    ineligible = executor.apply(claim(
         "op-ineligible",
         "goal-preconditions",
         "todo-known",
         agent_id="agent-not-allowed",
     ))
-    dependency_blocked = authority.apply(
+    dependency_blocked = executor.apply(
         claim("op-dependency-blocked", "goal-preconditions", "todo-dependency-blocked")
     )
-    gate_blocked = authority.apply(
+    gate_blocked = executor.apply(
         claim("op-gate-blocked", "goal-preconditions", "todo-gate-blocked")
     )
     head, generation = load_head(provider, "goal-preconditions")
@@ -293,6 +324,7 @@ def probe_bootstrap_and_preconditions() -> None:
     assert gate_blocked["result"] == "rejected" and gate_blocked["reason"] == "gate_closed"
     assert head["authority_revision"] == 0 and head["receipt_index"] == {}
     assert generation == initial_generation
+    assert_production_valid(provider, "goal-preconditions")
     private_todo = initial_todo()
     private_todo["raw_todo_body"] = "must not enter the shared head"
     assert_bootstrap_rejected(private_todo, "fields do not match v0")
@@ -316,19 +348,18 @@ def probe_bootstrap_and_preconditions() -> None:
         dependency_and_gate_checked=True,
         bootstrap_privacy_allowlist_checked=True,
         repository_metadata_checked=True,
+        production_validator_round_trip=True,
     )
 
 
 def probe_a_b_replay_a() -> None:
     provider = DeterministicProvider()
     bootstrap(provider, "goal-review", ["todo-review", "todo-followup"])
-    authority = CoordinationAuthority(provider, "goal-review", fixed_clock(1100))
+    executor = authority(provider, "goal-review", 1100)
     envelope_a = claim("op-review-a", "goal-review", "todo-review")
-    first_a = authority.apply(envelope_a)
-    first_b = authority.apply(claim("op-followup-b", "goal-review", "todo-followup"))
-    replay_a = CoordinationAuthority(provider, "goal-review", fixed_clock(9000)).apply(
-        envelope_a
-    )
+    first_a = executor.apply(envelope_a)
+    first_b = executor.apply(claim("op-followup-b", "goal-review", "todo-followup"))
+    replay_a = authority(provider, "goal-review", 9000).apply(envelope_a)
     head, generation = load_head(provider, "goal-review")
     assert first_b["result"] == "applied"
     assert_exact_replay(first_a, replay_a)
@@ -337,6 +368,7 @@ def probe_a_b_replay_a() -> None:
         "original_receipt"
     ]
     assert len(head["receipt_index"]) == 2
+    assert_production_valid(provider, "goal-review")
     out(
         "contract.a_success_b_advance_replay_a",
         ok=True,
@@ -352,33 +384,34 @@ def probe_a_b_replay_a() -> None:
 def probe_operation_identity() -> None:
     provider = DeterministicProvider()
     bootstrap(provider, "goal-digest", ["todo-original", "todo-mutated"])
-    authority = CoordinationAuthority(provider, "goal-digest", fixed_clock(1200))
+    executor = authority(provider, "goal-digest", 1200)
     original = claim(
         "op-stable",
         "goal-digest",
         "todo-original",
         transport={"attempt": 1, "trace_id": "trace-a"},
     )
-    first = authority.apply(original)
+    first = executor.apply(original)
     transport_retry = copy.deepcopy(original)
     transport_retry["transport"] = {"attempt": 2, "trace_id": "trace-b"}
-    assert_exact_replay(first, authority.apply(transport_retry))
+    assert_exact_replay(first, executor.apply(transport_retry))
 
     changed = copy.deepcopy(original)
     changed["command"]["todo_id"] = "todo-mutated"
-    mismatch = authority.apply(changed)
+    mismatch = executor.apply(changed)
     assert mismatch["result"] == "rejected"
     assert mismatch["reason"] == "operation_identity_mismatch"
     unknown = copy.deepcopy(original)
     unknown["unexpected_semantic_field"] = True
     try:
-        authority.apply(unknown)
-    except ValueError as exc:
+        executor.apply(unknown)
+    except EnvelopeError as exc:
         assert "unknown command envelope fields" in str(exc)
     else:
         raise AssertionError("unknown semantic field was ignored")
     head, _ = load_head(provider, "goal-digest")
     assert len(head["receipt_index"]) == 1
+    assert_production_valid(provider, "goal-digest")
     out(
         "contract.operation_identity",
         ok=True,
@@ -393,14 +426,10 @@ def probe_competing_claims() -> None:
         provider.arm_load_barrier(2)
 
         def run(index: int):
-            return CoordinationAuthority(
-                provider,
-                goal_id,
-                fixed_clock(1300 + index),
-            ).apply(envelopes[index])
+            return authority(provider, goal_id, 1300 + index).apply(envelopes[index])
 
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            return list(executor.map(run, range(2)))
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            return list(pool.map(run, range(2)))
 
     same_provider = DeterministicProvider(generation_step=23)
     bootstrap(same_provider, "goal-race", ["todo-one-winner"])
@@ -430,6 +459,7 @@ def probe_competing_claims() -> None:
     assert set(head["coordination"]["leases"]) == {"todo-one-winner"}
     assert head["coordination"]["leases"]["todo-one-winner"]["owner"] == winner
     assert generation == 46
+    assert_production_valid(same_provider, "goal-race")
 
     independent_provider = DeterministicProvider(generation_step=29)
     bootstrap(independent_provider, "goal-independent", ["todo-a", "todo-b"])
@@ -477,16 +507,15 @@ def probe_competing_claims() -> None:
         "original_receipt"
     ]["todo_id"] == "todo-b"
     assert independent_generation == 87
-    replayed = CoordinationAuthority(
-        independent_provider,
-        "goal-independent",
-        fixed_clock(9000),
-    ).apply(independent_envelopes[0])
+    replayed = authority(independent_provider, "goal-independent", 9000).apply(
+        independent_envelopes[0]
+    )
     assert_exact_replay(independent_results[0], replayed)
     assert load_head(independent_provider, "goal-independent") == (
         independent_head,
         independent_generation,
     )
+    assert_production_valid(independent_provider, "goal-independent")
     out(
         "contract.competing_claims",
         ok=True,
@@ -504,9 +533,7 @@ def probe_crash_windows_and_ambiguity() -> None:
     bootstrap(provider, "goal-faults", ["todo-before", "todo-after", "todo-ambiguous"])
     before = claim("op-before", "goal-faults", "todo-before")
     provider.arm_fault("failed_before")
-    failed = CoordinationAuthority(provider, "goal-faults", fixed_clock(1400)).apply(
-        before
-    )
+    failed = authority(provider, "goal-faults", 1400).apply(before)
     assert failed["result"] == "failed"
     assert failed["reason"] == "provider_failed_before_cas"
     head, generation = load_head(provider, "goal-faults")
@@ -514,7 +541,7 @@ def probe_crash_windows_and_ambiguity() -> None:
     assert generation == 17
     provider.arm_fault("crash_before")
     try:
-        CoordinationAuthority(provider, "goal-faults", fixed_clock(1400)).apply(before)
+        authority(provider, "goal-faults", 1400).apply(before)
     except SimulatedCrash:
         pass
     else:
@@ -526,60 +553,55 @@ def probe_crash_windows_and_ambiguity() -> None:
     after = claim("op-after", "goal-faults", "todo-after")
     provider.arm_fault("crash_after")
     try:
-        CoordinationAuthority(provider, "goal-faults", fixed_clock(1500)).apply(after)
+        authority(provider, "goal-faults", 1500).apply(after)
     except SimulatedCrash:
         pass
     else:
         raise AssertionError("after-CAS crash was not injected")
     committed, committed_generation = load_head(provider, "goal-faults")
     durable_receipt = committed["receipt_index"]["op-after"]["original_receipt"]
-    replay = CoordinationAuthority(provider, "goal-faults", fixed_clock(9000)).apply(after)
+    replay = authority(provider, "goal-faults", 9000).apply(after)
     assert replay["result"] == "already_applied"
     assert replay["original_receipt"] == durable_receipt
     assert load_head(provider, "goal-faults") == (committed, committed_generation)
 
     ambiguous = claim("op-ambiguous", "goal-faults", "todo-ambiguous")
     provider.arm_fault("ambiguous_after")
-    reconciled = CoordinationAuthority(provider, "goal-faults", fixed_clock(1600)).apply(
-        ambiguous
-    )
+    reconciled = authority(provider, "goal-faults", 1600).apply(ambiguous)
     final_head, _ = load_head(provider, "goal-faults")
     assert reconciled["result"] == "already_applied"
     assert final_head["authority_revision"] == 2 and len(final_head["receipt_index"]) == 2
+    assert_production_valid(provider, "goal-faults")
 
     ambiguous_before_provider = DeterministicProvider()
     bootstrap(ambiguous_before_provider, "goal-ambiguous-before", ["todo-target"])
     before_head = load_head(ambiguous_before_provider, "goal-ambiguous-before")
     ambiguous_before_provider.arm_fault("ambiguous_before")
-    unproved = CoordinationAuthority(
-        ambiguous_before_provider,
-        "goal-ambiguous-before",
-        fixed_clock(1650),
-    ).apply(claim("op-unproved", "goal-ambiguous-before", "todo-target"))
+    unproved = authority(ambiguous_before_provider, "goal-ambiguous-before", 1650).apply(
+        claim("op-unproved", "goal-ambiguous-before", "todo-target")
+    )
     assert unproved["result"] == "failed"
     assert unproved["reason"] == "provider_outcome_unproved"
     assert load_head(ambiguous_before_provider, "goal-ambiguous-before") == before_head
+    assert_production_valid(ambiguous_before_provider, "goal-ambiguous-before")
 
     ambiguous_advance_provider = DeterministicProvider()
     bootstrap(ambiguous_advance_provider, "goal-ambiguous-advance", ["todo-target"])
     ambiguous_advance_provider.arm_fault("ambiguous_with_unrelated_advance")
-    retried = CoordinationAuthority(
-        ambiguous_advance_provider,
-        "goal-ambiguous-advance",
-        fixed_clock(1675),
+    retried = authority(
+        ambiguous_advance_provider, "goal-ambiguous-advance", 1675
     ).apply(claim("op-retried", "goal-ambiguous-advance", "todo-target"))
     retried_head, _ = load_head(ambiguous_advance_provider, "goal-ambiguous-advance")
     assert retried["result"] == "applied"
     assert retried_head["authority_revision"] == 1
     assert set(retried_head["receipt_index"]) == {"op-retried"}
+    assert_production_valid(ambiguous_advance_provider, "goal-ambiguous-advance")
 
     ambiguous_committed_provider = DeterministicProvider()
     bootstrap(ambiguous_committed_provider, "goal-ambiguous-committed", ["todo-target"])
     ambiguous_committed_provider.arm_fault("ambiguous_after_with_unrelated_advance")
-    recovered = CoordinationAuthority(
-        ambiguous_committed_provider,
-        "goal-ambiguous-committed",
-        fixed_clock(1685),
+    recovered = authority(
+        ambiguous_committed_provider, "goal-ambiguous-committed", 1685
     ).apply(claim("op-recovered", "goal-ambiguous-committed", "todo-target"))
     recovered_head, _ = load_head(
         ambiguous_committed_provider,
@@ -588,20 +610,20 @@ def probe_crash_windows_and_ambiguity() -> None:
     assert recovered["result"] == "already_applied"
     assert recovered_head["authority_revision"] == 1
     assert set(recovered_head["receipt_index"]) == {"op-recovered"}
+    assert_production_valid(ambiguous_committed_provider, "goal-ambiguous-committed")
 
     contention_provider = DeterministicProvider()
     bootstrap(contention_provider, "goal-contention", ["todo-target"])
     contention_provider.arm_contention(8)
-    exhausted = CoordinationAuthority(
-        contention_provider,
-        "goal-contention",
-        fixed_clock(1700),
-    ).apply(claim("op-contention", "goal-contention", "todo-target"))
+    exhausted = authority(contention_provider, "goal-contention", 1700).apply(
+        claim("op-contention", "goal-contention", "todo-target")
+    )
     contention_head, _ = load_head(contention_provider, "goal-contention")
     assert exhausted["result"] == "failed"
     assert exhausted["reason"] == "provider_contention_exhausted"
     assert "op-contention" not in contention_head["receipt_index"]
     assert contention_head["coordination"]["todos"]["todo-target"]["status"] == "open"
+    assert_production_valid(contention_provider, "goal-contention")
     out(
         "contract.crash_windows_and_ambiguity",
         ok=True,
@@ -620,15 +642,16 @@ def probe_crash_windows_and_ambiguity() -> None:
 def probe_version_domains_and_retain_all() -> None:
     provider = DeterministicProvider(generation_step=101)
     bootstrap(provider, "goal-versions", ["todo-a", "todo-b"])
-    authority = CoordinationAuthority(provider, "goal-versions", fixed_clock(1700))
-    first = authority.apply(claim("op-a", "goal-versions", "todo-a"))
-    second = authority.apply(claim("op-b", "goal-versions", "todo-b"))
+    executor = authority(provider, "goal-versions", 1700)
+    first = executor.apply(claim("op-a", "goal-versions", "todo-a"))
+    second = executor.apply(claim("op-b", "goal-versions", "todo-b"))
     head, generation = load_head(provider, "goal-versions")
     assert generation == 303 and head["authority_revision"] == 2
     assert first["original_receipt"]["lease_epoch"] == 1
     assert second["original_receipt"]["lease_epoch"] == 1
     assert head["receipt_retention"] == {"mode": "retain_all_v0"}
     assert len(head["receipt_index"]) == 2
+    assert_production_valid(provider, "goal-versions")
     out(
         "contract.version_domains_and_retain_all",
         ok=True,
@@ -815,7 +838,7 @@ class FakeNoKVClient:
 
     It raises the exception classes the SDK raises since NoKV 0.11.0
     (``nokv-python`` maps ``NotFound`` to ``FileNotFoundError`` and
-    ``AlreadyExists`` to ``FileExistsError``; other RPC failures stay
+    ``AlreadyExists`` to ``FileExistsError``; every other client failure stays
     ``RuntimeError``).  Generations restart at 1 per path lifetime and every
     replacement advances by one, like the live workspace.
     """
@@ -823,6 +846,7 @@ class FakeNoKVClient:
     def __init__(self):
         self.paths: dict[tuple[str, str], tuple[bytes, int]] = {}
         self.stat_failure: Exception | None = None
+        self.read_failure: Exception | None = None
 
     def stat(self, workbench: str, path: str) -> dict:
         if self.stat_failure is not None:
@@ -835,6 +859,9 @@ class FakeNoKVClient:
         return {"generation": generation}
 
     def read(self, workbench: str, path: str) -> dict:
+        if self.read_failure is not None:
+            failure, self.read_failure = self.read_failure, None
+            raise failure
         try:
             data, generation = self.paths[(workbench, path)]
         except KeyError:
@@ -863,18 +890,21 @@ class FakeNoKVClient:
 
 
 def probe_nokv_adapter_exception_mapping() -> None:
-    """The NoKV byte-CAS adapter must classify SDK exceptions into RFC verbs.
+    """The NoKV byte-CAS adapter classifies SDK failures by exception class only.
 
-    ``load`` returns ``(None, 0)`` for an uninitialized head, and
-    ``compare_and_put`` returns typed ``applied | conflict | ambiguous | failed``
-    for every SDK outcome it can observe: it never leaks ``FileNotFoundError``,
-    ``FileExistsError``, or ``RuntimeError`` to the authority.
+    ``load`` returns ``(None, 0)`` only for the SDK's typed missing signal
+    (``FileNotFoundError``); any other client failure raises the typed
+    ``ProviderUnavailableError`` instead of masquerading as an uninitialized
+    goal or escaping as a bare ``RuntimeError``.  ``compare_and_put`` reports
+    typed ``applied | conflict | ambiguous | failed`` for every SDK outcome:
+    error prose is never a channel, because real non-missing failures carry
+    messages such as ``invalid root route: root placement does not exist``.
     """
 
     client = FakeNoKVClient()
     goal_id = "adapter-mapping"
     provider = NoKVCoordinationProvider(client, "wb-adapter", goal_id)
-    head = bootstrap_aggregate(goal_id, {})
+    head = bootstrap_head(goal_id, {})
 
     assert provider.load() == (None, 0)
     created = provider.compare_and_put(0, head)
@@ -909,21 +939,74 @@ def probe_nokv_adapter_exception_mapping() -> None:
     assert failed["result"] == "failed", failed
     assert provider.load() == (advanced, 2)
 
-    # legacy SDKs raised RuntimeError for a missing path; both spellings stay classified
+    # A routing outage whose message carries a not-found token must classify
+    # as unavailable, never as missing: (None, 0) would tell the authority
+    # the goal is uninitialized and authorize a bootstrap-create during an
+    # outage.  This is the real string shape ClientError::InvalidRoute
+    # produces through the 0.11 SDK.
+    routing_outage = RuntimeError("invalid root route: root placement does not exist")
+    client.read_failure = routing_outage
+    try:
+        provider.load()
+    except ProviderUnavailableError as exc:
+        assert "root placement does not exist" in str(exc)
+    else:
+        raise AssertionError("routing outage was classified as missing")
+
+    # The same routing outage during the CAS pre-check is a typed failed
+    # verdict, never the conflict-or-create path a misclassified generation 0
+    # would take.
+    client.stat_failure = RuntimeError(
+        "logical shard LogicalShardId([34]) was not found"
+    )
+    outage_verdict = provider.compare_and_put(2, advanced)
+    assert outage_verdict["result"] == "failed", outage_verdict
+    assert "was not found" in outage_verdict["error"]
+
+    # A token-free outage is the same typed unavailable, not a bare
+    # RuntimeError leak.
+    client.read_failure = RuntimeError("connection refused by endpoint")
+    try:
+        provider.load()
+    except ProviderUnavailableError:
+        pass
+    else:
+        raise AssertionError("token-free outage did not raise typed unavailable")
+
+    # Pre-0.11 SDKs signalled missing with RuntimeError prose.  They cannot
+    # route the post-#465 control plane and are outside the pinned baseline,
+    # so that prose now classifies as unavailable rather than missing.
     class LegacyClient(FakeNoKVClient):
         def read(self, workbench: str, path: str) -> dict:
             if (workbench, path) not in self.paths:
                 raise RuntimeError("workspace request failed: path not found")
             return super().read(workbench, path)
 
-        def stat(self, workbench: str, path: str) -> dict:
-            if (workbench, path) not in self.paths:
-                raise RuntimeError("workspace request failed: path not found")
-            return super().stat(workbench, path)
-
     legacy = NoKVCoordinationProvider(LegacyClient(), "wb-legacy", goal_id)
-    assert legacy.load() == (None, 0)
-    assert legacy.compare_and_put(0, head)["result"] == "applied"
+    try:
+        legacy.load()
+    except ProviderUnavailableError:
+        pass
+    else:
+        raise AssertionError("legacy prose was still classified as missing")
+
+    # Corrupt persisted bytes and unserializable heads stay typed too, in
+    # parity with the file provider's seam contract.
+    corrupt_client = FakeNoKVClient()
+    corrupt_client.paths[("wb-corrupt", f"goals/{goal_id}/coordination-head.json")] = (
+        b"{not json",
+        3,
+    )
+    corrupt = NoKVCoordinationProvider(corrupt_client, "wb-corrupt", goal_id)
+    try:
+        corrupt.load()
+    except ProviderProtocolError:
+        pass
+    else:
+        raise AssertionError("corrupt persisted bytes escaped untyped")
+    unserializable = provider.compare_and_put(2, {"x": float("nan")})
+    assert unserializable["result"] == "failed", unserializable
+    assert "serializable" in unserializable["error"]
 
     out(
         "contract.nokv_adapter_exception_mapping",
@@ -932,7 +1015,11 @@ def probe_nokv_adapter_exception_mapping() -> None:
         create_only_race_typed=True,
         stale_generation_typed=True,
         pre_publish_failure_typed=True,
-        legacy_runtime_error_still_classified=True,
+        routing_outage_not_missing=True,
+        outage_raises_typed_unavailable=True,
+        legacy_prose_unsupported=True,
+        corrupt_bytes_typed=True,
+        unserializable_head_typed_failed=True,
     )
 
 
@@ -955,6 +1042,13 @@ def run_contract() -> None:
     out("contract.summary", ok=True, probes=len(PROBES))
 
 
+def main() -> int:
+    if len(sys.argv) != 2 or sys.argv[1] != "contract":
+        print("usage: python probes.py contract", file=sys.stderr)
+        return 2
+    run_contract()
+    return 0
+
+
 if __name__ == "__main__":
-    command = sys.argv[1] if len(sys.argv) > 1 else "contract"
-    {"contract": run_contract}[command]()
+    sys.exit(main())

--- a/examples/nokv-shadow-provider/provider.py
+++ b/examples/nokv-shadow-provider/provider.py
@@ -1,183 +1,72 @@
-"""Claim-only coordination authority proof with a NoKV byte-CAS adapter.
+"""NoKV byte-CAS coordination provider for the shared-goal authority RFC.
 
-LoopX authority owns domain semantics and receipts.  The provider sees only
-deterministic bytes plus an opaque generation.  Coordination state and the
-complete receipt index are committed in one CAS; v0 performs no receipt GC.
+Storage adapter only. Domain semantics, receipts, and head validation belong
+to the production authority modules under
+``loopx.control_plane.coordination``; this module maps the RFC provider verbs
+(``load`` / ``compare_and_put``) onto the NoKV Python SDK and nothing else.
+The canonical byte encoding is imported from the production head codec so the
+adapter cannot fork the digest/parity basis.
+
+Failure classification is by exception class ONLY. Since NoKV 0.11.0 (the
+pinned RFC baseline) the SDK raises ``FileNotFoundError`` for a missing path
+and ``FileExistsError`` for a create-only collision; every other RPC,
+transport, routing, or publication failure is a ``RuntimeError``. Error prose
+is never a channel: real non-missing failures carry messages such as
+``invalid root route: root placement does not exist`` and ``logical shard ...
+was not found``, so any message-token fallback misclassifies an outage as an
+uninitialized goal - the one confusion RFC section 6.2 forbids (``missing``
+must never collapse into ``unavailable``). Pre-0.11 SDKs cannot route the
+post-#465 control plane at all and are outside the supported baseline.
 """
 
 from __future__ import annotations
 
-import copy
-import hashlib
 import json
-import re
-import time
 import uuid
-from datetime import datetime, timezone
-from pathlib import PurePosixPath, PureWindowsPath
-from typing import Callable
 
-
-HEAD_SCHEMA = "loopx_coordination_head_v0"
-COMMAND_SCHEMA = "loopx_command_v0"
-RECEIPT_SCHEMA = "loopx_authority_receipt_v0"
-RETAIN_ALL = {"mode": "retain_all_v0"}
-
-
-def _deterministic_bytes(value: dict) -> bytes:
-    return json.dumps(
-        value,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-    ).encode("utf-8")
-
-
-def _digest(value: dict) -> str:
-    return "sha256:" + hashlib.sha256(_deterministic_bytes(value)).hexdigest()
-
-
-def _lease_id(operation_id: str) -> str:
-    value = hashlib.sha256(f"lease:{operation_id}".encode()).hexdigest()
-    return "lease_" + value[:24]
-
-
-def _format_time(timestamp: float) -> str:
-    return (
-        datetime.fromtimestamp(timestamp, timezone.utc)
-        .isoformat(timespec="milliseconds")
-        .replace("+00:00", "Z")
-    )
-
-
-def _parse_time(value: str) -> float:
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
-
-
-def bootstrap_aggregate(goal_id: str, todos: dict) -> dict:
-    """Build the explicit migration head from already-existing open todos."""
-    todo_fields = {
-        "todo_revision",
-        "status",
-        "claimed_by",
-        "eligibility",
-        "repository",
-        "code_revision",
-        "last_lease_epoch",
-    }
-    eligibility_fields = {
-        "authorization_projection_revision",
-        "authorization_projection_digest",
-        "allowed_agent_ids",
-        "dependencies_satisfied",
-        "dependency_revision",
-        "gates_open",
-        "gate_revision",
-    }
-    if not isinstance(goal_id, str) or not goal_id:
-        raise ValueError("bootstrap goal_id must be a non-empty string")
-    if not isinstance(todos, dict):
-        raise ValueError("bootstrap todos must be an object")
-    normalized = {}
-    for todo_id, source in todos.items():
-        if not isinstance(todo_id, str) or not todo_id:
-            raise ValueError("bootstrap todo ids must be non-empty strings")
-        if not isinstance(source, dict) or set(source) != todo_fields:
-            raise ValueError(f"bootstrap todo {todo_id!r} fields do not match v0")
-        if not isinstance(source.get("todo_revision"), int):
-            raise ValueError(f"bootstrap todo {todo_id!r} lacks todo_revision")
-        if source.get("status") != "open" or source.get("claimed_by") is not None:
-            raise ValueError(f"bootstrap todo {todo_id!r} must be open and unclaimed")
-        if not isinstance(source.get("last_lease_epoch"), int):
-            raise ValueError(f"bootstrap todo {todo_id!r} lacks last_lease_epoch")
-        repository = source.get("repository")
-        if (
-            not isinstance(repository, str)
-            or not repository
-            or repository.startswith("file://")
-            or PurePosixPath(repository).is_absolute()
-            or PureWindowsPath(repository).is_absolute()
-            or re.fullmatch(
-                r"git:[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+",
-                repository,
-            ) is None
-        ):
-            raise ValueError(f"bootstrap todo {todo_id!r} repository is not portable")
-        code_revision = source.get("code_revision")
-        if not isinstance(code_revision, str) or re.fullmatch(
-            r"[0-9a-fA-F]{7,64}",
-            code_revision,
-        ) is None:
-            raise ValueError(f"bootstrap todo {todo_id!r} code_revision is invalid")
-
-        eligibility = source.get("eligibility")
-        if not isinstance(eligibility, dict) or set(eligibility) != eligibility_fields:
-            raise ValueError(f"bootstrap todo {todo_id!r} eligibility fields do not match v0")
-        revision_fields = (
-            "authorization_projection_revision",
-            "dependency_revision",
-            "gate_revision",
-        )
-        if any(
-            not isinstance(eligibility[field], int) or eligibility[field] < 0
-            for field in revision_fields
-        ):
-            raise ValueError(f"bootstrap todo {todo_id!r} eligibility revisions are invalid")
-        digest = eligibility["authorization_projection_digest"]
-        if not isinstance(digest, str) or not digest.startswith("sha256:"):
-            raise ValueError(f"bootstrap todo {todo_id!r} authorization digest is invalid")
-        allowed = eligibility["allowed_agent_ids"]
-        if not isinstance(allowed, list) or any(
-            not isinstance(agent_id, str) or not agent_id for agent_id in allowed
-        ):
-            raise ValueError(f"bootstrap todo {todo_id!r} allowed_agent_ids are invalid")
-        if not isinstance(eligibility["dependencies_satisfied"], bool) or not isinstance(
-            eligibility["gates_open"], bool
-        ):
-            raise ValueError(f"bootstrap todo {todo_id!r} eligibility decisions are invalid")
-        normalized[todo_id] = {
-            "todo_revision": source["todo_revision"],
-            "status": "open",
-            "claimed_by": None,
-            "eligibility": {
-                field: copy.deepcopy(eligibility[field])
-                for field in sorted(eligibility_fields)
-            },
-            "repository": repository,
-            "code_revision": code_revision,
-            "last_lease_epoch": source["last_lease_epoch"],
-        }
-    return {
-        "schema_version": HEAD_SCHEMA,
-        "goal_id": goal_id,
-        "authority_revision": 0,
-        "coordination": {"todos": normalized, "leases": {}},
-        "receipt_index": {},
-        "receipt_retention": copy.deepcopy(RETAIN_ALL),
-    }
+from loopx.control_plane.coordination.head import (
+    HeadValidationError,
+    canonical_head_bytes,
+)
 
 
 class ProviderProtocolError(RuntimeError):
     """Persisted bytes or a provider result violated the reviewed contract."""
 
 
-class NoKVCoordinationProvider:
-    """Map one goal's deterministic head bytes to a NoKV generation CAS.
+class ProviderUnavailableError(RuntimeError):
+    """The storage plane could not serve the request; nothing is proven.
 
-    The NoKV Python SDK raises ``FileNotFoundError`` for a missing path and
-    ``FileExistsError`` for a create-only collision since NoKV 0.11.0
-    (``nokv-python`` maps the ``NotFound`` / ``AlreadyExists`` RPC codes to
-    those ``OSError`` subclasses); every other RPC, transport, or publication
-    failure is a ``RuntimeError``. Earlier SDKs raised ``RuntimeError`` for
-    all of them. The adapter classifies by exception class first and by the
-    documented not-found message tokens second, so both generations of the
-    SDK map onto the same typed provider verbs. It never treats human error
-    text as commit proof: a publish that raises is ``ambiguous`` and the
-    authority reloads its atomically stored receipt index.
+    Raised on read paths, where the RFC verbs offer no typed channel. It is
+    categorically different from ``(None, 0)``: missing is a proven absence
+    that authorizes bootstrap-create, while unavailable means the head's
+    existence is unknown and every decision must fail closed.
+    """
+
+
+def _generation_from(metadata) -> int:
+    try:
+        return int(metadata["generation"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ProviderProtocolError(
+            f"provider result omitted a usable generation: {exc}"
+        ) from exc
+
+
+class NoKVCoordinationProvider:
+    """Map one goal's canonical head bytes to a NoKV generation CAS.
+
+    ``load`` returns ``(head | None, provider_generation)`` where ``None``
+    is proven absence (``FileNotFoundError`` from the SDK) and any other
+    client failure raises the typed :class:`ProviderUnavailableError`.
+    ``compare_and_put`` reports the four RFC verbs: an outage before the
+    publish is typed ``failed`` (provably no write), and a publish that
+    raises is ``ambiguous`` - human error text is never parsed as commit
+    proof; the authority reloads and trusts only its atomically stored
+    receipt index.
     """
 
     _CLIENT_ERRORS = (RuntimeError, OSError)
-    _NOT_FOUND_TOKENS = ("not found", "does not exist", "no such path")
 
     def __init__(self, client, workbench: str, goal_id: str):
         self.client = client
@@ -185,34 +74,32 @@ class NoKVCoordinationProvider:
         self.goal_id = goal_id
         self.head_path = f"goals/{goal_id}/coordination-head.json"
 
-    @classmethod
-    def _not_found(cls, exc: BaseException) -> bool:
-        if isinstance(exc, FileNotFoundError):
-            return True
-        message = str(exc).lower()
-        return any(token in message for token in cls._NOT_FOUND_TOKENS)
-
     def load(self):
         """Return ``(aggregate | None, provider_generation)``."""
         try:
             result = self.client.read(self.workbench, self.head_path)
+        except FileNotFoundError:
+            return None, 0
         except self._CLIENT_ERRORS as exc:
-            if self._not_found(exc):
-                return None, 0
-            raise
-        aggregate = json.loads(bytes(result["bytes"]))
+            raise ProviderUnavailableError(str(exc)) from exc
+        try:
+            aggregate = json.loads(bytes(result["bytes"]))
+        except ValueError as exc:
+            raise ProviderProtocolError(
+                f"coordination head is not valid JSON: {exc}"
+            ) from exc
         if not isinstance(aggregate, dict):
             raise ProviderProtocolError("coordination head must be an object")
-        return aggregate, int(result["metadata"]["generation"])
+        return aggregate, _generation_from(result["metadata"])
 
     def _generation(self) -> int:
         try:
             metadata = self.client.stat(self.workbench, self.head_path)
+        except FileNotFoundError:
+            return 0
         except self._CLIENT_ERRORS as exc:
-            if self._not_found(exc):
-                return 0
-            raise
-        return int(metadata["generation"])
+            raise ProviderUnavailableError(str(exc)) from exc
+        return _generation_from(metadata)
 
     def compare_and_put(
         self,
@@ -222,16 +109,23 @@ class NoKVCoordinationProvider:
         """Serialize and conditionally store an opaque aggregate."""
         try:
             current = self._generation()
-        except self._CLIENT_ERRORS as exc:
-            # No publish was attempted, so this provider failure proves no write.
+        except ProviderUnavailableError as exc:
+            # No publish was attempted, so this failure proves no write.
             return {"result": "failed", "error": str(exc)}
         if current != expected_provider_generation:
             return {"result": "conflict", "current_provider_generation": current}
         try:
+            payload = canonical_head_bytes(aggregate)
+        except HeadValidationError as exc:
+            # Serialization runs before any publish, so this failure proves
+            # no write; it surfaces as the typed verb exactly like the file
+            # provider, never as an unclassified exception through the seam.
+            return {"result": "failed", "error": str(exc)}
+        try:
             result = self.client.publish_bytes(
                 self.workbench,
                 self.head_path,
-                _deterministic_bytes(aggregate),
+                payload,
                 content_type="application/json",
                 expected_generation=(
                     None if expected_provider_generation == 0
@@ -246,378 +140,13 @@ class NoKVCoordinationProvider:
             # response all reload; the authority trusts only its atomically
             # stored receipt index.
             return {"result": "ambiguous"}
+        try:
+            applied_generation = int(result["generation"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ProviderProtocolError(
+                f"publish result omitted a usable generation: {exc}"
+            ) from exc
         return {
             "result": "applied",
-            "provider_generation": int(result["generation"]),
+            "provider_generation": applied_generation,
         }
-
-
-class CoordinationAuthority:
-    """Reference proof for one command: claim an existing runnable todo."""
-
-    _TOP_FIELDS = {
-        "schema_version",
-        "operation_id",
-        "actor",
-        "goal_id",
-        "command",
-        "transport",
-    }
-    _ACTOR_FIELDS = {"agent_id", "device_id"}
-    _COMMAND_FIELDS = {
-        "type",
-        "todo_id",
-        "expected_todo_revision",
-        "expected_preconditions",
-        "lease_ttl_seconds",
-    }
-    _PRECONDITION_FIELDS = {
-        "authorization_projection_revision",
-        "authorization_projection_digest",
-        "dependency_revision",
-        "gate_revision",
-    }
-    _MAX_CAS_ATTEMPTS = 8
-
-    def __init__(
-        self,
-        provider,
-        goal_id: str,
-        now: Callable[[], float] = time.time,
-    ):
-        self.provider = provider
-        self.goal_id = goal_id
-        self.now = now
-
-    def apply(self, envelope: dict) -> dict:
-        request = self._semantic_request(envelope)
-        operation_id = request["operation_id"]
-        request_digest = _digest(request)
-        head, provider_generation = self.provider.load()
-        if head is None:
-            return {
-                "result": "failed",
-                "reason": "coordination_head_uninitialized",
-                "provider_generation": provider_generation,
-            }
-        head = self._validated_head(head)
-
-        for attempt in range(self._MAX_CAS_ATTEMPTS):
-            replay = self._replay(
-                head,
-                provider_generation,
-                operation_id,
-                request_digest,
-            )
-            if replay is not None:
-                return replay
-            transition = self._claim(head, request, request_digest)
-            if isinstance(transition, dict):
-                transition.update({
-                    "observed_authority_revision": head["authority_revision"],
-                    "provider_generation": provider_generation,
-                })
-                return transition
-            proposed, original_receipt = transition
-            provider_result = self.provider.compare_and_put(
-                provider_generation,
-                proposed,
-            )
-            result_kind = provider_result.get("result")
-            if result_kind == "applied":
-                return self._success(
-                    "applied",
-                    original_receipt,
-                    proposed,
-                    provider_result["provider_generation"],
-                )
-            if result_kind not in {"conflict", "ambiguous", "failed"}:
-                raise ProviderProtocolError(
-                    f"unknown provider result: {provider_result!r}"
-                )
-            if result_kind == "failed":
-                return {
-                    "result": "failed",
-                    "reason": "provider_failed_before_cas",
-                    "observed_authority_revision": head["authority_revision"],
-                    "provider_generation": provider_generation,
-                }
-
-            latest, latest_generation = self.provider.load()
-            if latest is None:
-                return {
-                    "result": "failed",
-                    "reason": "coordination_head_missing_after_cas",
-                    "provider_generation": latest_generation,
-                }
-            latest = self._validated_head(latest)
-            replay = self._replay(
-                latest,
-                latest_generation,
-                operation_id,
-                request_digest,
-            )
-            if replay is not None:
-                return replay
-            if latest_generation == provider_generation:
-                return {
-                    "result": "failed",
-                    "reason": "provider_outcome_unproved",
-                    "observed_authority_revision": latest["authority_revision"],
-                    "provider_generation": latest_generation,
-                }
-            head, provider_generation = latest, latest_generation
-
-        return {
-            "result": "failed",
-            "reason": "provider_contention_exhausted",
-            "observed_authority_revision": head["authority_revision"],
-            "provider_generation": provider_generation,
-        }
-
-    def _semantic_request(self, envelope: dict) -> dict:
-        if not isinstance(envelope, dict):
-            raise ValueError("command envelope must be an object")
-        unknown = set(envelope) - self._TOP_FIELDS
-        if unknown:
-            raise ValueError(f"unknown command envelope fields: {sorted(unknown)}")
-        if envelope.get("schema_version") != COMMAND_SCHEMA:
-            raise ValueError("unsupported command envelope schema")
-        operation_id = envelope.get("operation_id")
-        if not isinstance(operation_id, str) or not operation_id:
-            raise ValueError("operation_id must be a non-empty string")
-        if envelope.get("goal_id") != self.goal_id:
-            raise ValueError("command goal_id does not match this authority")
-        if "transport" in envelope and not isinstance(envelope["transport"], dict):
-            raise ValueError("transport metadata must be an object")
-
-        actor = envelope.get("actor")
-        if not isinstance(actor, dict) or set(actor) != self._ACTOR_FIELDS:
-            raise ValueError("actor must contain only agent_id and device_id")
-        if not all(isinstance(actor[key], str) and actor[key] for key in self._ACTOR_FIELDS):
-            raise ValueError("actor ids must be non-empty strings")
-        command = envelope.get("command")
-        if not isinstance(command, dict) or set(command) != self._COMMAND_FIELDS:
-            raise ValueError("claim_work fields do not match the v0 proof")
-        if command.get("type") != "claim_work":
-            raise ValueError("reference proof supports only claim_work")
-        if not isinstance(command["todo_id"], str) or not command["todo_id"]:
-            raise ValueError("todo_id must be a non-empty string")
-        if not isinstance(command["expected_todo_revision"], int):
-            raise ValueError("expected_todo_revision must be an integer")
-        preconditions = command["expected_preconditions"]
-        if not isinstance(preconditions, dict) or set(preconditions) != (
-            self._PRECONDITION_FIELDS
-        ):
-            raise ValueError("expected_preconditions fields do not match v0")
-        revision_fields = (
-            "authorization_projection_revision",
-            "dependency_revision",
-            "gate_revision",
-        )
-        if any(
-            not isinstance(preconditions[field], int) or preconditions[field] < 0
-            for field in revision_fields
-        ):
-            raise ValueError("expected_preconditions revisions must be non-negative")
-        digest = preconditions["authorization_projection_digest"]
-        if not isinstance(digest, str) or not digest.startswith("sha256:"):
-            raise ValueError("expected authorization projection digest is invalid")
-        if not isinstance(command["lease_ttl_seconds"], int) or command[
-            "lease_ttl_seconds"
-        ] <= 0:
-            raise ValueError("lease_ttl_seconds must be positive")
-
-        # ``transport`` is deliberately excluded; all semantic fields are
-        # explicitly projected, and unknown fields already failed closed.
-        return {
-            "schema_version": COMMAND_SCHEMA,
-            "operation_id": operation_id,
-            "actor": {key: actor[key] for key in sorted(self._ACTOR_FIELDS)},
-            "goal_id": self.goal_id,
-            "command": {key: copy.deepcopy(command[key]) for key in sorted(self._COMMAND_FIELDS)},
-        }
-
-    def _validated_head(self, head: dict) -> dict:
-        expected_fields = {
-            "schema_version",
-            "goal_id",
-            "authority_revision",
-            "coordination",
-            "receipt_index",
-            "receipt_retention",
-        }
-        if set(head) != expected_fields:
-            raise ProviderProtocolError("coordination head fields do not match v0")
-        if head["schema_version"] != HEAD_SCHEMA or head["goal_id"] != self.goal_id:
-            raise ProviderProtocolError("coordination head identity mismatch")
-        if not isinstance(head["authority_revision"], int):
-            raise ProviderProtocolError("authority_revision must be an integer")
-        coordination = head["coordination"]
-        if not isinstance(coordination, dict) or set(coordination) != {"todos", "leases"}:
-            raise ProviderProtocolError("coordination must contain todos and leases")
-        if not isinstance(coordination["todos"], dict) or not isinstance(
-            coordination["leases"], dict
-        ):
-            raise ProviderProtocolError("todos and leases must be objects")
-        if not isinstance(head["receipt_index"], dict):
-            raise ProviderProtocolError("receipt_index must be an object")
-        if head["receipt_retention"] != RETAIN_ALL:
-            raise ProviderProtocolError("v0 requires retain_all_v0")
-        return head
-
-    def _replay(
-        self,
-        head: dict,
-        provider_generation: int,
-        operation_id: str,
-        request_digest: str,
-    ):
-        entry = head["receipt_index"].get(operation_id)
-        if entry is None:
-            return None
-        if entry.get("request_digest") != request_digest:
-            return {
-                "result": "rejected",
-                "reason": "operation_identity_mismatch",
-                "operation_id": operation_id,
-                "observed_authority_revision": head["authority_revision"],
-                "provider_generation": provider_generation,
-            }
-        receipt = entry.get("original_receipt")
-        if not isinstance(receipt, dict):
-            raise ProviderProtocolError("receipt entry lacks original_receipt")
-        return self._success("already_applied", receipt, head, provider_generation)
-
-    def _claim(self, head: dict, request: dict, request_digest: str):
-        command = request["command"]
-        todo = head["coordination"]["todos"].get(command["todo_id"])
-        if todo is None:
-            return {"result": "rejected", "reason": "todo_not_found"}
-        if todo.get("todo_revision") != command["expected_todo_revision"]:
-            return {
-                "result": "conflict",
-                "reason": "todo_revision_mismatch",
-                "expected_todo_revision": command["expected_todo_revision"],
-                "observed_todo_revision": todo.get("todo_revision"),
-            }
-        if todo.get("status") != "open" or todo.get("claimed_by") is not None:
-            return {"result": "rejected", "reason": "todo_not_open"}
-        eligibility = todo.get("eligibility")
-        if not isinstance(eligibility, dict):
-            return {"result": "rejected", "reason": "eligibility_missing"}
-        observed_preconditions = {
-            field: eligibility.get(field)
-            for field in self._PRECONDITION_FIELDS
-        }
-        if observed_preconditions != command["expected_preconditions"]:
-            return {
-                "result": "conflict",
-                "reason": "precondition_snapshot_mismatch",
-                "expected_preconditions": copy.deepcopy(
-                    command["expected_preconditions"]
-                ),
-                "observed_preconditions": observed_preconditions,
-            }
-        if request["actor"]["agent_id"] not in eligibility.get("allowed_agent_ids", []):
-            return {"result": "rejected", "reason": "actor_ineligible"}
-        if eligibility.get("dependencies_satisfied") is not True:
-            return {"result": "rejected", "reason": "dependencies_not_satisfied"}
-        if eligibility.get("gates_open") is not True:
-            return {"result": "rejected", "reason": "gate_closed"}
-
-        now = float(self.now())
-        lease_epoch = int(todo.get("last_lease_epoch", 0)) + 1
-        lease = {
-            "lease_id": _lease_id(request["operation_id"]),
-            "owner": request["actor"]["agent_id"],
-            "lease_epoch": lease_epoch,
-            "expires_at": _format_time(now + command["lease_ttl_seconds"]),
-            "write_scopes": [],
-        }
-        proposed = copy.deepcopy(head)
-        proposed["authority_revision"] += 1
-        proposed_todo = proposed["coordination"]["todos"][command["todo_id"]]
-        proposed_todo.update({
-            "todo_revision": todo["todo_revision"] + 1,
-            # LoopX keeps a claimed todo open; ``claimed_by`` and the hard
-            # lease carry ownership without inventing a new lifecycle state.
-            "status": "open",
-            "claimed_by": request["actor"]["agent_id"],
-            "last_lease_epoch": lease_epoch,
-        })
-        proposed["coordination"]["leases"][command["todo_id"]] = lease
-        receipt = {
-            "schema_version": RECEIPT_SCHEMA,
-            "operation_id": request["operation_id"],
-            "request_digest": request_digest,
-            "actor": copy.deepcopy(request["actor"]),
-            "todo_id": command["todo_id"],
-            "command": "claim_work",
-            "accepted_authority_revision": proposed["authority_revision"],
-            "accepted_todo_revision": proposed_todo["todo_revision"],
-            "applied_at": _format_time(now),
-            "lease_id": lease["lease_id"],
-            "lease_epoch": lease_epoch,
-            "expires_at": lease["expires_at"],
-        }
-        proposed["receipt_index"][request["operation_id"]] = {
-            "request_digest": request_digest,
-            "original_receipt": copy.deepcopy(receipt),
-        }
-        return proposed, receipt
-
-    def _success(self, result: str, receipt: dict, head: dict, generation: int) -> dict:
-        lease = head["coordination"]["leases"].get(receipt["todo_id"])
-        if lease is None or (
-            lease.get("lease_id") != receipt.get("lease_id")
-            or lease.get("lease_epoch") != receipt.get("lease_epoch")
-        ):
-            status = "superseded"
-        elif _parse_time(lease["expires_at"]) <= self.now():
-            status = "expired"
-        else:
-            status = "active"
-        return {
-            "result": result,
-            "original_receipt": copy.deepcopy(receipt),
-            "observed_authority_revision": head["authority_revision"],
-            "authorization_status": status,
-            "provider_generation": generation,
-        }
-
-
-def sample_envelope(
-    operation_id: str | None = None,
-    agent_id: str = "agent-a",
-    device_id: str = "dev-laptop",
-    goal_id: str = "ark-agent-loop-shared",
-    todo_id: str = "todo-0042",
-    expected_todo_revision: int = 7,
-    expected_preconditions: dict | None = None,
-    lease_ttl_seconds: int = 600,
-    transport: dict | None = None,
-) -> dict:
-    if expected_preconditions is None:
-        expected_preconditions = {
-            "authorization_projection_revision": 3,
-            "authorization_projection_digest": "sha256:bootstrap-auth",
-            "dependency_revision": 12,
-            "gate_revision": 5,
-        }
-    envelope = {
-        "schema_version": COMMAND_SCHEMA,
-        "operation_id": operation_id or str(uuid.uuid4()),
-        "actor": {"agent_id": agent_id, "device_id": device_id},
-        "goal_id": goal_id,
-        "command": {
-            "type": "claim_work",
-            "todo_id": todo_id,
-            "expected_todo_revision": expected_todo_revision,
-            "expected_preconditions": copy.deepcopy(expected_preconditions),
-            "lease_ttl_seconds": lease_ttl_seconds,
-        },
-    }
-    if transport is not None:
-        envelope["transport"] = copy.deepcopy(transport)
-    return envelope

--- a/examples/nokv-shadow-provider/provider.py
+++ b/examples/nokv-shadow-provider/provider.py
@@ -44,13 +44,27 @@ class ProviderUnavailableError(RuntimeError):
     """
 
 
-def _generation_from(metadata) -> int:
-    try:
-        return int(metadata["generation"])
-    except (KeyError, TypeError, ValueError) as exc:
+def _decoded_generation(value, *, source: str) -> int:
+    """The one strict decoder for the authoritative CAS token.
+
+    bool is an int subclass and ``int(True) == 1``: a malformed SDK response
+    carrying ``generation: true`` must never be repaired into generation 1,
+    exactly as the head codec refuses bool-disguised revisions and epochs.
+    Stored generations start at 1; the absent sentinel 0 is synthesized by
+    the adapter, never decoded.
+    """
+
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
         raise ProviderProtocolError(
-            f"provider result omitted a usable generation: {exc}"
-        ) from exc
+            f"{source} carried an invalid generation: {value!r}"
+        )
+    return value
+
+
+def _result_field(result, field: str, *, source: str):
+    if not isinstance(result, dict) or field not in result:
+        raise ProviderProtocolError(f"{source} omitted required field {field!r}")
+    return result[field]
 
 
 class NoKVCoordinationProvider:
@@ -82,15 +96,20 @@ class NoKVCoordinationProvider:
             return None, 0
         except self._CLIENT_ERRORS as exc:
             raise ProviderUnavailableError(str(exc)) from exc
+        raw = _result_field(result, "bytes", source="read result")
         try:
-            aggregate = json.loads(bytes(result["bytes"]))
-        except ValueError as exc:
+            aggregate = json.loads(bytes(raw))
+        except (TypeError, ValueError) as exc:
             raise ProviderProtocolError(
                 f"coordination head is not valid JSON: {exc}"
             ) from exc
         if not isinstance(aggregate, dict):
             raise ProviderProtocolError("coordination head must be an object")
-        return aggregate, _generation_from(result["metadata"])
+        metadata = _result_field(result, "metadata", source="read result")
+        return aggregate, _decoded_generation(
+            _result_field(metadata, "generation", source="read metadata"),
+            source="read metadata",
+        )
 
     def _generation(self) -> int:
         try:
@@ -99,7 +118,10 @@ class NoKVCoordinationProvider:
             return 0
         except self._CLIENT_ERRORS as exc:
             raise ProviderUnavailableError(str(exc)) from exc
-        return _generation_from(metadata)
+        return _decoded_generation(
+            _result_field(metadata, "generation", source="stat result"),
+            source="stat result",
+        )
 
     def compare_and_put(
         self,
@@ -107,6 +129,18 @@ class NoKVCoordinationProvider:
         aggregate: dict,
     ) -> dict:
         """Serialize and conditionally store an opaque aggregate."""
+        if (
+            not isinstance(expected_provider_generation, int)
+            or isinstance(expected_provider_generation, bool)
+            or expected_provider_generation < 0
+        ):
+            # The caller's CAS token is typed state exactly like the stored
+            # one: a bool or negative expectation must not reach comparison
+            # or publish arithmetic.
+            return {
+                "result": "failed",
+                "error": "expected_provider_generation must be a non-negative integer",
+            }
         try:
             current = self._generation()
         except ProviderUnavailableError as exc:
@@ -140,13 +174,10 @@ class NoKVCoordinationProvider:
             # response all reload; the authority trusts only its atomically
             # stored receipt index.
             return {"result": "ambiguous"}
-        try:
-            applied_generation = int(result["generation"])
-        except (KeyError, TypeError, ValueError) as exc:
-            raise ProviderProtocolError(
-                f"publish result omitted a usable generation: {exc}"
-            ) from exc
         return {
             "result": "applied",
-            "provider_generation": applied_generation,
+            "provider_generation": _decoded_generation(
+                _result_field(result, "generation", source="publish result"),
+                source="publish result",
+            ),
         }

--- a/loopx/control_plane/work_items/local_lease_record.py
+++ b/loopx/control_plane/work_items/local_lease_record.py
@@ -69,6 +69,13 @@ def lease_epoch(lease: dict[str, Any] | None) -> int:
     if raw_epoch is None:
         # A pre-lease_epoch record is the first visible generation.
         return 1
+    if isinstance(raw_epoch, bool):
+        # bool is an int subclass: JSON true must not become epoch 1.
+        raise TaskLeaseError(
+            "lease epoch must be a positive integer",
+            code="corrupt_lease",
+            payload={"lease_epoch": raw_epoch},
+        )
     try:
         epoch = int(raw_epoch)
     except (TypeError, ValueError) as exc:
@@ -92,6 +99,12 @@ def lease_version(lease: dict[str, Any] | None) -> int:
     raw_version = (lease or {}).get("version")
     if raw_version is None:
         return 0
+    if isinstance(raw_version, bool):
+        raise TaskLeaseError(
+            "lease version must be a non-negative integer",
+            code="corrupt_lease",
+            payload={"version": raw_version},
+        )
     try:
         version = int(raw_version)
     except (TypeError, ValueError) as exc:
@@ -115,6 +128,12 @@ def lease_acquire_ttl_seconds(lease: dict[str, Any] | None) -> int | None:
     raw_ttl = (lease or {}).get("acquire_ttl_seconds")
     if raw_ttl is None:
         return None
+    if isinstance(raw_ttl, bool):
+        raise TaskLeaseError(
+            "lease acquire_ttl_seconds must be an integer",
+            code="corrupt_lease",
+            payload={"acquire_ttl_seconds": raw_ttl},
+        )
     try:
         return int(raw_ttl)
     except (TypeError, ValueError) as exc:
@@ -159,6 +178,14 @@ def require_expected_version(expected_version: int | None, *, action: str) -> in
             f"task lease {action} requires the current lease version",
             code="version_required",
             payload={"action": action},
+        )
+    if isinstance(expected_version, bool):
+        # bool is an int subclass; JSON true from a tool argument must not
+        # silently become expected version 1.
+        raise TaskLeaseError(
+            f"task lease {action} requires an integer lease version",
+            code="version_required",
+            payload={"action": action, "expected_version": expected_version},
         )
     return int(expected_version)
 

--- a/loopx/goal_mode_mcp.py
+++ b/loopx/goal_mode_mcp.py
@@ -7,7 +7,14 @@ import subprocess
 import sys
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any
+
+try:  # pydantic ships with the FastMCP extra; base installs have no pydantic.
+    from pydantic import Strict
+except ImportError:  # pragma: no cover - exercised on base installs only
+    class Strict:  # type: ignore[no-redef]
+        """Inert stand-in so the shared annotation still evaluates without
+        pydantic; FastMCP cannot run on such an install anyway."""
 
 from .control_plane.host_adapter_settlement import (
     HostTodoSettlementRequest,
@@ -16,6 +23,13 @@ from .control_plane.host_adapter_settlement import (
 
 
 ContextResolver = Callable[[], dict[str, Any] | None]
+
+# The one boundary type for a caller-supplied lease version. FastMCP validates
+# tool arguments with pydantic, and lax pydantic coerces JSON true to 1 before
+# any loopx code runs, so strictness must live in the annotation itself; the
+# control-plane method and the FastMCP wrapper share this alias so the two
+# signatures cannot drift.
+ExpectedTaskLeaseVersion = Annotated[int, Strict()] | None
 
 
 @dataclass(frozen=True)
@@ -163,7 +177,7 @@ class GoalModeMCPControlPlane:
         evidence: str,
         next_agent_todo: str = "",
         task_lease_idempotency_key: str = "",
-        task_lease_expected_version: int | None = None,
+        task_lease_expected_version: ExpectedTaskLeaseVersion = None,
         no_follow_up: bool = False,
     ) -> str:
         goal_id, _ = self.context()
@@ -257,7 +271,7 @@ def create_fastmcp_server(
         evidence: str,
         next_agent_todo: str = "",
         task_lease_idempotency_key: str = "",
-        task_lease_expected_version: int | None = None,
+        task_lease_expected_version: ExpectedTaskLeaseVersion = None,
         no_follow_up: bool = False,
     ) -> str:
         """Complete one verified todo, write follow-up state, then spend quota."""

--- a/loopx/visible_governance.py
+++ b/loopx/visible_governance.py
@@ -59,14 +59,17 @@ def _build_authority_boundary_table() -> list[dict[str, Any]]:
                 "authority_revision, todo_revision, lease_epoch, "
                 "receipt_index, eligibility projections"
             ),
-            "shipped": False,
+            "shipped": True,
             "shipped_equivalent": (
-                "NoKV shadow provider (examples/nokv-shadow-provider/) -- "
-                "reference proof only, not wired into LoopX runtime"
+                "loopx.control_plane.coordination.head (production "
+                "loopx_coordination_head_v0 codec) + file/NoKV providers "
+                "behind one CAS seam -- coverage-only, not yet the runtime "
+                "source of truth"
             ),
             "gap": (
-                "No production coordination_head module exists; the shadow "
-                "provider CoordinationAuthority is a contract example"
+                "Production callers still write Markdown/lease files; "
+                "promotion to canonical waits on the Stage 3 gates "
+                "(retention, lineage fence, lease lifecycle)"
             ),
         },
         {

--- a/loopx/visible_governance.py
+++ b/loopx/visible_governance.py
@@ -59,17 +59,16 @@ def _build_authority_boundary_table() -> list[dict[str, Any]]:
                 "authority_revision, todo_revision, lease_epoch, "
                 "receipt_index, eligibility projections"
             ),
-            "shipped": True,
+            "shipped": False,
             "shipped_equivalent": (
-                "loopx.control_plane.coordination.head (production "
-                "loopx_coordination_head_v0 codec) + file/NoKV providers "
-                "behind one CAS seam -- coverage-only, not yet the runtime "
-                "source of truth"
+                "loopx.control_plane.coordination head codec + file/NoKV "
+                "providers behind one CAS seam -- coverage-only modules, "
+                "not the runtime source of truth"
             ),
             "gap": (
-                "Production callers still write Markdown/lease files; "
-                "promotion to canonical waits on the Stage 3 gates "
-                "(retention, lineage fence, lease lifecycle)"
+                "Runtime still writes Markdown/lease files; no production "
+                "coordination head document exists, and canonical promotion "
+                "waits on the Stage 3 gates"
             ),
         },
         {

--- a/tests/control_plane/test_task_lease.py
+++ b/tests/control_plane/test_task_lease.py
@@ -129,6 +129,25 @@ def test_lease_epoch_migrates_legacy_records_and_rejects_corruption() -> None:
         assert error.value.code == "corrupt_lease"
 
 
+def test_bool_disguised_lease_integers_fail_closed() -> None:
+    """bool is an int subclass: a JSON ``true`` must not become epoch/version/
+    TTL ``1`` silently.  The shared Stage 2 head codec already rejects bool
+    (head._is_count); the local record codec is the migration source for
+    ``last_lease_epoch`` seeding, so the same typed corrupt_lease applies
+    before any local-to-shared migration."""
+
+    for raw in (True, False):
+        with pytest.raises(TaskLeaseError) as error:
+            task_lease.lease_epoch({"lease_epoch": raw})
+        assert error.value.code == "corrupt_lease"
+        with pytest.raises(TaskLeaseError) as error:
+            task_lease.lease_version({"version": raw})
+        assert error.value.code == "corrupt_lease"
+        with pytest.raises(TaskLeaseError) as error:
+            task_lease.lease_acquire_ttl_seconds({"acquire_ttl_seconds": raw})
+        assert error.value.code == "corrupt_lease"
+
+
 def test_task_lease_lifecycle_preserves_idempotency_and_versions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_goal_mode_mcp_completion_validation.py
+++ b/tests/test_goal_mode_mcp_completion_validation.py
@@ -122,3 +122,33 @@ def test_mcp_complete_task_fails_closed_on_failing_declared_validation(
     assert "spend-slot" not in output
     assert "refresh-state" not in output
     assert _agent_todo_status(state, todo_id) != "done"
+
+def test_expected_lease_version_annotation_rejects_bool_at_the_boundary() -> None:
+    """FastMCP validates tool arguments with pydantic, and lax pydantic
+    coerces JSON ``true`` to ``1`` BEFORE any loopx code runs - by the time
+    the lease CAS compares versions the bool is indistinguishable from a
+    legitimate 1.  The boundary annotation is therefore the only place the
+    rejection can happen, and it is single-sourced so the control-plane
+    method and the FastMCP wrapper cannot drift."""
+
+    import pydantic
+
+    from loopx import goal_mode_mcp
+
+    adapter = pydantic.TypeAdapter(goal_mode_mcp.ExpectedTaskLeaseVersion)
+    for disguised in (True, False):
+        try:
+            adapter.validate_python(disguised)
+        except pydantic.ValidationError:
+            pass
+        else:
+            raise AssertionError(f"bool {disguised} was coerced to an int")
+    assert adapter.validate_python(7) == 7
+    assert adapter.validate_python(None) is None
+
+    import typing
+
+    hints = typing.get_type_hints(
+        goal_mode_mcp.GoalModeMCPControlPlane.complete_task, include_extras=True
+    )
+    assert hints["task_lease_expected_version"] == goal_mode_mcp.ExpectedTaskLeaseVersion


### PR DESCRIPTION
## What this closes

Three of the promotion-blocking gaps named in the Stage 1/2 post-merge audit, each reproduced by fault injection before fixing, each fixed at the root after comparing at least three candidate designs.

### 1. The verification oracle had forked (P1)

`probes.py` - the README-documented merge-relevant regression - still drove a second reference authority whose heads lack `handoff_mode`. Reproduced bidirectionally: old-oracle heads fail the production `validated_head`, production heads fail the old validator, and both dialects carry the same schema string, so nothing could tell them apart on disk. The 9/9 pass was not evidence about production code.

Fix: the probes now drive the production `CoordinationAuthorityExecutor` + head codec, every claim/CAS probe round-trips its persisted head through the production validator, and the second authority is **deleted** (the adapter also serializes through the production canonical codec, killing the byte-basis fork). Assertion coverage was adversarially diffed probe-by-probe: reason codes, generation arithmetic (17/46/51/87/303), receipt topology, and privacy rejections survive verbatim; the only inversion is deliberate and loud (legacy RuntimeError-prose "missing" is now typed unavailable, see below). The stale `visible_governance` ledger row ("no production coordination_head module exists") is corrected.

Designs considered: (a) migrate probes onto production and delete the old authority - chosen; (b) patch `handoff_mode` into the old authority - rejected, keeps two engines and this incident IS the drift such a pair produces; (c) delete probes and lean on the pytest suites - rejected, the probes carry offline contract checks (adapter exception mapping, durable-completion projection) that live nowhere else.

### 2. The NoKV adapter classified failures by error prose (P1)

`_not_found` matched tokens ("not found", "does not exist") over any `RuntimeError`. Real non-missing failures carry those tokens: `ClientError::InvalidRoute` reaches Python as `RuntimeError("invalid root route: root placement does not exist")` (nokv-python maps only `NotFound`/`AlreadyExists` to typed exceptions). Reproduced offline with the real message shapes and live with a SIGKILLed owner: a routing outage read as `(None, 0)` - an *uninitialized goal*, authorizing bootstrap-create during an outage, the one confusion RFC section 6.2 forbids - and a token-free outage escaped as a bare `RuntimeError`.

Fix: classification by exception class only. `FileNotFoundError` is the one missing signal (pinned to the 0.11 SDK mapping); any other read-path failure raises the typed `ProviderUnavailableError`; a pre-publish outage stays the typed `failed` verb; corrupt persisted bytes and unserializable heads surface as `ProviderProtocolError`/typed `failed` in parity with the file provider. The token list is gone - pre-0.11 SDKs, its only justification, cannot route the post-#465 control plane at all.

Designs compared in a literal battery against the real fault matrix (5 rows: SDK missing, two token-bearing outages, two token-free outages): **class-only** classifies all 5 correctly; **tightened tokens** misclassifies both routing outages as missing and still leaks bare errors; **retry-then-classify** does the same while multiplying the SDK's own 3 internal attempts to 12. Prose is not a channel.

### 3. The local lease codec accepted bool-disguised integers (P2)

`int(True) == 1`: a JSON `true` in a persisted record became epoch/version/TTL `1` silently, while the Stage 2 shared head codec already rejects bool - and this codec is the migration source that seeds `last_lease_epoch` for local-to-shared bootstrap. Test-driven (red first): `lease_epoch`, `lease_version`, `lease_acquire_ttl_seconds` now reject bool with the typed `corrupt_lease`; `require_expected_version` rejects a bool API argument. Writers never persist bool (fields flow from typed `LeaseSnapshot` integers), so no legacy record can regress. Designs: reject (chosen, mirrors `head._is_count`), coerce (silent repair, rejected), schema migration (nothing to migrate, rejected).

**Found during adversarial verification, fixed here:** the codec guards cannot intercept the MCP route at all - FastMCP validates tool arguments with lax pydantic, and lax pydantic coerces JSON `true` to `1` *before any loopx code runs*, indistinguishable from a legitimate version 1 (which passes the CAS on first-generation leases). The only effective layer is the annotation FastMCP builds its model from, so `task_lease_expected_version` is now the single-sourced `ExpectedTaskLeaseVersion = Annotated[int, Strict()] | None`, shared by the control-plane method and the FastMCP wrapper. Verified through the real FastMCP `func_metadata` machinery: JSON `true` -> `ValidationError`, integers and null unchanged. The import is guarded for base installs (pydantic ships with the FastMCP extra).

## Not fixed here, disclosed

The CLI/SDK CAS parity gap (claim 3 of the audit) is NoKV-side and closed by a companion NoKV PR adding caller-pinned `expected_generation` to `workbench_put_file`. The Full Public Smokes' 3 pre-existing failures on main are unrelated to this line and remain.

## Verification

- Fault-injection acceptance script: every injected fault (routing-token outage, token-free outage, SDK missing, bool matrix, forked-oracle artifacts) resolves typed, exit 0.
- Migrated probes 9/9 + pytest wrapper; adversarial probe-by-probe assertion diff found no weakened contract.
- Focused: 111 tests across probes wrapper, goal-mode MCP, task-lease, and the three coordination suites; full `tests/control_plane + tests/canary + tests/architecture` passes with only the four known machine-environment failures identical on pristine main; ruff clean; strict mypy (15 files) clean.
- Live against a real NoKV 0.11.0 stack: eight-scenario file/NoKV parity 8/8 identical with the rewritten adapter; SIGKILLed owner now surfaces typed `ProviderUnavailableError` on load and typed `failed` on compare_and_put.
