### PR TITLE
docs(book): teach community contribution paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Repository governance files remain owned by the lead maintainer.
 /.github/CODEOWNERS @huangruiteng
 /.github/GOVERNANCE.md @huangruiteng
-/CONTRIBUTOR_TASKS.md @huangruiteng
+/docs/development/contributor-tasks.md @huangruiteng
 /docs/project/technical-directions*.md @huangruiteng
 
 # Frontend source and bundled web assets.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,7 +10,7 @@ contact_links:
     url: https://github.com/huangruiteng/loopx/security/advisories/new
     about: Privately report suspected unpatched vulnerabilities. Do not open a public issue.
   - name: Contributor task board
-    url: https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTOR_TASKS.md
+    url: https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md
     about: Start here for public, claimable work.
   - name: Current technical directions
     url: https://github.com/huangruiteng/loopx/blob/main/docs/project/technical-directions.md

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -16,7 +16,7 @@ channels.
 | Informal peer help | [Discord](https://discord.gg/XmGgQyCFZd) | Onboarding, workflow comparison, show and tell, and community conversation. Chat is not an authoritative support or release record. |
 
 Public contributor work belongs on the
-[Contributor Task Board](../CONTRIBUTOR_TASKS.md) or in the contributor-task
+[Contributor Task Board](../docs/development/contributor-tasks.md) or in the contributor-task
 issue form. The
 [Technical Directions map](../docs/project/technical-directions.md) explains
 which programs are active and what maturity or promotion gate applies. Pull

--- a/docs/book/chapters/source-protocol-map.md
+++ b/docs/book/chapters/source-protocol-map.md
@@ -322,7 +322,7 @@ contract。`loopx/extensions/` 也不是“所有外部集成”的收纳箱：�
 外部开发者不应从本地 maintainer state 猜工作。公开入口是：
 
 1. 阅读
-   [`CONTRIBUTOR_TASKS.md`](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)；
+   [Contributor Task Board](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)；
 2. 选择 `Starter`、`Focused` 或已达成设计共识的任务；
 3. 阅读任务涉及的协议和 validation；
 4. 在关联 Issue 中声明准备处理的最小切片；
@@ -334,7 +334,7 @@ contract。`loopx/extensions/` 也不是“所有外部集成”的收纳箱：�
 - `.loopx/`、`.codex/goals/` 或 live active state；
 - private benchmark trace、raw agent session 或 verifier output；
 - 内部文档、生产凭据、本机路径；
-- maintainer-owned live run 的推测性复刻。
+- `Maintainer-owned` live run 的推测性复刻。
 
 公开贡献需要从 public-safe protocol、Issue 和 fixture 建立上下文。
 
@@ -348,6 +348,71 @@ contract。`loopx/extensions/` 也不是“所有外部集成”的收纳箱：�
 
 无论交付类型是什么，都要说明它改变了哪个读者结果、由哪个 authority 保持事实，以及什么事件会
 使文档、fixture 或 compatibility claim 过期。
+
+### 社区信号怎样变成有边界的工作
+
+本节与英文对应章节保持语义镜像；案例、状态、结论或链接目标的实质差异属于文档缺陷。
+
+<!-- community-casebook:signal-to-bounded-work:start -->
+<!-- community-casebook:question-before-fix -->
+
+**问题也可以是贡献。** 在
+[“怎么给任务设置停止点？”](https://github.com/huangruiteng/loopx/discussions/3069)
+中，用户报告的是“任务完成后仍空转”。在确认它属于产品缺陷前，社区先把问题拆成 Goal
+acceptance、terminal closure、quota budget 与 monitor cadence 四个可检查假设。好的 Q&A
+不是立刻猜一处代码，而是把模糊体验变成最小诊断路径。
+
+<!-- community-casebook:user-idea-to-contract -->
+
+**方法论建议先映射已有合同。**
+[“look back and retain”](https://github.com/huangruiteng/loopx/issues/2353)
+从用户长期使用经验出发，提出 Agent 应解释路线为什么改变、哪些旧工作仍有效。讨论没有直接创建
+第二套 memory 系统，而是先对照 evidence log、Vision acceptance 与 `goal_path_delta_v0`，再确认
+剩余语义缺口。这类 Issue 可以在不写代码的情况下改进产品方向。
+
+<!-- community-casebook:claim-before-code -->
+
+**认领要先收窄 authority。**
+[Pi `task_lease_v0` 任务](https://github.com/huangruiteng/loopx/issues/3549)
+把 existing capability owner、Host facade、in-scope、non-goals、目标 base branch 与验证命令写在
+实现之前。它没有把“Pi 需要 lease 操作”扩张成新的 scheduler、存储或自动 lease lifecycle。
+
+这些记录只是学习样本，不是当前任务状态的副本。准备参与时仍要重新打开 Issue，确认它尚未被
+关闭、改向或认领，并以
+[Contributor Task Board](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)
+为当前公开入口；`Maintainer-owned` 工作只能请求独立 helper slice，不能平行复刻。
+<!-- community-casebook:signal-to-bounded-work:end -->
+
+### RFC Review Lab：先判状态，再谈实现
+
+本节与英文对应章节保持语义镜像。
+
+<!-- community-casebook:rfc-review-lab:start -->
+<!-- community-casebook:rfc-status -->
+
+先从 [RFC Index](https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/README.md)
+读取正式状态。`Accepted`、`Active research`、`Draft` 与 `Draft integration proposal` 允许的动作
+不同；一份 RFC 或 Discussion 存在，不等于某个实现已经发布，也不自动生成可认领任务。
+
+<!-- community-casebook:rfc-community-proposal -->
+
+例如社区 Discussion
+[#3157](https://github.com/huangruiteng/loopx/discussions/3157)
+提出 event-driven control plane 与统一 policy decision。评审时不要从“目录是否漂亮”开始，应先问：
+
+1. 当前 quota、scheduler、event store 与 worker 的 canonical authority / owner 分别是谁？
+2. 提案是在组合现有规则，还是复制第二套 decision authority？
+3. event store 是否被误当成具备 delivery semantics 的 event bus？
+4. 哪一阶段第一次改变默认行为，是否有独立 migration gate？
+5. 最小可验证切片是什么，失败后如何回到当前路径？
+
+<!-- community-casebook:rfc-output -->
+
+一份有用的 RFC review 应输出 `accept`、`revise`、`require_evidence` 或 `defer` 之类的明确
+disposition，并指出 owner、下一产物与复核条件。需要跨方向同步讨论时，可以进入
+[Open Strategy Review](https://github.com/huangruiteng/loopx/blob/main/docs/community/open-strategy-reviews.md)；
+会议不会替代版本化 RFC、bounded Issue、PR review 或 maintainer authority。
+<!-- community-casebook:rfc-review-lab:end -->
 
 ## 判断改动是否过大
 

--- a/docs/book/chapters/source-validation-to-pr.md
+++ b/docs/book/chapters/source-validation-to-pr.md
@@ -434,7 +434,7 @@ What remains owner-held?
 ## 关联 Issue 与公开任务
 
 非 trivial 工作优先关联
-[`CONTRIBUTOR_TASKS.md`](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)
+[Contributor Task Board](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)
 或 GitHub Issue：
 
 - 在开始大改前声明准备处理的 slice；
@@ -472,6 +472,71 @@ Issue 是公开协作边界，不是把本地 Goal state 整体粘贴上去的�
 5. PR 描述和文档是否也要重组？
 
 如果 review 暴露协议歧义，先达成语义共识；不要让两个相互矛盾的 test 同时“通过”。
+
+## 两个真实社区贡献案例
+
+本节与英文对应章节保持语义镜像；案例事实、结论、链接目标或风险边界的实质差异属于文档缺陷。
+
+<!-- community-casebook:small-pr:start -->
+<!-- community-casebook:small-pr-problem -->
+
+### 案例一：把一个 CLI 不一致修成完整小 PR
+
+[PR #3540](https://github.com/huangruiteng/loopx/pull/3540)
+来自一次真实 first-run/deep-use 观察：`loopx --format json doctor` 可以工作，但更符合用户直觉的
+`loopx doctor --format json` 会在 argparse 阶段失败。贡献者没有新建第二套 renderer，而是复用
+现有 subcommand format contract。
+
+<!-- community-casebook:small-pr-scope -->
+
+最终改动只涉及 parser wiring、doctor handler 与一条端到端 CLI regression。验证同时覆盖：
+
+- 新的子命令参数位置；
+- 旧的全局参数位置；
+- 二者同时出现时的 precedence；
+- 非法格式在执行诊断前 fail closed。
+
+<!-- community-casebook:small-pr-lesson -->
+
+这个案例的价值不在“只改了几行”，而在于它形成了完整链条：
+
+```text
+真实用户摩擦
+  -> 已有公共合同
+  -> 正确 owner
+  -> 正向、兼容与负向验证
+  -> reviewer 可独立判断
+```
+
+小 PR 不等于低标准。它只是把同一个用户结果控制在更容易验证和回滚的范围内。
+<!-- community-casebook:small-pr:end -->
+
+<!-- community-casebook:review-repair:start -->
+<!-- community-casebook:review-repair-problem -->
+
+### 案例二：用反例评审高风险状态写入
+
+[PR #3529](https://github.com/huangruiteng/loopx/pull/3529)
+把 shared-goal coordination 的 aggregate head、file provider 和 `claim_work` executor 做成一个
+provider-neutral Stage 2 切片。第一版已有大量正向测试，但 reviewer 仍构造了更强的非法状态：
+partial write 被误报为 `applied`、损坏 receipt 导致未分类异常、超大 TTL 越过 typed boundary、
+Windows 无法导入锁实现，以及无时区时间和 bool-as-int 进入持久状态。
+
+<!-- community-casebook:review-repair-response -->
+
+作者没有给这些输入逐个加字符串特判，而是修复它们共同指向的 trust boundary：
+
+- durable write 必须 write-all、fsync、atomic replace，并在不确定时返回 `ambiguous`；
+- persisted receipt、timestamp 与 generation 在进入 executor 前完成 typed validation；
+- lock 复用仓库已有跨平台 owner；
+- RFC、负例测试和 CI 同步记录 machine-enforced obligation。
+
+<!-- community-casebook:review-repair-lesson -->
+
+这个案例说明，review 不是在代码完成后“挑风格”。高价值 review 会提出一个能击穿当前 invariant
+的具体 counterexample，并要求修复落在真正的 owner；作者则用新的负例证明同类非法状态不能再次
+进入 semantic core。最终 `APPROVE` 只适用于重新验证后的 exact head。
+<!-- community-casebook:review-repair:end -->
 
 ## Merge 后还要验证什么
 

--- a/docs/book/en/chapters/source-protocol-map.md
+++ b/docs/book/en/chapters/source-protocol-map.md
@@ -338,7 +338,7 @@ instead of teaching the protocol.
 Do not infer public work from maintainer-local state. Use public surfaces:
 
 1. Read
-   [`CONTRIBUTOR_TASKS.md`](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md).
+   the [Contributor Task Board](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md).
 2. Choose a `Starter`, `Focused`, or already-agreed design task.
 3. Read the protocols and validation named by that task.
 4. State the smallest intended slice in the linked Issue.
@@ -350,7 +350,7 @@ Do not create public tasks from:
 - `.loopx/`, `.codex/goals/`, or live active state;
 - private benchmark traces, raw Agent sessions, or verifier output;
 - internal documents, production credentials, or machine paths;
-- speculative duplication of maintainer-owned live runs.
+- speculative duplication of `Maintainer-owned` live runs.
 
 Public contributions build context from public-safe protocols, Issues, and fixtures.
 
@@ -364,6 +364,79 @@ Contributions do not have to change runtime code. Public tasks can also deliver:
 
 For every artifact, state the reader-visible result, the authority that maintains the fact, and the event
 that makes the document, fixture, or compatibility claim stale.
+
+### How a community signal becomes bounded work
+
+This section and its Chinese counterpart are semantic mirrors. A material difference in cases, status,
+conclusions, or link targets is a documentation defect.
+
+<!-- community-casebook:signal-to-bounded-work:start -->
+<!-- community-casebook:question-before-fix -->
+
+**A question can be a contribution.** In
+[“How do I give a task a stopping point?”](https://github.com/huangruiteng/loopx/discussions/3069),
+a user reported that a completed task kept spinning. Before declaring a product defect, the community
+separated the report into four testable hypotheses: Goal acceptance, terminal closure, quota budget, and
+monitor cadence. Useful Q&A turns an imprecise experience into a minimal diagnostic path instead of
+guessing a code location.
+
+<!-- community-casebook:user-idea-to-contract -->
+
+**Map a methodology suggestion to existing contracts first.**
+[“Look back and retain”](https://github.com/huangruiteng/loopx/issues/2353)
+started from long-term user experience: an Agent should explain why its route changed and which earlier
+work remains valid. The discussion did not immediately create a second memory system. It first compared
+the idea with the evidence log, Vision acceptance, and `goal_path_delta_v0`, then identified the remaining
+semantic gap. An Issue like this can improve product direction without shipping code.
+
+<!-- community-casebook:claim-before-code -->
+
+**Narrow authority before claiming implementation.** The
+[Pi `task_lease_v0` task](https://github.com/huangruiteng/loopx/issues/3549)
+records the existing capability owner, Host facade, in-scope work, non-goals, target base branch, and
+validation commands before implementation. It does not turn “Pi needs lease operations” into a new
+scheduler, storage system, or automatic lease lifecycle.
+
+These records are learning examples, not copies of current task state. Before participating, reopen the
+Issue to confirm that it has not been closed, redirected, or claimed, and use the
+[Contributor Task Board](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)
+as the current public entrypoint. For `Maintainer-owned` work, ask for an independent helper slice instead
+of reproducing the active implementation in parallel.
+<!-- community-casebook:signal-to-bounded-work:end -->
+
+### RFC Review Lab: establish status before implementation
+
+This section and its Chinese counterpart are semantic mirrors.
+
+<!-- community-casebook:rfc-review-lab:start -->
+<!-- community-casebook:rfc-status -->
+
+Start with the
+[RFC Index](https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/README.md)
+and read the formal status. `Accepted`, `Active research`, `Draft`, and `Draft integration proposal`
+permit different actions. The existence of an RFC or Discussion does not prove that an implementation is
+shipped, and it does not automatically create claimable work.
+
+<!-- community-casebook:rfc-community-proposal -->
+
+For example, community Discussion
+[#3157](https://github.com/huangruiteng/loopx/discussions/3157)
+proposes an event-driven control plane and unified policy decision. Do not begin review by asking whether
+the proposed directory tree looks clean. Ask:
+
+1. Where is the canonical authority and owner for quota, scheduler, event-store, and worker semantics?
+2. Does the proposal compose existing rules or create a second decision authority?
+3. Does it mistake an event store for an event bus with delivery semantics?
+4. Which stage first changes default behavior, and does it have an independent migration gate?
+5. What is the smallest verifiable slice, and how does failure return to the current path?
+
+<!-- community-casebook:rfc-output -->
+
+A useful RFC review returns an explicit disposition such as `accept`, `revise`, `require_evidence`, or
+`defer`, plus an owner, next artifact, and review condition. Cross-direction questions may enter an
+[Open Strategy Review](https://github.com/huangruiteng/loopx/blob/main/docs/community/open-strategy-reviews.md).
+A meeting does not replace a versioned RFC, bounded Issue, PR review, or maintainer authority.
+<!-- community-casebook:rfc-review-lab:end -->
 
 ## Decide whether the slice is right-sized
 

--- a/docs/book/en/chapters/source-validation-to-pr.md
+++ b/docs/book/en/chapters/source-validation-to-pr.md
@@ -439,7 +439,7 @@ What remains owner-held?
 ## Link public work, not local runtime state
 
 Nontrivial contributions should link
-[`CONTRIBUTOR_TASKS.md`](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)
+the [Contributor Task Board](https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md)
 or a GitHub Issue:
 
 - state the intended slice before a large change;
@@ -477,6 +477,76 @@ Do not implement every comment mechanically. Ask:
 5. Does the PR description or documentation need recomposition?
 
 If review exposes protocol ambiguity, agree on semantics first. Do not make two contradictory tests pass.
+
+## Two real community contribution cases
+
+This section and its Chinese counterpart are semantic mirrors. A material difference in case facts,
+conclusions, link targets, or risk boundaries is a documentation defect.
+
+<!-- community-casebook:small-pr:start -->
+<!-- community-casebook:small-pr-problem -->
+
+### Case one: turn a CLI inconsistency into a complete small PR
+
+[PR #3540](https://github.com/huangruiteng/loopx/pull/3540)
+started from a real first-run and deep-use observation: `loopx --format json doctor` worked, while the more
+intuitive `loopx doctor --format json` failed during argparse processing. The contributor reused the
+existing subcommand format contract instead of creating a second renderer.
+
+<!-- community-casebook:small-pr-scope -->
+
+The final change covered only parser wiring, the doctor handler, and one end-to-end CLI regression.
+Validation covered:
+
+- the new subcommand argument position;
+- the existing global argument position;
+- precedence when both forms appear;
+- fail-closed rejection of an invalid format before diagnostics run.
+
+<!-- community-casebook:small-pr-lesson -->
+
+The value of this case is not that it changed only a few lines. It completed the whole chain:
+
+```text
+real user friction
+  -> existing public contract
+  -> correct owner
+  -> positive, compatibility, and negative validation
+  -> independently reviewable result
+```
+
+A small PR is not a lower-standard PR. It keeps one user outcome easier to validate and reverse.
+<!-- community-casebook:small-pr:end -->
+
+<!-- community-casebook:review-repair:start -->
+<!-- community-casebook:review-repair-problem -->
+
+### Case two: review high-risk state writes with counterexamples
+
+[PR #3529](https://github.com/huangruiteng/loopx/pull/3529)
+implemented a provider-neutral Stage 2 slice for shared-goal coordination: the aggregate head, file
+provider, and `claim_work` executor. The first revision already had broad positive coverage, but review
+still produced stronger illegal states: a partial write reported as `applied`, a corrupt receipt escaping
+as an untyped exception, an oversized TTL crossing the typed boundary, a lock implementation that could
+not import on Windows, and persisted naive timestamps or bool-as-int generations.
+
+<!-- community-casebook:review-repair-response -->
+
+The author did not add string checks for each example. The repair strengthened the shared trust boundary:
+
+- durable writes use write-all, fsync, and atomic replace, returning `ambiguous` when the outcome cannot be
+  proven;
+- persisted receipts, timestamps, and generations pass typed validation before the executor consumes them;
+- locking reuses the repository's existing cross-platform owner;
+- the RFC, negative tests, and CI describe the same machine-enforced obligation.
+
+<!-- community-casebook:review-repair-lesson -->
+
+This case shows that review is not style feedback after implementation. A high-value review supplies a
+concrete counterexample that breaks the intended invariant and asks for the repair at the real owner. The
+author then adds negative evidence proving that the same class of illegal state cannot re-enter the
+semantic core. The final `APPROVE` applies only to the revalidated exact head.
+<!-- community-casebook:review-repair:end -->
 
 ## Distinguish merge, release, deployment, and observation
 

--- a/examples/dev-book-publication-smoke.py
+++ b/examples/dev-book-publication-smoke.py
@@ -66,6 +66,25 @@ def compact(text: str) -> str:
     return " ".join(text.split())
 
 
+def markdown_link_targets(markdown: str) -> list[str]:
+    return re.findall(r"(?<!!)\[[^]]+\]\(([^)]+)\)", markdown)
+
+
+def semantic_checkpoints(markdown: str) -> list[str]:
+    return re.findall(
+        r"<!-- community-casebook:([a-z0-9-]+(?::(?:start|end))?) -->",
+        markdown,
+    )
+
+
+def marked_section(markdown: str, section_id: str) -> str:
+    start = f"<!-- community-casebook:{section_id}:start -->"
+    end = f"<!-- community-casebook:{section_id}:end -->"
+    assert start in markdown, start
+    assert end in markdown, end
+    return markdown.split(start, 1)[1].split(end, 1)[0]
+
+
 def assert_bilingual_concepts(
     zh_path: str,
     en_path: str,
@@ -76,6 +95,84 @@ def assert_bilingual_concepts(
     for zh_marker, en_marker in concepts:
         assert zh_marker in zh_text, f"{zh_path}: missing bilingual marker {zh_marker}"
         assert en_marker in en_text, f"{en_path}: missing bilingual marker {en_marker}"
+
+
+def assert_community_casebook_is_bilingual() -> None:
+    protocol_map_zh = read(BOOK / "chapters" / "source-protocol-map.md")
+    protocol_map_en = read(BOOK / "en" / "chapters" / "source-protocol-map.md")
+    validation_zh = read(BOOK / "chapters" / "source-validation-to-pr.md")
+    validation_en = read(BOOK / "en" / "chapters" / "source-validation-to-pr.md")
+
+    expected_protocol_checkpoints = [
+        "signal-to-bounded-work:start",
+        "question-before-fix",
+        "user-idea-to-contract",
+        "claim-before-code",
+        "signal-to-bounded-work:end",
+        "rfc-review-lab:start",
+        "rfc-status",
+        "rfc-community-proposal",
+        "rfc-output",
+        "rfc-review-lab:end",
+    ]
+    expected_validation_checkpoints = [
+        "small-pr:start",
+        "small-pr-problem",
+        "small-pr-scope",
+        "small-pr-lesson",
+        "small-pr:end",
+        "review-repair:start",
+        "review-repair-problem",
+        "review-repair-response",
+        "review-repair-lesson",
+        "review-repair:end",
+    ]
+    assert semantic_checkpoints(protocol_map_zh) == expected_protocol_checkpoints
+    assert semantic_checkpoints(protocol_map_en) == expected_protocol_checkpoints
+    assert semantic_checkpoints(validation_zh) == expected_validation_checkpoints
+    assert semantic_checkpoints(validation_en) == expected_validation_checkpoints
+
+    for zh_text, en_text, section_id, required_targets in (
+        (
+            protocol_map_zh,
+            protocol_map_en,
+            "signal-to-bounded-work",
+            (
+                "https://github.com/huangruiteng/loopx/discussions/3069",
+                "https://github.com/huangruiteng/loopx/issues/2353",
+                "https://github.com/huangruiteng/loopx/issues/3549",
+                "https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md",
+            ),
+        ),
+        (
+            protocol_map_zh,
+            protocol_map_en,
+            "rfc-review-lab",
+            (
+                "https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/README.md",
+                "https://github.com/huangruiteng/loopx/discussions/3157",
+                "https://github.com/huangruiteng/loopx/blob/main/docs/community/open-strategy-reviews.md",
+            ),
+        ),
+        (
+            validation_zh,
+            validation_en,
+            "small-pr",
+            ("https://github.com/huangruiteng/loopx/pull/3540",),
+        ),
+        (
+            validation_zh,
+            validation_en,
+            "review-repair",
+            ("https://github.com/huangruiteng/loopx/pull/3529",),
+        ),
+    ):
+        zh_targets = markdown_link_targets(marked_section(zh_text, section_id))
+        en_targets = markdown_link_targets(marked_section(en_text, section_id))
+        assert zh_targets == en_targets, section_id
+        for target in required_targets:
+            assert zh_targets.count(target) == 1, target
+            assert en_targets.count(target) == 1, target
 
 
 def validate_rendered_site(site_dir: Path) -> None:
@@ -259,6 +356,8 @@ def main() -> int:
 
     for page in COURSE_PAGES:
         assert (CONTROL_PLANE_COURSE / f"{page}.md").is_file(), page
+
+    assert_community_casebook_is_bilingual()
 
     reading_guides = (
         read(BOOK / "chapters" / "00-reading-guide.md"),

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -85,22 +85,6 @@ def compact(text: str) -> str:
     return " ".join(text.split())
 
 
-def markdown_link_targets(markdown: str) -> list[str]:
-    return re.findall(r"(?<!!)\[[^]]+\]\(([^)]+)\)", markdown)
-
-
-def semantic_checkpoints(markdown: str) -> list[str]:
-    return re.findall(r"<!-- community-casebook:([a-z0-9-]+(?::(?:start|end))?) -->", markdown)
-
-
-def marked_section(markdown: str, section_id: str) -> str:
-    start = f"<!-- community-casebook:{section_id}:start -->"
-    end = f"<!-- community-casebook:{section_id}:end -->"
-    assert start in markdown, start
-    assert end in markdown, end
-    return markdown.split(start, 1)[1].split(end, 1)[0]
-
-
 def subsection(text: str, heading: str) -> str:
     marker = f"### {heading}"
     assert marker in text, marker
@@ -208,138 +192,6 @@ def assert_contributor_task_board_is_current() -> None:
         "| GH-C93 |",
     ):
         assert stale not in tasks, stale
-
-
-def assert_community_casebook_is_bilingual() -> None:
-    protocol_map_zh = read("docs/book/chapters/source-protocol-map.md")
-    protocol_map_en = read("docs/book/en/chapters/source-protocol-map.md")
-    validation_zh = read("docs/book/chapters/source-validation-to-pr.md")
-    validation_en = read("docs/book/en/chapters/source-validation-to-pr.md")
-
-    expected_protocol_checkpoints = [
-        "signal-to-bounded-work:start",
-        "question-before-fix",
-        "user-idea-to-contract",
-        "claim-before-code",
-        "signal-to-bounded-work:end",
-        "rfc-review-lab:start",
-        "rfc-status",
-        "rfc-community-proposal",
-        "rfc-output",
-        "rfc-review-lab:end",
-    ]
-    expected_validation_checkpoints = [
-        "small-pr:start",
-        "small-pr-problem",
-        "small-pr-scope",
-        "small-pr-lesson",
-        "small-pr:end",
-        "review-repair:start",
-        "review-repair-problem",
-        "review-repair-response",
-        "review-repair-lesson",
-        "review-repair:end",
-    ]
-    assert semantic_checkpoints(protocol_map_zh) == expected_protocol_checkpoints
-    assert semantic_checkpoints(protocol_map_en) == expected_protocol_checkpoints
-    assert semantic_checkpoints(validation_zh) == expected_validation_checkpoints
-    assert semantic_checkpoints(validation_en) == expected_validation_checkpoints
-
-    for zh_text, en_text, section_id, required_targets in (
-        (
-            protocol_map_zh,
-            protocol_map_en,
-            "signal-to-bounded-work",
-            (
-                "https://github.com/huangruiteng/loopx/discussions/3069",
-                "https://github.com/huangruiteng/loopx/issues/2353",
-                "https://github.com/huangruiteng/loopx/issues/3549",
-                "https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md",
-            ),
-        ),
-        (
-            protocol_map_zh,
-            protocol_map_en,
-            "rfc-review-lab",
-            (
-                "https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/README.md",
-                "https://github.com/huangruiteng/loopx/discussions/3157",
-                "https://github.com/huangruiteng/loopx/blob/main/docs/community/open-strategy-reviews.md",
-            ),
-        ),
-        (
-            validation_zh,
-            validation_en,
-            "small-pr",
-            (
-                "https://github.com/huangruiteng/loopx/pull/3540",
-            ),
-        ),
-        (
-            validation_zh,
-            validation_en,
-            "review-repair",
-            (
-                "https://github.com/huangruiteng/loopx/pull/3529",
-            ),
-        ),
-    ):
-        zh_targets = markdown_link_targets(marked_section(zh_text, section_id))
-        en_targets = markdown_link_targets(marked_section(en_text, section_id))
-        assert zh_targets == en_targets, section_id
-        for target in required_targets:
-            assert zh_targets.count(target) == 1, target
-            assert en_targets.count(target) == 1, target
-
-    mirrored_concepts = (
-        (
-            compact(marked_section(protocol_map_zh, "signal-to-bounded-work")),
-            compact(marked_section(protocol_map_en, "signal-to-bounded-work")),
-            (
-                ("Maintainer-owned", "Maintainer-owned"),
-                ("Contributor Task Board", "Contributor Task Board"),
-                ("Goal acceptance", "Goal acceptance"),
-                ("goal_path_delta_v0", "goal_path_delta_v0"),
-                ("non-goals", "non-goals"),
-            ),
-        ),
-        (
-            compact(marked_section(protocol_map_zh, "rfc-review-lab")),
-            compact(marked_section(protocol_map_en, "rfc-review-lab")),
-            (
-                ("canonical authority", "canonical authority"),
-                ("event store", "event store"),
-                ("event bus", "event bus"),
-                ("最小可验证切片", "smallest verifiable slice"),
-                ("不会替代版本化 RFC", "does not replace a versioned RFC"),
-            ),
-        ),
-        (
-            compact(marked_section(validation_zh, "small-pr")),
-            compact(marked_section(validation_en, "small-pr")),
-            (
-                ("真实 first-run", "real first-run"),
-                ("argparse", "argparse"),
-                ("现有 subcommand format contract", "existing subcommand format contract"),
-                ("正向、兼容与负向验证", "positive, compatibility, and negative validation"),
-            ),
-        ),
-        (
-            compact(marked_section(validation_zh, "review-repair")),
-            compact(marked_section(validation_en, "review-repair")),
-            (
-                ("partial write", "partial write"),
-                ("bool-as-int", "bool-as-int"),
-                ("真正的 owner", "real owner"),
-                ("semantic core", "semantic core"),
-                ("exact head", "exact head"),
-            ),
-        ),
-    )
-    for zh_section, en_section, concepts in mirrored_concepts:
-        for zh_marker, en_marker in concepts:
-            assert zh_marker in zh_section, zh_marker
-            assert en_marker in en_section, en_marker
 
 
 def assert_contributor_task_links_are_current() -> None:
@@ -651,7 +503,6 @@ def main() -> int:
     assert_local_doc_links_resolve()
     assert_effect_interpreter_docs_are_canonical()
     assert_contributor_task_board_is_current()
-    assert_community_casebook_is_bilingual()
     assert_contributor_task_links_are_current()
     assert_technical_direction_governance_is_current()
 

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -85,6 +85,22 @@ def compact(text: str) -> str:
     return " ".join(text.split())
 
 
+def markdown_link_targets(markdown: str) -> list[str]:
+    return re.findall(r"(?<!!)\[[^]]+\]\(([^)]+)\)", markdown)
+
+
+def semantic_checkpoints(markdown: str) -> list[str]:
+    return re.findall(r"<!-- community-casebook:([a-z0-9-]+(?::(?:start|end))?) -->", markdown)
+
+
+def marked_section(markdown: str, section_id: str) -> str:
+    start = f"<!-- community-casebook:{section_id}:start -->"
+    end = f"<!-- community-casebook:{section_id}:end -->"
+    assert start in markdown, start
+    assert end in markdown, end
+    return markdown.split(start, 1)[1].split(end, 1)[0]
+
+
 def subsection(text: str, heading: str) -> str:
     marker = f"### {heading}"
     assert marker in text, marker
@@ -192,6 +208,162 @@ def assert_contributor_task_board_is_current() -> None:
         "| GH-C93 |",
     ):
         assert stale not in tasks, stale
+
+
+def assert_community_casebook_is_bilingual() -> None:
+    protocol_map_zh = read("docs/book/chapters/source-protocol-map.md")
+    protocol_map_en = read("docs/book/en/chapters/source-protocol-map.md")
+    validation_zh = read("docs/book/chapters/source-validation-to-pr.md")
+    validation_en = read("docs/book/en/chapters/source-validation-to-pr.md")
+
+    expected_protocol_checkpoints = [
+        "signal-to-bounded-work:start",
+        "question-before-fix",
+        "user-idea-to-contract",
+        "claim-before-code",
+        "signal-to-bounded-work:end",
+        "rfc-review-lab:start",
+        "rfc-status",
+        "rfc-community-proposal",
+        "rfc-output",
+        "rfc-review-lab:end",
+    ]
+    expected_validation_checkpoints = [
+        "small-pr:start",
+        "small-pr-problem",
+        "small-pr-scope",
+        "small-pr-lesson",
+        "small-pr:end",
+        "review-repair:start",
+        "review-repair-problem",
+        "review-repair-response",
+        "review-repair-lesson",
+        "review-repair:end",
+    ]
+    assert semantic_checkpoints(protocol_map_zh) == expected_protocol_checkpoints
+    assert semantic_checkpoints(protocol_map_en) == expected_protocol_checkpoints
+    assert semantic_checkpoints(validation_zh) == expected_validation_checkpoints
+    assert semantic_checkpoints(validation_en) == expected_validation_checkpoints
+
+    for zh_text, en_text, section_id, required_targets in (
+        (
+            protocol_map_zh,
+            protocol_map_en,
+            "signal-to-bounded-work",
+            (
+                "https://github.com/huangruiteng/loopx/discussions/3069",
+                "https://github.com/huangruiteng/loopx/issues/2353",
+                "https://github.com/huangruiteng/loopx/issues/3549",
+                "https://github.com/huangruiteng/loopx/blob/main/docs/development/contributor-tasks.md",
+            ),
+        ),
+        (
+            protocol_map_zh,
+            protocol_map_en,
+            "rfc-review-lab",
+            (
+                "https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/README.md",
+                "https://github.com/huangruiteng/loopx/discussions/3157",
+                "https://github.com/huangruiteng/loopx/blob/main/docs/community/open-strategy-reviews.md",
+            ),
+        ),
+        (
+            validation_zh,
+            validation_en,
+            "small-pr",
+            (
+                "https://github.com/huangruiteng/loopx/pull/3540",
+            ),
+        ),
+        (
+            validation_zh,
+            validation_en,
+            "review-repair",
+            (
+                "https://github.com/huangruiteng/loopx/pull/3529",
+            ),
+        ),
+    ):
+        zh_targets = markdown_link_targets(marked_section(zh_text, section_id))
+        en_targets = markdown_link_targets(marked_section(en_text, section_id))
+        assert zh_targets == en_targets, section_id
+        for target in required_targets:
+            assert zh_targets.count(target) == 1, target
+            assert en_targets.count(target) == 1, target
+
+    mirrored_concepts = (
+        (
+            compact(marked_section(protocol_map_zh, "signal-to-bounded-work")),
+            compact(marked_section(protocol_map_en, "signal-to-bounded-work")),
+            (
+                ("Maintainer-owned", "Maintainer-owned"),
+                ("Contributor Task Board", "Contributor Task Board"),
+                ("Goal acceptance", "Goal acceptance"),
+                ("goal_path_delta_v0", "goal_path_delta_v0"),
+                ("non-goals", "non-goals"),
+            ),
+        ),
+        (
+            compact(marked_section(protocol_map_zh, "rfc-review-lab")),
+            compact(marked_section(protocol_map_en, "rfc-review-lab")),
+            (
+                ("canonical authority", "canonical authority"),
+                ("event store", "event store"),
+                ("event bus", "event bus"),
+                ("最小可验证切片", "smallest verifiable slice"),
+                ("不会替代版本化 RFC", "does not replace a versioned RFC"),
+            ),
+        ),
+        (
+            compact(marked_section(validation_zh, "small-pr")),
+            compact(marked_section(validation_en, "small-pr")),
+            (
+                ("真实 first-run", "real first-run"),
+                ("argparse", "argparse"),
+                ("现有 subcommand format contract", "existing subcommand format contract"),
+                ("正向、兼容与负向验证", "positive, compatibility, and negative validation"),
+            ),
+        ),
+        (
+            compact(marked_section(validation_zh, "review-repair")),
+            compact(marked_section(validation_en, "review-repair")),
+            (
+                ("partial write", "partial write"),
+                ("bool-as-int", "bool-as-int"),
+                ("真正的 owner", "real owner"),
+                ("semantic core", "semantic core"),
+                ("exact head", "exact head"),
+            ),
+        ),
+    )
+    for zh_section, en_section, concepts in mirrored_concepts:
+        for zh_marker, en_marker in concepts:
+            assert zh_marker in zh_section, zh_marker
+            assert en_marker in en_section, en_marker
+
+
+def assert_contributor_task_links_are_current() -> None:
+    for path in (
+        ".github/ISSUE_TEMPLATE/config.yml",
+        ".github/SUPPORT.md",
+        "docs/book/chapters/source-protocol-map.md",
+        "docs/book/en/chapters/source-protocol-map.md",
+        "docs/book/chapters/source-validation-to-pr.md",
+        "docs/book/en/chapters/source-validation-to-pr.md",
+    ):
+        assert "docs/development/contributor-tasks.md" in read(path), path
+
+    assert "/docs/development/contributor-tasks.md @huangruiteng" in read(
+        ".github/CODEOWNERS"
+    )
+    for path in (
+        ".github/ISSUE_TEMPLATE/config.yml",
+        ".github/SUPPORT.md",
+        ".github/CODEOWNERS",
+    ):
+        assert "main/CONTRIBUTOR_TASKS.md" not in read(path), path
+        assert "../CONTRIBUTOR_TASKS.md" not in read(path), path
+        assert "/CONTRIBUTOR_TASKS.md @" not in read(path), path
 
 
 def assert_technical_direction_governance_is_current() -> None:
@@ -479,6 +651,8 @@ def main() -> int:
     assert_local_doc_links_resolve()
     assert_effect_interpreter_docs_are_canonical()
     assert_contributor_task_board_is_current()
+    assert_community_casebook_is_bilingual()
+    assert_contributor_task_links_are_current()
     assert_technical_direction_governance_is_current()
 
     collaboration_rfc = read(


### PR DESCRIPTION
## Summary

- add bilingual community case studies to the existing contribution chapters instead of creating a parallel casebook surface
- show how a question becomes a diagnostic path, a user idea maps to existing contracts, and a task claim narrows authority before implementation
- add an RFC Review Lab that distinguishes shipped, research, draft, and integration-proposal states
- teach two real contribution loops: the focused doctor CLI fix (#3540) and counterexample-driven shared coordination review (#3529)
- repair stale Contributor Task Board links in GitHub support and ownership surfaces
- extend the docs-governance smoke with bilingual semantic checkpoints, matching case links, paired concept assertions, and stale-link rejection

## Evidence sources

- GitHub Discussion #3069
- GitHub Issues #2353 and #3549
- merged PRs #3540 and #3529
- current RFC index and Open Strategy Review contract

The examples are historical learning records, not snapshots of current claimability. Readers are told to reopen the live Issue and Task Board before acting.

## Validation

- `python3 examples/docs-governance-smoke.py`
- `python3 examples/dev-book-publication-smoke.py`
- `python3 -m py_compile examples/docs-governance-smoke.py`
- `python3 -m mkdocs build --strict -f docs/book/mkdocs.zh.yaml`
- `python3 -m mkdocs build --strict -f docs/book/mkdocs.en.yaml`
- `loopx check` on all changed public paths: 0 errors; only unrelated existing local-state projection warnings
- `git diff --check`

## Scope

Documentation, community navigation repair, and focused docs-governance validation only. No runtime behavior, permissions, benchmark execution, or public first-screen changes.