### PR TITLE
fix(runtime): retry transient startup exits

### DIFF
--- a/loopx/control_plane/effect_runtime.py
+++ b/loopx/control_plane/effect_runtime.py
@@ -618,7 +618,13 @@ def effect_runtime_request(
                 params=params,
                 timeout=timeout,
             )
-        except (EffectRuntimeRemoteError, EffectRuntimeStartupError):
+        except EffectRuntimeRemoteError:
+            raise
+        except EffectRuntimeStartupError as exc:
+            last_error = exc
+            if attempt == 0 and retry_safe:
+                info_path.unlink(missing_ok=True)
+                continue
             raise
         except (OSError, RuntimeError) as exc:
             last_error = exc

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -491,6 +491,72 @@ def test_early_runtime_exit_surfaces_stable_startup_diagnostic(
     assert launch["close_fds"] is True
 
 
+@pytest.mark.parametrize(
+    ("retry_safe", "successful_attempt", "expected_attempts"),
+    [
+        (False, None, 1),
+        (True, None, 2),
+        (True, 2, 2),
+    ],
+)
+def test_request_startup_retry_boundary(
+    tmp_path: Path,
+    monkeypatch,
+    retry_safe: bool,
+    successful_attempt: int | None,
+    expected_attempts: int,
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    attempts = {"count": 0}
+    ready_info = {
+        "schema_version": effect_runtime.EFFECT_RUNTIME_INFO_SCHEMA_VERSION,
+        "fingerprint": effect_runtime._runtime_fingerprint(),
+        "pid": os.getpid(),
+        "host": "127.0.0.1",
+        "port": 1,
+        "token": "fixture-token",
+    }
+
+    def start_runtime(*, fingerprint: str, info_path: Path):
+        attempts["count"] += 1
+        assert fingerprint == ready_info["fingerprint"]
+        assert info_path.parent == runtime_dir
+        if attempts["count"] == successful_attempt:
+            return ready_info
+        raise effect_runtime.EffectRuntimeStartupError(
+            "runtime exited before ready",
+            diagnostic_code="runtime_exited_before_ready",
+        )
+
+    monkeypatch.setattr(effect_runtime, "_start_runtime", start_runtime)
+    monkeypatch.setattr(
+        effect_runtime,
+        "_request_with_info",
+        lambda info, **_kwargs: {"result": {"pid": info["pid"]}},
+    )
+
+    if successful_attempt is not None:
+        assert effect_runtime.effect_runtime_result(
+            "runtime.ping",
+            {},
+            retry_safe=retry_safe,
+        ) == {"pid": os.getpid()}
+    else:
+        with pytest.raises(
+            effect_runtime.EffectRuntimeStartupError,
+            match="runtime exited before ready",
+        ) as exc_info:
+            effect_runtime.effect_runtime_result(
+                "turn_journal.write",
+                {},
+                retry_safe=retry_safe,
+            )
+        assert exc_info.value.diagnostic_code == "runtime_exited_before_ready"
+
+    assert attempts["count"] == expected_attempts
+
+
 def test_managed_runtime_releases_memory_after_idle_timeout(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- include managed-runtime startup in the existing retry-safe request budget;
- retry one transient `runtime_exited_before_ready` outcome without expanding
  the total request attempt count beyond two;
- preserve the original typed startup diagnostic for non-retry-safe requests
  and after the second failed startup;
- add deterministic tests for no retry, successful second startup, and bounded
  double failure.

## Why

Unrelated PRs repeatedly failed the native Windows lifecycle job at
`test_retry_safe_typed_write_recovers_after_unexpected_runtime_exit`.
The request path retried socket/request failures but invoked `_start_runtime`
outside that retry boundary, so a transient early runtime exit bypassed the
retry-safe contract.

This is an independent runtime fix. It does not change the behavior or review
scope of the affected documentation, Todo, or benchmark PRs.

## Validation

- `25 passed` in `tests/control_plane/test_effect_runtime_integration.py`;
- `77 passed, 6 skipped` across the focused runtime and Windows lifecycle
  equivalent set;
- Ruff and Python compile checks passed;
- `loopx canary premerge --from-git-diff`: 9/9 selected checks passed;
- LoopX public/private boundary scan passed;
- `git diff --check` passed.

## Future-Facing Scope

The bounded pass was applied at the existing request retry owner. No new
runtime lifecycle state, retry counter, compatibility wrapper, or scheduler
surface was added.
