### PR TITLE
fix(runtime): preserve guided start runtime in continuation commands

### DIFF
--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -328,7 +328,7 @@ def build_start_goal_host_surface_selection_packet(
     resolved_project = str(_resolve_project(project))
     registry_path = Path(resolved_project) / ".loopx" / "registry.json"
     registry_payload, _registry_error = _read_registry(registry_path)
-    command_runtime_root = _command_runtime_root(
+    command_runtime_root, _ = _runtime_roots(
         registry_payload,
         registry_path=registry_path,
         runtime_root_arg=runtime_root_arg,
@@ -483,44 +483,24 @@ def _read_registry(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     return payload, None
 
 
-def _command_runtime_root(
+def _runtime_roots(
     registry: dict[str, Any] | None,
     *,
     registry_path: Path,
     runtime_root_arg: str | None,
-) -> str | None:
-    """Return only an explicit override that command cwd cannot recover."""
-
-    if not runtime_root_arg:
-        return None
-    return str(
-        resolve_runtime_root(
-            registry or {},
-            override=runtime_root_arg,
-            registry_path=registry_path,
+) -> tuple[str | None, str | None]:
+    if runtime_root_arg:
+        resolved = str(
+            resolve_runtime_root(
+                registry or {},
+                override=runtime_root_arg,
+                registry_path=registry_path,
+            )
         )
-    )
-
-
-def _identity_runtime_root(
-    registry: dict[str, Any] | None,
-    *,
-    registry_path: Path,
-    runtime_root_arg: str | None,
-) -> str | None:
-    """Resolve the global runtime used by registration and thread binding."""
-
-    if not runtime_root_arg and (
-        not isinstance(registry, dict) or not registry.get("common_runtime_root")
-    ):
-        return None
-    return str(
-        resolve_runtime_root(
-            registry or {},
-            override=runtime_root_arg,
-            registry_path=registry_path,
-        )
-    )
+        return resolved, resolved
+    if not isinstance(registry, dict) or not registry.get("common_runtime_root"):
+        return None, None
+    return None, str(resolve_runtime_root(registry, registry_path=registry_path))
 
 
 def _select_goal(goals: list[dict[str, Any]], goal_id: str | None) -> tuple[str, dict[str, Any] | None]:
@@ -812,12 +792,7 @@ def build_loopx_bootstrap_command_pack(
         None,
     )
     registered_agents = registered_agent_ids_for_goal(registry_goal)
-    command_runtime_root = _command_runtime_root(
-        registry_payload,
-        registry_path=registry_path,
-        runtime_root_arg=runtime_root_arg,
-    )
-    identity_runtime_root = _identity_runtime_root(
+    command_runtime_root, identity_runtime_root = _runtime_roots(
         registry_payload,
         registry_path=registry_path,
         runtime_root_arg=runtime_root_arg,
@@ -1158,7 +1133,7 @@ def _build_multi_goal_start_selection_packet(
     normalized_goal_text = " ".join(goal_text.split())
     normalized_thread_id = normalize_thread_id(thread_id)
     resolved_project = str(inspection["project"])
-    command_runtime_root = _command_runtime_root(
+    command_runtime_root, _ = _runtime_roots(
         registry,
         registry_path=registry_path,
         runtime_root_arg=runtime_root_arg,

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -489,17 +489,38 @@ def _command_runtime_root(
     registry_path: Path,
     runtime_root_arg: str | None,
 ) -> str | None:
-    if runtime_root_arg:
-        return str(
-            resolve_runtime_root(
-                registry or {},
-                override=runtime_root_arg,
-                registry_path=registry_path,
-            )
-        )
-    if not isinstance(registry, dict) or not registry.get("common_runtime_root"):
+    """Return only an explicit override that command cwd cannot recover."""
+
+    if not runtime_root_arg:
         return None
-    return str(resolve_runtime_root(registry, registry_path=registry_path))
+    return str(
+        resolve_runtime_root(
+            registry or {},
+            override=runtime_root_arg,
+            registry_path=registry_path,
+        )
+    )
+
+
+def _identity_runtime_root(
+    registry: dict[str, Any] | None,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> str | None:
+    """Resolve the global runtime used by registration and thread binding."""
+
+    if not runtime_root_arg and (
+        not isinstance(registry, dict) or not registry.get("common_runtime_root")
+    ):
+        return None
+    return str(
+        resolve_runtime_root(
+            registry or {},
+            override=runtime_root_arg,
+            registry_path=registry_path,
+        )
+    )
 
 
 def _select_goal(goals: list[dict[str, Any]], goal_id: str | None) -> tuple[str, dict[str, Any] | None]:
@@ -645,12 +666,13 @@ def _bootstrap_command(
     project: str,
     goal_id: str,
     cli_bin: str,
+    runtime_root: str | None,
     dry_run: bool,
     fine_grained: bool = False,
 ) -> str:
     lines = [
         f"cd {shell_arg(project)}",
-        f"{shell_arg(cli_bin)} bootstrap \\",
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} bootstrap \\",
         "  --project . \\",
         f"  --goal-id {shell_arg(goal_id)} \\",
         f"  --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)} \\",
@@ -676,12 +698,13 @@ def _goal_start_bootstrap_command(
     goal_id: str,
     goal_text: str | None,
     cli_bin: str,
+    runtime_root: str | None,
     fine_grained: bool,
 ) -> str:
     objective = goal_text or "<exact /loopx goal text>"
     lines = [
         f"cd {shell_arg(project)}",
-        f"{shell_arg(cli_bin)} bootstrap \\",
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} bootstrap \\",
         "  --project . \\",
         f"  --goal-id {shell_arg(goal_id)} \\",
         f"  --objective {shell_arg(objective)} \\",
@@ -794,6 +817,11 @@ def build_loopx_bootstrap_command_pack(
         registry_path=registry_path,
         runtime_root_arg=runtime_root_arg,
     )
+    identity_runtime_root = _identity_runtime_root(
+        registry_payload,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+    )
     thread_binding = resolve_thread_agent_binding(
         registry_goal,
         host_surface=host_surface,
@@ -820,6 +848,7 @@ def build_loopx_bootstrap_command_pack(
         project=resolved_project,
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
+        runtime_root=command_runtime_root,
         dry_run=True,
         fine_grained=fine_grained,
     )
@@ -827,6 +856,7 @@ def build_loopx_bootstrap_command_pack(
         project=resolved_project,
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
+        runtime_root=command_runtime_root,
         dry_run=False,
         fine_grained=fine_grained,
     )
@@ -835,6 +865,7 @@ def build_loopx_bootstrap_command_pack(
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
         runtime_root=command_runtime_root,
+        identity_runtime_root=identity_runtime_root,
         agent_id=effective_agent_id,
         registered_agents=registered_agents,
         available_capabilities=available_capabilities,
@@ -866,6 +897,7 @@ def build_loopx_bootstrap_command_pack(
         render_quota_guard_command(
             resolved_goal_id,
             cli_bin=cli_bin,
+            runtime_root=command_runtime_root,
             agent_id=str(selected_agent_id) if selected_agent_id else None,
             available_capabilities=available_capabilities,
             begin_turn=guided_start_begins_turn,
@@ -876,12 +908,17 @@ def build_loopx_bootstrap_command_pack(
         else None
     )
     goal_start_quota_should_run = quota_guard_command
-    status_command = _project_command(resolved_project, f"{shell_arg(cli_bin)} status")
+    command_prefix = render_cli_command_prefix(
+        cli_bin=cli_bin,
+        runtime_root=command_runtime_root,
+    )
+    status_command = _project_command(resolved_project, f"{command_prefix} status")
     goal_start_bootstrap_command = _goal_start_bootstrap_command(
         project=resolved_project,
         goal_id=resolved_goal_id,
         goal_text=normalized_goal_text,
         cli_bin=cli_bin,
+        runtime_root=command_runtime_root,
         fine_grained=fine_grained,
     )
     goal_start_plan_prompt = build_goal_start_prompt(
@@ -937,7 +974,7 @@ def build_loopx_bootstrap_command_pack(
             {"form": "/loopx <goal text>", "mode": "goal_plan_write_and_activate"},
         ],
         "canonical_cli_command": (
-            f"{shell_arg(cli_bin)} bootstrap-command-pack --project {shell_arg(resolved_project)} "
+            f"{command_prefix} bootstrap-command-pack --project {shell_arg(resolved_project)} "
             f"--goal-id {shell_arg(resolved_goal_id)}"
             + (
                 f" --agent-id {shell_arg(str(selected_agent_id))}"
@@ -989,7 +1026,7 @@ def build_loopx_bootstrap_command_pack(
             fine_grained=fine_grained,
         ),
         "commands": {
-            "doctor": f"{shell_arg(cli_bin)} doctor",
+            "doctor": f"{command_prefix} doctor",
             "status": status_command,
             "quota_guard": quota_guard_command,
             "heartbeat_prompt": heartbeat_prompt_command,
@@ -1001,7 +1038,7 @@ def build_loopx_bootstrap_command_pack(
                 {
                     "goal_start_configure_turn_granularity": _project_command(
                         resolved_project,
-                        f"{shell_arg(cli_bin)} configure-goal --goal-id "
+                        f"{command_prefix} configure-goal --goal-id "
                         f"{shell_arg(resolved_goal_id)} "
                         "--execution-turn-granularity fine --execute",
                     )
@@ -1011,7 +1048,7 @@ def build_loopx_bootstrap_command_pack(
             ),
             "goal_start_plan_prompt": goal_start_plan_prompt,
             "goal_start_bind_thread": (
-                f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=command_runtime_root)} "
+                f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=identity_runtime_root)} "
                 f"bind-agent-thread --goal-id {shell_arg(resolved_goal_id)} "
                 f"--thread-id {shell_arg(normalized_thread_id)} --host-surface {shell_arg(host_surface)} "
                 f"--agent-id {shell_arg(str(selected_agent_id))} --execute"
@@ -1025,13 +1062,14 @@ def build_loopx_bootstrap_command_pack(
             "goal_start_refresh_state": render_refresh_state_command(
                 resolved_goal_id,
                 cli_bin=cli_bin,
+                runtime_root=command_runtime_root,
                 project=".",
                 agent_id=str(selected_agent_id) if selected_agent_id else None,
                 progress_scope="agent_lane" if selected_agent_id else None,
             ),
             "goal_start_host_loop_activation": host_loop_activation.get("activation_input_command"),
             "goal_start_agent_onboard_recheck": (
-                f"{shell_arg(cli_bin)} agent-onboard "
+                f"{command_prefix} agent-onboard "
                 f"--agent-type {shell_arg(agent_type)} "
                 f"--project {shell_arg(resolved_project)} "
                 f"--goal-id {shell_arg(resolved_goal_id)}"
@@ -1559,7 +1597,8 @@ def build_start_goal_guided_packet(
                 "id": "write_ordered_todos",
                 "kind": "operator_or_agent_actions",
                 "command_template": (
-                    f"{shell_arg(cli_bin)} todo add --goal-id "
+                    f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=command_pack.get('command_runtime_root'))} "
+                    f"todo add --goal-id "
                     f"{shell_arg(str(command_pack.get('goal_id') or ''))} "
                     "--project . "
                     "--role agent "

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -31,10 +31,12 @@ from .project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_KIND,
     DEFAULT_HANDOFF_ADAPTER_STATUS,
     render_available_capability_args,
+    render_cli_command_prefix,
     render_quota_guard_command,
     render_refresh_state_command,
     shell_arg,
 )
+from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 from .slash_commands import build_slash_command_catalog
 from .thread_agent_binding import normalize_thread_id, resolve_thread_agent_binding
@@ -201,6 +203,7 @@ def _start_goal_command(
     thread_id: str | None,
     new_peer: bool,
     cli_bin: str,
+    runtime_root: str | None = None,
     host_surface: str,
     goal_text: str,
     available_capabilities: list[str] | None,
@@ -209,7 +212,8 @@ def _start_goal_command(
     include_command_pack_detail: bool,
 ) -> str:
     return (
-        f"{shell_arg(cli_bin)} --format json start-goal --guided "
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+        f"--format json start-goal --guided "
         f"--project {shell_arg(project)}"
         + (f" --goal-id {shell_arg(goal_id)}" if goal_id else "")
         + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
@@ -236,6 +240,7 @@ def _start_goal_detail_command(
     thread_id: str | None,
     new_peer: bool,
     cli_bin: str,
+    runtime_root: str | None = None,
     host_surface: str,
     goal_text: str,
     available_capabilities: list[str] | None,
@@ -249,6 +254,7 @@ def _start_goal_detail_command(
         thread_id=thread_id,
         new_peer=new_peer,
         cli_bin=cli_bin,
+        runtime_root=runtime_root,
         host_surface=host_surface,
         goal_text=goal_text,
         available_capabilities=available_capabilities,
@@ -315,10 +321,18 @@ def build_start_goal_host_surface_selection_packet(
     capability_route: str | None = None,
     fine_grained: bool = False,
     include_command_pack_detail: bool = False,
+    runtime_root_arg: str | None = None,
 ) -> dict[str, Any]:
     """Fail closed when the caller has not identified the current Codex host."""
 
     resolved_project = str(_resolve_project(project))
+    registry_path = Path(resolved_project) / ".loopx" / "registry.json"
+    registry_payload, _registry_error = _read_registry(registry_path)
+    command_runtime_root = _command_runtime_root(
+        registry_payload,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+    )
     normalized_goal_text = " ".join(goal_text.split())
     host_descriptions = {
         "codex-app": "Codex desktop app with heartbeat automation support",
@@ -343,7 +357,8 @@ def build_start_goal_host_surface_selection_packet(
     choices: list[dict[str, Any]] = []
     for host_surface in START_GOAL_HOST_SURFACES:
         rerun_command = (
-            f"{shell_arg(cli_bin)} start-goal --guided "
+            f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=command_runtime_root)} "
+            f"start-goal --guided "
             f"--project {shell_arg(resolved_project)}"
             + (f" --goal-id {shell_arg(goal_id)}" if goal_id else "")
             + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
@@ -466,6 +481,25 @@ def _read_registry(path: Path) -> tuple[dict[str, Any] | None, str | None]:
     if not isinstance(payload, dict):
         return None, "registry root must be a JSON object"
     return payload, None
+
+
+def _command_runtime_root(
+    registry: dict[str, Any] | None,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> str | None:
+    if runtime_root_arg:
+        return str(
+            resolve_runtime_root(
+                registry or {},
+                override=runtime_root_arg,
+                registry_path=registry_path,
+            )
+        )
+    if not isinstance(registry, dict) or not registry.get("common_runtime_root"):
+        return None
+    return str(resolve_runtime_root(registry, registry_path=registry_path))
 
 
 def _select_goal(goals: list[dict[str, Any]], goal_id: str | None) -> tuple[str, dict[str, Any] | None]:
@@ -725,6 +759,7 @@ def build_loopx_bootstrap_command_pack(
     capability_route: str | None = None,
     fine_grained: bool = False,
     resolve_linked_worktree_alias: bool = True,
+    runtime_root_arg: str | None = None,
 ) -> dict[str, Any]:
     inspection = inspect_bootstrap_connection(
         project,
@@ -754,6 +789,11 @@ def build_loopx_bootstrap_command_pack(
         None,
     )
     registered_agents = registered_agent_ids_for_goal(registry_goal)
+    command_runtime_root = _command_runtime_root(
+        registry_payload,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+    )
     thread_binding = resolve_thread_agent_binding(
         registry_goal,
         host_surface=host_surface,
@@ -794,6 +834,7 @@ def build_loopx_bootstrap_command_pack(
         agent_type=agent_type,
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
+        runtime_root=command_runtime_root,
         agent_id=effective_agent_id,
         registered_agents=registered_agents,
         available_capabilities=available_capabilities,
@@ -929,6 +970,7 @@ def build_loopx_bootstrap_command_pack(
         "goal_id": resolved_goal_id,
         "agent_id": selected_agent_id,
         "requested_agent_id": agent_id,
+        "command_runtime_root": command_runtime_root,
         "agent_type": agent_type,
         "host_surface": host_surface,
         "project_connection": inspection,
@@ -969,7 +1011,8 @@ def build_loopx_bootstrap_command_pack(
             ),
             "goal_start_plan_prompt": goal_start_plan_prompt,
             "goal_start_bind_thread": (
-                f"{shell_arg(cli_bin)} bind-agent-thread --goal-id {shell_arg(resolved_goal_id)} "
+                f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=command_runtime_root)} "
+                f"bind-agent-thread --goal-id {shell_arg(resolved_goal_id)} "
                 f"--thread-id {shell_arg(normalized_thread_id)} --host-surface {shell_arg(host_surface)} "
                 f"--agent-id {shell_arg(str(selected_agent_id))} --execute"
                 if (
@@ -1054,6 +1097,7 @@ def _build_multi_goal_start_selection_packet(
     thread_id: str | None,
     new_peer: bool,
     cli_bin: str,
+    runtime_root_arg: str | None,
     host_surface: str,
     goal_text: str,
     available_capabilities: list[str] | None,
@@ -1076,6 +1120,11 @@ def _build_multi_goal_start_selection_packet(
     normalized_goal_text = " ".join(goal_text.split())
     normalized_thread_id = normalize_thread_id(thread_id)
     resolved_project = str(inspection["project"])
+    command_runtime_root = _command_runtime_root(
+        registry,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+    )
     issue_fix_commands = build_issue_fix_goal_command_templates(
         cli_bin=cli_bin,
         goal_id="<selected-goal-id>",
@@ -1086,7 +1135,8 @@ def _build_multi_goal_start_selection_packet(
         if not candidate_goal_id:
             continue
         rerun_command = (
-            f"{shell_arg(cli_bin)} start-goal --guided "
+            f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=command_runtime_root)} "
+            f"start-goal --guided "
             f"--project {shell_arg(resolved_project)} "
             f"--goal-id {shell_arg(candidate_goal_id)}"
             + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
@@ -1328,6 +1378,7 @@ def build_start_goal_guided_packet(
     capability_route: str | None = None,
     fine_grained: bool = False,
     include_command_pack_detail: bool = False,
+    runtime_root_arg: str | None = None,
 ) -> dict[str, Any]:
     if goal_id is None:
         selection_packet = _build_multi_goal_start_selection_packet(
@@ -1336,6 +1387,7 @@ def build_start_goal_guided_packet(
             thread_id=thread_id,
             new_peer=new_peer,
             cli_bin=cli_bin,
+            runtime_root_arg=runtime_root_arg,
             host_surface=host_surface,
             goal_text=goal_text,
             available_capabilities=available_capabilities,
@@ -1358,6 +1410,7 @@ def build_start_goal_guided_packet(
         capability_route=capability_route,
         fine_grained=fine_grained,
         resolve_linked_worktree_alias=False,
+        runtime_root_arg=runtime_root_arg,
     )
     commands = command_pack.get("commands")
     commands = commands if isinstance(commands, dict) else {}
@@ -1373,6 +1426,7 @@ def build_start_goal_guided_packet(
                 thread_id=thread_id,
                 new_peer=new_peer,
                 cli_bin=cli_bin,
+                runtime_root=command_pack.get("command_runtime_root"),
                 host_surface=host_surface,
                 goal_text=str(command_pack.get("goal_text") or goal_text),
                 available_capabilities=available_capabilities,
@@ -1639,6 +1693,7 @@ def build_start_goal_guided_packet(
         thread_id=thread_id,
         new_peer=new_peer,
         cli_bin=cli_bin,
+        runtime_root=command_pack.get("command_runtime_root"),
         host_surface=host_surface,
         goal_text=str(command_pack.get("goal_text") or goal_text),
         available_capabilities=available_capabilities,

--- a/loopx/cli_commands/start_goal.py
+++ b/loopx/cli_commands/start_goal.py
@@ -193,6 +193,8 @@ def _resolve_start_goal_input(args: argparse.Namespace) -> tuple[str, str | None
 def handle_start_goal_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
+    *,
+    runtime_root_arg: str | None = None,
 ) -> int:
     if not bool(getattr(args, "guided", False)):
         payload = {
@@ -230,6 +232,7 @@ def handle_start_goal_command(
             capability_route=capability_route,
             fine_grained=fine_grained,
             include_command_pack_detail=bool(args.include_command_pack_detail),
+            runtime_root_arg=runtime_root_arg,
         )
         print_payload(payload, args.format, render_start_goal_guided_markdown)
         return 0
@@ -246,6 +249,7 @@ def handle_start_goal_command(
         capability_route=capability_route,
         fine_grained=fine_grained,
         include_command_pack_detail=bool(args.include_command_pack_detail),
+        runtime_root_arg=runtime_root_arg,
     )
     print_payload(payload, args.format, render_start_goal_guided_markdown)
     return 0

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -93,6 +93,8 @@ def handle_agent_onboard_command(
 def handle_loopx_bootstrap_command_pack_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
+    *,
+    runtime_root_arg: str | None = None,
 ) -> int:
     payload = build_loopx_bootstrap_command_pack(
         project=Path(args.project),
@@ -106,6 +108,7 @@ def handle_loopx_bootstrap_command_pack_command(
         available_capabilities=args.available_capabilities,
         capability_route=args.capability_route,
         fine_grained=bool(args.fine_grained),
+        runtime_root_arg=runtime_root_arg,
     )
     if bool(getattr(args, "message_only", False)):
         print(str(payload.get("message") or ""))
@@ -176,4 +179,8 @@ def handle_starter_bootstrap_command(
     handler = handlers.get(str(getattr(args, "command", "")))
     if handler is None:
         return None
+    if handler is handle_start_goal_command:
+        return handler(args, print_payload, runtime_root_arg=args.runtime_root)
+    if handler is handle_loopx_bootstrap_command_pack_command:
+        return handler(args, print_payload, runtime_root_arg=args.runtime_root)
     return handler(args, print_payload)

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -1295,6 +1295,7 @@ def build_host_loop_activation_packet(
     goal_id: str,
     cli_bin: str = "loopx",
     runtime_root: str | None = None,
+    identity_runtime_root: str | None = None,
     agent_id: str | None = None,
     registered_agents: list[str] | None = None,
     available_capabilities: list[str] | None = None,
@@ -1410,8 +1411,13 @@ def build_host_loop_activation_packet(
             if requested_agent_id
             else "<new-public-safe-agent-id>"
         )
+        registration_runtime_root = (
+            identity_runtime_root
+            if identity_runtime_root is not None
+            else runtime_root
+        )
         register_command = (
-            f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+            f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=registration_runtime_root)} "
             f"register-agent --goal-id {shell_arg(goal_id)} "
             f"--agent-id {shell_arg(fresh_agent_id)} --require-new"
         )

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -10,6 +10,7 @@ from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
 )
 from .project_prompt import (
+    render_cli_command_prefix,
     render_heartbeat_prompt_command,
     render_heartbeat_prompt_json_command,
     shell_arg,
@@ -481,6 +482,7 @@ def _heartbeat_commands(
     goal_id: str,
     agent_type: str,
     cli_bin: str,
+    runtime_root: str | None = None,
     agent_id: str | None,
     available_capabilities: list[str] | None = None,
 ) -> dict[str, str]:
@@ -515,6 +517,7 @@ def _heartbeat_commands(
         "heartbeat_prompt_json": render_heartbeat_prompt_json_command(
             goal_id,
             cli_bin=cli_bin,
+            runtime_root=runtime_root,
             agent_id=agent_id,
             agent_scope=agent_scope,
             available_capabilities=available_capabilities,
@@ -524,6 +527,7 @@ def _heartbeat_commands(
         "heartbeat_prompt": render_heartbeat_prompt_command(
             goal_id,
             cli_bin=cli_bin,
+            runtime_root=runtime_root,
             agent_id=agent_id,
             agent_scope=agent_scope,
             available_capabilities=available_capabilities,
@@ -1290,6 +1294,7 @@ def build_host_loop_activation_packet(
     agent_type: str,
     goal_id: str,
     cli_bin: str = "loopx",
+    runtime_root: str | None = None,
     agent_id: str | None = None,
     registered_agents: list[str] | None = None,
     available_capabilities: list[str] | None = None,
@@ -1313,6 +1318,7 @@ def build_host_loop_activation_packet(
             goal_id=goal_id,
             agent_type=canonical,
             cli_bin=cli_bin,
+            runtime_root=runtime_root,
             agent_id=str(selected_agent_id) if selected_agent_id else None,
             available_capabilities=normalized_available_capabilities,
         )
@@ -1370,6 +1376,7 @@ def build_host_loop_activation_packet(
                 goal_id=goal_id,
                 agent_type=canonical,
                 cli_bin=cli_bin,
+                runtime_root=runtime_root,
                 agent_id=candidate,
                 available_capabilities=normalized_available_capabilities,
             )
@@ -1404,7 +1411,8 @@ def build_host_loop_activation_packet(
             else "<new-public-safe-agent-id>"
         )
         register_command = (
-            f"{shell_arg(cli_bin)} register-agent --goal-id {shell_arg(goal_id)} "
+            f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+            f"register-agent --goal-id {shell_arg(goal_id)} "
             f"--agent-id {shell_arg(fresh_agent_id)} --require-new"
         )
         fresh_registration = (

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -10,10 +10,9 @@ from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
 )
 from .project_prompt import (
-    render_cli_command_prefix,
     render_heartbeat_prompt_command,
     render_heartbeat_prompt_json_command,
-    shell_arg,
+    render_register_agent_command,
 )
 
 SCHEMA_VERSION = "loopx_host_loop_activation_v1"
@@ -508,11 +507,7 @@ def _heartbeat_commands(
     }
     agent_scope = scope_by_type.get(agent_type, scope_by_type["other-agent"])
     scheduler_binding = scheduler_command_binding_for_agent_type(agent_type)
-    renderer_binding = (
-        {"visible_goal_host": "traex-cli"}
-        if agent_type == "traex-cli"
-        else {}
-    )
+    renderer_binding = {"visible_goal_host": "traex-cli"} if agent_type == "traex-cli" else {}
     commands = {
         "heartbeat_prompt_json": render_heartbeat_prompt_json_command(
             goal_id,
@@ -1406,20 +1401,12 @@ def build_host_loop_activation_packet(
             )
             choices.append(choice)
         requested_agent_id = identity.get("requested_agent_id")
-        fresh_agent_id = (
-            str(requested_agent_id)
-            if requested_agent_id
-            else "<new-public-safe-agent-id>"
-        )
-        registration_runtime_root = (
-            identity_runtime_root
-            if identity_runtime_root is not None
-            else runtime_root
-        )
-        register_command = (
-            f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=registration_runtime_root)} "
-            f"register-agent --goal-id {shell_arg(goal_id)} "
-            f"--agent-id {shell_arg(fresh_agent_id)} --require-new"
+        fresh_agent_id = str(requested_agent_id or "<new-public-safe-agent-id>")
+        register_command = render_register_agent_command(
+            goal_id,
+            agent_id=fresh_agent_id,
+            cli_bin=cli_bin,
+            runtime_root=identity_runtime_root or runtime_root,
         )
         fresh_registration = (
             {

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -42,6 +42,20 @@ def render_cli_command_prefix(
     return prefix
 
 
+def render_register_agent_command(
+    goal_id: str,
+    *,
+    agent_id: str,
+    cli_bin: str = "loopx",
+    runtime_root: str | Path | None = None,
+) -> str:
+    return (
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+        f"register-agent --goal-id {shell_arg(goal_id)} "
+        f"--agent-id {shell_arg(agent_id)} --require-new"
+    )
+
+
 def shell_arg_or_placeholder(value: str) -> str:
     text = str(value)
     if text.startswith("<") and text.endswith(">"):

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -31,6 +31,17 @@ def shell_arg(value: str) -> str:
     return shlex.quote(value)
 
 
+def render_cli_command_prefix(
+    *,
+    cli_bin: str = "loopx",
+    runtime_root: str | Path | None = None,
+) -> str:
+    prefix = shell_arg(cli_bin)
+    if runtime_root is not None:
+        prefix += f" --runtime-root {shell_arg(str(runtime_root))}"
+    return prefix
+
+
 def shell_arg_or_placeholder(value: str) -> str:
     text = str(value)
     if text.startswith("<") and text.endswith(">"):
@@ -221,6 +232,7 @@ def render_heartbeat_prompt_command(
     goal_id: str,
     *,
     cli_bin: str = "loopx",
+    runtime_root: str | Path | None = None,
     agent_id: str | None = None,
     agent_scope: str = "Codex CLI /goal visible TUI loop",
     body: str = "thin",
@@ -242,7 +254,8 @@ def render_heartbeat_prompt_command(
         else ""
     )
     return (
-        f"{shell_arg(cli_bin)} heartbeat-prompt --{shell_arg(body)} "
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+        f"heartbeat-prompt --{shell_arg(body)} "
         f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}{capability_args}"
         f"{scheduler_args}{visible_goal_arg}"
     )
@@ -252,6 +265,7 @@ def render_heartbeat_prompt_json_command(
     goal_id: str,
     *,
     cli_bin: str = "loopx",
+    runtime_root: str | Path | None = None,
     agent_id: str | None = None,
     agent_scope: str = "Codex CLI /goal visible TUI loop",
     body: str = "thin",
@@ -273,7 +287,8 @@ def render_heartbeat_prompt_json_command(
         else ""
     )
     return (
-        f"{shell_arg(cli_bin)} --format json heartbeat-prompt --{shell_arg(body)} "
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+        f"--format json heartbeat-prompt --{shell_arg(body)} "
         f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}{capability_args}"
         f"{scheduler_args}{visible_goal_arg}"
     )

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -107,6 +107,7 @@ def render_quota_guard_command(
     goal_id: str,
     *,
     cli_bin: str = "loopx",
+    runtime_root: str | Path | None = None,
     agent_id: str | None = None,
     available_capabilities: Any = None,
     runtime_profile: str | None = None,
@@ -146,7 +147,7 @@ def render_quota_guard_command(
         f"--registry {SHARED_GLOBAL_REGISTRY} " if include_shared_registry else ""
     )
     return (
-        f"{shell_arg(cli_bin)} --format json "
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} --format json "
         f"{registry_arg}"
         f"quota should-run --goal-id {shell_arg(goal_id)}{agent_arg}"
         f"{capability_args}{scheduler_args}{turn_arg}"
@@ -176,6 +177,7 @@ def render_refresh_state_command(
     goal_id: str,
     *,
     cli_bin: str = "loopx",
+    runtime_root: str | Path | None = None,
     project: str | None = None,
     agent_id: str | None = None,
     progress_scope: str | None = None,
@@ -202,7 +204,8 @@ def render_refresh_state_command(
         else ""
     )
     return (
-        f"{shell_arg(cli_bin)} refresh-state --goal-id {shell_arg(goal_id)}"
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+        f"refresh-state --goal-id {shell_arg(goal_id)}"
         f"{project_arg}{classification_arg}{scale_arg}{outcome_arg}{agent_arg}{scope_arg}"
     )
 

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -766,14 +766,17 @@ def test_cli_codex_app_reuses_ambient_thread_binding(
     assert payload["guided_transaction"].get("blocked_by") is None
 
 
-def test_start_goal_binds_selected_lane_before_todo_writeback(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_start_goal_binds_selected_lane_before_todo_writeback(tmp_path: Path) -> None:
     project = _write_connected_project(tmp_path)
     source_registry = project / ".loopx" / "registry.json"
     runtime = tmp_path / "runtime"
     runtime.mkdir()
     source_payload = json.loads(source_registry.read_text(encoding="utf-8"))
+    source_payload["common_runtime_root"] = str(runtime)
+    source_registry.write_text(
+        json.dumps(source_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
     global_payload = {
         **source_payload,
         "registry_role": "global-local",
@@ -783,8 +786,6 @@ def test_start_goal_binds_selected_lane_before_todo_writeback(
         json.dumps(global_payload, indent=2) + "\n",
         encoding="utf-8",
     )
-    monkeypatch.setenv("LOOPX_RUNTIME_ROOT", str(runtime))
-
     first = build_start_goal_guided_packet(
         project=project,
         goal_id=GOAL_ID,
@@ -813,8 +814,9 @@ def test_start_goal_binds_selected_lane_before_todo_writeback(
 
     output = io.StringIO()
     bind_argv = shlex.split(bind_step["command"])
+    assert bind_argv[bind_argv.index("--runtime-root") + 1] == str(runtime)
     with contextlib.redirect_stdout(output):
-        exit_code = cli_main(["--runtime-root", str(runtime), *bind_argv[1:]])
+        exit_code = cli_main(bind_argv[1:])
     assert exit_code == 0, output.getvalue()
 
     second = build_start_goal_guided_packet(
@@ -833,6 +835,138 @@ def test_start_goal_binds_selected_lane_before_todo_writeback(
     assert "bind_thread_identity" not in {
         step["id"] for step in second["guided_transaction"]["ordered_steps"]
     }
+
+
+def test_fresh_agent_registration_preserves_guided_runtime_root(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    source_registry = project / ".loopx" / "registry.json"
+    runtime = tmp_path / "runtime"
+    runtime.mkdir()
+    source_payload = json.loads(source_registry.read_text(encoding="utf-8"))
+    source_payload["common_runtime_root"] = str(runtime)
+    source_payload["goals"][0]["coordination"]["registered_agents"] = []
+    source_registry.write_text(
+        json.dumps(source_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    global_payload = {
+        **source_payload,
+        "registry_role": "global-local",
+    }
+    global_payload["goals"][0]["source_registry"] = str(source_registry)
+    global_registry = runtime / "registry.global.json"
+    global_registry.write_text(
+        json.dumps(global_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id="fresh-agent",
+        thread_id="thread-fresh-agent",
+        cli_bin="loopx",
+        host_surface="codex-app",
+        goal_text=GOAL_TEXT,
+        available_capabilities=["network"],
+    )
+
+    gate = payload["guided_transaction"]["identity_selection_gate"]
+    fresh_registration = gate["fresh_agent_registration"]
+    execute_command = fresh_registration["execute_command"]
+    rerun_command = fresh_registration["rerun_start_goal_command"]
+    execute_args = shlex.split(execute_command)
+    rerun_args = shlex.split(rerun_command)
+    assert execute_args[execute_args.index("--runtime-root") + 1] == str(runtime)
+    assert rerun_args[rerun_args.index("--runtime-root") + 1] == str(runtime)
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(execute_args[1:])
+    assert exit_code == 0, output.getvalue()
+
+    registered_source = json.loads(source_registry.read_text(encoding="utf-8"))
+    registered_global = json.loads(global_registry.read_text(encoding="utf-8"))
+    assert registered_source["goals"][0]["coordination"]["registered_agents"] == [
+        "fresh-agent"
+    ]
+    assert registered_global["goals"][0]["coordination"]["registered_agents"] == [
+        "fresh-agent"
+    ]
+
+
+def test_start_goal_cli_preserves_explicit_runtime_root_in_registration_command(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    source_registry = project / ".loopx" / "registry.json"
+    runtime = project / "explicit-runtime"
+    runtime.mkdir()
+    source_payload = json.loads(source_registry.read_text(encoding="utf-8"))
+    source_payload["goals"][0]["coordination"]["registered_agents"] = []
+    source_registry.write_text(
+        json.dumps(source_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    global_payload = {
+        **source_payload,
+        "registry_role": "global-local",
+        "common_runtime_root": str(runtime),
+    }
+    global_payload["goals"][0]["source_registry"] = str(source_registry)
+    global_registry = runtime / "registry.global.json"
+    global_registry.write_text(
+        json.dumps(global_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--runtime-root",
+                "explicit-runtime",
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                "explicit-runtime-agent",
+                "--thread-id",
+                "thread-explicit-runtime",
+                "--host-surface",
+                "codex-app",
+                "--goal-text",
+                GOAL_TEXT,
+            ]
+        )
+    assert exit_code == 0, output.getvalue()
+
+    payload = json.loads(output.getvalue())
+    registration = payload["guided_transaction"]["identity_selection_gate"][
+        "fresh_agent_registration"
+    ]
+    execute_args = shlex.split(registration["execute_command"])
+    assert execute_args[execute_args.index("--runtime-root") + 1] == str(runtime)
+
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(execute_args[1:])
+    assert exit_code == 0, output.getvalue()
+
+    registered_source = json.loads(source_registry.read_text(encoding="utf-8"))
+    registered_global = json.loads(global_registry.read_text(encoding="utf-8"))
+    assert registered_source["goals"][0]["coordination"]["registered_agents"] == [
+        "explicit-runtime-agent"
+    ]
+    assert registered_global["goals"][0]["coordination"]["registered_agents"] == [
+        "explicit-runtime-agent"
+    ]
 
 
 def test_dsh_native_start_goal_binds_the_exact_same_session_lane(

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -766,7 +766,9 @@ def test_cli_codex_app_reuses_ambient_thread_binding(
     assert payload["guided_transaction"].get("blocked_by") is None
 
 
-def test_start_goal_binds_selected_lane_before_todo_writeback(tmp_path: Path) -> None:
+def test_start_goal_binds_selected_lane_before_todo_writeback(
+    tmp_path: Path,
+) -> None:
     project = _write_connected_project(tmp_path)
     source_registry = project / ".loopx" / "registry.json"
     runtime = tmp_path / "runtime"
@@ -880,7 +882,7 @@ def test_fresh_agent_registration_preserves_guided_runtime_root(
     execute_args = shlex.split(execute_command)
     rerun_args = shlex.split(rerun_command)
     assert execute_args[execute_args.index("--runtime-root") + 1] == str(runtime)
-    assert rerun_args[rerun_args.index("--runtime-root") + 1] == str(runtime)
+    assert "--runtime-root" not in rerun_args
 
     output = io.StringIO()
     with contextlib.redirect_stdout(output):
@@ -967,6 +969,60 @@ def test_start_goal_cli_preserves_explicit_runtime_root_in_registration_command(
     assert registered_global["goals"][0]["coordination"]["registered_agents"] == [
         "explicit-runtime-agent"
     ]
+
+
+def test_guided_state_commands_share_explicit_runtime_root(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    runtime = project / "explicit-runtime"
+    runtime.mkdir()
+
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        thread_id="thread-runtime-consistency",
+        cli_bin="loopx",
+        host_surface="codex-app",
+        goal_text=GOAL_TEXT,
+        available_capabilities=["network"],
+        runtime_root_arg="explicit-runtime",
+        include_command_pack_detail=True,
+    )
+
+    expected_runtime = str(runtime)
+    command_pack = payload["command_pack"]
+    commands = command_pack["commands"]
+
+    def assert_runtime(command: str) -> None:
+        tokens = shlex.split(command)
+        runtime_index = tokens.index("--runtime-root")
+        assert tokens[runtime_index + 1] == expected_runtime
+
+    assert_runtime(command_pack["canonical_cli_command"])
+    for command_key in (
+        "goal_start_connect_if_needed",
+        "goal_start_bind_thread",
+        "goal_start_refresh_state",
+        "goal_start_host_loop_activation",
+        "goal_start_agent_onboard_recheck",
+        "goal_start_quota_should_run",
+    ):
+        command = commands[command_key]
+        assert command is not None
+        assert_runtime(command)
+
+    ordered_steps = payload["guided_transaction"]["ordered_steps"]
+    for step_id, command_key in (
+        ("write_ordered_todos", "command_template"),
+        ("refresh_state", "command"),
+        ("quota_guard", "command"),
+    ):
+        step = next(step for step in ordered_steps if step["id"] == step_id)
+        command = step[command_key]
+        assert command is not None
+        assert_runtime(command)
 
 
 def test_dsh_native_start_goal_binds_the_exact_same_session_lane(


### PR DESCRIPTION
## What changed

Guided `start-goal` can be invoked against a non-default LoopX runtime, but the generated fresh-agent registration, thread-binding, host activation, and rerun commands previously dropped that runtime and fell back to the default global registry.

This keeps the resolved runtime consistent across the guided identity and continuation commands. Explicit runtime roots, persisted `common_runtime_root`, and relative runtime roots are covered.

## Validation

- Targeted Python regression suite: 196 passed
- TypeScript control-plane tests: 151 passed
- TypeScript control-plane typecheck: passed
- Changed-file Ruff, mypy, compile, and `git diff --check`: passed
- Full Python pytest: 4390 passed, 10 skipped, 7 existing baseline failures in dashboard runtime fixtures and the existing 2806/2800 host prompt budget test

No new dependencies.