### PR TITLE
feat(auto-research): close the wish-to-artifact loop

### DIFF
--- a/docs/reference/protocols/auto-research-wish-to-artifact-v0.md
+++ b/docs/reference/protocols/auto-research-wish-to-artifact-v0.md
@@ -1,0 +1,88 @@
+# Auto Research Wish-to-Artifact v0
+
+Auto Research accepts an open question today and can already produce
+hypotheses, dev and held-out evidence, terminal decisions, independent review,
+and Explore findings. This protocol closes the delivery contract around those
+existing records. It does not add another scheduler, research store, or
+capability.
+
+## Contract
+
+`auto_research_delivery_contract_v0` wraps the existing
+`research_contract_v0` with:
+
+- one original public-safe wish and a stable `wish_id`;
+- assumptions and non-goals;
+- required artifact declarations;
+- acceptance criteria bound to exact hypothesis ids;
+- fallback artifacts and reentry conditions for unsuccessful outcomes.
+
+Normalization derives `contract_revision` from the complete normalized
+contract. Recording the contract does not imply user acceptance. Evidence
+produced from the delivery contract carries the atomic lineage tuple
+(`wish_id`, `contract_ref`, `contract_revision`). All three fields must be
+present and match exactly; partial or mismatched lineage is excluded from
+verification. A compact contract event is
+appended once per wish and revision. Legacy `research_contract_v0` packets
+retain their prior event shape and remain supported.
+
+## Receipt
+
+```bash
+loopx auto-research artifact-receipt \
+  --contract delivery-contract.public.json \
+  --format json
+```
+
+The command is read-only. It folds the current contract revision, Auto Research
+evidence graph, terminal decisions, independent reviews, and artifact
+references into `auto_research_artifact_receipt_v0`.
+
+The aggregate status is one of:
+
+| Status | Meaning |
+| --- | --- |
+| `verified` | Every required criterion has a current promoted decision, the required review, and every declared artifact. |
+| `partial` | Some criterion or artifact is verified, but the complete delivery contract is not satisfied. |
+| `inconclusive` | Evidence, a terminal decision, or a required independent review is still missing or conflicting. |
+| `not_fulfilled` | Current evidence supports a terminal retired decision for at least one required criterion, with any required independent review. |
+| `stale` | The recorded evidence or terminal decision belongs to an older contract revision. |
+
+`not_fulfilled` is intentionally stronger than an unsuccessful attempt. One
+failed command, one regressed dev result, or an unresolved retry does not prove
+that the wish cannot be fulfilled.
+
+## Failure Feedback
+
+Every non-verified receipt includes:
+
+- `failure_kinds`: typed reasons derived from current evidence, decision, and
+  review state;
+- `unmet_criteria`: required contract criteria not satisfied;
+- `verified_boundary`: criteria that remain verified;
+- `missing_required_artifact_refs`: declared required artifacts not observed;
+- `fallback_artifact_refs`: declared fallback artifacts that were actually
+  observed;
+- `reentry_conditions`: owner-authored conditions plus precise criterion-level
+  repair hints.
+
+The receipt does not infer user acceptance. It also does not install or promote
+a Skill, mutate an extension, spend quota, or write project state. A
+`learning_disposition=candidate` only means that a verified or terminally
+not-fulfilled outcome is eligible for a later governed experience review.
+
+## Staleness
+
+A terminal decision remains bound to the hypothesis evidence revision. The
+hypothesis and evidence now also carry the delivery `contract_revision`.
+Changing the wish assumptions, required artifacts, acceptance criteria, or
+failure policy creates a new contract revision. A receipt for that new revision
+must not reuse the old revision's evidence as current delivery proof.
+
+## Public Boundary
+
+The delivery contract and receipt use public-safe text and opaque or relative
+artifact references. They do not contain raw logs, raw trajectories,
+credentials, private material, or absolute local paths. Environment-specific
+replay state remains adapter-owned; only bounded public evidence references may
+enter this contract.

--- a/examples/auto-research-artifact-receipt-smoke.py
+++ b/examples/auto-research-artifact-receipt-smoke.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -24,7 +22,9 @@ from examples.auto_research_lightweight_fixture import (  # noqa: E402
     TODO_ID,
     eval_result,
     research_contract,
+    run_auto_research_cli,
     write_json,
+    write_registry,
 )
 
 
@@ -90,72 +90,12 @@ def delivery_contract() -> dict[str, Any]:
         },
     }
 
-
-def run_cli(
-    registry: Path,
-    *args: str,
-    expect_ok: bool = True,
-) -> dict[str, Any]:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry),
-            "--format",
-            "json",
-            "auto-research",
-            *args,
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    payload = json.loads(result.stdout)
-    if expect_ok:
-        assert result.returncode == 0 and payload["ok"] is True, (result, payload)
-    else:
-        assert result.returncode != 0 and payload["ok"] is False, (result, payload)
-    return payload
-
-
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
-        runtime_root = temp / "runtime"
-        project = temp / "project"
-        project.mkdir()
-        registry = temp / "registry.json"
-        registry.write_text(
-            json.dumps(
-                {
-                    "schema_version": "0.1",
-                    "common_runtime_root": str(runtime_root),
-                    "goals": [
-                        {
-                            "id": GOAL_ID,
-                            "repo": str(project),
-                            "state_file": "ACTIVE_GOAL_STATE.md",
-                            "adapter": {
-                                "kind": "fixture",
-                                "status": "connected-read-only",
-                            },
-                            "coordination": {
-                                "agent_model": "peer_v1",
-                                "registered_agents": [
-                                    AGENT_ID,
-                                    PROMOTER,
-                                    REVIEWER,
-                                ],
-                            },
-                        }
-                    ],
-                }
-            ),
-            encoding="utf-8",
+        registry = write_registry(
+            temp,
+            registered_agents=[AGENT_ID, PROMOTER, REVIEWER],
         )
         contract_path = temp / "delivery-contract.public.json"
         dev_path = temp / "dev-result.public.json"
@@ -168,7 +108,7 @@ def main() -> int:
         write_json(dev_path, dev)
         write_json(holdout_path, holdout)
 
-        packet = run_cli(
+        packet = run_auto_research_cli(
             registry,
             "evidence",
             "--contract",
@@ -196,13 +136,13 @@ def main() -> int:
         )
         packet_path = temp / "evidence-packet.public.json"
         write_json(packet_path, packet)
-        first_append = run_cli(
+        first_append = run_auto_research_cli(
             registry,
             "append-evidence",
             "--packet",
             str(packet_path),
         )
-        second_append = run_cli(
+        second_append = run_auto_research_cli(
             registry,
             "append-evidence",
             "--packet",
@@ -211,7 +151,7 @@ def main() -> int:
         assert first_append["counts_by_kind"]["validation"] == 1, first_append
         assert second_append["appended_count"] == 0, second_append
 
-        run_cli(
+        run_auto_research_cli(
             registry,
             "decide",
             "--goal-id",
@@ -228,7 +168,7 @@ def main() -> int:
             "decision:heldout",
             "--execute",
         )
-        run_cli(
+        run_auto_research_cli(
             registry,
             "review",
             "--goal-id",
@@ -244,7 +184,7 @@ def main() -> int:
             "review:independent",
             "--execute",
         )
-        receipt = run_cli(
+        receipt = run_auto_research_cli(
             registry,
             "artifact-receipt",
             "--contract",

--- a/examples/auto-research-artifact-receipt-smoke.py
+++ b/examples/auto-research-artifact-receipt-smoke.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Exercise the Auto Research Wish-to-Artifact receipt lifecycle."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from examples.auto_research_lightweight_fixture import (  # noqa: E402
+    AGENT_ID,
+    GOAL_ID,
+    HYPOTHESIS_ID,
+    HYPOTHESIS_TEXT,
+    MECHANISM_FAMILY,
+    TODO_ID,
+    eval_result,
+    research_contract,
+    write_json,
+)
+
+
+PROMOTER = "evaluator-promoter"
+REVIEWER = "independent-reviewer"
+EXPERIMENT_REF = "artifact:state-a2a-experiment"
+REPORT_REF = "artifact:state-a2a-report"
+
+
+def delivery_contract() -> dict[str, Any]:
+    return {
+        "schema_version": "auto_research_delivery_contract_v0",
+        "contract_ref": "contract:state-a2a-evidence",
+        "wish": {
+            "original_text": (
+                "Verify whether state-mediated handoffs improve the shared "
+                "research candidate."
+            ),
+            "intent_summary": (
+                "Run a bounded dev and holdout comparison and deliver the "
+                "experiment plus a result report."
+            ),
+            "assumptions": [
+                "The public fixture metric represents useful progress."
+            ],
+            "non_goals": [
+                "Do not publish or deploy the experimental candidate."
+            ],
+        },
+        "research_contract": research_contract(),
+        "required_artifacts": [
+            {
+                "artifact_ref": EXPERIMENT_REF,
+                "kind": "experiment",
+                "description": "Runnable state-mediated comparison.",
+                "required": True,
+            },
+            {
+                "artifact_ref": REPORT_REF,
+                "kind": "report",
+                "description": "Evidence-backed result and limitation report.",
+                "required": True,
+            },
+        ],
+        "acceptance_criteria": [
+            {
+                "criterion_id": "heldout_result",
+                "description": (
+                    "The candidate has a terminal held-out decision with "
+                    "independent review."
+                ),
+                "hypothesis_id": HYPOTHESIS_ID,
+                "required_artifact_refs": [EXPERIMENT_REF, REPORT_REF],
+                "requires_independent_review": True,
+                "required": True,
+            }
+        ],
+        "failure_policy": {
+            "fallback_artifact_refs": [REPORT_REF],
+            "reentry_conditions": [
+                "Provide a new public evaluator or revised held-out task set."
+            ],
+        },
+    }
+
+
+def run_cli(
+    registry: Path,
+    *args: str,
+    expect_ok: bool = True,
+) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "auto-research",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    if expect_ok:
+        assert result.returncode == 0 and payload["ok"] is True, (result, payload)
+    else:
+        assert result.returncode != 0 and payload["ok"] is False, (result, payload)
+    return payload
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        runtime_root = temp / "runtime"
+        project = temp / "project"
+        project.mkdir()
+        registry = temp / "registry.json"
+        registry.write_text(
+            json.dumps(
+                {
+                    "schema_version": "0.1",
+                    "common_runtime_root": str(runtime_root),
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "repo": str(project),
+                            "state_file": "ACTIVE_GOAL_STATE.md",
+                            "adapter": {
+                                "kind": "fixture",
+                                "status": "connected-read-only",
+                            },
+                            "coordination": {
+                                "agent_model": "peer_v1",
+                                "registered_agents": [
+                                    AGENT_ID,
+                                    PROMOTER,
+                                    REVIEWER,
+                                ],
+                            },
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        contract_path = temp / "delivery-contract.public.json"
+        dev_path = temp / "dev-result.public.json"
+        holdout_path = temp / "holdout-result.public.json"
+        write_json(contract_path, delivery_contract())
+        dev = eval_result("dev")
+        holdout = eval_result("holdout")
+        dev["artifact_refs"].extend([EXPERIMENT_REF, REPORT_REF])
+        holdout["artifact_refs"].extend([EXPERIMENT_REF, REPORT_REF])
+        write_json(dev_path, dev)
+        write_json(holdout_path, holdout)
+
+        packet = run_cli(
+            registry,
+            "evidence",
+            "--contract",
+            str(contract_path),
+            "--eval-result",
+            str(dev_path),
+            "--eval-result",
+            str(holdout_path),
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--todo-id",
+            TODO_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--mechanism-family",
+            MECHANISM_FAMILY,
+            "--hypothesis",
+            HYPOTHESIS_TEXT,
+        )
+        assert packet["delivery_contract"]["wish"]["wish_id"].startswith("wish_")
+        assert packet["contract_lineage"]["contract_revision"].startswith(
+            "sha256:"
+        )
+        packet_path = temp / "evidence-packet.public.json"
+        write_json(packet_path, packet)
+        first_append = run_cli(
+            registry,
+            "append-evidence",
+            "--packet",
+            str(packet_path),
+        )
+        second_append = run_cli(
+            registry,
+            "append-evidence",
+            "--packet",
+            str(packet_path),
+        )
+        assert first_append["counts_by_kind"]["validation"] == 1, first_append
+        assert second_append["appended_count"] == 0, second_append
+
+        run_cli(
+            registry,
+            "decide",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--outcome",
+            "promoted",
+            "--reason",
+            "holdout_validated",
+            "--agent-id",
+            PROMOTER,
+            "--evidence-ref",
+            "decision:heldout",
+            "--execute",
+        )
+        run_cli(
+            registry,
+            "review",
+            "--goal-id",
+            GOAL_ID,
+            "--hypothesis-id",
+            HYPOTHESIS_ID,
+            "--reviewer-agent-id",
+            REVIEWER,
+            "--verdict",
+            "approve",
+            "--require-independent",
+            "--evidence-ref",
+            "review:independent",
+            "--execute",
+        )
+        receipt = run_cli(
+            registry,
+            "artifact-receipt",
+            "--contract",
+            str(contract_path),
+        )
+        assert receipt["status"] == "verified", receipt
+        assert receipt["failure_feedback"] is None, receipt
+        assert receipt["artifacts"]["missing_required_refs"] == [], receipt
+        assert receipt["acceptance_results"][0]["status"] == "verified", receipt
+        assert receipt["boundary"]["automatic_skill_promotion"] is False, receipt
+
+    print("auto-research-artifact-receipt-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/auto-research-terminal-results-cli-smoke.py
+++ b/examples/auto-research-terminal-results-cli-smoke.py
@@ -4,11 +4,9 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -22,83 +20,25 @@ from examples.auto_research_lightweight_fixture import (  # noqa: E402
     HYPOTHESIS_TEXT,
     MECHANISM_FAMILY,
     TODO_ID,
+    run_auto_research_cli,
     write_contract_and_results,
+    write_registry,
 )
 
 
 PROMOTER = "evaluator-promoter"
 REVIEWER = "independent-reviewer"
 
-
-def run_cli(
-    registry: Path,
-    *args: str,
-    expect_ok: bool = True,
-) -> dict[str, Any]:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry),
-            "--format",
-            "json",
-            "auto-research",
-            *args,
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    payload = json.loads(result.stdout)
-    if expect_ok:
-        assert result.returncode == 0 and payload["ok"] is True, (result, payload)
-    else:
-        assert result.returncode != 0 and payload["ok"] is False, (result, payload)
-    return payload
-
-
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
-        runtime_root = temp / "runtime"
-        project = temp / "project"
-        project.mkdir()
-        registry = temp / "registry.json"
-        registry.write_text(
-            json.dumps(
-                {
-                    "schema_version": "0.1",
-                    "common_runtime_root": str(runtime_root),
-                    "goals": [
-                        {
-                            "id": GOAL_ID,
-                            "repo": str(project),
-                            "state_file": "ACTIVE_GOAL_STATE.md",
-                            "adapter": {
-                                "kind": "fixture",
-                                "status": "connected-read-only",
-                            },
-                            "coordination": {
-                                "agent_model": "peer_v1",
-                                "registered_agents": [
-                                    AGENT_ID,
-                                    PROMOTER,
-                                    REVIEWER,
-                                ],
-                            },
-                        }
-                    ],
-                }
-            ),
-            encoding="utf-8",
+        registry = write_registry(
+            temp,
+            registered_agents=[AGENT_ID, PROMOTER, REVIEWER],
         )
         contract, dev, holdout = write_contract_and_results(temp)
         packet_path = temp / "packet.json"
-        packet = run_cli(
+        packet = run_auto_research_cli(
             registry,
             "evidence",
             "--contract",
@@ -121,13 +61,13 @@ def main() -> int:
             HYPOTHESIS_TEXT,
         )
         packet_path.write_text(json.dumps(packet), encoding="utf-8")
-        run_cli(
+        run_auto_research_cli(
             registry,
             "append-evidence",
             "--packet",
             str(packet_path),
         )
-        unregistered = run_cli(
+        unregistered = run_auto_research_cli(
             registry,
             "decide",
             "--goal-id",
@@ -144,7 +84,7 @@ def main() -> int:
             expect_ok=False,
         )
         assert "not registered" in unregistered["error"], unregistered
-        run_cli(
+        run_auto_research_cli(
             registry,
             "decide",
             "--goal-id",
@@ -161,7 +101,7 @@ def main() -> int:
             "decision:heldout",
             "--execute",
         )
-        self_review = run_cli(
+        self_review = run_auto_research_cli(
             registry,
             "review",
             "--goal-id",
@@ -175,7 +115,7 @@ def main() -> int:
             "--execute",
         )
         assert self_review["review"]["independent"] is False, self_review
-        run_cli(
+        run_auto_research_cli(
             registry,
             "review",
             "--goal-id",
@@ -191,7 +131,7 @@ def main() -> int:
             "review:independent",
             "--execute",
         )
-        result = run_cli(
+        result = run_auto_research_cli(
             registry,
             "results",
             "--goal-id",
@@ -201,14 +141,14 @@ def main() -> int:
             "--include-history",
         )
         assert result["results"][0]["finding_status"] == "confirmed", result
-        first = run_cli(
+        first = run_auto_research_cli(
             registry,
             "project-results",
             "--goal-id",
             GOAL_ID,
             "--execute",
         )
-        second = run_cli(
+        second = run_auto_research_cli(
             registry,
             "project-results",
             "--goal-id",
@@ -218,7 +158,7 @@ def main() -> int:
         assert first["appended_count"] > 0, first
         assert second["appended_count"] == 0, second
         assert second["reused_count"] == second["event_count"], second
-        readback = run_cli(
+        readback = run_auto_research_cli(
             registry,
             "results",
             "--goal-id",

--- a/examples/auto_research_lightweight_fixture.py
+++ b/examples/auto_research_lightweight_fixture.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
 GOAL_ID = "loopx-auto-research-demo"
 METRIC_NAME = "fixture_quality_score"
 BASELINE = 1.0
@@ -56,6 +59,73 @@ def eval_result(split: str, *, value: float | None | object = None) -> dict[str,
 
 def write_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_registry(
+    temp: Path,
+    *,
+    registered_agents: list[str],
+) -> Path:
+    runtime_root = temp / "runtime"
+    project = temp / "project"
+    project.mkdir()
+    registry = temp / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(project),
+                        "state_file": "ACTIVE_GOAL_STATE.md",
+                        "adapter": {
+                            "kind": "fixture",
+                            "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": registered_agents,
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry
+
+
+def run_auto_research_cli(
+    registry: Path,
+    *args: str,
+    expect_ok: bool = True,
+) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "auto-research",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    payload = json.loads(result.stdout)
+    if expect_ok:
+        assert result.returncode == 0 and payload["ok"] is True, (result, payload)
+    else:
+        assert result.returncode != 0 and payload["ok"] is False, (result, payload)
+    return payload
 
 
 def write_contract_and_results(temp: Path) -> tuple[Path, Path, Path]:

--- a/loopx/capabilities/auto_research/README.md
+++ b/loopx/capabilities/auto_research/README.md
@@ -65,6 +65,29 @@ one open question; auto-research supplies a fixed output contract; the generic
 kernel owns the runner, real Codex TUI panes, pane-local A2A tick, and
 todo/evidence/status protocol.
 
+When the run must end in a verifiable deliverable rather than only a research
+finding, the curator writes `auto_research_delivery_contract_v0`. The envelope
+keeps the original wish, assumptions, required artifacts, acceptance criteria,
+failure fallbacks, and reentry conditions together with the existing
+`research_contract_v0`. Evidence created from that file is bound to its
+atomic `wish_id`, `contract_ref`, and `contract_revision` lineage; partial or
+mismatched lineage is not eligible for verification.
+
+After terminal decisions and any required independent reviews exist, build the
+read-only delivery receipt:
+
+```bash
+loopx auto-research artifact-receipt \
+  --contract delivery-contract.public.json
+```
+
+The receipt distinguishes `verified`, `partial`, `inconclusive`,
+`not_fulfilled`, and `stale`. A single failed attempt is never enough for
+`not_fulfilled`; that state requires a terminal retirement decision and any
+independent review required by the delivery contract. Non-verified receipts
+return the unmet criteria, verified boundary, available fallback artifacts, and
+reentry conditions.
+
 The contract also includes the next one-command launch surface:
 
 ```bash

--- a/loopx/capabilities/auto_research/artifact_receipt.py
+++ b/loopx/capabilities/auto_research/artifact_receipt.py
@@ -7,6 +7,9 @@ from typing import Any
 
 from .delivery_contract import (
     AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+    AutoResearchContractLineage,
+    auto_research_contract_lineage_matches,
+    normalize_auto_research_contract_lineage,
     normalize_auto_research_delivery_contract,
 )
 from .research_state import build_research_evidence_graph_from_rollout_events
@@ -65,13 +68,15 @@ def _lineage_events(
 def _artifact_refs(
     events: Sequence[Mapping[str, Any]],
     *,
-    contract_revision: str,
+    expected_lineage: AutoResearchContractLineage,
 ) -> list[str]:
     refs = {
         str(ref)
         for event in events
-        if str(_details(event).get("contract_revision") or "")
-        == contract_revision
+        if auto_research_contract_lineage_matches(
+            _details(event),
+            expected=expected_lineage,
+        )
         for ref in event.get("artifact_refs") or []
         if str(ref).strip()
     }
@@ -79,20 +84,14 @@ def _artifact_refs(
 
 
 def _failure_kind(result: Mapping[str, Any]) -> str:
-    decision = result.get("terminal_decision")
     if result.get("decision_state") == "conflict":
         return "conflicting_terminal_decisions"
     review = result.get("peer_review")
     if isinstance(review, Mapping):
-        if review.get("state") == "conflict":
-            return "conflicting_peer_reviews"
-        if review.get("state") == "independent_reviewed":
-            if review.get("verdict") == "needs_more_evidence":
-                return "needs_more_evidence"
-            if review.get("verdict") == "reject":
-                return "independent_review_rejected"
-        if review.get("state") in {"self_review_only", "unreviewed"}:
-            return "independent_review_missing"
+        review_failure = _review_failure_kind(review)
+        if review_failure:
+            return review_failure
+    decision = result.get("terminal_decision")
     if (
         isinstance(decision, Mapping)
         and decision.get("outcome") == "retired"
@@ -104,118 +103,240 @@ def _failure_kind(result: Mapping[str, Any]) -> str:
     return "terminal_decision_missing"
 
 
+def _review_failure_kind(review: Mapping[str, Any]) -> str | None:
+    state = str(review.get("state") or "")
+    verdict = (
+        str(review.get("verdict") or "")
+        if state == "independent_reviewed"
+        else None
+    )
+    return {
+        ("conflict", None): "conflicting_peer_reviews",
+        ("independent_reviewed", "needs_more_evidence"): "needs_more_evidence",
+        ("independent_reviewed", "reject"): "independent_review_rejected",
+        ("self_review_only", None): "independent_review_missing",
+        ("unreviewed", None): "independent_review_missing",
+    }.get((state, verdict))
+
+
+def _result_parts(
+    result: Mapping[str, Any] | None,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    if not isinstance(result, Mapping):
+        return {}, {}
+    decision = result.get("terminal_decision")
+    review = result.get("peer_review")
+    return (
+        decision if isinstance(decision, Mapping) else {},
+        review if isinstance(review, Mapping) else {},
+    )
+
+
+def _lineage_state(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    expected_lineage: AutoResearchContractLineage,
+) -> tuple[list[str], list[Mapping[str, Any]]]:
+    observed_revisions = sorted(
+        {
+            str(_details(event).get("contract_revision") or "")
+            for event in events
+            if _details(event).get("contract_revision")
+        }
+    )
+    current = [
+        event
+        for event in events
+        if auto_research_contract_lineage_matches(
+            _details(event),
+            expected=expected_lineage,
+        )
+    ]
+    return observed_revisions, current
+
+
+def _result_artifact_refs(
+    result: Mapping[str, Any] | None,
+    *,
+    decision: Mapping[str, Any],
+    review: Mapping[str, Any],
+) -> list[str]:
+    if not isinstance(result, Mapping) or result.get("decision_state") != "current":
+        return []
+    refs = list(decision.get("evidence_refs") or [])
+    refs.extend(
+        str(ref)
+        for item in review.get("reviews") or []
+        if isinstance(item, Mapping)
+        for ref in item.get("evidence_refs") or []
+    )
+    return refs
+
+
+def _has_complete_research_lineage(
+    events: Sequence[Mapping[str, Any]],
+) -> bool:
+    event_kinds = {str(event.get("event_kind") or "") for event in events}
+    return {"research_hypothesis", "research_evidence"} <= event_kinds
+
+
+def _criterion_artifact_state(
+    criterion: Mapping[str, Any],
+    *,
+    current_lineage: Sequence[Mapping[str, Any]],
+    expected_lineage: AutoResearchContractLineage,
+    result: Mapping[str, Any] | None,
+    decision: Mapping[str, Any],
+    review: Mapping[str, Any],
+) -> tuple[list[str], list[str]]:
+    if not _has_complete_research_lineage(current_lineage):
+        return [], sorted(criterion["required_artifact_refs"])
+    observed = sorted(
+        set(
+            _artifact_refs(
+                current_lineage,
+                expected_lineage=expected_lineage,
+            )
+        )
+        | set(
+            _result_artifact_refs(
+                result,
+                decision=decision,
+                review=review,
+            )
+        )
+    )
+    missing = sorted(set(criterion["required_artifact_refs"]) - set(observed))
+    return observed, missing
+
+
+def _criterion_status(
+    criterion: Mapping[str, Any],
+    *,
+    result: Mapping[str, Any] | None,
+    decision: Mapping[str, Any],
+    review: Mapping[str, Any],
+    current_lineage: Sequence[Mapping[str, Any]],
+    observed_revisions: Sequence[str],
+    missing_artifacts: Sequence[str],
+) -> str:
+    if observed_revisions and not current_lineage:
+        return "stale"
+    if not _has_complete_research_lineage(current_lineage) or result is None:
+        return "inconclusive"
+    if result.get("decision_state") == "stale":
+        return "stale"
+    if result.get("decision_state") == "conflict":
+        return "inconclusive"
+    independent_approved = (
+        review.get("state") == "independent_reviewed"
+        and review.get("verdict") == "approve"
+    )
+    review_satisfied = (
+        not criterion["requires_independent_review"] or independent_approved
+    )
+    if decision.get("outcome") == "retired":
+        return "not_fulfilled" if review_satisfied else "inconclusive"
+    if decision.get("outcome") != "promoted" or not review_satisfied:
+        return "inconclusive"
+    return "partial" if missing_artifacts else "verified"
+
+
+def _criterion_failure_kind(
+    *,
+    status: str,
+    criterion: Mapping[str, Any],
+    result: Mapping[str, Any] | None,
+    evidence_node: Mapping[str, Any] | None,
+    review: Mapping[str, Any],
+    current_lineage: Sequence[Mapping[str, Any]],
+) -> str:
+    if status == "stale":
+        return "contract_revision_changed"
+    if status == "partial":
+        return "required_artifact_missing"
+    if (
+        status == "inconclusive"
+        and not _has_complete_research_lineage(current_lineage)
+    ):
+        return "contract_evidence_missing"
+    review_failure = _review_failure_kind(review)
+    if isinstance(result, Mapping) and _result_has_review_failure(
+        criterion,
+        result=result,
+        review=review,
+        review_failure=review_failure,
+    ):
+        return _failure_kind(result)
+    if (
+        status != "verified"
+        and isinstance(evidence_node, Mapping)
+        and evidence_node.get("failure_kind")
+    ):
+        return str(evidence_node["failure_kind"])
+    if status != "verified" and isinstance(result, Mapping):
+        return _failure_kind(result)
+    return ""
+
+
+def _result_has_review_failure(
+    criterion: Mapping[str, Any],
+    *,
+    result: Mapping[str, Any],
+    review: Mapping[str, Any],
+    review_failure: str | None,
+) -> bool:
+    return (
+        result.get("decision_state") == "conflict"
+        or review.get("state") == "conflict"
+        or (
+            criterion["requires_independent_review"]
+            and review_failure == "independent_review_missing"
+        )
+        or review_failure
+        in {"needs_more_evidence", "independent_review_rejected"}
+    )
+
+
 def _criterion_result(
     criterion: Mapping[str, Any],
     *,
     result: Mapping[str, Any] | None,
     evidence_node: Mapping[str, Any] | None,
     lineage_events: Sequence[Mapping[str, Any]],
-    contract_revision: str,
+    expected_lineage: AutoResearchContractLineage,
 ) -> dict[str, Any]:
-    observed_revisions = sorted(
-        {
-            str(_details(event).get("contract_revision") or "")
-            for event in lineage_events
-            if _details(event).get("contract_revision")
-        }
+    observed_revisions, current_lineage = _lineage_state(
+        lineage_events,
+        expected_lineage=expected_lineage,
     )
-    current_lineage = [
-        event
-        for event in lineage_events
-        if str(_details(event).get("contract_revision") or "")
-        == contract_revision
-    ]
-    review = (
-        result.get("peer_review")
-        if isinstance(result, Mapping)
-        and isinstance(result.get("peer_review"), Mapping)
-        else {}
-    )
-    decision = (
-        result.get("terminal_decision")
-        if isinstance(result, Mapping)
-        and isinstance(result.get("terminal_decision"), Mapping)
-        else {}
-    )
-    result_artifact_refs: list[str] = []
-    if isinstance(result, Mapping) and result.get("decision_state") == "current":
-        result_artifact_refs.extend(decision.get("evidence_refs") or [])
-        for item in review.get("reviews") or []:
-            if isinstance(item, Mapping):
-                result_artifact_refs.extend(item.get("evidence_refs") or [])
-    observed_artifacts = sorted(
-        set(
-            _artifact_refs(
-                lineage_events,
-                contract_revision=contract_revision,
-            )
-        )
-        | {str(ref) for ref in result_artifact_refs if str(ref).strip()}
-    )
-    missing_artifacts = sorted(
-        set(criterion["required_artifact_refs"]) - set(observed_artifacts)
+    decision, review = _result_parts(result)
+    observed_artifacts, missing_artifacts = _criterion_artifact_state(
+        criterion,
+        current_lineage=current_lineage,
+        expected_lineage=expected_lineage,
+        result=result,
+        decision=decision,
+        review=review,
     )
 
-    if observed_revisions and not current_lineage:
-        status = "stale"
-    elif not current_lineage or result is None:
-        status = "inconclusive"
-    elif result.get("decision_state") in {"conflict", "stale"}:
-        status = (
-            "stale"
-            if result.get("decision_state") == "stale"
-            else "inconclusive"
-        )
-    elif decision.get("outcome") == "retired":
-        independently_confirmed = (
-            not criterion["requires_independent_review"]
-            or (
-                review.get("state") == "independent_reviewed"
-                and review.get("verdict") == "approve"
-            )
-        )
-        status = "not_fulfilled" if independently_confirmed else "inconclusive"
-    elif decision.get("outcome") != "promoted":
-        status = "inconclusive"
-    elif criterion["requires_independent_review"] and not (
-        review.get("state") == "independent_reviewed"
-        and review.get("verdict") == "approve"
-    ):
-        status = "inconclusive"
-    elif missing_artifacts:
-        status = "partial"
-    else:
-        status = "verified"
-
-    if status == "stale":
-        failure_kind = "contract_revision_changed"
-    elif status == "partial":
-        failure_kind = "required_artifact_missing"
-    elif status == "inconclusive" and not current_lineage:
-        failure_kind = "contract_evidence_missing"
-    elif (
-        isinstance(result, Mapping)
-        and (
-            result.get("decision_state") == "conflict"
-            or review.get("state") == "conflict"
-            or (
-                criterion["requires_independent_review"]
-                and review.get("state") in {"self_review_only", "unreviewed"}
-            )
-            or review.get("verdict") in {"needs_more_evidence", "reject"}
-        )
-    ):
-        failure_kind = _failure_kind(result)
-    elif (
-        isinstance(evidence_node, Mapping)
-        and evidence_node.get("failure_kind")
-        and status != "verified"
-    ):
-        failure_kind = str(evidence_node["failure_kind"])
-    elif isinstance(result, Mapping) and status != "verified":
-        failure_kind = _failure_kind(result)
-    else:
-        failure_kind = ""
+    status = _criterion_status(
+        criterion,
+        result=result,
+        decision=decision,
+        review=review,
+        current_lineage=current_lineage,
+        observed_revisions=observed_revisions,
+        missing_artifacts=missing_artifacts,
+    )
+    failure_kind = _criterion_failure_kind(
+        status=status,
+        criterion=criterion,
+        result=result,
+        evidence_node=evidence_node,
+        review=review,
+        current_lineage=current_lineage,
+    )
     return {
         "criterion_id": criterion["criterion_id"],
         "description": criterion["description"],
@@ -225,23 +346,27 @@ def _criterion_result(
         "required_artifact_refs": list(criterion["required_artifact_refs"]),
         "observed_artifact_refs": observed_artifacts,
         "missing_artifact_refs": missing_artifacts,
-        "decision_state": (
-            str(result.get("decision_state") or "missing")
-            if isinstance(result, Mapping)
-            else "missing"
-        ),
+        "decision_state": _decision_state(result),
         "terminal_outcome": str(decision.get("outcome") or ""),
         "terminal_reason": str(decision.get("reason") or ""),
         "review_state": str(review.get("state") or "not_applicable"),
         "review_verdict": str(review.get("verdict") or ""),
         "failure_kind": failure_kind,
-        "measurement_scope": (
-            str(evidence_node.get("measurement_scope") or "")
-            if isinstance(evidence_node, Mapping)
-            else ""
-        ),
+        "measurement_scope": _measurement_scope(evidence_node),
         "observed_contract_revisions": observed_revisions,
     }
+
+
+def _decision_state(result: Mapping[str, Any] | None) -> str:
+    if not isinstance(result, Mapping):
+        return "missing"
+    return str(result.get("decision_state") or "missing")
+
+
+def _measurement_scope(evidence_node: Mapping[str, Any] | None) -> str:
+    if not isinstance(evidence_node, Mapping):
+        return ""
+    return str(evidence_node.get("measurement_scope") or "")
 
 
 def _receipt_status(
@@ -288,24 +413,11 @@ def _failure_feedback(
         if item.get("status") == "verified"
     ]
     fallbacks = sorted(set(fallback_artifact_refs) & set(observed_artifact_refs))
-    derived_reentry = [
-        f"resolve:{item['criterion_id']}:{item['failure_kind']}"
-        for item in failed
-    ]
-    failure_kinds = {
-        str(item.get("failure_kind") or "")
-        for item in failed
-        if item.get("failure_kind")
-    }
-    if contract_state == "missing":
-        failure_kinds.add("contract_record_missing")
-        derived_reentry.insert(0, "record_current_delivery_contract")
-    if missing_required_artifacts:
-        failure_kinds.add("required_artifact_missing")
-        derived_reentry.extend(
-            f"provide:{artifact_ref}"
-            for artifact_ref in missing_required_artifacts
-        )
+    failure_kinds, derived_reentry = _failure_reentry_details(
+        failed,
+        contract_state=contract_state,
+        missing_required_artifacts=missing_required_artifacts,
+    )
     summaries = {
         "stale": (
             "The delivery contract changed after the recorded research evidence; "
@@ -337,58 +449,75 @@ def _failure_feedback(
     }
 
 
-def build_auto_research_artifact_receipt(
+def _failure_reentry_details(
+    failed: Sequence[Mapping[str, Any]],
     *,
-    delivery_contract: Mapping[str, Any],
-    rollout_events: Sequence[Mapping[str, Any]],
-    registered_agent_ids: Sequence[str],
-) -> dict[str, Any]:
-    contract = normalize_auto_research_delivery_contract(delivery_contract)
-    research_contract = contract["research_contract"]
-    contract_events = _contract_events(
-        rollout_events,
-        wish_id=contract["wish"]["wish_id"],
-    )
-    latest_revision = (
-        str(_details(contract_events[-1]).get("contract_revision") or "")
-        if contract_events
-        else ""
-    )
-    contract_state = (
-        "current"
-        if latest_revision == contract["contract_revision"]
-        else "stale"
-        if latest_revision
-        else "missing"
-    )
-    current_research_events = [
-        event
-        for event in rollout_events
-        if str(event.get("event_kind") or "")
-        not in {"research_hypothesis", "research_evidence"}
-        or str(_details(event).get("contract_revision") or "")
-        == contract["contract_revision"]
-    ]
-    evidence_graph = build_research_evidence_graph_from_rollout_events(
-        goal_id=research_contract["goal_id"],
-        rollout_events=[dict(event) for event in current_research_events],
-    )
-    query = build_terminal_result_query(
-        evidence_graph=evidence_graph,
-        rollout_events=rollout_events,
-        registered_agent_ids=registered_agent_ids,
-        include_history=True,
-    )
-    results = {
-        str(item.get("hypothesis_id") or ""): item
-        for item in query["results"]
+    contract_state: str,
+    missing_required_artifacts: Sequence[str],
+) -> tuple[set[str], list[str]]:
+    failure_kinds = {
+        str(item.get("failure_kind") or "")
+        for item in failed
+        if item.get("failure_kind")
     }
-    evidence_nodes = {
+    reentry = [
+        f"resolve:{item['criterion_id']}:{item['failure_kind']}"
+        for item in failed
+    ]
+    if contract_state == "missing":
+        failure_kinds.add("contract_record_missing")
+        reentry.insert(0, "record_current_delivery_contract")
+    if missing_required_artifacts:
+        failure_kinds.add("required_artifact_missing")
+        reentry.extend(
+            f"provide:{artifact_ref}"
+            for artifact_ref in missing_required_artifacts
+        )
+    return failure_kinds, reentry
+
+
+def _contract_state(
+    contract_events: Sequence[Mapping[str, Any]],
+    *,
+    expected_lineage: AutoResearchContractLineage,
+) -> tuple[str | None, str]:
+    latest_revision = None
+    if contract_events:
+        latest_revision = (
+            str(_details(contract_events[-1]).get("contract_revision") or "")
+            or None
+        )
+    if latest_revision is None:
+        return None, "missing"
+    if contract_events and auto_research_contract_lineage_matches(
+        _details(contract_events[-1]),
+        expected=expected_lineage,
+    ):
+        return latest_revision, "current"
+    return latest_revision, "stale"
+
+
+def _indexed_records(
+    records: object,
+) -> dict[str, Mapping[str, Any]]:
+    if not isinstance(records, Sequence):
+        return {}
+    return {
         str(item.get("hypothesis_id") or ""): item
-        for item in evidence_graph.get("nodes") or []
+        for item in records
         if isinstance(item, Mapping)
     }
-    criteria = [
+
+
+def _acceptance_results(
+    *,
+    contract: Mapping[str, Any],
+    rollout_events: Sequence[Mapping[str, Any]],
+    results: Mapping[str, Mapping[str, Any]],
+    evidence_nodes: Mapping[str, Mapping[str, Any]],
+    expected_lineage: AutoResearchContractLineage,
+) -> list[dict[str, Any]]:
+    return [
         _criterion_result(
             criterion,
             result=results.get(criterion["hypothesis_id"]),
@@ -397,24 +526,101 @@ def build_auto_research_artifact_receipt(
                 rollout_events,
                 hypothesis_id=criterion["hypothesis_id"],
             ),
-            contract_revision=contract["contract_revision"],
+            expected_lineage=expected_lineage,
         )
         for criterion in contract["acceptance_criteria"]
     ]
-    observed_artifact_refs = sorted(
+
+
+def _artifact_summary(
+    contract: Mapping[str, Any],
+    criteria: Sequence[Mapping[str, Any]],
+) -> tuple[list[str], list[str]]:
+    observed = sorted(
         {
-            ref
+            str(ref)
             for criterion in criteria
             for ref in criterion["observed_artifact_refs"]
         }
     )
-    missing_required_artifacts = sorted(
+    missing = sorted(
         {
-            artifact["artifact_ref"]
+            str(artifact["artifact_ref"])
             for artifact in contract["required_artifacts"]
             if artifact["required"]
         }
-        - set(observed_artifact_refs)
+        - set(observed)
+    )
+    return observed, missing
+
+
+def _verification_summary(
+    *,
+    criteria: Sequence[Mapping[str, Any]],
+    contract: Mapping[str, Any],
+    evidence_graph_revision: str,
+) -> dict[str, Any]:
+    return {
+        "required_count": sum(item["required"] for item in criteria),
+        "verified_count": sum(
+            item["status"] == "verified" for item in criteria
+        ),
+        "not_fulfilled_count": sum(
+            item["status"] == "not_fulfilled" for item in criteria
+        ),
+        "independent_review_required": any(
+            item["requires_independent_review"]
+            for item in contract["acceptance_criteria"]
+        ),
+        "evidence_graph_revision": evidence_graph_revision,
+    }
+
+
+def build_auto_research_artifact_receipt(
+    *,
+    delivery_contract: Mapping[str, Any],
+    rollout_events: Sequence[Mapping[str, Any]],
+    registered_agent_ids: Sequence[str],
+) -> dict[str, Any]:
+    contract = normalize_auto_research_delivery_contract(delivery_contract)
+    research_contract = contract["research_contract"]
+    expected_lineage = normalize_auto_research_contract_lineage(
+        {
+            "wish_id": contract["wish"]["wish_id"],
+            "contract_ref": contract["contract_ref"],
+            "contract_revision": contract["contract_revision"],
+        },
+        field="delivery_contract",
+        required=True,
+    )
+    contract_events = _contract_events(
+        rollout_events,
+        wish_id=contract["wish"]["wish_id"],
+    )
+    latest_revision, contract_state = _contract_state(
+        contract_events,
+        expected_lineage=expected_lineage,
+    )
+    evidence_graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=research_contract["goal_id"],
+        rollout_events=[dict(event) for event in rollout_events],
+    )
+    query = build_terminal_result_query(
+        evidence_graph=evidence_graph,
+        rollout_events=rollout_events,
+        registered_agent_ids=registered_agent_ids,
+        include_history=True,
+    )
+    criteria = _acceptance_results(
+        contract=contract,
+        rollout_events=rollout_events,
+        results=_indexed_records(query["results"]),
+        evidence_nodes=_indexed_records(evidence_graph.get("nodes")),
+        expected_lineage=expected_lineage,
+    )
+    observed_artifact_refs, missing_required_artifacts = _artifact_summary(
+        contract,
+        criteria,
     )
     status = _receipt_status(
         criteria,
@@ -429,7 +635,7 @@ def build_auto_research_artifact_receipt(
         "contract": {
             "contract_ref": contract["contract_ref"],
             "contract_revision": contract["contract_revision"],
-            "latest_recorded_revision": latest_revision or None,
+            "latest_recorded_revision": latest_revision,
             "state": contract_state,
         },
         "status": status,
@@ -439,22 +645,11 @@ def build_auto_research_artifact_receipt(
             "missing_required_refs": missing_required_artifacts,
         },
         "acceptance_results": criteria,
-        "verification_summary": {
-            "required_count": len(
-                [item for item in criteria if item["required"]]
-            ),
-            "verified_count": len(
-                [item for item in criteria if item["status"] == "verified"]
-            ),
-            "not_fulfilled_count": len(
-                [item for item in criteria if item["status"] == "not_fulfilled"]
-            ),
-            "independent_review_required": any(
-                item["requires_independent_review"]
-                for item in contract["acceptance_criteria"]
-            ),
-            "evidence_graph_revision": query["evidence_graph_revision"],
-        },
+        "verification_summary": _verification_summary(
+            criteria=criteria,
+            contract=contract,
+            evidence_graph_revision=query["evidence_graph_revision"],
+        ),
         "failure_feedback": _failure_feedback(
             status=status,
             contract_state=contract_state,
@@ -467,9 +662,7 @@ def build_auto_research_artifact_receipt(
             observed_artifact_refs=observed_artifact_refs,
         ),
         "learning_disposition": (
-            "candidate"
-            if status in {"verified", "not_fulfilled"}
-            else "none"
+            "candidate" if status in {"verified", "not_fulfilled"} else "none"
         ),
         "boundary": {
             "raw_logs_recorded": False,

--- a/loopx/capabilities/auto_research/artifact_receipt.py
+++ b/loopx/capabilities/auto_research/artifact_receipt.py
@@ -1,0 +1,507 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .delivery_contract import (
+    AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+    normalize_auto_research_delivery_contract,
+)
+from .research_state import build_research_evidence_graph_from_rollout_events
+from .terminal_result_query import build_terminal_result_query
+from ...agent_registry import registered_agent_ids_from_registry
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+
+
+AUTO_RESEARCH_ARTIFACT_RECEIPT_SCHEMA_VERSION = (
+    "auto_research_artifact_receipt_v0"
+)
+ARTIFACT_RECEIPT_STATUSES = {
+    "verified",
+    "partial",
+    "inconclusive",
+    "not_fulfilled",
+    "stale",
+}
+
+
+def _details(event: Mapping[str, Any]) -> Mapping[str, Any]:
+    value = event.get("details")
+    return value if isinstance(value, Mapping) else {}
+
+
+def _contract_events(
+    rollout_events: Sequence[Mapping[str, Any]],
+    *,
+    wish_id: str,
+) -> list[Mapping[str, Any]]:
+    return [
+        event
+        for event in rollout_events
+        if str(event.get("classification") or "")
+        == AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
+        and str(_details(event).get("wish_id") or "") == wish_id
+    ]
+
+
+def _lineage_events(
+    rollout_events: Sequence[Mapping[str, Any]],
+    *,
+    hypothesis_id: str,
+) -> list[Mapping[str, Any]]:
+    return [
+        event
+        for event in rollout_events
+        if str(_details(event).get("hypothesis_id") or "") == hypothesis_id
+        and str(event.get("event_kind") or "")
+        in {"research_hypothesis", "research_evidence"}
+    ]
+
+
+def _artifact_refs(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    contract_revision: str,
+) -> list[str]:
+    refs = {
+        str(ref)
+        for event in events
+        if str(_details(event).get("contract_revision") or "")
+        == contract_revision
+        for ref in event.get("artifact_refs") or []
+        if str(ref).strip()
+    }
+    return sorted(refs)
+
+
+def _failure_kind(result: Mapping[str, Any]) -> str:
+    decision = result.get("terminal_decision")
+    if result.get("decision_state") == "conflict":
+        return "conflicting_terminal_decisions"
+    review = result.get("peer_review")
+    if isinstance(review, Mapping):
+        if review.get("state") == "conflict":
+            return "conflicting_peer_reviews"
+        if review.get("state") == "independent_reviewed":
+            if review.get("verdict") == "needs_more_evidence":
+                return "needs_more_evidence"
+            if review.get("verdict") == "reject":
+                return "independent_review_rejected"
+        if review.get("state") in {"self_review_only", "unreviewed"}:
+            return "independent_review_missing"
+    if (
+        isinstance(decision, Mapping)
+        and decision.get("outcome") == "retired"
+        and decision.get("reason")
+    ):
+        return str(decision["reason"])
+    if result.get("research_status") == "needs_retry":
+        return "research_retry_pending"
+    return "terminal_decision_missing"
+
+
+def _criterion_result(
+    criterion: Mapping[str, Any],
+    *,
+    result: Mapping[str, Any] | None,
+    evidence_node: Mapping[str, Any] | None,
+    lineage_events: Sequence[Mapping[str, Any]],
+    contract_revision: str,
+) -> dict[str, Any]:
+    observed_revisions = sorted(
+        {
+            str(_details(event).get("contract_revision") or "")
+            for event in lineage_events
+            if _details(event).get("contract_revision")
+        }
+    )
+    current_lineage = [
+        event
+        for event in lineage_events
+        if str(_details(event).get("contract_revision") or "")
+        == contract_revision
+    ]
+    review = (
+        result.get("peer_review")
+        if isinstance(result, Mapping)
+        and isinstance(result.get("peer_review"), Mapping)
+        else {}
+    )
+    decision = (
+        result.get("terminal_decision")
+        if isinstance(result, Mapping)
+        and isinstance(result.get("terminal_decision"), Mapping)
+        else {}
+    )
+    result_artifact_refs: list[str] = []
+    if isinstance(result, Mapping) and result.get("decision_state") == "current":
+        result_artifact_refs.extend(decision.get("evidence_refs") or [])
+        for item in review.get("reviews") or []:
+            if isinstance(item, Mapping):
+                result_artifact_refs.extend(item.get("evidence_refs") or [])
+    observed_artifacts = sorted(
+        set(
+            _artifact_refs(
+                lineage_events,
+                contract_revision=contract_revision,
+            )
+        )
+        | {str(ref) for ref in result_artifact_refs if str(ref).strip()}
+    )
+    missing_artifacts = sorted(
+        set(criterion["required_artifact_refs"]) - set(observed_artifacts)
+    )
+
+    if observed_revisions and not current_lineage:
+        status = "stale"
+    elif not current_lineage or result is None:
+        status = "inconclusive"
+    elif result.get("decision_state") in {"conflict", "stale"}:
+        status = (
+            "stale"
+            if result.get("decision_state") == "stale"
+            else "inconclusive"
+        )
+    elif decision.get("outcome") == "retired":
+        independently_confirmed = (
+            not criterion["requires_independent_review"]
+            or (
+                review.get("state") == "independent_reviewed"
+                and review.get("verdict") == "approve"
+            )
+        )
+        status = "not_fulfilled" if independently_confirmed else "inconclusive"
+    elif decision.get("outcome") != "promoted":
+        status = "inconclusive"
+    elif criterion["requires_independent_review"] and not (
+        review.get("state") == "independent_reviewed"
+        and review.get("verdict") == "approve"
+    ):
+        status = "inconclusive"
+    elif missing_artifacts:
+        status = "partial"
+    else:
+        status = "verified"
+
+    if status == "stale":
+        failure_kind = "contract_revision_changed"
+    elif status == "partial":
+        failure_kind = "required_artifact_missing"
+    elif status == "inconclusive" and not current_lineage:
+        failure_kind = "contract_evidence_missing"
+    elif (
+        isinstance(result, Mapping)
+        and (
+            result.get("decision_state") == "conflict"
+            or review.get("state") == "conflict"
+            or (
+                criterion["requires_independent_review"]
+                and review.get("state") in {"self_review_only", "unreviewed"}
+            )
+            or review.get("verdict") in {"needs_more_evidence", "reject"}
+        )
+    ):
+        failure_kind = _failure_kind(result)
+    elif (
+        isinstance(evidence_node, Mapping)
+        and evidence_node.get("failure_kind")
+        and status != "verified"
+    ):
+        failure_kind = str(evidence_node["failure_kind"])
+    elif isinstance(result, Mapping) and status != "verified":
+        failure_kind = _failure_kind(result)
+    else:
+        failure_kind = ""
+    return {
+        "criterion_id": criterion["criterion_id"],
+        "description": criterion["description"],
+        "hypothesis_id": criterion["hypothesis_id"],
+        "required": criterion["required"],
+        "status": status,
+        "required_artifact_refs": list(criterion["required_artifact_refs"]),
+        "observed_artifact_refs": observed_artifacts,
+        "missing_artifact_refs": missing_artifacts,
+        "decision_state": (
+            str(result.get("decision_state") or "missing")
+            if isinstance(result, Mapping)
+            else "missing"
+        ),
+        "terminal_outcome": str(decision.get("outcome") or ""),
+        "terminal_reason": str(decision.get("reason") or ""),
+        "review_state": str(review.get("state") or "not_applicable"),
+        "review_verdict": str(review.get("verdict") or ""),
+        "failure_kind": failure_kind,
+        "measurement_scope": (
+            str(evidence_node.get("measurement_scope") or "")
+            if isinstance(evidence_node, Mapping)
+            else ""
+        ),
+        "observed_contract_revisions": observed_revisions,
+    }
+
+
+def _receipt_status(
+    criteria: Sequence[Mapping[str, Any]],
+    *,
+    missing_required_artifacts: Sequence[str],
+    contract_state: str,
+) -> str:
+    required = [item for item in criteria if item.get("required") is True]
+    statuses = {str(item.get("status") or "") for item in required}
+    if contract_state == "stale" or "stale" in statuses:
+        return "stale"
+    if contract_state != "current":
+        return "inconclusive"
+    if "not_fulfilled" in statuses:
+        return "not_fulfilled"
+    if required and statuses == {"verified"} and not missing_required_artifacts:
+        return "verified"
+    if "verified" in statuses or "partial" in statuses:
+        return "partial"
+    return "inconclusive"
+
+
+def _failure_feedback(
+    *,
+    status: str,
+    contract_state: str,
+    criteria: Sequence[Mapping[str, Any]],
+    missing_required_artifacts: Sequence[str],
+    fallback_artifact_refs: Sequence[str],
+    reentry_conditions: Sequence[str],
+    observed_artifact_refs: Sequence[str],
+) -> dict[str, Any] | None:
+    if status == "verified":
+        return None
+    failed = [
+        item
+        for item in criteria
+        if item.get("required") is True and item.get("status") != "verified"
+    ]
+    verified = [
+        item
+        for item in criteria
+        if item.get("status") == "verified"
+    ]
+    fallbacks = sorted(set(fallback_artifact_refs) & set(observed_artifact_refs))
+    derived_reentry = [
+        f"resolve:{item['criterion_id']}:{item['failure_kind']}"
+        for item in failed
+    ]
+    failure_kinds = {
+        str(item.get("failure_kind") or "")
+        for item in failed
+        if item.get("failure_kind")
+    }
+    if contract_state == "missing":
+        failure_kinds.add("contract_record_missing")
+        derived_reentry.insert(0, "record_current_delivery_contract")
+    if missing_required_artifacts:
+        failure_kinds.add("required_artifact_missing")
+        derived_reentry.extend(
+            f"provide:{artifact_ref}"
+            for artifact_ref in missing_required_artifacts
+        )
+    summaries = {
+        "stale": (
+            "The delivery contract changed after the recorded research evidence; "
+            "rerun the affected criteria against the current contract."
+        ),
+        "not_fulfilled": (
+            "The current evidence supports a terminal conclusion that at least "
+            "one required criterion cannot be fulfilled under this contract."
+        ),
+        "partial": (
+            "Some required criteria or artifacts are verified, but the complete "
+            "delivery contract is not satisfied."
+        ),
+        "inconclusive": (
+            "The available evidence is insufficient for a verified or terminal "
+            "not-fulfilled conclusion."
+        ),
+    }
+    return {
+        "summary": summaries[status],
+        "failure_kinds": sorted(failure_kinds),
+        "unmet_criteria": [str(item["criterion_id"]) for item in failed],
+        "verified_boundary": [str(item["criterion_id"]) for item in verified],
+        "missing_required_artifact_refs": list(missing_required_artifacts),
+        "fallback_artifact_refs": fallbacks,
+        "reentry_conditions": list(
+            dict.fromkeys([*reentry_conditions, *derived_reentry])
+        ),
+    }
+
+
+def build_auto_research_artifact_receipt(
+    *,
+    delivery_contract: Mapping[str, Any],
+    rollout_events: Sequence[Mapping[str, Any]],
+    registered_agent_ids: Sequence[str],
+) -> dict[str, Any]:
+    contract = normalize_auto_research_delivery_contract(delivery_contract)
+    research_contract = contract["research_contract"]
+    contract_events = _contract_events(
+        rollout_events,
+        wish_id=contract["wish"]["wish_id"],
+    )
+    latest_revision = (
+        str(_details(contract_events[-1]).get("contract_revision") or "")
+        if contract_events
+        else ""
+    )
+    contract_state = (
+        "current"
+        if latest_revision == contract["contract_revision"]
+        else "stale"
+        if latest_revision
+        else "missing"
+    )
+    current_research_events = [
+        event
+        for event in rollout_events
+        if str(event.get("event_kind") or "")
+        not in {"research_hypothesis", "research_evidence"}
+        or str(_details(event).get("contract_revision") or "")
+        == contract["contract_revision"]
+    ]
+    evidence_graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=research_contract["goal_id"],
+        rollout_events=[dict(event) for event in current_research_events],
+    )
+    query = build_terminal_result_query(
+        evidence_graph=evidence_graph,
+        rollout_events=rollout_events,
+        registered_agent_ids=registered_agent_ids,
+        include_history=True,
+    )
+    results = {
+        str(item.get("hypothesis_id") or ""): item
+        for item in query["results"]
+    }
+    evidence_nodes = {
+        str(item.get("hypothesis_id") or ""): item
+        for item in evidence_graph.get("nodes") or []
+        if isinstance(item, Mapping)
+    }
+    criteria = [
+        _criterion_result(
+            criterion,
+            result=results.get(criterion["hypothesis_id"]),
+            evidence_node=evidence_nodes.get(criterion["hypothesis_id"]),
+            lineage_events=_lineage_events(
+                rollout_events,
+                hypothesis_id=criterion["hypothesis_id"],
+            ),
+            contract_revision=contract["contract_revision"],
+        )
+        for criterion in contract["acceptance_criteria"]
+    ]
+    observed_artifact_refs = sorted(
+        {
+            ref
+            for criterion in criteria
+            for ref in criterion["observed_artifact_refs"]
+        }
+    )
+    missing_required_artifacts = sorted(
+        {
+            artifact["artifact_ref"]
+            for artifact in contract["required_artifacts"]
+            if artifact["required"]
+        }
+        - set(observed_artifact_refs)
+    )
+    status = _receipt_status(
+        criteria,
+        missing_required_artifacts=missing_required_artifacts,
+        contract_state=contract_state,
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_ARTIFACT_RECEIPT_SCHEMA_VERSION,
+        "goal_id": research_contract["goal_id"],
+        "wish": contract["wish"],
+        "contract": {
+            "contract_ref": contract["contract_ref"],
+            "contract_revision": contract["contract_revision"],
+            "latest_recorded_revision": latest_revision or None,
+            "state": contract_state,
+        },
+        "status": status,
+        "artifacts": {
+            "required": contract["required_artifacts"],
+            "observed_refs": observed_artifact_refs,
+            "missing_required_refs": missing_required_artifacts,
+        },
+        "acceptance_results": criteria,
+        "verification_summary": {
+            "required_count": len(
+                [item for item in criteria if item["required"]]
+            ),
+            "verified_count": len(
+                [item for item in criteria if item["status"] == "verified"]
+            ),
+            "not_fulfilled_count": len(
+                [item for item in criteria if item["status"] == "not_fulfilled"]
+            ),
+            "independent_review_required": any(
+                item["requires_independent_review"]
+                for item in contract["acceptance_criteria"]
+            ),
+            "evidence_graph_revision": query["evidence_graph_revision"],
+        },
+        "failure_feedback": _failure_feedback(
+            status=status,
+            contract_state=contract_state,
+            criteria=criteria,
+            missing_required_artifacts=missing_required_artifacts,
+            fallback_artifact_refs=contract["failure_policy"][
+                "fallback_artifact_refs"
+            ],
+            reentry_conditions=contract["failure_policy"]["reentry_conditions"],
+            observed_artifact_refs=observed_artifact_refs,
+        ),
+        "learning_disposition": (
+            "candidate"
+            if status in {"verified", "not_fulfilled"}
+            else "none"
+        ),
+        "boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "user_acceptance_inferred": False,
+            "automatic_skill_promotion": False,
+        },
+    }
+
+
+def load_auto_research_artifact_receipt(
+    *,
+    contract_path: str | Path,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> dict[str, Any]:
+    raw_contract = json.loads(
+        Path(contract_path).expanduser().read_text(encoding="utf-8")
+    )
+    if not isinstance(raw_contract, Mapping):
+        raise ValueError("delivery contract file must contain a JSON object")
+    contract = normalize_auto_research_delivery_contract(raw_contract)
+    goal_id = contract["research_contract"]["goal_id"]
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    events = load_rollout_events(rollout_event_log_path(runtime_root, goal_id))
+    return build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=events,
+        registered_agent_ids=registered_agent_ids_from_registry(
+            registry_path,
+            goal_id,
+        ),
+    )

--- a/loopx/capabilities/auto_research/catalog_entry.py
+++ b/loopx/capabilities/auto_research/catalog_entry.py
@@ -56,6 +56,11 @@ AUTO_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
             "write_boundary": "read-only projection over rollout and Explore result events",
         },
         {
+            "command": "loopx auto-research artifact-receipt --contract <delivery-contract.json>",
+            "purpose": "Fold one versioned research wish contract, current evidence, terminal decisions, and independent reviews into a read-only delivery receipt.",
+            "write_boundary": "read-only projection; does not infer user acceptance, promote skills, or write project state",
+        },
+        {
             "command": "loopx auto-research project-results --goal-id <goal-id> --execute",
             "purpose": "Project current terminal outcomes into deterministic existing Explore node and finding events.",
             "write_boundary": "goal-scoped Explore result log only; repeated projection is idempotent",
@@ -92,12 +97,23 @@ AUTO_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
             "module": "loopx.capabilities.auto_research.terminal_results",
             "doc": "docs/reference/protocols/decentralized-auto-research-state-v0.md",
         },
+        {
+            "schema_version": "auto_research_delivery_contract_v0",
+            "module": "loopx.capabilities.auto_research.delivery_contract",
+            "doc": "docs/reference/protocols/auto-research-wish-to-artifact-v0.md",
+        },
+        {
+            "schema_version": "auto_research_artifact_receipt_v0",
+            "module": "loopx.capabilities.auto_research.artifact_receipt",
+            "doc": "docs/reference/protocols/auto-research-wish-to-artifact-v0.md",
+        },
     ],
     "smokes": [
         "python3 examples/auto-research-user-contract-entry-smoke.py",
         "python3 examples/auto-research-worker-turn-smoke.py",
         "python3 examples/auto-research-terminal-results-smoke.py",
         "python3 examples/auto-research-terminal-results-cli-smoke.py",
+        "python3 examples/auto-research-artifact-receipt-smoke.py",
     ],
     "docs": [
         "loopx/capabilities/auto_research/README.md",
@@ -108,6 +124,8 @@ AUTO_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
         "Completion and uplift require role-authored evidence and projected outcomes; the launcher does not manufacture research results.",
         "Promotion and retirement candidates are not terminal decisions; explicit decisions bind one hypothesis evidence revision.",
         "Same-agent review remains visible but cannot be labeled independent or upgrade a finding to confirmed or refuted.",
+        "A delivery receipt aggregates existing evidence and never treats one failed attempt as proof that a wish cannot be fulfilled.",
+        "A not-fulfilled receipt requires a terminal retirement decision plus any independent review required by the delivery contract.",
     ],
     "next_real_step": (
         "Use the one-question entrypoint for bounded research and preserve every promoted or rejected outcome in canonical evidence."

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .artifact_receipt import load_auto_research_artifact_receipt
 from .human_view import render_auto_research_markdown
 from .research_state import (
     build_auto_research_projection,
@@ -75,6 +76,7 @@ AUTO_RESEARCH_IO_FAILED_ERROR_CODE = "auto_research_io_failed"
 AUTO_RESEARCH_SUBCOMMANDS = frozenset(
     {
         "append-evidence",
+        "artifact-receipt",
         "capture-live-evidence",
         "contract",
         "decide",
@@ -502,6 +504,20 @@ def register_auto_research_commands(
         "--execute",
         action="store_true",
         help="Append the deterministic Explore events. Omit to preview.",
+    )
+
+    artifact_receipt_parser = auto_research_sub.add_parser(
+        "artifact-receipt",
+        help=(
+            "Build a read-only Wish-to-Artifact receipt from one delivery "
+            "contract and the current Auto Research evidence."
+        ),
+    )
+    add_subcommand_format(artifact_receipt_parser)
+    artifact_receipt_parser.add_argument(
+        "--contract",
+        required=True,
+        help="Path to auto_research_delivery_contract_v0 JSON.",
     )
 
     live_evidence_parser = auto_research_sub.add_parser(
@@ -1245,6 +1261,12 @@ def handle_auto_research_command(
                 goal_id=args.goal_id,
                 dry_run=not args.execute,
             )
+        elif args.auto_research_command == "artifact-receipt":
+            payload = load_auto_research_artifact_receipt(
+                contract_path=args.contract,
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+            )
         elif args.auto_research_command == "capture-live-evidence":
             payload = capture_live_codex_e2e_evidence(
                 packet_path=args.packet,
@@ -1452,7 +1474,7 @@ def handle_auto_research_command(
             raise ValueError(
                 "auto-research requires the `contract`, `frontier`, `evidence`, "
                 "`append-evidence`, `decide`, `review`, `results`, "
-                "`project-results`, `capture-live-evidence`, "
+                "`project-results`, `artifact-receipt`, `capture-live-evidence`, "
                 "`worker-turn`, `worker-loop`, `demo-supervisor`, `demo-e2e`, "
                 "or `start` subcommand"
             )

--- a/loopx/capabilities/auto_research/delivery_contract.py
+++ b/loopx/capabilities/auto_research/delivery_contract.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, NamedTuple
+
+from .evidence_packet import (
+    _compact_public_text,
+    _compact_public_text_list,
+    _compact_public_token,
+    validate_research_contract,
+)
 
 
 AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION = (
@@ -46,6 +53,81 @@ _CRITERION_FIELDS = {
     "required",
 }
 _FAILURE_POLICY_FIELDS = {"fallback_artifact_refs", "reentry_conditions"}
+AUTO_RESEARCH_CONTRACT_LINEAGE_FIELDS = (
+    "wish_id",
+    "contract_ref",
+    "contract_revision",
+)
+
+
+class AutoResearchContractLineage(NamedTuple):
+    wish_id: str
+    contract_ref: str
+    contract_revision: str
+
+
+class AutoResearchContractLineageError(ValueError):
+    pass
+
+
+def normalize_auto_research_contract_lineage(
+    value: Mapping[str, Any],
+    *,
+    field: str,
+    required: bool = False,
+) -> AutoResearchContractLineage | None:
+    supplied = {
+        name
+        for name in AUTO_RESEARCH_CONTRACT_LINEAGE_FIELDS
+        if str(value.get(name) or "").strip()
+    }
+    if not supplied:
+        if required:
+            raise AutoResearchContractLineageError(
+                f"{field} requires complete contract lineage"
+            )
+        return None
+    if supplied != set(AUTO_RESEARCH_CONTRACT_LINEAGE_FIELDS):
+        raise AutoResearchContractLineageError(
+            f"{field} contract lineage must provide wish_id, contract_ref, "
+            "and contract_revision together"
+        )
+    try:
+        return AutoResearchContractLineage(
+            *(
+                _compact_public_text(
+                    value.get(name),
+                    field=f"{field}.{name}",
+                    max_len=180,
+                )
+                for name in AUTO_RESEARCH_CONTRACT_LINEAGE_FIELDS
+            )
+        )
+    except ValueError as exc:
+        raise AutoResearchContractLineageError(str(exc)) from exc
+
+
+def auto_research_contract_lineage_matches(
+    value: Mapping[str, Any],
+    *,
+    expected: AutoResearchContractLineage | None,
+) -> bool:
+    try:
+        return (
+            normalize_auto_research_contract_lineage(
+                value,
+                field="contract_lineage",
+            )
+            == expected
+        )
+    except ValueError:
+        return False
+
+
+def auto_research_contract_lineage_dict(
+    lineage: AutoResearchContractLineage,
+) -> dict[str, str]:
+    return dict(zip(AUTO_RESEARCH_CONTRACT_LINEAGE_FIELDS, lineage))
 
 
 def _strict_mapping(
@@ -100,52 +182,13 @@ def _wish_id(*, goal_id: str, original_text: str) -> str:
     return f"wish_{hashlib.sha256(encoded).hexdigest()[:16]}"
 
 
-def normalize_auto_research_delivery_contract(
-    value: Mapping[str, Any],
+def _normalize_wish(
+    value: object,
+    *,
+    goal_id: str,
 ) -> dict[str, Any]:
-    from .evidence_packet import (
-        _compact_public_text,
-        _compact_public_text_list,
-        _compact_public_token,
-        validate_research_contract,
-    )
-
-    raw = _strict_mapping(
-        value,
-        field="delivery_contract",
-        allowed=_DELIVERY_CONTRACT_FIELDS,
-    )
-    if raw.get("schema_version") != AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION:
-        raise ValueError(
-            "delivery_contract.schema_version must be "
-            f"{AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION}"
-        )
-    research_contract = validate_research_contract(
-        dict(
-            _strict_mapping(
-                raw.get("research_contract"),
-                field="delivery_contract.research_contract",
-                allowed={
-                    "schema_version",
-                    "goal_id",
-                    "research_objective",
-                    "editable_scope",
-                    "protected_scope",
-                    "metric",
-                    "dev_eval",
-                    "holdout_eval",
-                    "promotion_policy",
-                },
-            )
-        )
-    )
-    contract_ref = _compact_public_text(
-        raw.get("contract_ref"),
-        field="delivery_contract.contract_ref",
-        max_len=160,
-    )
     wish = _strict_mapping(
-        raw.get("wish"),
+        value,
         field="delivery_contract.wish",
         allowed=_WISH_FIELDS,
     )
@@ -155,13 +198,13 @@ def normalize_auto_research_delivery_contract(
         max_len=500,
     )
     derived_wish_id = _wish_id(
-        goal_id=research_contract["goal_id"],
+        goal_id=goal_id,
         original_text=original_text,
     )
     provided_wish_id = wish.get("wish_id")
     if provided_wish_id and provided_wish_id != derived_wish_id:
         raise ValueError("delivery_contract.wish.wish_id does not match the wish")
-    normalized_wish = {
+    return {
         "wish_id": derived_wish_id,
         "original_text": original_text,
         "intent_summary": _compact_public_text(
@@ -187,11 +230,13 @@ def normalize_auto_research_delivery_contract(
         ),
     }
 
+
+def _normalize_required_artifacts(value: object) -> list[dict[str, Any]]:
     required_artifacts: list[dict[str, Any]] = []
     seen_artifact_refs: set[str] = set()
     for index, item in enumerate(
         _bounded_list(
-            raw.get("required_artifacts"),
+            value,
             field="delivery_contract.required_artifacts",
             maximum=MAX_REQUIRED_ARTIFACTS,
         )
@@ -243,12 +288,19 @@ def normalize_auto_research_delivery_contract(
         raise ValueError(
             "delivery_contract requires at least one required artifact"
         )
+    return required_artifacts
 
+
+def _normalize_acceptance_criteria(
+    value: object,
+    *,
+    artifact_refs: set[str],
+) -> list[dict[str, Any]]:
     acceptance_criteria: list[dict[str, Any]] = []
     seen_criterion_ids: set[str] = set()
     for index, item in enumerate(
         _bounded_list(
-            raw.get("acceptance_criteria"),
+            value,
             field="delivery_contract.acceptance_criteria",
             maximum=MAX_ACCEPTANCE_CRITERIA,
         )
@@ -282,7 +334,7 @@ def normalize_auto_research_delivery_contract(
                 f"[{index}].required_artifact_refs"
             ),
         )
-        unknown_refs = sorted(set(required_refs) - seen_artifact_refs)
+        unknown_refs = sorted(set(required_refs) - artifact_refs)
         if unknown_refs:
             raise ValueError(
                 "acceptance criteria reference undeclared artifacts: "
@@ -337,9 +389,16 @@ def normalize_auto_research_delivery_contract(
         raise ValueError(
             "delivery_contract requires at least one required acceptance criterion"
         )
+    return acceptance_criteria
 
+
+def _normalize_failure_policy(
+    value: object,
+    *,
+    artifact_refs: set[str],
+) -> dict[str, list[str]]:
     failure_policy = _strict_mapping(
-        raw.get("failure_policy") or {},
+        value or {},
         field="delivery_contract.failure_policy",
         allowed=_FAILURE_POLICY_FIELDS,
     )
@@ -351,30 +410,84 @@ def normalize_auto_research_delivery_contract(
         ),
         field="delivery_contract.failure_policy.fallback_artifact_refs",
     )
-    unknown_fallbacks = sorted(set(fallback_artifact_refs) - seen_artifact_refs)
+    unknown_fallbacks = sorted(set(fallback_artifact_refs) - artifact_refs)
     if unknown_fallbacks:
         raise ValueError(
             "failure policy references undeclared artifacts: "
             + ", ".join(unknown_fallbacks)
         )
+    return {
+        "fallback_artifact_refs": fallback_artifact_refs,
+        "reentry_conditions": _compact_public_text_list(
+            _bounded_list(
+                failure_policy.get("reentry_conditions") or [],
+                field="delivery_contract.failure_policy.reentry_conditions",
+                maximum=MAX_REENTRY_CONDITIONS,
+            ),
+            field="delivery_contract.failure_policy.reentry_conditions",
+        ),
+    }
+
+
+def normalize_auto_research_delivery_contract(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    raw = _strict_mapping(
+        value,
+        field="delivery_contract",
+        allowed=_DELIVERY_CONTRACT_FIELDS,
+    )
+    if raw.get("schema_version") != AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION:
+        raise ValueError(
+            "delivery_contract.schema_version must be "
+            f"{AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION}"
+        )
+    research_contract = validate_research_contract(
+        dict(
+            _strict_mapping(
+                raw.get("research_contract"),
+                field="delivery_contract.research_contract",
+                allowed={
+                    "schema_version",
+                    "goal_id",
+                    "research_objective",
+                    "editable_scope",
+                    "protected_scope",
+                    "metric",
+                    "dev_eval",
+                    "holdout_eval",
+                    "promotion_policy",
+                },
+            )
+        )
+    )
+    required_artifacts = _normalize_required_artifacts(
+        raw.get("required_artifacts")
+    )
+    artifact_refs = {
+        str(artifact["artifact_ref"]) for artifact in required_artifacts
+    }
     normalized = {
         "schema_version": AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
-        "contract_ref": contract_ref,
-        "wish": normalized_wish,
+        "contract_ref": _compact_public_text(
+            raw.get("contract_ref"),
+            field="delivery_contract.contract_ref",
+            max_len=160,
+        ),
+        "wish": _normalize_wish(
+            raw.get("wish"),
+            goal_id=research_contract["goal_id"],
+        ),
         "research_contract": research_contract,
         "required_artifacts": required_artifacts,
-        "acceptance_criteria": acceptance_criteria,
-        "failure_policy": {
-            "fallback_artifact_refs": fallback_artifact_refs,
-            "reentry_conditions": _compact_public_text_list(
-                _bounded_list(
-                    failure_policy.get("reentry_conditions") or [],
-                    field="delivery_contract.failure_policy.reentry_conditions",
-                    maximum=MAX_REENTRY_CONDITIONS,
-                ),
-                field="delivery_contract.failure_policy.reentry_conditions",
-            ),
-        },
+        "acceptance_criteria": _normalize_acceptance_criteria(
+            raw.get("acceptance_criteria"),
+            artifact_refs=artifact_refs,
+        ),
+        "failure_policy": _normalize_failure_policy(
+            raw.get("failure_policy"),
+            artifact_refs=artifact_refs,
+        ),
     }
     contract_revision = _canonical_digest(normalized)
     provided_revision = raw.get("contract_revision")

--- a/loopx/capabilities/auto_research/delivery_contract.py
+++ b/loopx/capabilities/auto_research/delivery_contract.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION = (
+    "auto_research_delivery_contract_v0"
+)
+AUTO_RESEARCH_CONTRACT_LINEAGE_SCHEMA_VERSION = (
+    "auto_research_contract_lineage_v0"
+)
+
+MAX_ASSUMPTIONS = 8
+MAX_NON_GOALS = 8
+MAX_REQUIRED_ARTIFACTS = 12
+MAX_ACCEPTANCE_CRITERIA = 12
+MAX_REENTRY_CONDITIONS = 8
+
+_DELIVERY_CONTRACT_FIELDS = {
+    "schema_version",
+    "contract_ref",
+    "contract_revision",
+    "wish",
+    "research_contract",
+    "required_artifacts",
+    "acceptance_criteria",
+    "failure_policy",
+}
+_WISH_FIELDS = {
+    "wish_id",
+    "original_text",
+    "intent_summary",
+    "assumptions",
+    "non_goals",
+}
+_ARTIFACT_FIELDS = {"artifact_ref", "kind", "description", "required"}
+_CRITERION_FIELDS = {
+    "criterion_id",
+    "description",
+    "hypothesis_id",
+    "required_artifact_refs",
+    "requires_independent_review",
+    "required",
+}
+_FAILURE_POLICY_FIELDS = {"fallback_artifact_refs", "reentry_conditions"}
+
+
+def _strict_mapping(
+    value: object,
+    *,
+    field: str,
+    allowed: set[str],
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{field} must be an object")
+    unexpected = sorted(set(value) - allowed)
+    if unexpected:
+        raise ValueError(
+            f"{field} contains unsupported fields: {', '.join(unexpected)}"
+        )
+    return value
+
+
+def _bounded_list(
+    value: object,
+    *,
+    field: str,
+    maximum: int,
+) -> Sequence[Any]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{field} must be a list")
+    if len(value) > maximum:
+        raise ValueError(f"{field} must contain at most {maximum} items")
+    return value
+
+
+def _boolean(value: object, *, field: str, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise ValueError(f"{field} must be a boolean")
+    return value
+
+
+def _canonical_digest(value: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _wish_id(*, goal_id: str, original_text: str) -> str:
+    encoded = f"{goal_id}\n{original_text}".encode("utf-8")
+    return f"wish_{hashlib.sha256(encoded).hexdigest()[:16]}"
+
+
+def normalize_auto_research_delivery_contract(
+    value: Mapping[str, Any],
+) -> dict[str, Any]:
+    from .evidence_packet import (
+        _compact_public_text,
+        _compact_public_text_list,
+        _compact_public_token,
+        validate_research_contract,
+    )
+
+    raw = _strict_mapping(
+        value,
+        field="delivery_contract",
+        allowed=_DELIVERY_CONTRACT_FIELDS,
+    )
+    if raw.get("schema_version") != AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION:
+        raise ValueError(
+            "delivery_contract.schema_version must be "
+            f"{AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION}"
+        )
+    research_contract = validate_research_contract(
+        dict(
+            _strict_mapping(
+                raw.get("research_contract"),
+                field="delivery_contract.research_contract",
+                allowed={
+                    "schema_version",
+                    "goal_id",
+                    "research_objective",
+                    "editable_scope",
+                    "protected_scope",
+                    "metric",
+                    "dev_eval",
+                    "holdout_eval",
+                    "promotion_policy",
+                },
+            )
+        )
+    )
+    contract_ref = _compact_public_text(
+        raw.get("contract_ref"),
+        field="delivery_contract.contract_ref",
+        max_len=160,
+    )
+    wish = _strict_mapping(
+        raw.get("wish"),
+        field="delivery_contract.wish",
+        allowed=_WISH_FIELDS,
+    )
+    original_text = _compact_public_text(
+        wish.get("original_text"),
+        field="delivery_contract.wish.original_text",
+        max_len=500,
+    )
+    derived_wish_id = _wish_id(
+        goal_id=research_contract["goal_id"],
+        original_text=original_text,
+    )
+    provided_wish_id = wish.get("wish_id")
+    if provided_wish_id and provided_wish_id != derived_wish_id:
+        raise ValueError("delivery_contract.wish.wish_id does not match the wish")
+    normalized_wish = {
+        "wish_id": derived_wish_id,
+        "original_text": original_text,
+        "intent_summary": _compact_public_text(
+            wish.get("intent_summary"),
+            field="delivery_contract.wish.intent_summary",
+            max_len=300,
+        ),
+        "assumptions": _compact_public_text_list(
+            _bounded_list(
+                wish.get("assumptions") or [],
+                field="delivery_contract.wish.assumptions",
+                maximum=MAX_ASSUMPTIONS,
+            ),
+            field="delivery_contract.wish.assumptions",
+        ),
+        "non_goals": _compact_public_text_list(
+            _bounded_list(
+                wish.get("non_goals") or [],
+                field="delivery_contract.wish.non_goals",
+                maximum=MAX_NON_GOALS,
+            ),
+            field="delivery_contract.wish.non_goals",
+        ),
+    }
+
+    required_artifacts: list[dict[str, Any]] = []
+    seen_artifact_refs: set[str] = set()
+    for index, item in enumerate(
+        _bounded_list(
+            raw.get("required_artifacts"),
+            field="delivery_contract.required_artifacts",
+            maximum=MAX_REQUIRED_ARTIFACTS,
+        )
+    ):
+        artifact = _strict_mapping(
+            item,
+            field=f"delivery_contract.required_artifacts[{index}]",
+            allowed=_ARTIFACT_FIELDS,
+        )
+        artifact_ref = _compact_public_text(
+            artifact.get("artifact_ref"),
+            field=f"delivery_contract.required_artifacts[{index}].artifact_ref",
+            max_len=180,
+        )
+        if artifact_ref in seen_artifact_refs:
+            raise ValueError(
+                "delivery_contract.required_artifacts artifact_ref values "
+                "must be unique"
+            )
+        seen_artifact_refs.add(artifact_ref)
+        required_artifacts.append(
+            {
+                "artifact_ref": artifact_ref,
+                "kind": _compact_public_token(
+                    artifact.get("kind"),
+                    field=f"delivery_contract.required_artifacts[{index}].kind",
+                ),
+                "description": _compact_public_text(
+                    artifact.get("description"),
+                    field=(
+                        "delivery_contract.required_artifacts"
+                        f"[{index}].description"
+                    ),
+                    max_len=300,
+                ),
+                "required": _boolean(
+                    artifact.get("required"),
+                    field=(
+                        "delivery_contract.required_artifacts"
+                        f"[{index}].required"
+                    ),
+                    default=True,
+                ),
+            }
+        )
+    if not required_artifacts:
+        raise ValueError("delivery_contract requires at least one artifact")
+    if not any(item["required"] for item in required_artifacts):
+        raise ValueError(
+            "delivery_contract requires at least one required artifact"
+        )
+
+    acceptance_criteria: list[dict[str, Any]] = []
+    seen_criterion_ids: set[str] = set()
+    for index, item in enumerate(
+        _bounded_list(
+            raw.get("acceptance_criteria"),
+            field="delivery_contract.acceptance_criteria",
+            maximum=MAX_ACCEPTANCE_CRITERIA,
+        )
+    ):
+        criterion = _strict_mapping(
+            item,
+            field=f"delivery_contract.acceptance_criteria[{index}]",
+            allowed=_CRITERION_FIELDS,
+        )
+        criterion_id = _compact_public_token(
+            criterion.get("criterion_id"),
+            field=f"delivery_contract.acceptance_criteria[{index}].criterion_id",
+        )
+        if criterion_id in seen_criterion_ids:
+            raise ValueError(
+                "delivery_contract.acceptance_criteria criterion_id values "
+                "must be unique"
+            )
+        seen_criterion_ids.add(criterion_id)
+        required_refs = _compact_public_text_list(
+            _bounded_list(
+                criterion.get("required_artifact_refs") or [],
+                field=(
+                    "delivery_contract.acceptance_criteria"
+                    f"[{index}].required_artifact_refs"
+                ),
+                maximum=MAX_REQUIRED_ARTIFACTS,
+            ),
+            field=(
+                "delivery_contract.acceptance_criteria"
+                f"[{index}].required_artifact_refs"
+            ),
+        )
+        unknown_refs = sorted(set(required_refs) - seen_artifact_refs)
+        if unknown_refs:
+            raise ValueError(
+                "acceptance criteria reference undeclared artifacts: "
+                + ", ".join(unknown_refs)
+            )
+        if len(set(required_refs)) != len(required_refs):
+            raise ValueError(
+                "acceptance criteria required_artifact_refs must be unique"
+            )
+        acceptance_criteria.append(
+            {
+                "criterion_id": criterion_id,
+                "description": _compact_public_text(
+                    criterion.get("description"),
+                    field=(
+                        "delivery_contract.acceptance_criteria"
+                        f"[{index}].description"
+                    ),
+                    max_len=300,
+                ),
+                "hypothesis_id": _compact_public_token(
+                    criterion.get("hypothesis_id"),
+                    field=(
+                        "delivery_contract.acceptance_criteria"
+                        f"[{index}].hypothesis_id"
+                    ),
+                ),
+                "required_artifact_refs": required_refs,
+                "requires_independent_review": _boolean(
+                    criterion.get("requires_independent_review"),
+                    field=(
+                        "delivery_contract.acceptance_criteria"
+                        f"[{index}].requires_independent_review"
+                    ),
+                    default=True,
+                ),
+                "required": _boolean(
+                    criterion.get("required"),
+                    field=(
+                        "delivery_contract.acceptance_criteria"
+                        f"[{index}].required"
+                    ),
+                    default=True,
+                ),
+            }
+        )
+    if not acceptance_criteria:
+        raise ValueError(
+            "delivery_contract requires at least one acceptance criterion"
+        )
+    if not any(item["required"] for item in acceptance_criteria):
+        raise ValueError(
+            "delivery_contract requires at least one required acceptance criterion"
+        )
+
+    failure_policy = _strict_mapping(
+        raw.get("failure_policy") or {},
+        field="delivery_contract.failure_policy",
+        allowed=_FAILURE_POLICY_FIELDS,
+    )
+    fallback_artifact_refs = _compact_public_text_list(
+        _bounded_list(
+            failure_policy.get("fallback_artifact_refs") or [],
+            field="delivery_contract.failure_policy.fallback_artifact_refs",
+            maximum=MAX_REQUIRED_ARTIFACTS,
+        ),
+        field="delivery_contract.failure_policy.fallback_artifact_refs",
+    )
+    unknown_fallbacks = sorted(set(fallback_artifact_refs) - seen_artifact_refs)
+    if unknown_fallbacks:
+        raise ValueError(
+            "failure policy references undeclared artifacts: "
+            + ", ".join(unknown_fallbacks)
+        )
+    normalized = {
+        "schema_version": AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+        "contract_ref": contract_ref,
+        "wish": normalized_wish,
+        "research_contract": research_contract,
+        "required_artifacts": required_artifacts,
+        "acceptance_criteria": acceptance_criteria,
+        "failure_policy": {
+            "fallback_artifact_refs": fallback_artifact_refs,
+            "reentry_conditions": _compact_public_text_list(
+                _bounded_list(
+                    failure_policy.get("reentry_conditions") or [],
+                    field="delivery_contract.failure_policy.reentry_conditions",
+                    maximum=MAX_REENTRY_CONDITIONS,
+                ),
+                field="delivery_contract.failure_policy.reentry_conditions",
+            ),
+        },
+    }
+    contract_revision = _canonical_digest(normalized)
+    provided_revision = raw.get("contract_revision")
+    if provided_revision and provided_revision != contract_revision:
+        raise ValueError(
+            "delivery_contract.contract_revision does not match normalized content"
+        )
+    normalized["contract_revision"] = contract_revision
+    return normalized
+
+
+def build_auto_research_contract_lineage(
+    research_contract: Mapping[str, Any],
+    *,
+    delivery_contract: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if delivery_contract:
+        normalized_delivery = normalize_auto_research_delivery_contract(
+            delivery_contract
+        )
+        return {
+            "schema_version": AUTO_RESEARCH_CONTRACT_LINEAGE_SCHEMA_VERSION,
+            "contract_revision": normalized_delivery["contract_revision"],
+            "contract_ref": normalized_delivery["contract_ref"],
+            "wish_id": normalized_delivery["wish"]["wish_id"],
+            "delivery_contract_schema_version": (
+                AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
+            ),
+        }
+    return {
+        "schema_version": AUTO_RESEARCH_CONTRACT_LINEAGE_SCHEMA_VERSION,
+        "contract_revision": _canonical_digest(dict(research_contract)),
+        "contract_ref": None,
+        "wish_id": None,
+        "delivery_contract_schema_version": None,
+    }

--- a/loopx/capabilities/auto_research/evidence_packet.py
+++ b/loopx/capabilities/auto_research/evidence_packet.py
@@ -337,7 +337,7 @@ def validate_research_hypothesis(item: dict[str, Any]) -> dict[str, Any]:
     status = _compact_public_token(item.get("status"), field="hypothesis.status")
     if status not in HYPOTHESIS_STATUSES:
         raise ValueError(f"hypothesis.status must be one of {', '.join(sorted(HYPOTHESIS_STATUSES))}")
-    return {
+    normalized = {
         "schema_version": schema,
         "hypothesis_id": _compact_public_token(item.get("hypothesis_id"), field="hypothesis_id"),
         "parent_hypothesis_id": (
@@ -358,6 +358,14 @@ def validate_research_hypothesis(item: dict[str, Any]) -> dict[str, Any]:
         ),
         "blocked_by": _compact_public_text_list(item.get("blocked_by"), field="blocked_by"),
     }
+    for field in ("wish_id", "contract_ref", "contract_revision"):
+        if item.get(field):
+            normalized[field] = _compact_public_text(
+                item.get(field),
+                field=f"hypothesis.{field}",
+                max_len=180,
+            )
+    return normalized
 
 
 def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
@@ -387,7 +395,7 @@ def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(
             "remediation attempts require data_or_measurement_gap failure_kind"
         )
-    return {
+    normalized = {
         "schema_version": schema,
         "hypothesis_id": _compact_public_token(item.get("hypothesis_id"), field="hypothesis_id"),
         "todo_id": _compact_public_token(item.get("todo_id"), field="todo_id"),
@@ -413,6 +421,14 @@ def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
         "raw_logs_recorded": False,
         "private_artifacts_recorded": False,
     }
+    for field in ("wish_id", "contract_ref", "contract_revision"):
+        if item.get(field):
+            normalized[field] = _compact_public_text(
+                item.get(field),
+                field=f"evidence.{field}",
+                max_len=180,
+            )
+    return normalized
 
 
 def _load_json_object(path: str | Path, *, field: str) -> dict[str, Any]:
@@ -527,11 +543,28 @@ def build_auto_research_evidence_packet(
 ) -> dict[str, Any]:
     """Build public-safe research hypothesis/evidence records from eval outputs."""
 
+    from .delivery_contract import (
+        AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+        build_auto_research_contract_lineage,
+        normalize_auto_research_delivery_contract,
+    )
+
+    delivery_contract: dict[str, Any] | None = None
+    if (
+        contract.get("schema_version")
+        == AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
+    ):
+        delivery_contract = normalize_auto_research_delivery_contract(contract)
+        contract = delivery_contract["research_contract"]
     normalized_contract, benchmark_context = _normalize_research_contract_for_packet(
         contract,
         contract_root=Path(contract_root).expanduser() if contract_root else None,
     )
     contract = normalized_contract
+    contract_lineage = build_auto_research_contract_lineage(
+        contract,
+        delivery_contract=delivery_contract,
+    )
     if not eval_results:
         raise ValueError("at least one eval result is required")
     hypothesis_token = _compact_public_token(hypothesis_id, field="hypothesis_id")
@@ -550,6 +583,15 @@ def build_auto_research_evidence_packet(
         )
         for index, result in enumerate(eval_results)
     ]
+    if contract_lineage.get("wish_id"):
+        for event in events:
+            event.update(
+                {
+                    "wish_id": contract_lineage["wish_id"],
+                    "contract_ref": contract_lineage["contract_ref"],
+                    "contract_revision": contract_lineage["contract_revision"],
+                }
+            )
     status = _derive_hypothesis_status(events)
     blocked_by = []
     if status == "contradicted":
@@ -567,10 +609,17 @@ def build_auto_research_evidence_packet(
             "grounding_refs": grounding_refs or [],
             "novelty_audit_ref": novelty_audit_ref,
             "blocked_by": blocked_by,
+            "wish_id": contract_lineage.get("wish_id"),
+            "contract_ref": contract_lineage.get("contract_ref"),
+            "contract_revision": (
+                contract_lineage["contract_revision"]
+                if contract_lineage.get("wish_id")
+                else None
+            ),
         }
     )
     negative_count = len([event for event in events if _is_negative_evidence_event(event)])
-    return {
+    packet = {
         "ok": True,
         "schema_version": AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION,
         "research_contract": contract,
@@ -593,6 +642,10 @@ def build_auto_research_evidence_packet(
             "source": "public_eval_result_projection",
         },
     }
+    if delivery_contract:
+        packet["delivery_contract"] = delivery_contract
+        packet["contract_lineage"] = contract_lineage
+    return packet
 
 
 def load_auto_research_evidence_packet_inputs(
@@ -620,6 +673,11 @@ def load_auto_research_evidence_packet(path: str | Path) -> dict[str, Any]:
 
 
 def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str, Any]:
+    from .delivery_contract import (
+        build_auto_research_contract_lineage,
+        normalize_auto_research_delivery_contract,
+    )
+
     payload = _json_obj(payload, field="auto_research_evidence_packet")
     schema = _compact_public_token(payload.get("schema_version"), field="schema_version")
     if schema != AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION:
@@ -627,6 +685,32 @@ def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str,
     if payload.get("ok") is False:
         raise ValueError("auto_research_evidence_packet.ok must not be false")
     contract = validate_research_contract(_json_obj(payload.get("research_contract"), field="research_contract"))
+    delivery_contract = (
+        normalize_auto_research_delivery_contract(
+            _json_obj(
+                payload.get("delivery_contract"),
+                field="delivery_contract",
+            )
+        )
+        if payload.get("delivery_contract") is not None
+        else None
+    )
+    if (
+        delivery_contract
+        and delivery_contract["research_contract"] != contract
+    ):
+        raise ValueError(
+            "delivery_contract.research_contract must match research_contract"
+        )
+    expected_lineage = build_auto_research_contract_lineage(
+        contract,
+        delivery_contract=delivery_contract,
+    )
+    provided_lineage = payload.get("contract_lineage")
+    if provided_lineage is not None and provided_lineage != expected_lineage:
+        raise ValueError(
+            "contract_lineage must match the normalized delivery contract"
+        )
     hypothesis = validate_research_hypothesis(_json_obj(payload.get("hypothesis"), field="hypothesis"))
     evidence_events = [
         validate_research_evidence_event(_json_obj(item, field="evidence_events[]"))
@@ -639,10 +723,24 @@ def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str,
             raise ValueError("evidence event hypothesis_id must match packet hypothesis")
         if event["todo_id"] != hypothesis["todo_id"]:
             raise ValueError("evidence event todo_id must match packet hypothesis")
+        if delivery_contract and any(
+            event.get(field) != expected_lineage[field]
+            for field in ("wish_id", "contract_ref", "contract_revision")
+        ):
+            raise ValueError(
+                "delivery evidence lineage must match the normalized contract"
+            )
+    if delivery_contract and any(
+        hypothesis.get(field) != expected_lineage[field]
+        for field in ("wish_id", "contract_ref", "contract_revision")
+    ):
+        raise ValueError(
+            "delivery hypothesis lineage must match the normalized contract"
+        )
     public_boundary = _json_obj(payload.get("public_boundary"), field="public_boundary")
     if public_boundary.get("raw_logs_recorded") or public_boundary.get("private_artifacts_recorded"):
         raise ValueError("auto_research_evidence_packet must not record raw logs or private artifacts")
-    return {
+    normalized = {
         "ok": True,
         "schema_version": schema,
         "research_contract": contract,
@@ -667,6 +765,10 @@ def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str,
             "source": "public_eval_result_projection",
         },
     }
+    if delivery_contract:
+        normalized["delivery_contract"] = delivery_contract
+        normalized["contract_lineage"] = expected_lineage
+    return normalized
 
 
 def build_auto_research_rollout_events(
@@ -678,6 +780,7 @@ def build_auto_research_rollout_events(
     contract = packet["research_contract"]
     hypothesis = packet["hypothesis"]
     summary = packet["summary"]
+    lineage = packet.get("contract_lineage") or {}
     goal_id = contract["goal_id"]
     hypothesis_id = hypothesis["hypothesis_id"]
     claimed_by = hypothesis["claimed_by"]
@@ -687,7 +790,56 @@ def build_auto_research_rollout_events(
     ]
     if hypothesis.get("novelty_audit_ref"):
         source_refs.append({"kind": "novelty_audit", "id": hypothesis["novelty_audit_ref"]})
-    events = [
+    hypothesis_details = {
+        "hypothesis_id": hypothesis_id,
+        "parent_hypothesis_id": hypothesis.get("parent_hypothesis_id") or "",
+        "mechanism_family": hypothesis["mechanism_family"],
+        "evidence_event_count": summary["evidence_event_count"],
+        "negative_evidence_count": summary["negative_evidence_count"],
+        "needs_retry_count": summary["needs_retry_count"],
+        "protected_scope_clean": summary["protected_scope_clean"],
+    }
+    if lineage.get("wish_id"):
+        hypothesis_details.update(
+            {
+                "wish_id": lineage["wish_id"],
+                "contract_ref": lineage["contract_ref"],
+                "contract_revision": lineage["contract_revision"],
+            }
+        )
+    events = []
+    if lineage.get("wish_id"):
+        events.append(
+            build_rollout_event(
+                goal_id=goal_id,
+                event_kind="validation",
+                status="recorded",
+                classification=packet["delivery_contract"]["schema_version"],
+                labels=[
+                    "auto_research",
+                    "delivery_contract",
+                    "wish_to_artifact",
+                ],
+                summary=(
+                    "Auto Research delivery contract recorded for "
+                    f"{lineage['wish_id']} at {lineage['contract_revision']}."
+                ),
+                artifact_refs=[lineage["contract_ref"]],
+                details={
+                    "wish_id": lineage["wish_id"],
+                    "contract_ref": lineage["contract_ref"],
+                    "contract_revision": lineage["contract_revision"],
+                    "required_artifact_count": len(
+                        packet["delivery_contract"]["required_artifacts"]
+                    ),
+                    "acceptance_criterion_count": len(
+                        packet["delivery_contract"]["acceptance_criteria"]
+                    ),
+                },
+                recorded_at=recorded_at,
+            )
+        )
+    events.append(
         build_rollout_event(
             goal_id=goal_id,
             event_kind="research_hypothesis",
@@ -708,20 +860,35 @@ def build_auto_research_rollout_events(
                 f"{hypothesis['hypothesis']}"
             ),
             source_refs=source_refs,
-            details={
-                "hypothesis_id": hypothesis_id,
-                "parent_hypothesis_id": hypothesis.get("parent_hypothesis_id") or "",
-                "mechanism_family": hypothesis["mechanism_family"],
-                "evidence_event_count": summary["evidence_event_count"],
-                "negative_evidence_count": summary["negative_evidence_count"],
-                "needs_retry_count": summary["needs_retry_count"],
-                "protected_scope_clean": summary["protected_scope_clean"],
-            },
+            details=hypothesis_details,
             recorded_at=recorded_at,
         )
-    ]
+    )
     for evidence in packet["evidence_events"]:
         metric = evidence["metric"]
+        evidence_details = {
+            "hypothesis_id": evidence["hypothesis_id"],
+            "attempt": evidence["attempt"],
+            "split": evidence["split"],
+            "metric_name": metric["name"],
+            "metric_value": metric["value"],
+            "metric_direction": metric["direction"],
+            "baseline_metric": evidence["baseline_metric"],
+            "primary_metric_status": evidence["primary_metric_status"],
+            "failure_kind": evidence["failure_kind"] or "",
+            "measurement_scope": evidence["measurement_scope"] or "",
+            "remediation_attempt": evidence["remediation_attempt"],
+            "eval_status": evidence["eval_status"],
+            "protected_scope_clean": evidence["protected_scope_clean"],
+        }
+        if lineage.get("wish_id"):
+            evidence_details.update(
+                {
+                    "wish_id": lineage["wish_id"],
+                    "contract_ref": lineage["contract_ref"],
+                    "contract_revision": lineage["contract_revision"],
+                }
+            )
         events.append(
             build_rollout_event(
                 goal_id=goal_id,
@@ -746,21 +913,7 @@ def build_auto_research_rollout_events(
                     f"value={metric['value']}"
                 ),
                 artifact_refs=evidence["artifact_refs"],
-                details={
-                    "hypothesis_id": evidence["hypothesis_id"],
-                    "attempt": evidence["attempt"],
-                    "split": evidence["split"],
-                    "metric_name": metric["name"],
-                    "metric_value": metric["value"],
-                    "metric_direction": metric["direction"],
-                    "baseline_metric": evidence["baseline_metric"],
-                    "primary_metric_status": evidence["primary_metric_status"],
-                    "failure_kind": evidence["failure_kind"] or "",
-                    "measurement_scope": evidence["measurement_scope"] or "",
-                    "remediation_attempt": evidence["remediation_attempt"],
-                    "eval_status": evidence["eval_status"],
-                    "protected_scope_clean": evidence["protected_scope_clean"],
-                },
+                details=evidence_details,
                 recorded_at=recorded_at,
             )
         )

--- a/loopx/capabilities/auto_research/evidence_packet.py
+++ b/loopx/capabilities/auto_research/evidence_packet.py
@@ -358,14 +358,27 @@ def validate_research_hypothesis(item: dict[str, Any]) -> dict[str, Any]:
         ),
         "blocked_by": _compact_public_text_list(item.get("blocked_by"), field="blocked_by"),
     }
-    for field in ("wish_id", "contract_ref", "contract_revision"):
-        if item.get(field):
-            normalized[field] = _compact_public_text(
-                item.get(field),
-                field=f"hypothesis.{field}",
-                max_len=180,
-            )
+    normalized.update(
+        _normalized_record_contract_lineage(
+            item,
+            field="hypothesis",
+        )
+    )
     return normalized
+
+
+def _normalized_record_contract_lineage(
+    item: dict[str, Any],
+    *,
+    field: str,
+) -> dict[str, str]:
+    from .delivery_contract import (
+        auto_research_contract_lineage_dict,
+        normalize_auto_research_contract_lineage,
+    )
+
+    lineage = normalize_auto_research_contract_lineage(item, field=field)
+    return auto_research_contract_lineage_dict(lineage) if lineage else {}
 
 
 def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
@@ -421,13 +434,12 @@ def validate_research_evidence_event(item: dict[str, Any]) -> dict[str, Any]:
         "raw_logs_recorded": False,
         "private_artifacts_recorded": False,
     }
-    for field in ("wish_id", "contract_ref", "contract_revision"):
-        if item.get(field):
-            normalized[field] = _compact_public_text(
-                item.get(field),
-                field=f"evidence.{field}",
-                max_len=180,
-            )
+    normalized.update(
+        _normalized_record_contract_lineage(
+            item,
+            field="evidence",
+        )
+    )
     return normalized
 
 
@@ -524,6 +536,56 @@ def _is_retry_evidence_event(event: dict[str, Any]) -> bool:
     )
 
 
+def _normalize_packet_contract(
+    contract: dict[str, Any],
+    *,
+    contract_root: str | Path | None,
+) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any], dict[str, Any] | None]:
+    from .delivery_contract import (
+        AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+        build_auto_research_contract_lineage,
+        normalize_auto_research_delivery_contract,
+    )
+
+    delivery_contract: dict[str, Any] | None = None
+    if (
+        contract.get("schema_version")
+        == AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
+    ):
+        delivery_contract = normalize_auto_research_delivery_contract(contract)
+        contract = delivery_contract["research_contract"]
+    normalized_contract, benchmark_context = _normalize_research_contract_for_packet(
+        contract,
+        contract_root=Path(contract_root).expanduser() if contract_root else None,
+    )
+    return (
+        normalized_contract,
+        delivery_contract,
+        build_auto_research_contract_lineage(
+            normalized_contract,
+            delivery_contract=delivery_contract,
+        ),
+        benchmark_context,
+    )
+
+
+def _apply_contract_lineage(
+    *,
+    hypothesis: dict[str, Any],
+    evidence_events: list[dict[str, Any]],
+    lineage: dict[str, Any],
+) -> None:
+    if not lineage.get("wish_id"):
+        return
+    values = _normalized_record_contract_lineage(
+        lineage,
+        field="contract_lineage",
+    )
+    hypothesis.update(values)
+    for event in evidence_events:
+        event.update(values)
+
+
 def build_auto_research_evidence_packet(
     *,
     contract: dict[str, Any],
@@ -543,27 +605,11 @@ def build_auto_research_evidence_packet(
 ) -> dict[str, Any]:
     """Build public-safe research hypothesis/evidence records from eval outputs."""
 
-    from .delivery_contract import (
-        AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
-        build_auto_research_contract_lineage,
-        normalize_auto_research_delivery_contract,
-    )
-
-    delivery_contract: dict[str, Any] | None = None
-    if (
-        contract.get("schema_version")
-        == AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
-    ):
-        delivery_contract = normalize_auto_research_delivery_contract(contract)
-        contract = delivery_contract["research_contract"]
-    normalized_contract, benchmark_context = _normalize_research_contract_for_packet(
+    contract, delivery_contract, contract_lineage, benchmark_context = (
+        _normalize_packet_contract(
         contract,
-        contract_root=Path(contract_root).expanduser() if contract_root else None,
-    )
-    contract = normalized_contract
-    contract_lineage = build_auto_research_contract_lineage(
-        contract,
-        delivery_contract=delivery_contract,
+        contract_root=contract_root,
+        )
     )
     if not eval_results:
         raise ValueError("at least one eval result is required")
@@ -583,19 +629,7 @@ def build_auto_research_evidence_packet(
         )
         for index, result in enumerate(eval_results)
     ]
-    if contract_lineage.get("wish_id"):
-        for event in events:
-            event.update(
-                {
-                    "wish_id": contract_lineage["wish_id"],
-                    "contract_ref": contract_lineage["contract_ref"],
-                    "contract_revision": contract_lineage["contract_revision"],
-                }
-            )
     status = _derive_hypothesis_status(events)
-    blocked_by = []
-    if status == "contradicted":
-        blocked_by.append("evidence_or_boundary_guardrail_failed")
     hypothesis_node = validate_research_hypothesis(
         {
             "schema_version": RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
@@ -608,15 +642,17 @@ def build_auto_research_evidence_packet(
             "status": status,
             "grounding_refs": grounding_refs or [],
             "novelty_audit_ref": novelty_audit_ref,
-            "blocked_by": blocked_by,
-            "wish_id": contract_lineage.get("wish_id"),
-            "contract_ref": contract_lineage.get("contract_ref"),
-            "contract_revision": (
-                contract_lineage["contract_revision"]
-                if contract_lineage.get("wish_id")
-                else None
+            "blocked_by": (
+                ["evidence_or_boundary_guardrail_failed"]
+                if status == "contradicted"
+                else []
             ),
         }
+    )
+    _apply_contract_lineage(
+        hypothesis=hypothesis_node,
+        evidence_events=events,
+        lineage=contract_lineage,
     )
     negative_count = len([event for event in events if _is_negative_evidence_event(event)])
     packet = {
@@ -672,19 +708,16 @@ def load_auto_research_evidence_packet(path: str | Path) -> dict[str, Any]:
     )
 
 
-def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str, Any]:
+def _delivery_contract_for_packet(
+    payload: dict[str, Any],
+    *,
+    research_contract: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     from .delivery_contract import (
         build_auto_research_contract_lineage,
         normalize_auto_research_delivery_contract,
     )
 
-    payload = _json_obj(payload, field="auto_research_evidence_packet")
-    schema = _compact_public_token(payload.get("schema_version"), field="schema_version")
-    if schema != AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION:
-        raise ValueError(f"schema_version must be {AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION}")
-    if payload.get("ok") is False:
-        raise ValueError("auto_research_evidence_packet.ok must not be false")
-    contract = validate_research_contract(_json_obj(payload.get("research_contract"), field="research_contract"))
     delivery_contract = (
         normalize_auto_research_delivery_contract(
             _json_obj(
@@ -695,15 +728,8 @@ def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str,
         if payload.get("delivery_contract") is not None
         else None
     )
-    if (
-        delivery_contract
-        and delivery_contract["research_contract"] != contract
-    ):
-        raise ValueError(
-            "delivery_contract.research_contract must match research_contract"
-        )
     expected_lineage = build_auto_research_contract_lineage(
-        contract,
+        research_contract,
         delivery_contract=delivery_contract,
     )
     provided_lineage = payload.get("contract_lineage")
@@ -711,35 +737,107 @@ def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str,
         raise ValueError(
             "contract_lineage must match the normalized delivery contract"
         )
+    return delivery_contract, expected_lineage
+
+
+def _validate_packet_lineage(
+    *,
+    delivery_contract: dict[str, Any] | None,
+    expected_lineage: dict[str, Any],
+    hypothesis: dict[str, Any],
+    evidence_events: list[dict[str, Any]],
+) -> None:
+    if not delivery_contract:
+        return
+    from .delivery_contract import (
+        auto_research_contract_lineage_matches,
+        normalize_auto_research_contract_lineage,
+    )
+
+    expected = normalize_auto_research_contract_lineage(
+        expected_lineage,
+        field="contract_lineage",
+        required=True,
+    )
+    if not auto_research_contract_lineage_matches(
+        hypothesis,
+        expected=expected,
+    ):
+        raise ValueError(
+            "delivery hypothesis lineage must match the normalized contract"
+        )
+    for event in evidence_events:
+        if not auto_research_contract_lineage_matches(
+            event,
+            expected=expected,
+        ):
+            raise ValueError(
+                "delivery evidence lineage must match the normalized contract"
+            )
+
+
+def _validate_packet_event_links(
+    *,
+    hypothesis: dict[str, Any],
+    evidence_events: list[dict[str, Any]],
+) -> None:
+    if not evidence_events:
+        raise ValueError(
+            "auto_research_evidence_packet requires at least one evidence event"
+        )
+    for event in evidence_events:
+        if event["hypothesis_id"] != hypothesis["hypothesis_id"]:
+            raise ValueError(
+                "evidence event hypothesis_id must match packet hypothesis"
+            )
+        if event["todo_id"] != hypothesis["todo_id"]:
+            raise ValueError(
+                "evidence event todo_id must match packet hypothesis"
+            )
+
+
+def _validate_packet_public_boundary(payload: dict[str, Any]) -> None:
+    public_boundary = _json_obj(
+        payload.get("public_boundary"),
+        field="public_boundary",
+    )
+    if public_boundary.get("raw_logs_recorded") or public_boundary.get(
+        "private_artifacts_recorded"
+    ):
+        raise ValueError(
+            "auto_research_evidence_packet must not record raw logs or "
+            "private artifacts"
+        )
+
+
+def validate_auto_research_evidence_packet(payload: dict[str, Any]) -> dict[str, Any]:
+    payload = _json_obj(payload, field="auto_research_evidence_packet")
+    schema = _compact_public_token(payload.get("schema_version"), field="schema_version")
+    if schema != AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION}")
+    if payload.get("ok") is False:
+        raise ValueError("auto_research_evidence_packet.ok must not be false")
+    contract = validate_research_contract(_json_obj(payload.get("research_contract"), field="research_contract"))
+    delivery_contract, expected_lineage = _delivery_contract_for_packet(
+        payload,
+        research_contract=contract,
+    )
     hypothesis = validate_research_hypothesis(_json_obj(payload.get("hypothesis"), field="hypothesis"))
     evidence_events = [
         validate_research_evidence_event(_json_obj(item, field="evidence_events[]"))
         for item in _json_list(payload.get("evidence_events"), field="evidence_events")
     ]
-    if not evidence_events:
-        raise ValueError("auto_research_evidence_packet requires at least one evidence event")
-    for event in evidence_events:
-        if event["hypothesis_id"] != hypothesis["hypothesis_id"]:
-            raise ValueError("evidence event hypothesis_id must match packet hypothesis")
-        if event["todo_id"] != hypothesis["todo_id"]:
-            raise ValueError("evidence event todo_id must match packet hypothesis")
-        if delivery_contract and any(
-            event.get(field) != expected_lineage[field]
-            for field in ("wish_id", "contract_ref", "contract_revision")
-        ):
-            raise ValueError(
-                "delivery evidence lineage must match the normalized contract"
-            )
-    if delivery_contract and any(
-        hypothesis.get(field) != expected_lineage[field]
-        for field in ("wish_id", "contract_ref", "contract_revision")
-    ):
-        raise ValueError(
-            "delivery hypothesis lineage must match the normalized contract"
-        )
-    public_boundary = _json_obj(payload.get("public_boundary"), field="public_boundary")
-    if public_boundary.get("raw_logs_recorded") or public_boundary.get("private_artifacts_recorded"):
-        raise ValueError("auto_research_evidence_packet must not record raw logs or private artifacts")
+    _validate_packet_event_links(
+        hypothesis=hypothesis,
+        evidence_events=evidence_events,
+    )
+    _validate_packet_lineage(
+        delivery_contract=delivery_contract,
+        expected_lineage=expected_lineage,
+        hypothesis=hypothesis,
+        evidence_events=evidence_events,
+    )
+    _validate_packet_public_boundary(payload)
     normalized = {
         "ok": True,
         "schema_version": schema,

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -7,6 +7,7 @@ on legacy presentation helpers.
 
 from __future__ import annotations
 
+from .artifact_receipt import AUTO_RESEARCH_ARTIFACT_RECEIPT_SCHEMA_VERSION
 from .evidence_packet import AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION
 from .preset import build_auto_research_minimal_a2a_recipe
 from .user_contract import AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION
@@ -368,7 +369,7 @@ def _render_worker_turn(payload: dict[str, object]) -> str:
         f"- holdout_metric: `{payload.get('holdout_metric')}`",
         f"- appended_count: `{append.get('appended_count')}`",
         f"- live_evidence_written: `{live_evidence.get('written')}`",
-        f"- public_boundary: raw_logs=`False`, private_artifacts=`False`, paths=`local-only`",
+        "- public_boundary: raw_logs=`False`, private_artifacts=`False`, paths=`local-only`",
     ]
     return "\n".join(lines) + "\n"
 
@@ -750,6 +751,40 @@ def _render_terminal_result_projection(payload: dict[str, object]) -> str:
     ) + "\n"
 
 
+def _render_artifact_receipt(payload: dict[str, object]) -> str:
+    wish = _dict_value(payload, "wish")
+    contract = _dict_value(payload, "contract")
+    artifacts = _dict_value(payload, "artifacts")
+    feedback = _dict_value(payload, "failure_feedback")
+    lines = [
+        "# LoopX Auto Research Artifact Receipt",
+        "",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- wish_id: `{wish.get('wish_id')}`",
+        f"- status: `{payload.get('status')}`",
+        f"- contract_state: `{contract.get('state')}`",
+        f"- contract_revision: `{contract.get('contract_revision')}`",
+        f"- observed_artifacts: `{len(artifacts.get('observed_refs') or [])}`",
+        f"- missing_required_artifacts: `{len(artifacts.get('missing_required_refs') or [])}`",
+    ]
+    if feedback:
+        lines.extend(
+            [
+                "",
+                "## Feedback",
+                "",
+                str(feedback.get("summary") or ""),
+                "",
+                f"- failure_kinds: `{_join_or_none(feedback.get('failure_kinds'))}`",
+                f"- unmet_criteria: `{_join_or_none(feedback.get('unmet_criteria'))}`",
+                f"- verified_boundary: `{_join_or_none(feedback.get('verified_boundary'))}`",
+                f"- fallback_artifacts: `{_join_or_none(feedback.get('fallback_artifact_refs'))}`",
+                f"- reentry_conditions: `{_join_or_none(feedback.get('reentry_conditions'))}`",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
 def _render_generic(payload: dict[str, object]) -> str:
     lines = [
         "# LoopX Auto Research",
@@ -791,4 +826,6 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         return _render_terminal_result_query(payload)
     if schema == "auto_research_terminal_result_projection_v0":
         return _render_terminal_result_projection(payload)
+    if schema == AUTO_RESEARCH_ARTIFACT_RECEIPT_SCHEMA_VERSION:
+        return _render_artifact_receipt(payload)
     return render_auto_research_projection_markdown(payload)

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -19,7 +19,6 @@ from .evidence_packet import (
     RESEARCH_EVIDENCE_EVENT_SCHEMA_VERSION,
     RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
     _compact_public_text,
-    _compact_public_text_list,
     _compact_public_token,
     _derive_hypothesis_status,
     _finite_float,
@@ -318,6 +317,9 @@ def _research_hypothesis_from_rollout_event(event: dict[str, Any]) -> dict[str, 
             "grounding_refs": grounding_refs,
             "novelty_audit_ref": novelty_audit_ref,
             "blocked_by": blocked_by,
+            "wish_id": details.get("wish_id") or None,
+            "contract_ref": details.get("contract_ref") or None,
+            "contract_revision": details.get("contract_revision") or None,
         }
     )
 
@@ -349,6 +351,9 @@ def _research_evidence_from_rollout_event(event: dict[str, Any]) -> dict[str, An
             "remediation_attempt": bool(details.get("remediation_attempt")),
             "artifact_refs": event.get("artifact_refs") or [],
             "protected_scope_clean": bool(details.get("protected_scope_clean")),
+            "wish_id": details.get("wish_id") or None,
+            "contract_ref": details.get("contract_ref") or None,
+            "contract_revision": details.get("contract_revision") or None,
         }
     )
 
@@ -374,6 +379,9 @@ def _synthetic_hypothesis_from_evidence(events: list[dict[str, Any]]) -> dict[st
             "grounding_refs": [],
             "novelty_audit_ref": None,
             "blocked_by": blocked_by,
+            "wish_id": first.get("wish_id"),
+            "contract_ref": first.get("contract_ref"),
+            "contract_revision": first.get("contract_revision"),
         }
     )
 
@@ -453,6 +461,22 @@ def build_research_evidence_graph_from_records(
     events_by_hypothesis: dict[str, list[dict[str, Any]]] = {}
     for event in events:
         events_by_hypothesis.setdefault(event["hypothesis_id"], []).append(event)
+    for hypothesis_id, item_events in events_by_hypothesis.items():
+        hypothesis = hypotheses_by_id.get(hypothesis_id)
+        if not hypothesis:
+            continue
+        hypothesis_revision = str(hypothesis.get("contract_revision") or "")
+        event_revisions = {
+            str(event.get("contract_revision") or "")
+            for event in item_events
+        }
+        if len(event_revisions) > 1 or (
+            event_revisions and event_revisions != {hypothesis_revision}
+        ):
+            raise ValueError(
+                "research evidence contract lineage conflicts for hypothesis "
+                f"{hypothesis_id}"
+            )
     nodes = []
     for item in hypotheses:
         item_events = events_by_hypothesis.get(item["hypothesis_id"], [])
@@ -520,6 +544,15 @@ def build_research_evidence_graph_from_records(
                 "measurement_scope": _failure_measurement_scope(item_events),
                 "remediation_attempt_count": remediation_attempt_count,
                 "source_kind": source,
+                **(
+                    {
+                        "wish_id": item["wish_id"],
+                        "contract_ref": item["contract_ref"],
+                        "contract_revision": item["contract_revision"],
+                    }
+                    if item.get("wish_id")
+                    else {}
+                ),
             }
         )
     return {
@@ -573,6 +606,17 @@ def build_research_evidence_graph_from_rollout_events(
     for hypothesis_id, events in events_by_hypothesis.items():
         if hypothesis_id not in hypotheses_by_id:
             hypotheses_by_id[hypothesis_id] = _synthetic_hypothesis_from_evidence(events)
+    evidence_events = [
+        evidence
+        for evidence in evidence_events
+        if str(evidence.get("contract_revision") or "")
+        == str(
+            hypotheses_by_id.get(evidence["hypothesis_id"], {}).get(
+                "contract_revision"
+            )
+            or ""
+        )
+    ]
 
     first_metric_event = evidence_events[0] if evidence_events else None
     metric = first_metric_event["metric"] if first_metric_event else {}

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -13,6 +13,12 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .delivery_contract import (
+    AutoResearchContractLineageError,
+    auto_research_contract_lineage_dict,
+    auto_research_contract_lineage_matches,
+    normalize_auto_research_contract_lineage,
+)
 from .evidence_packet import (
     METRIC_DIRECTIONS,
     RESEARCH_FAILURE_KINDS,
@@ -289,6 +295,27 @@ def _rollout_hypothesis_text(event: dict[str, Any], details: dict[str, Any]) -> 
     return _compact_public_text(fallback, field="rollout.summary.hypothesis")
 
 
+def _rollout_contract_lineage(details: dict[str, Any]) -> dict[str, Any]:
+    lineage = normalize_auto_research_contract_lineage(
+        details,
+        field="rollout.details",
+    )
+    return auto_research_contract_lineage_dict(lineage) if lineage else {}
+
+
+def _hypothesis_blocked_by(
+    *,
+    status: object,
+    negative_count: int,
+    retry_count: int,
+) -> list[str]:
+    if str(status) == "contradicted" or negative_count:
+        return ["evidence_or_boundary_guardrail_failed"]
+    if str(status) == "needs_retry" or retry_count:
+        return ["needs_retry_evidence"]
+    return []
+
+
 def _research_hypothesis_from_rollout_event(event: dict[str, Any]) -> dict[str, Any] | None:
     if str(event.get("event_kind") or "") != "research_hypothesis":
         return None
@@ -299,11 +326,6 @@ def _research_hypothesis_from_rollout_event(event: dict[str, Any]) -> dict[str, 
     negative_count = int(details.get("negative_evidence_count") or 0)
     retry_count = int(details.get("needs_retry_count") or 0)
     status = details.get("status") or event.get("status") or "active"
-    blocked_by: list[str] = []
-    if str(status) == "contradicted" or negative_count:
-        blocked_by.append("evidence_or_boundary_guardrail_failed")
-    elif str(status) == "needs_retry" or retry_count:
-        blocked_by.append("needs_retry_evidence")
     return validate_research_hypothesis(
         {
             "schema_version": RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
@@ -316,10 +338,12 @@ def _research_hypothesis_from_rollout_event(event: dict[str, Any]) -> dict[str, 
             "status": status,
             "grounding_refs": grounding_refs,
             "novelty_audit_ref": novelty_audit_ref,
-            "blocked_by": blocked_by,
-            "wish_id": details.get("wish_id") or None,
-            "contract_ref": details.get("contract_ref") or None,
-            "contract_revision": details.get("contract_revision") or None,
+            "blocked_by": _hypothesis_blocked_by(
+                status=status,
+                negative_count=negative_count,
+                retry_count=retry_count,
+            ),
+            **_rollout_contract_lineage(details),
         }
     )
 
@@ -351,9 +375,7 @@ def _research_evidence_from_rollout_event(event: dict[str, Any]) -> dict[str, An
             "remediation_attempt": bool(details.get("remediation_attempt")),
             "artifact_refs": event.get("artifact_refs") or [],
             "protected_scope_clean": bool(details.get("protected_scope_clean")),
-            "wish_id": details.get("wish_id") or None,
-            "contract_ref": details.get("contract_ref") or None,
-            "contract_revision": details.get("contract_revision") or None,
+            **_rollout_contract_lineage(details),
         }
     )
 
@@ -461,22 +483,6 @@ def build_research_evidence_graph_from_records(
     events_by_hypothesis: dict[str, list[dict[str, Any]]] = {}
     for event in events:
         events_by_hypothesis.setdefault(event["hypothesis_id"], []).append(event)
-    for hypothesis_id, item_events in events_by_hypothesis.items():
-        hypothesis = hypotheses_by_id.get(hypothesis_id)
-        if not hypothesis:
-            continue
-        hypothesis_revision = str(hypothesis.get("contract_revision") or "")
-        event_revisions = {
-            str(event.get("contract_revision") or "")
-            for event in item_events
-        }
-        if len(event_revisions) > 1 or (
-            event_revisions and event_revisions != {hypothesis_revision}
-        ):
-            raise ValueError(
-                "research evidence contract lineage conflicts for hypothesis "
-                f"{hypothesis_id}"
-            )
     nodes = []
     for item in hypotheses:
         item_events = events_by_hypothesis.get(item["hypothesis_id"], [])
@@ -544,15 +550,6 @@ def build_research_evidence_graph_from_records(
                 "measurement_scope": _failure_measurement_scope(item_events),
                 "remediation_attempt_count": remediation_attempt_count,
                 "source_kind": source,
-                **(
-                    {
-                        "wish_id": item["wish_id"],
-                        "contract_ref": item["contract_ref"],
-                        "contract_revision": item["contract_revision"],
-                    }
-                    if item.get("wish_id")
-                    else {}
-                ),
             }
         )
     return {
@@ -589,16 +586,9 @@ def build_research_evidence_graph_from_rollout_events(
     rollout_events: list[dict[str, Any]],
 ) -> dict[str, Any]:
     goal = _compact_public_token(goal_id, field="goal_id")
-    hypotheses_by_id: dict[str, dict[str, Any]] = {}
-    evidence_events: list[dict[str, Any]] = []
-    for event in rollout_events:
-        hypothesis = _research_hypothesis_from_rollout_event(event)
-        if hypothesis:
-            hypotheses_by_id[hypothesis["hypothesis_id"]] = hypothesis
-            continue
-        evidence = _research_evidence_from_rollout_event(event)
-        if evidence:
-            evidence_events.append(evidence)
+    hypotheses_by_id, evidence_events = _research_records_from_rollout_events(
+        rollout_events
+    )
 
     events_by_hypothesis: dict[str, list[dict[str, Any]]] = {}
     for evidence in evidence_events:
@@ -609,18 +599,18 @@ def build_research_evidence_graph_from_rollout_events(
     evidence_events = [
         evidence
         for evidence in evidence_events
-        if str(evidence.get("contract_revision") or "")
-        == str(
-            hypotheses_by_id.get(evidence["hypothesis_id"], {}).get(
-                "contract_revision"
-            )
-            or ""
+        if auto_research_contract_lineage_matches(
+            evidence,
+            expected=normalize_auto_research_contract_lineage(
+                hypotheses_by_id.get(evidence["hypothesis_id"], {}),
+                field="hypothesis",
+            ),
         )
     ]
 
     first_metric_event = evidence_events[0] if evidence_events else None
     metric = first_metric_event["metric"] if first_metric_event else {}
-    return build_research_evidence_graph_from_records(
+    graph = build_research_evidence_graph_from_records(
         goal_id=goal,
         hypotheses=list(hypotheses_by_id.values()),
         evidence_events=evidence_events,
@@ -629,6 +619,68 @@ def build_research_evidence_graph_from_rollout_events(
         baseline_metric=first_metric_event.get("baseline_metric") if first_metric_event else None,
         source_kind=ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND,
     )
+    _apply_contract_lineage_to_graph(
+        graph,
+        hypotheses_by_id=hypotheses_by_id,
+    )
+    return graph
+
+
+def _research_records_from_rollout_events(
+    rollout_events: list[dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    hypotheses_by_id: dict[str, dict[str, Any]] = {}
+    evidence_events: list[dict[str, Any]] = []
+    invalid_lineage_hypothesis_ids: set[str] = set()
+    for event in rollout_events:
+        try:
+            hypothesis = _research_hypothesis_from_rollout_event(event)
+        except AutoResearchContractLineageError:
+            invalid_lineage_hypothesis_ids.add(
+                str((event.get("details") or {}).get("hypothesis_id") or "")
+            )
+            continue
+        if hypothesis:
+            hypotheses_by_id[hypothesis["hypothesis_id"]] = hypothesis
+            continue
+        try:
+            evidence = _research_evidence_from_rollout_event(event)
+        except AutoResearchContractLineageError:
+            invalid_lineage_hypothesis_ids.add(
+                str((event.get("details") or {}).get("hypothesis_id") or "")
+            )
+            continue
+        if evidence:
+            evidence_events.append(evidence)
+    invalid_lineage_hypothesis_ids.discard("")
+    for hypothesis_id in invalid_lineage_hypothesis_ids:
+        hypotheses_by_id.pop(hypothesis_id, None)
+    evidence_events = [
+        event
+        for event in evidence_events
+        if event["hypothesis_id"] not in invalid_lineage_hypothesis_ids
+    ]
+    return hypotheses_by_id, evidence_events
+
+
+def _apply_contract_lineage_to_graph(
+    graph: dict[str, Any],
+    *,
+    hypotheses_by_id: dict[str, dict[str, Any]],
+) -> None:
+    for node in graph.get("nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        hypothesis = hypotheses_by_id.get(str(node.get("hypothesis_id") or ""))
+        if not hypothesis:
+            continue
+        lineage = normalize_auto_research_contract_lineage(
+            hypothesis,
+            field="hypothesis",
+        )
+        if not lineage:
+            continue
+        node.update(auto_research_contract_lineage_dict(lineage))
 
 
 def build_research_evidence_graph(fixture: dict[str, Any]) -> dict[str, Any]:

--- a/loopx/capabilities/auto_research/role_profiles.py
+++ b/loopx/capabilities/auto_research/role_profiles.py
@@ -147,6 +147,7 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
             "review_terminal_decision",
         ],
         "write_scope": [
+            "auto_research_delivery_contract_v0",
             "research_contract_v0",
             "auto_research_peer_review_v0",
             "todo_item_v0",

--- a/loopx/capabilities/auto_research/rollout_append.py
+++ b/loopx/capabilities/auto_research/rollout_append.py
@@ -5,6 +5,7 @@ import json
 from pathlib import Path
 from typing import Mapping
 
+from .delivery_contract import AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
 from .evidence_packet import (
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
     build_auto_research_rollout_events,
@@ -30,6 +31,22 @@ def _event_content_key(event: Mapping[str, object]) -> str:
     return json.dumps(content, sort_keys=True, ensure_ascii=True)
 
 
+def _delivery_contract_key(event: Mapping[str, object]) -> tuple[str, str] | None:
+    if (
+        event.get("classification")
+        != AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
+    ):
+        return None
+    details = event.get("details")
+    if not isinstance(details, Mapping):
+        return None
+    wish_id = str(details.get("wish_id") or "")
+    contract_revision = str(details.get("contract_revision") or "")
+    if not wish_id or not contract_revision:
+        return None
+    return wish_id, contract_revision
+
+
 def append_auto_research_rollout_events(
     *,
     packet_path: str,
@@ -52,11 +69,25 @@ def append_auto_research_rollout_events(
         for event in existing_events
         if event.get("event_id")
     }
+    existing_contract_ids = {
+        key: str(event["event_id"])
+        for event in existing_events
+        if event.get("event_id")
+        and (key := _delivery_contract_key(event)) is not None
+    }
     appended_ids: list[str] = []
     skipped_ids: list[str] = []
     effective_ids: list[str] = []
     for event in events:
         event_id = str(event["event_id"])
+        contract_key = _delivery_contract_key(event)
+        existing_contract_id = (
+            existing_contract_ids.get(contract_key) if contract_key else None
+        )
+        if existing_contract_id:
+            skipped_ids.append(existing_contract_id)
+            effective_ids.append(existing_contract_id)
+            continue
         content_key = _event_content_key(event)
         existing_content_id = existing_content_ids.get(content_key)
         if existing_content_id:
@@ -71,6 +102,8 @@ def append_auto_research_rollout_events(
             append_rollout_event(log_path, event)
             existing_ids.add(event_id)
             existing_content_ids[content_key] = event_id
+            if contract_key:
+                existing_contract_ids[contract_key] = event_id
         appended_ids.append(event_id)
         effective_ids.append(event_id)
     counts_by_kind = Counter(str(event.get("event_kind") or "") for event in events)

--- a/loopx/capabilities/auto_research/rollout_append.py
+++ b/loopx/capabilities/auto_research/rollout_append.py
@@ -5,7 +5,6 @@ import json
 from pathlib import Path
 from typing import Mapping
 
-from .delivery_contract import AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
 from .evidence_packet import (
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
     build_auto_research_rollout_events,
@@ -31,22 +30,6 @@ def _event_content_key(event: Mapping[str, object]) -> str:
     return json.dumps(content, sort_keys=True, ensure_ascii=True)
 
 
-def _delivery_contract_key(event: Mapping[str, object]) -> tuple[str, str] | None:
-    if (
-        event.get("classification")
-        != AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
-    ):
-        return None
-    details = event.get("details")
-    if not isinstance(details, Mapping):
-        return None
-    wish_id = str(details.get("wish_id") or "")
-    contract_revision = str(details.get("contract_revision") or "")
-    if not wish_id or not contract_revision:
-        return None
-    return wish_id, contract_revision
-
-
 def append_auto_research_rollout_events(
     *,
     packet_path: str,
@@ -69,25 +52,11 @@ def append_auto_research_rollout_events(
         for event in existing_events
         if event.get("event_id")
     }
-    existing_contract_ids = {
-        key: str(event["event_id"])
-        for event in existing_events
-        if event.get("event_id")
-        and (key := _delivery_contract_key(event)) is not None
-    }
     appended_ids: list[str] = []
     skipped_ids: list[str] = []
     effective_ids: list[str] = []
     for event in events:
         event_id = str(event["event_id"])
-        contract_key = _delivery_contract_key(event)
-        existing_contract_id = (
-            existing_contract_ids.get(contract_key) if contract_key else None
-        )
-        if existing_contract_id:
-            skipped_ids.append(existing_contract_id)
-            effective_ids.append(existing_contract_id)
-            continue
         content_key = _event_content_key(event)
         existing_content_id = existing_content_ids.get(content_key)
         if existing_content_id:
@@ -102,8 +71,6 @@ def append_auto_research_rollout_events(
             append_rollout_event(log_path, event)
             existing_ids.add(event_id)
             existing_content_ids[content_key] = event_id
-            if contract_key:
-                existing_contract_ids[contract_key] = event_id
         appended_ids.append(event_id)
         effective_ids.append(event_id)
     counts_by_kind = Counter(str(event.get("event_kind") or "") for event in events)

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -109,12 +109,14 @@ The pane-local tick can point at a todo; it cannot count as benchmark evidence.
 
 ## Research Curator
 
-Use when the role owns objective, metric, editable scope, protected scope,
+Use when the role owns the original research wish, objective, required
+artifacts, acceptance criteria, metric, editable scope, protected scope,
 budget, and gates.
 
 Allowed actions:
 
-- create or refresh `research_contract_v0`;
+- create or refresh `auto_research_delivery_contract_v0`, embedding the
+  existing `research_contract_v0`;
 - make protected boundaries explicit;
 - write user/operator gate todos when promotion or publication needs judgment;
 - request read-only projections from existing evidence.
@@ -130,9 +132,14 @@ loopx --format json auto-research frontier \
 Artifact contract:
 
 - objective is public-safe and bounded;
+- the original wish, assumptions, non-goals, and contract reference are
+  public-safe and explicit;
+- every required artifact and acceptance criterion has a stable public-safe id;
 - metric direction and protected evaluator are explicit;
 - write scope and protected scope are named;
 - promotion policy says what evidence is sufficient.
+- failure policy names fallback artifacts and the conditions for re-entering
+  research when the current contract cannot be fulfilled.
 
 Must not:
 
@@ -238,6 +245,12 @@ When evidence reaches a terminal boundary:
 - use `loopx auto-research review --require-independent` only from a different
   registered peer than both the hypothesis producer and decision agent;
 - treat self-review as visible review evidence, never as independent review;
+- when the curator supplied `auto_research_delivery_contract_v0`, run
+  `loopx auto-research artifact-receipt --contract <contract-file>` after the
+  terminal decision and required review;
+- return every non-verified receipt to the user with its failure kinds,
+  verified boundary, fallback artifacts, and reentry conditions; do not turn
+  one failed attempt into a terminal impossibility claim;
 - use `loopx auto-research project-results` after decisions and reviews so
   exact `loopx auto-research results` queries can verify Explore readback.
 
@@ -259,6 +272,9 @@ loopx auto-research review \
   --verdict approve \
   --require-independent \
   --execute
+
+loopx auto-research artifact-receipt \
+  --contract "<delivery-contract-file>"
 ```
 
 Must not:

--- a/tests/test_auto_research_artifact_receipt.py
+++ b/tests/test_auto_research_artifact_receipt.py
@@ -1,0 +1,558 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from loopx.capabilities.auto_research.artifact_receipt import (
+    AUTO_RESEARCH_ARTIFACT_RECEIPT_SCHEMA_VERSION,
+    build_auto_research_artifact_receipt,
+)
+from loopx.capabilities.auto_research.delivery_contract import (
+    AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+    normalize_auto_research_delivery_contract,
+)
+from loopx.capabilities.auto_research.evidence_packet import (
+    build_auto_research_evidence_packet,
+    build_auto_research_rollout_events,
+)
+from loopx.capabilities.auto_research.research_state import (
+    build_research_evidence_graph_from_rollout_events,
+)
+from loopx.capabilities.auto_research.terminal_result_contract import (
+    build_peer_review_event,
+    build_terminal_decision_event,
+)
+
+
+GOAL_ID = "wish-artifact-fixture"
+PRODUCER = "research-executor"
+PROMOTER = "evaluator-promoter"
+REVIEWER = "independent-reviewer"
+REGISTERED_AGENTS = [PRODUCER, PROMOTER, REVIEWER]
+
+
+def _research_contract() -> dict[str, Any]:
+    return {
+        "schema_version": "research_contract_v0",
+        "goal_id": GOAL_ID,
+        "research_objective": (
+            "Test whether a reusable skill improves held-out tool use."
+        ),
+        "editable_scope": ["candidate_skill", "experiment_driver"],
+        "protected_scope": ["heldout_tasks", "metric_definition"],
+        "metric": {
+            "name": "heldout_success_rate",
+            "direction": "maximize",
+            "baseline": 0.5,
+        },
+        "dev_eval": "run public dev evaluator",
+        "holdout_eval": "run public holdout evaluator",
+        "promotion_policy": "dev_and_holdout_improved",
+    }
+
+
+def _delivery_contract(
+    *,
+    include_report: bool = True,
+    reentry_conditions: list[str] | None = None,
+) -> dict[str, Any]:
+    artifacts = [
+        {
+            "artifact_ref": "artifact:experiment",
+            "kind": "experiment",
+            "description": "Runnable comparison experiment.",
+            "required": True,
+        },
+    ]
+    required_refs = ["artifact:experiment"]
+    if include_report:
+        artifacts.append(
+            {
+                "artifact_ref": "artifact:report",
+                "kind": "report",
+                "description": "Evidence-backed result and limitation report.",
+                "required": True,
+            }
+        )
+        required_refs.append("artifact:report")
+    return {
+        "schema_version": AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION,
+        "contract_ref": "contract:skill-library-generalization",
+        "wish": {
+            "original_text": (
+                "Verify whether a durable skill library improves general tool "
+                "use instead of memorizing one repository."
+            ),
+            "intent_summary": (
+                "Compare a fixed base agent with and without the skill library "
+                "on held-out repositories."
+            ),
+            "assumptions": ["A public held-out task split is available."],
+            "non_goals": ["Do not train or deploy a production model."],
+        },
+        "research_contract": _research_contract(),
+        "required_artifacts": artifacts,
+        "acceptance_criteria": [
+            {
+                "criterion_id": "heldout_generalization",
+                "description": (
+                    "Held-out performance is terminally decided from clean "
+                    "evidence and an independent review."
+                ),
+                "hypothesis_id": "hyp_generalization",
+                "required_artifact_refs": required_refs,
+                "requires_independent_review": True,
+                "required": True,
+            }
+        ],
+        "failure_policy": {
+            "fallback_artifact_refs": ["artifact:report"]
+            if include_report
+            else [],
+            "reentry_conditions": reentry_conditions
+            or ["Provide a new held-out repository split."],
+        },
+    }
+
+
+def _eval_result(
+    *,
+    split: str,
+    value: float,
+    metric_status: str,
+    artifact_refs: list[str],
+    failure_kind: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "auto_research_lightweight_eval_result_v0",
+        "split": split,
+        "metric": {
+            "name": "heldout_success_rate",
+            "direction": "maximize",
+            "value": value,
+            "baseline": 0.5,
+        },
+        "eval_status": "scored",
+        "primary_metric_status": metric_status,
+        "failure_kind": failure_kind,
+        "artifact_refs": artifact_refs,
+        "protected_scope_clean": True,
+        "no_upload": True,
+    }
+
+
+def _packet(
+    delivery_contract: dict[str, Any],
+    *,
+    supported: bool,
+    include_report: bool = True,
+) -> dict[str, Any]:
+    refs = ["artifact:experiment"]
+    if include_report:
+        refs.append("artifact:report")
+    return build_auto_research_evidence_packet(
+        contract=delivery_contract,
+        eval_results=[
+            _eval_result(
+                split="dev",
+                value=0.7 if supported else 0.4,
+                metric_status="improved" if supported else "regressed",
+                artifact_refs=refs,
+                failure_kind=None if supported else "mechanism_contradicted",
+            ),
+            _eval_result(
+                split="holdout",
+                value=0.65 if supported else 0.35,
+                metric_status="improved" if supported else "regressed",
+                artifact_refs=refs,
+                failure_kind=None if supported else "mechanism_contradicted",
+            ),
+        ],
+        hypothesis_id="hyp_generalization",
+        todo_id="todo_generalization",
+        agent_id=PRODUCER,
+        claimed_by=PRODUCER,
+        mechanism_family="skill_library_generalization",
+        hypothesis="The skill library improves held-out tool use.",
+    )
+
+
+def _terminal_events(
+    packet: dict[str, Any],
+    *,
+    supported: bool,
+) -> list[dict[str, Any]]:
+    events = build_auto_research_rollout_events(
+        packet,
+        recorded_at="2026-08-25T00:00:00Z",
+    )
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=GOAL_ID,
+        rollout_events=events,
+    )
+    decision = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="hyp_generalization",
+        outcome="promoted" if supported else "retired",
+        reason="holdout_validated" if supported else "contradicted",
+        decided_by=PROMOTER,
+        evidence_refs=["decision:generalization"],
+        recorded_at="2026-08-25T00:01:00Z",
+    )
+    review = build_peer_review_event(
+        evidence_graph=graph,
+        rollout_events=[*events, decision],
+        hypothesis_id="hyp_generalization",
+        reviewer_agent_id=REVIEWER,
+        verdict="approve",
+        evidence_refs=["review:independent"],
+        require_independent=True,
+        registered_agent_ids=REGISTERED_AGENTS,
+        recorded_at="2026-08-25T00:02:00Z",
+    )
+    return [*events, decision, review]
+
+
+def _tampered_evidence_lineage(
+    events: list[dict[str, Any]],
+    *,
+    field: str,
+    value: str | None,
+) -> list[dict[str, Any]]:
+    tampered = deepcopy(events)
+    for event in tampered:
+        if event["event_kind"] != "research_evidence":
+            continue
+        if value is None:
+            event["details"].pop(field, None)
+        else:
+            event["details"][field] = value
+    return tampered
+
+
+def _assert_lineage_tampering_fails_closed(
+    events: list[dict[str, Any]],
+) -> None:
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=GOAL_ID,
+        rollout_events=events,
+    )
+    assert graph["evidence_event_count"] == 0
+    assert all(not node["artifact_refs"] for node in graph["nodes"])
+
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=_delivery_contract(),
+        rollout_events=events,
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] != "verified"
+    assert receipt["acceptance_results"][0]["status"] != "verified"
+    assert "artifact:experiment" in receipt["artifacts"][
+        "missing_required_refs"
+    ]
+
+
+def test_delivery_contract_normalization_is_stable() -> None:
+    normalized = normalize_auto_research_delivery_contract(_delivery_contract())
+    assert normalize_auto_research_delivery_contract(normalized) == normalized
+    assert normalized["wish"]["wish_id"].startswith("wish_")
+    assert normalized["contract_revision"].startswith("sha256:")
+
+
+def test_legacy_research_contract_keeps_existing_event_shape() -> None:
+    packet = build_auto_research_evidence_packet(
+        contract=_research_contract(),
+        eval_results=[
+            _eval_result(
+                split="dev",
+                value=0.7,
+                metric_status="improved",
+                artifact_refs=["artifact:experiment"],
+            )
+        ],
+        hypothesis_id="hyp_generalization",
+        todo_id="todo_generalization",
+        agent_id=PRODUCER,
+        claimed_by=PRODUCER,
+        mechanism_family="skill_library_generalization",
+        hypothesis="The skill library improves held-out tool use.",
+    )
+    events = build_auto_research_rollout_events(packet)
+    assert "delivery_contract" not in packet
+    assert [event["event_kind"] for event in events] == [
+        "research_hypothesis",
+        "research_evidence",
+    ]
+    assert all(
+        "contract_revision" not in event.get("details", {})
+        for event in events
+    )
+
+
+def test_verified_artifact_receipt_closes_the_delivery_contract() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=True)
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=_terminal_events(packet, supported=True),
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["schema_version"] == AUTO_RESEARCH_ARTIFACT_RECEIPT_SCHEMA_VERSION
+    assert receipt["status"] == "verified"
+    assert receipt["failure_feedback"] is None
+    assert receipt["contract"]["state"] == "current"
+    assert receipt["artifacts"]["missing_required_refs"] == []
+    assert receipt["acceptance_results"][0]["status"] == "verified"
+    assert receipt["learning_disposition"] == "candidate"
+    assert receipt["boundary"]["user_acceptance_inferred"] is False
+
+
+def test_terminally_unfulfilled_wish_returns_actionable_feedback() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=False)
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=_terminal_events(packet, supported=False),
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "not_fulfilled"
+    feedback = receipt["failure_feedback"]
+    assert feedback["failure_kinds"] == ["mechanism_contradicted"]
+    assert feedback["unmet_criteria"] == ["heldout_generalization"]
+    assert feedback["verified_boundary"] == []
+    assert feedback["fallback_artifact_refs"] == ["artifact:report"]
+    assert feedback["reentry_conditions"] == [
+        "Provide a new held-out repository split.",
+        "resolve:heldout_generalization:mechanism_contradicted",
+    ]
+    assert receipt["learning_disposition"] == "candidate"
+
+
+def test_retired_result_without_required_review_remains_inconclusive() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=False)
+    events = build_auto_research_rollout_events(packet)
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=GOAL_ID,
+        rollout_events=events,
+    )
+    decision = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="hyp_generalization",
+        outcome="retired",
+        reason="contradicted",
+        decided_by=PROMOTER,
+    )
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=[*events, decision],
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "inconclusive"
+    assert receipt["failure_feedback"]["failure_kinds"] == [
+        "independent_review_missing"
+    ]
+
+
+def test_missing_artifact_is_partial_not_verified() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=True, include_report=False)
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=_terminal_events(packet, supported=True),
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "partial"
+    assert receipt["artifacts"]["missing_required_refs"] == ["artifact:report"]
+    assert receipt["failure_feedback"]["failure_kinds"] == [
+        "required_artifact_missing"
+    ]
+    assert receipt["failure_feedback"]["missing_required_artifact_refs"] == [
+        "artifact:report"
+    ]
+
+
+def test_contract_change_invalidates_prior_terminal_result() -> None:
+    old_contract = _delivery_contract()
+    old_packet = _packet(old_contract, supported=True)
+    events = _terminal_events(old_packet, supported=True)
+    changed_contract = _delivery_contract(
+        reentry_conditions=[
+            "Provide two new held-out repository families.",
+        ]
+    )
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=changed_contract,
+        rollout_events=events,
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "stale"
+    assert receipt["contract"]["state"] == "stale"
+    assert receipt["failure_feedback"]["failure_kinds"] == [
+        "contract_revision_changed",
+        "required_artifact_missing",
+    ]
+    assert (
+        receipt["failure_feedback"]["reentry_conditions"][0]
+        == "Provide two new held-out repository families."
+    )
+
+
+def test_latest_contract_revision_replaces_prior_hypothesis_evidence() -> None:
+    old_contract = _delivery_contract()
+    changed_contract = _delivery_contract(
+        reentry_conditions=["Provide two new held-out repository families."]
+    )
+    old_events = build_auto_research_rollout_events(
+        _packet(old_contract, supported=True)
+    )
+    new_events = build_auto_research_rollout_events(
+        _packet(changed_contract, supported=False)
+    )
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=GOAL_ID,
+        rollout_events=[*old_events, *new_events],
+    )
+    node = graph["nodes"][0]
+    assert graph["evidence_event_count"] == 2
+    assert node["status"] == "contradicted"
+    assert node["contract_revision"] != old_events[0]["details"][
+        "contract_revision"
+    ]
+
+
+def test_tampered_evidence_wish_id_cannot_verify_same_revision() -> None:
+    contract = _delivery_contract()
+    events = _terminal_events(_packet(contract, supported=True), supported=True)
+    _assert_lineage_tampering_fails_closed(
+        _tampered_evidence_lineage(
+            events,
+            field="wish_id",
+            value="wish_tampered",
+        )
+    )
+
+
+def test_tampered_evidence_contract_ref_cannot_verify_same_revision() -> None:
+    contract = _delivery_contract()
+    events = _terminal_events(_packet(contract, supported=True), supported=True)
+    _assert_lineage_tampering_fails_closed(
+        _tampered_evidence_lineage(
+            events,
+            field="contract_ref",
+            value="contract:tampered",
+        )
+    )
+
+
+def test_partial_evidence_lineage_cannot_verify_same_revision() -> None:
+    contract = _delivery_contract()
+    events = _terminal_events(_packet(contract, supported=True), supported=True)
+    _assert_lineage_tampering_fails_closed(
+        _tampered_evidence_lineage(
+            events,
+            field="contract_ref",
+            value=None,
+        )
+    )
+
+
+def test_partial_hypothesis_lineage_cannot_verify_or_raise_key_error() -> None:
+    contract = _delivery_contract()
+    events = deepcopy(
+        _terminal_events(_packet(contract, supported=True), supported=True)
+    )
+    for event in events:
+        if event["event_kind"] != "research_hypothesis":
+            continue
+        event["details"].pop("contract_ref")
+        event["details"].pop("contract_revision")
+    _assert_lineage_tampering_fails_closed(events)
+
+
+def test_missing_terminal_decision_is_inconclusive() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=True)
+    events = build_auto_research_rollout_events(packet)
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=events,
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "inconclusive"
+    assert receipt["failure_feedback"]["failure_kinds"] == [
+        "terminal_decision_missing"
+    ]
+
+
+def test_missing_contract_record_returns_reentry_feedback() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=True)
+    events = [
+        event
+        for event in _terminal_events(packet, supported=True)
+        if event["classification"] != AUTO_RESEARCH_DELIVERY_CONTRACT_SCHEMA_VERSION
+    ]
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=events,
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "inconclusive"
+    assert "contract_record_missing" in receipt["failure_feedback"][
+        "failure_kinds"
+    ]
+    assert receipt["failure_feedback"]["reentry_conditions"][0] == (
+        "Provide a new held-out repository split."
+    )
+    assert "record_current_delivery_contract" in receipt["failure_feedback"][
+        "reentry_conditions"
+    ]
+
+
+def test_independent_review_rejection_is_inconclusive_feedback() -> None:
+    contract = _delivery_contract()
+    packet = _packet(contract, supported=True)
+    events = build_auto_research_rollout_events(packet)
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=GOAL_ID,
+        rollout_events=events,
+    )
+    decision = build_terminal_decision_event(
+        evidence_graph=graph,
+        hypothesis_id="hyp_generalization",
+        outcome="promoted",
+        reason="holdout_validated",
+        decided_by=PROMOTER,
+    )
+    review = build_peer_review_event(
+        evidence_graph=graph,
+        rollout_events=[*events, decision],
+        hypothesis_id="hyp_generalization",
+        reviewer_agent_id=REVIEWER,
+        verdict="reject",
+        require_independent=True,
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    receipt = build_auto_research_artifact_receipt(
+        delivery_contract=contract,
+        rollout_events=[*events, decision, review],
+        registered_agent_ids=REGISTERED_AGENTS,
+    )
+    assert receipt["status"] == "inconclusive"
+    assert receipt["failure_feedback"]["failure_kinds"] == [
+        "independent_review_rejected"
+    ]
+
+
+def test_delivery_contract_rejects_undeclared_artifact_reference() -> None:
+    contract = _delivery_contract()
+    contract["acceptance_criteria"][0]["required_artifact_refs"].append(
+        "artifact:undeclared"
+    )
+    try:
+        normalize_auto_research_delivery_contract(contract)
+    except ValueError as exc:
+        assert "undeclared artifacts" in str(exc)
+    else:
+        raise AssertionError("undeclared artifact references must fail closed")


### PR DESCRIPTION
## Summary

- add `auto_research_delivery_contract_v0` as a thin envelope over the existing `research_contract_v0`, preserving the original wish, assumptions, required artifacts, acceptance criteria, failure fallbacks, and a stable contract revision
- propagate wish/contract lineage through existing Auto Research hypothesis and evidence events without changing the legacy `research_contract_v0` path
- add the read-only `loopx auto-research artifact-receipt --contract ...` projection with `verified`, `partial`, `inconclusive`, `not_fulfilled`, and `stale` outcomes
- return actionable non-verified feedback: failure kinds, unmet criteria, verified boundary, missing/fallback artifacts, and reentry conditions
- keep user acceptance and Skill/Extension promotion explicit; the receipt grants neither

## Scope and boundaries

- reuses the existing Auto Research evidence graph, terminal decision, independent review, rollout log, and Explore ownership
- adds no scheduler, task store, capability id, automatic Skill promotion, or extension mutation
- `not_fulfilled` requires a terminal retirement decision plus any independent review required by the delivery contract; one failed attempt remains inconclusive
- legacy `research_contract_v0` evidence packets retain their prior event shape
- future-facing pass: applied only at the adjacent contract/result boundary; broader Gadget Registry and generic Wish system were deliberately deferred

## Validation

- `pytest -q tests/test_auto_research_artifact_receipt.py tests/test_auto_research_control.py` — 19 passed
- Auto Research user-contract, evidence-writer, rollout-append, rollout-readpath, terminal-result, terminal-result CLI, and artifact-receipt smokes passed
- Ruff passed for all changed Python files
- `loopx canary premerge --from-git-diff --goal-id loopx-product` — standard tier passed, 18/18 selected checks, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan passed for all 15 changed files

## Review focus

- contract revision lineage and stale-result behavior
- aggregate receipt status precedence, especially `not_fulfilled` versus `inconclusive`
- compatibility of legacy `research_contract_v0` packets and events
- whether fallback artifacts and reentry conditions provide sufficient user feedback without overstating impossibility
