### PR TITLE
docs(book): add contributor welcome wagon

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -27,6 +27,7 @@ on:
       - "examples/readme-star-history-smoke.py"
       - "examples/frontstage-stargazer-fetch-smoke.py"
       - "examples/dev-book-publication-smoke.py"
+      - "examples/dev-book-welcome-wagon-smoke.py"
       - "examples/goal-channel-frontstage-fixture.py"
       - "examples/showcase-catalog-smoke.py"
       - "examples/status.example.json"
@@ -58,6 +59,7 @@ on:
       - "examples/readme-star-history-smoke.py"
       - "examples/frontstage-stargazer-fetch-smoke.py"
       - "examples/dev-book-publication-smoke.py"
+      - "examples/dev-book-welcome-wagon-smoke.py"
       - "examples/goal-channel-frontstage-fixture.py"
       - "examples/showcase-catalog-smoke.py"
       - "examples/status.example.json"
@@ -190,6 +192,9 @@ jobs:
 
       - name: Validate rendered Developer Book
         run: python3 examples/dev-book-publication-smoke.py --site-dir output/frontstage-pages/site/docs/book
+
+      - name: Validate Developer Book Welcome Wagon
+        run: python3 examples/dev-book-welcome-wagon-smoke.py --site-dir output/frontstage-pages/site/docs/book
 
       - name: Configure Pages
         if: github.event_name != 'pull_request'

--- a/docs/book/en/welcome-wagon.md
+++ b/docs/book/en/welcome-wagon.md
@@ -114,7 +114,9 @@ When the Host has no native `/loopx` entry, follow the guided route in the
 
 A successful first run should prove at least:
 
-- `loopx doctor` recognizes the release, skills, Host, and Effect runtime;
+- `loopx doctor` checks the release, skills, and Effect runtime; for
+  Host-specific checks, first use `loopx agent-onboard --list-agent-types` to
+  select the exact type, then run `loopx doctor --agent-type <agent-type>`;
 - `loopx status` shows the exact Goal, current Gate, and next Todo;
 - `.loopx/`, `.codex/goals/`, and `.local/` remain outside Git;
 - the current Host loop driver is active, or the output gives an explicit manual start step;

--- a/docs/book/en/welcome-wagon.md
+++ b/docs/book/en/welcome-wagon.md
@@ -1,0 +1,272 @@
+# Welcome Wagon: From Reader to Participant in 30 Minutes
+
+<!-- welcome-wagon:small-first-outcome -->
+
+> **Complete one real small thing first.** You do not need to finish the Dev
+> Book, understand the entire CLI, or modify the Kernel. Choose one route
+> below, leave a verifiable result, and then decide whether to go deeper.
+
+The Chinese and English pages are semantic mirrors. A material difference in sections, actions, commands,
+link targets, or boundaries is a documentation defect.
+
+<!-- welcome-wagon:four-routes -->
+
+<div class="grid cards" markdown>
+
+-   :material-play-circle-outline: **Run it once**
+
+    Install LoopX, connect your own project, and inspect the first state.
+
+    **About 15 minutes · Outcome: a recoverable Goal**
+
+-   :material-message-text-outline: **Share feedback**
+
+    Submit a sanitized first-run report, question, or longer usage story.
+
+    **About 10 minutes · Outcome: actionable public feedback**
+
+-   :material-source-pull: **Make a contribution**
+
+    Claim one bounded task and complete the smallest change and validation.
+
+    **About 45–60 minutes · Outcome: a reviewable PR**
+
+-   :material-comment-check-outline: **Review something**
+
+    Comment on an RFC, Issue, or PR with evidence before writing code.
+
+    **About 30 minutes · Outcome: a review that advances a decision**
+
+</div>
+
+## Choose Your Finish Line {#choose-finish-line}
+
+| What you want to do | Completion evidence | Start here |
+| --- | --- | --- |
+| Decide whether LoopX fits your project | `doctor` passes, project state is readable, and local state stays out of Git | [Route A](#run-once) |
+| Tell maintainers what worked or blocked you | A minimal, public-safe, reproducible report | [Route B](#share-feedback) |
+| Submit your first code or documentation change | Claimed task, bounded diff, validation, and DCO sign-off | [Route C](#first-contribution) |
+| Participate in architecture or direction | Separate shipped facts from proposals and identify evidence, risk, or a smallest slice | [Route D](#review-path) |
+
+The routes are independent. A user does not have to become a code contributor, and contributions are not
+limited to Kernel changes. Reproductions, documentation, deterministic fixtures, community answers, and
+design reviews all count.
+
+## Shared Starting Point: Inspect Before Writing {#inspect-first}
+
+<!-- welcome-wagon:inspect-before-write -->
+
+Run these commands from the target project root:
+
+```bash
+loopx --version
+node --version
+loopx doctor
+git status --short --branch
+```
+
+Current LoopX releases require Python 3.11+ and Node.js 22.6+. If `doctor` fails, repair the installation
+through [Installing LoopX](/loopx/docs/guides/installing-loopx/) before writing project state in a broken
+environment.
+
+<!-- welcome-wagon:public-private-boundary -->
+
+Never put credentials, private project names, internal links, absolute machine paths, raw transcripts,
+`.loopx/`, `.codex/goals/`, or unsanitized logs in public feedback or contributions.
+
+## A. Run LoopX Once {#run-once}
+
+<!-- welcome-wagon:run-first-goal -->
+
+### 1. Install and inspect
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx doctor
+```
+
+Restart the Agent Host after installation so it reloads workflow skills. Run `loopx doctor --deep` when
+you need to exercise the TypeScript Effect runtime. LoopX manages this runtime automatically; you do not
+start a daemon yourself.
+
+### 2. Connect a project you understand
+
+```bash
+cd /path/to/your-project
+loopx connect --dry-run
+loopx connect
+loopx status
+```
+
+If the project has no Goal to continue, ask your current Agent to run:
+
+```text
+$loopx <a cross-session task with a verifiable finish condition>
+```
+
+When the Host has no native `/loopx` entry, follow the guided route in the
+[Newcomer Command Path](/loopx/docs/guides/newcomer-command-path/).
+
+<!-- welcome-wagon:verify-first-goal -->
+
+### 3. Verify the outcome, not only the exit code
+
+A successful first run should prove at least:
+
+- `loopx doctor` recognizes the release, skills, Host, and Effect runtime;
+- `loopx status` shows the exact Goal, current Gate, and next Todo;
+- `.loopx/`, `.codex/goals/`, and `.local/` remain outside Git;
+- the current Host loop driver is active, or the output gives an explicit manual start step;
+- Goal selection, identity takeover, credentials, and external writes stop at a Gate.
+
+See [Connect an existing Git project](chapters/05-connect-existing-project.md) for the complete Agent
+onboarding contract.
+
+## B. Share One Real Experience {#share-feedback}
+
+<!-- welcome-wagon:share-feedback -->
+
+You do not need to fix code first. High-quality feedback is a contribution.
+
+```bash
+loopx first-run-report
+```
+
+The command prints a local environment summary and a prefilled Issue link. It sends **no telemetry**.
+Review the draft and remove anything that should not be public before submitting it.
+
+<!-- welcome-wagon:route-community-channel -->
+
+| Your situation | Use this route | Include |
+| --- | --- | --- |
+| First installation or connection | [First-run feedback](https://github.com/huangruiteng/loopx/issues/new?template=first_run.yml) | Version, OS, Host, and completed steps |
+| A run lasting hours or days | [Usage story](https://github.com/huangruiteng/loopx/issues/new?template=usage_story.yml) | Duration, capabilities, recovery, and outcome |
+| Reproducible incorrect behavior | [Bug report](https://github.com/huangruiteng/loopx/issues/new?template=bug_report.yml) | Minimal reproduction, expected/actual behavior, sanitized diagnostics |
+| Usage or design question | [GitHub Q&A](https://github.com/huangruiteng/loopx/discussions/categories/q-a) | Goal, current version, and attempted route |
+| A public workflow or outcome | [Show and tell](https://github.com/huangruiteng/loopx/discussions/categories/show-and-tell) | What ran, evidence, and limitations |
+
+For informal conversation, join [Discord](https://discord.gg/XmGgQyCFZd). Chat is useful for exploration;
+final bugs, decisions, and reproducible conclusions should return to an Issue, Discussion, PR, or
+versioned document.
+
+## C. Make Your First Contribution {#first-contribution}
+
+<!-- welcome-wagon:find-current-work -->
+
+### 1. Start from current work
+
+Read these in order:
+
+1. [Current Technical Directions](/loopx/docs/project/technical-directions/) to identify whether a
+   direction is shipped, incubating, research, draft, or held;
+2. the [Contributor Task Board](/loopx/docs/development/contributor-tasks/) to choose a
+   `Starter / Good First` task or another bounded task with design agreement;
+3. [CONTRIBUTING](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md) for setup, DCO,
+   public/private boundaries, and validation.
+
+The task board is a dynamic source of truth. This book does not copy its current rows. If a task has no
+Issue, open one with the
+[Contributor task form](https://github.com/huangruiteng/loopx/issues/new?template=contributor-task.yml)
+to establish a public coordination boundary.
+
+<!-- welcome-wagon:claim-bounded-slice -->
+
+### 2. Leave a useful claim comment
+
+A useful claim says:
+
+```text
+I plan to handle:
+- Smallest outcome:
+- Non-goals:
+- Expected files or owner:
+- Validation:
+- Target base branch:
+```
+
+Do not duplicate a `Maintainer-owned` task. Ask whether it can expose an independent fixture,
+documentation, accessibility, or public-safe replay slice.
+
+<!-- welcome-wagon:deliver-clean-loop -->
+
+### 3. Complete one clean loop
+
+```text
+problem
+  -> canonical owner
+  -> invariant
+  -> smallest coherent change
+  -> focused validation
+  -> signed commit
+  -> pull request
+```
+
+Good first contributions often include:
+
+- documentation navigation, terminology, or locale parity;
+- one missing negative case in an existing smoke;
+- a public-safe synthetic fixture;
+- CLI error or output consistency;
+- a narrow parity check for an existing Capability or Host.
+
+Do not confuse “easy to edit” with “safe to change.” Even a few lines should state the user outcome they
+change and the evidence that proves it.
+
+## D. Review An RFC Or Change {#review-path}
+
+<!-- welcome-wagon:review-by-maturity -->
+
+Start with the [RFC Index](/loopx/docs/architecture/rfcs/) and identify the material's status:
+
+| Status | Useful participation | Do not |
+| --- | --- | --- |
+| Accepted | Check implementation, add negative cases, improve compatibility and docs | Recreate a second semantic owner |
+| Active research | Improve experiment design, fixtures, attribution, and boundaries | Turn experimental results directly into default product claims |
+| Draft | Review the problem, authority, non-goals, smallest slice, and validation | Start a broad implementation before a bounded task exists |
+| Integration proposal | Add parity, characterization, and promotion evidence | Treat an integration branch as `main` truth |
+
+A first review can answer only six questions:
+
+1. Which user or maintainer problem does it solve?
+2. Where is the current canonical authority?
+3. Which statements describe shipped behavior, and which are proposals?
+4. Does it change defaults, permissions, or the public/private boundary?
+5. What is the smallest verifiable slice and the strongest counterexample?
+6. After failure or rollback, which state remains trustworthy?
+
+Cross-direction questions may enter an
+[Open Strategy Review](/loopx/docs/community/open-strategy-reviews/). It produces a disposition, owner,
+next artifact, and review trigger; it does not replace the RFC, Issue, or PR path with a meeting vote.
+
+## Ask For Help Without Losing The Signal {#ask-for-help}
+
+<!-- welcome-wagon:ask-with-signal -->
+
+Include:
+
+- `loopx --version`;
+- the Host or runtime surface;
+- the outcome you want;
+- the smallest public reproduction;
+- expected and actual behavior;
+- the sanitized result of any read-only diagnostics you ran.
+
+Do not paste a large log without context or say only that something “does not work.” A good question lets
+another person reproduce the problem, locate the owner, and propose a next action. See
+[LoopX Support](https://github.com/huangruiteng/loopx/blob/main/.github/SUPPORT.md) for channel and
+response boundaries.
+
+## Where To Go Next {#next-stop}
+
+<!-- welcome-wagon:choose-next-depth -->
+
+- To understand why a control plane helps, read
+  [From one session to long-running work](chapters/01-from-session-to-loop.md).
+- To connect your own project, read
+  [Connect an existing Git project](chapters/05-connect-existing-project.md).
+- To change LoopX, read the [Developer contribution map](chapters/source-protocol-map.md).
+- To enter the Kernel, follow the [Control-Plane Developer Course](chapters/12-control-plane-course.md).
+
+Complete one route before choosing the next. The Welcome Wagon is not meant to teach everything at once;
+it makes the first real action safe, verifiable, and easy for the community to receive.

--- a/docs/book/mkdocs.en.yaml
+++ b/docs/book/mkdocs.en.yaml
@@ -58,6 +58,7 @@ extra:
 nav:
   - Home: index.md
   - Start:
+      - Welcome Wagon: welcome-wagon.md
       - How to use this book: chapters/00-reading-guide.md
   - Developer Course:
       - Control-Plane Course: chapters/12-control-plane-course.md

--- a/docs/book/mkdocs.zh.yaml
+++ b/docs/book/mkdocs.zh.yaml
@@ -61,6 +61,7 @@ extra:
 nav:
   - 首页: index.md
   - 开始:
+      - Welcome Wagon: welcome-wagon.md
       - 如何使用本书: chapters/00-reading-guide.md
   - 开发者课程:
       - Control-Plane Course: chapters/12-control-plane-course.md

--- a/docs/book/welcome-wagon.md
+++ b/docs/book/welcome-wagon.md
@@ -1,0 +1,262 @@
+# Welcome Wagon：30 分钟从读者到参与者
+
+<!-- welcome-wagon:small-first-outcome -->
+
+> **先完成一件真实的小事。** 你不需要读完 Dev Book、理解全部 CLI，或先修改
+> Kernel。选择下面一条路线，留下一个可验证结果，再决定是否继续深入。
+
+中文与英文页面是语义镜像；章节、行动、命令、链接目标或边界出现实质差异都属于文档缺陷。
+
+<!-- welcome-wagon:four-routes -->
+
+<div class="grid cards" markdown>
+
+-   :material-play-circle-outline: **跑通一次**
+
+    在自己的项目里完成安装、连接和第一次状态回读。
+
+    **约 15 分钟 · 产物：可恢复的 Goal**
+
+-   :material-message-text-outline: **反馈一次**
+
+    提交脱敏的 first-run、问题或长期使用记录。
+
+    **约 10 分钟 · 产物：可行动的公开反馈**
+
+-   :material-source-pull: **贡献一次**
+
+    认领一个有边界的任务，完成最小改动与验证。
+
+    **约 45–60 分钟 · 产物：可审阅的 PR**
+
+-   :material-comment-check-outline: **评审一次**
+
+    用证据评论一个 RFC、Issue 或 PR，不急着写实现。
+
+    **约 30 分钟 · 产物：一条推进决策的 review**
+
+</div>
+
+## 先选你的完成线 {#choose-finish-line}
+
+| 你现在想做什么 | 完成标准 | 从哪里开始 |
+| --- | --- | --- |
+| 判断 LoopX 是否适合自己的项目 | `doctor` 通过，项目状态可读，本地状态未进入 Git | [路线 A](#run-once) |
+| 告诉维护者哪里好用或卡住 | 留下最小、公开安全、可复现的反馈 | [路线 B](#share-feedback) |
+| 提交第一份代码或文档贡献 | 任务已认领，改动有界，验证与 DCO 完整 | [路线 C](#first-contribution) |
+| 参与方向和架构讨论 | 区分已发布事实与提案，并指出证据、风险或最小切片 | [路线 D](#review-path) |
+
+四条路线互不依赖。使用者不必成为贡献者；贡献也不只等于修改 Kernel。复现问题、改善文档、
+补充 deterministic fixture、回答社区问题和评审设计都属于有效参与。
+
+## 共同起点：只读确认环境 {#inspect-first}
+
+<!-- welcome-wagon:inspect-before-write -->
+
+先在目标项目根目录运行：
+
+```bash
+loopx --version
+node --version
+loopx doctor
+git status --short --branch
+```
+
+LoopX 当前要求 Python 3.11+ 与 Node.js 22.6+。如果 `doctor` 失败，先按
+[安装指南](/loopx/docs/guides/installing-loopx/)修复安装，不要在错误环境里继续写项目状态。
+
+<!-- welcome-wagon:public-private-boundary -->
+
+在任何公开反馈或贡献中，都不要粘贴凭据、私有项目名、内部链接、本机绝对路径、raw transcript、
+`.loopx/`、`.codex/goals/` 或未脱敏日志。
+
+## A. 跑通一次 LoopX {#run-once}
+
+<!-- welcome-wagon:run-first-goal -->
+
+### 1. 安装并检查
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx doctor
+```
+
+安装后重启 Agent Host，让它重新加载 workflow skill。需要验证 TypeScript Effect runtime 时运行
+`loopx doctor --deep`；该 runtime 由 LoopX 自动管理，不需要手工启动 daemon。
+
+### 2. 连接一个你熟悉的项目
+
+```bash
+cd /path/to/your-project
+loopx connect --dry-run
+loopx connect
+loopx status
+```
+
+如果项目尚无可继续的 Goal，优先让当前 Agent 执行：
+
+```text
+$loopx <一个跨会话、可验证、完成条件明确的任务>
+```
+
+Host 没有原生 `/loopx` 入口时，使用
+[Newcomer Command Path](/loopx/docs/guides/newcomer-command-path/) 中的 guided route。
+
+<!-- welcome-wagon:verify-first-goal -->
+
+### 3. 验收，而不是只看退出码
+
+第一次成功至少应满足：
+
+- `loopx doctor` 能识别发布物、skill、Host 与 Effect runtime；
+- `loopx status` 能看到精确 Goal、当前 Gate 和下一项 Todo；
+- `.loopx/`、`.codex/goals/` 与 `.local/` 没有进入 Git；
+- 当前 Host 的 loop driver 已激活，或返回了明确的人工启动步骤；
+- 遇到 Goal 选择、identity takeover、凭据或外部写入时，流程停在 Gate。
+
+完整的 Agent 接入合同见[连接你的 Git 项目](chapters/05-connect-existing-project.md)。
+
+## B. 反馈一次真实体验 {#share-feedback}
+
+<!-- welcome-wagon:share-feedback -->
+
+不需要先修代码。高质量反馈本身就是贡献。
+
+```bash
+loopx first-run-report
+```
+
+这个命令只生成本地环境摘要和预填 Issue 链接，**不会发送 telemetry**。提交前仍需人工检查并
+删除任何不适合公开的信息。
+
+<!-- welcome-wagon:route-community-channel -->
+
+| 你的情况 | 使用入口 | 应包含 |
+| --- | --- | --- |
+| 第一次安装或连接 | [First-run feedback](https://github.com/huangruiteng/loopx/issues/new?template=first_run.yml) | 版本、OS、Host、完成步骤 |
+| 运行了数小时或数天 | [Usage story](https://github.com/huangruiteng/loopx/issues/new?template=usage_story.yml) | 时长、使用能力、恢复方式、结果 |
+| 可复现错误 | [Bug report](https://github.com/huangruiteng/loopx/issues/new?template=bug_report.yml) | 最小复现、期望、实际、脱敏诊断 |
+| 使用或设计问题 | [GitHub Q&A](https://github.com/huangruiteng/loopx/discussions/categories/q-a) | 目标、当前版本、已尝试路径 |
+| 可公开工作流或成果 | [Show and tell](https://github.com/huangruiteng/loopx/discussions/categories/show-and-tell) | 真实运行方式、证据与限制 |
+
+如果只是想先与其他使用者交流，可以加入
+[Discord](https://discord.gg/XmGgQyCFZd)。聊天适合探索；最终 bug、决定和可复现结论应回到
+Issue、Discussion、PR 或版本化文档。
+
+## C. 完成第一次贡献 {#first-contribution}
+
+<!-- welcome-wagon:find-current-work -->
+
+### 1. 从当前任务开始
+
+依次阅读：
+
+1. [Current Technical Directions](/loopx/docs/project/technical-directions/)：方向处于
+   shipped、incubating、research、draft 还是 held；
+2. [Contributor Task Board](/loopx/docs/development/contributor-tasks/)：选择 `Starter / Good First`
+   或已有共识的 bounded task；
+3. [CONTRIBUTING](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md)：安装、DCO、
+   public/private boundary 和验证要求。
+
+任务板是动态事实源。本书不会复制“当前可认领任务”列表；如果任务没有关联 Issue，先用
+[Contributor task 表单](https://github.com/huangruiteng/loopx/issues/new?template=contributor-task.yml)
+建立公开协作边界。
+
+<!-- welcome-wagon:claim-bounded-slice -->
+
+### 2. 留下一条认领评论
+
+一条有效认领应说明：
+
+```text
+我准备处理：
+- 最小结果：
+- 不做什么：
+- 预计文件或 owner：
+- 验证命令：
+- 目标 base branch：
+```
+
+`Maintainer-owned` 任务不要重复实现；可以询问是否能拆出 fixture、文档、可访问性或
+public-safe replay 等独立 helper slice。
+
+<!-- welcome-wagon:deliver-clean-loop -->
+
+### 3. 在干净分支完成一个闭环
+
+```text
+problem
+  -> canonical owner
+  -> invariant
+  -> smallest coherent change
+  -> focused validation
+  -> signed commit
+  -> pull request
+```
+
+第一次贡献优先考虑：
+
+- 文档导航、术语和中英文一致性；
+- 已有 smoke 的一个遗漏反例；
+- public-safe synthetic fixture；
+- CLI 错误信息或输出一致性；
+- 已有 Capability/Host 的 narrow parity check。
+
+不要把“容易改”误认为“可以随便改”。即使只有几行，也要说明改变了什么用户结果，以及什么
+证据能证明它。
+
+## D. 参与一次 RFC 或 Review {#review-path}
+
+<!-- welcome-wagon:review-by-maturity -->
+
+先从 [RFC Index](/loopx/docs/architecture/rfcs/) 判断材料状态：
+
+| 状态 | 可以做什么 | 不应该做什么 |
+| --- | --- | --- |
+| Accepted | 核对实现、补负例、修兼容与文档 | 重新发明另一套 semantic owner |
+| Active research | 改进实验设计、fixture、归因和边界 | 把实验结果直接写成默认产品能力 |
+| Draft | 评论问题、权威、非目标、最小切片和验证 | 未形成 bounded task 就开始大规模实现 |
+| Integration proposal | 做 parity、characterization 与 promotion evidence | 把 integration branch 当作 `main` 事实 |
+
+第一次 review 可以只回答六个问题：
+
+1. 它解决的是哪个用户或维护者问题？
+2. 当前 canonical authority 在哪里？
+3. 哪些是已发布事实，哪些只是提案？
+4. 默认行为、权限或 public/private boundary 是否变化？
+5. 最小可验证切片和最强反例是什么？
+6. 失败或回滚后，哪个状态仍然可信？
+
+跨方向问题可以进入
+[Open Strategy Review](/loopx/docs/community/open-strategy-reviews/)。它形成 disposition、owner、
+下一产物和复核 trigger，但不会用一次会议投票替代 RFC、Issue 或 PR。
+
+## 卡住时怎么求助 {#ask-for-help}
+
+<!-- welcome-wagon:ask-with-signal -->
+
+提问时附上：
+
+- `loopx --version`；
+- Host/runtime surface；
+- 你想完成的结果；
+- 最小公开复现；
+- expected 与 actual；
+- 已运行的只读诊断及其脱敏摘要。
+
+不要只贴一大段日志，也不要只说“不能用”。好的问题让其他人能复现、判断 owner，并给出下一条
+可执行动作。渠道与响应边界见
+[LoopX Support](https://github.com/huangruiteng/loopx/blob/main/.github/SUPPORT.md)。
+
+## 你的下一站 {#next-stop}
+
+<!-- welcome-wagon:choose-next-depth -->
+
+- 想理解为什么要用控制面：读[从一次会话到长程任务](chapters/01-from-session-to-loop.md)；
+- 想把自己的项目接进来：读[连接你的 Git 项目](chapters/05-connect-existing-project.md)；
+- 想修改 LoopX：读[开发者贡献地图](chapters/source-protocol-map.md)；
+- 想深入 Kernel：进入 [Control-Plane Developer Course](chapters/12-control-plane-course.md)。
+
+完成一条路线以后再选择下一条。Welcome Wagon 的目标不是让新人一次理解所有东西，而是让第一
+次真实行动足够安全、可验证，并且能被社区接住。

--- a/docs/book/welcome-wagon.md
+++ b/docs/book/welcome-wagon.md
@@ -109,7 +109,9 @@ Host 没有原生 `/loopx` 入口时，使用
 
 第一次成功至少应满足：
 
-- `loopx doctor` 能识别发布物、skill、Host 与 Effect runtime；
+- `loopx doctor` 能检查发布物、skill 与 Effect runtime；需要 Host-specific
+  检查时，先用 `loopx agent-onboard --list-agent-types` 选择准确类型，再运行
+  `loopx doctor --agent-type <agent-type>`；
 - `loopx status` 能看到精确 Goal、当前 Gate 和下一项 Todo；
 - `.loopx/`、`.codex/goals/` 与 `.local/` 没有进入 Git；
 - 当前 Host 的 loop driver 已激活，或返回了明确的人工启动步骤；

--- a/examples/dev-book-welcome-wagon-smoke.py
+++ b/examples/dev-book-welcome-wagon-smoke.py
@@ -51,6 +51,8 @@ SHARED_COMMANDS = (
     "git status --short --branch",
     "python3 -m pip install --upgrade loopx",
     "loopx workflow-skills --install",
+    "loopx agent-onboard --list-agent-types",
+    "loopx doctor --agent-type <agent-type>",
     "loopx connect --dry-run",
     "loopx connect",
     "loopx status",

--- a/examples/dev-book-welcome-wagon-smoke.py
+++ b/examples/dev-book-welcome-wagon-smoke.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate the bilingual Developer Book Welcome Wagon contract."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+from urllib.parse import urlparse
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOK = REPO_ROOT / "docs" / "book"
+ZH_PAGE = BOOK / "welcome-wagon.md"
+EN_PAGE = BOOK / "en" / "welcome-wagon.md"
+ZH_CONFIG = BOOK / "mkdocs.zh.yaml"
+EN_CONFIG = BOOK / "mkdocs.en.yaml"
+
+SECTION_IDS = (
+    "choose-finish-line",
+    "inspect-first",
+    "run-once",
+    "share-feedback",
+    "first-contribution",
+    "review-path",
+    "ask-for-help",
+    "next-stop",
+)
+
+SEMANTIC_CHECKPOINTS = (
+    "small-first-outcome",
+    "four-routes",
+    "inspect-before-write",
+    "public-private-boundary",
+    "run-first-goal",
+    "verify-first-goal",
+    "share-feedback",
+    "route-community-channel",
+    "find-current-work",
+    "claim-bounded-slice",
+    "deliver-clean-loop",
+    "review-by-maturity",
+    "ask-with-signal",
+    "choose-next-depth",
+)
+
+SHARED_COMMANDS = (
+    "loopx --version",
+    "node --version",
+    "loopx doctor",
+    "git status --short --branch",
+    "python3 -m pip install --upgrade loopx",
+    "loopx workflow-skills --install",
+    "loopx connect --dry-run",
+    "loopx connect",
+    "loopx status",
+    "loopx first-run-report",
+)
+
+SHARED_BOUNDARY_MARKERS = (
+    "Python 3.11+",
+    "Node.js 22.6+",
+    ".loopx/",
+    ".codex/goals/",
+    ".local/",
+    "Maintainer-owned",
+    "DCO",
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def markdown_link_targets(markdown: str) -> list[str]:
+    return re.findall(r"(?<!!)\[[^]]+\]\(([^)]+)\)", markdown)
+
+
+def explicit_section_ids(markdown: str) -> list[str]:
+    return re.findall(
+        r"^## .+ \{#([a-z0-9-]+)\}$",
+        markdown,
+        flags=re.MULTILINE,
+    )
+
+
+def semantic_checkpoints(markdown: str) -> list[str]:
+    return re.findall(
+        r"<!-- welcome-wagon:([a-z0-9-]+) -->",
+        markdown,
+    )
+
+
+def rendered_route_for_absolute_link(site_root: Path, target: str) -> Path | None:
+    parsed = urlparse(target)
+    if parsed.scheme or parsed.netloc or not parsed.path.startswith("/loopx/docs/"):
+        return None
+    relative = parsed.path.removeprefix("/loopx/docs/").strip("/")
+    return site_root / relative / "index.html"
+
+
+def validate_source() -> None:
+    welcome_zh = read(ZH_PAGE)
+    welcome_en = read(EN_PAGE)
+
+    assert explicit_section_ids(welcome_zh) == list(SECTION_IDS)
+    assert explicit_section_ids(welcome_en) == list(SECTION_IDS)
+    assert semantic_checkpoints(welcome_zh) == list(SEMANTIC_CHECKPOINTS)
+    assert semantic_checkpoints(welcome_en) == list(SEMANTIC_CHECKPOINTS)
+    assert markdown_link_targets(welcome_zh) == markdown_link_targets(welcome_en)
+
+    for command in SHARED_COMMANDS:
+        assert command in welcome_zh, f"welcome-wagon.md: missing command {command}"
+        assert command in welcome_en, f"en/welcome-wagon.md: missing command {command}"
+
+    for marker in SHARED_BOUNDARY_MARKERS:
+        assert marker in welcome_zh, f"welcome-wagon.md: missing semantic marker {marker}"
+        assert marker in welcome_en, f"en/welcome-wagon.md: missing semantic marker {marker}"
+
+    zh_config = read(ZH_CONFIG)
+    en_config = read(EN_CONFIG)
+    assert "Welcome Wagon: welcome-wagon.md" in zh_config
+    assert "Welcome Wagon: welcome-wagon.md" in en_config
+
+
+def validate_rendered_site(book_site_dir: Path) -> None:
+    rendered_pages = {
+        book_site_dir / "welcome-wagon" / "index.html": (
+            "Welcome Wagon：30 分钟从读者到参与者",
+            "跑通一次",
+            "反馈一次",
+            "贡献一次",
+            "评审一次",
+        ),
+        book_site_dir / "en" / "welcome-wagon" / "index.html": (
+            "Welcome Wagon: From Reader to Participant in 30 Minutes",
+            "Run it once",
+            "Share feedback",
+            "Make a contribution",
+            "Review something",
+        ),
+    }
+    for path, markers in rendered_pages.items():
+        assert path.is_file(), f"missing rendered Welcome Wagon page: {path}"
+        html = read(path)
+        for marker in markers:
+            assert marker in html, f"{path}: missing rendered marker {marker}"
+        for section_id in SECTION_IDS:
+            assert f'id="{section_id}"' in html, (
+                f"{path}: missing rendered semantic section id {section_id}"
+            )
+
+    docs_site_dir = book_site_dir.parent
+    for source in (ZH_PAGE, EN_PAGE):
+        for link in markdown_link_targets(read(source)):
+            rendered_target = rendered_route_for_absolute_link(docs_site_dir, link)
+            if rendered_target is not None:
+                assert rendered_target.is_file(), (
+                    f"{source.relative_to(BOOK)}: missing rendered cross-site route {link}"
+                )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--site-dir",
+        type=Path,
+        help="Combined Pages artifact path ending in site/docs/book.",
+    )
+    args = parser.parse_args()
+
+    validate_source()
+    if args.site_dir is not None:
+        validate_rendered_site(args.site_dir)
+
+    print("dev-book-welcome-wagon-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/frontstage-pages-workflow-smoke.py
+++ b/examples/frontstage-pages-workflow-smoke.py
@@ -95,6 +95,8 @@ def main() -> int:
         "output/frontstage-pages/site/site-assets/star-history.svg",
         "python3 examples/dev-book-publication-smoke.py",
         "python3 examples/dev-book-publication-smoke.py --site-dir output/frontstage-pages/site/docs/book",
+        "examples/dev-book-welcome-wagon-smoke.py",
+        "python3 examples/dev-book-welcome-wagon-smoke.py --site-dir output/frontstage-pages/site/docs/book",
         "npm run smoke:frontstage-share-bundle",
         "npm run export:frontstage-share -- --base /loopx/ --out-dir ../../../output/frontstage-pages",
         "mkdocs build --strict --site-dir output/frontstage-pages/site/docs",
@@ -129,6 +131,7 @@ def main() -> int:
         "docs/book/mkdocs.zh.yaml",
         "docs/book/mkdocs.en.yaml",
         "examples/dev-book-publication-smoke.py",
+        "examples/dev-book-welcome-wagon-smoke.py",
     ]:
         assert_pr_and_push_trigger(trigger_text, path)
 


### PR DESCRIPTION
## Summary

- add a bilingual Welcome Wagon with four outcome-based routes: run LoopX, share feedback, make a contribution, or review an RFC/change
- put the page first in each Developer Book Start section without changing the book homepage
- route newcomers to the current task board, issue forms, Discussions, Discord, and Open Strategy Reviews while preserving public/private boundaries
- add a dedicated smoke that requires Chinese/English semantic checkpoints, section ids, commands, and link targets to stay synchronized
- validate all `/loopx/docs/...` destinations against the combined Pages artifact, not an isolated book subsite

## Preview Review

The owner reviewed the local first-screen direction and explicitly approved continuing PR2. During review, an isolated-subsite preview exposed 404s for cross-site links. The preview was rebuilt with the same root-docs + Chinese book + English book layout used by GitHub Pages; both Welcome Wagon pages and their 70 local links returned HTTP 200.

## Validation

- `python3 examples/dev-book-welcome-wagon-smoke.py`
- `python3 examples/frontstage-pages-workflow-smoke.py`
- `python3 examples/dev-book-publication-smoke.py`
- strict combined Pages build for root docs, Chinese book, and English book
- `python3 examples/dev-book-welcome-wagon-smoke.py --site-dir /private/tmp/loopx-welcome-verify/loopx/docs/book`
- `loopx check` on all changed public paths: 0 errors; only unrelated existing local-state projection warnings
- `git diff --check`

## Scope

Documentation, navigation, and focused validation only. The page does not copy the dynamic task board, grant contribution authority, or change runtime behavior. External GitHub/Discord links remain explicit community destinations; internal Pages links must resolve inside the combined artifact.