### PR TITLE
fix(loopx): route wish intents through capabilities

### DIFF
--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -160,6 +160,17 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
                 "Identify the exact current host surface (codex-app, codex-app-ssh, codex-ide-plugin, codex-cli-tui, opencode, opencode2, traex-cli, pi, gemini-cli, cursor-agent, zcode, agy, deepseek-harness, or ark-managed-agent).",
+                (
+                    "Before generic Goal routing, honor an explicit Auto Research product "
+                    "request. If the visible arguments explicitly request using or starting "
+                    "`Auto Research`, or explicitly invoke the `auto-research` command, pass "
+                    "the complete visible request unchanged as one shell-escaped argument to "
+                    f'`{cli_bin} auto-research start "<complete visible $ARGUMENTS>" '
+                    "--execute` and follow that command's launcher or gate output. Do not run "
+                    "`start-goal` first, and do not infer this route from generic words such "
+                    "as research, wish, or a PR URL alone. For example, `使用 Auto Research，"
+                    "许愿……` is an explicit Auto Research request and must take this route."
+                ),
                 _loopx_start_goal_arguments_instruction(
                     cli_bin=cli_bin,
                     host_surface=None,
@@ -326,7 +337,7 @@ def materialize_loopx_entry_skill(
             "This entry skill is installed for the exact current host "
             f"`{host_surface}`; do not infer or substitute another host surface."
         )
-        instructions[2] = _loopx_start_goal_arguments_instruction(
+        instructions[3] = _loopx_start_goal_arguments_instruction(
             cli_bin=cli_bin,
             host_surface=host_surface,
         )

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -161,15 +161,20 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 "Visible command arguments: `$ARGUMENTS`.",
                 "Identify the exact current host surface (codex-app, codex-app-ssh, codex-ide-plugin, codex-cli-tui, opencode, opencode2, traex-cli, pi, gemini-cli, cursor-agent, zcode, agy, deepseek-harness, or ark-managed-agent).",
                 (
-                    "Before generic Goal routing, honor an explicit Auto Research product "
-                    "request. If the visible arguments explicitly request using or starting "
-                    "`Auto Research`, or explicitly invoke the `auto-research` command, pass "
-                    "the complete visible request unchanged as one shell-escaped argument to "
+                    "Before generic Goal routing, check only for an explicit leading Auto "
+                    "Research selector. Use the Auto Research route only when the trimmed "
+                    "visible arguments begin with `使用 Auto Research`, `启动 Auto Research`, "
+                    "`Use Auto Research`, `Start Auto Research`, or the literal "
+                    "`auto-research` command token. In that case, pass the complete visible "
+                    "request unchanged as one shell-escaped argument to "
                     f'`{cli_bin} auto-research start "<complete visible $ARGUMENTS>" '
                     "--execute` and follow that command's launcher or gate output. Do not run "
-                    "`start-goal` first, and do not infer this route from generic words such "
-                    "as research, wish, or a PR URL alone. For example, `使用 Auto Research，"
-                    "许愿……` is an explicit Auto Research request and must take this route."
+                    "`start-goal` first for that exact prefix. Otherwise always use the normal "
+                    "`start-goal` route, including when Auto Research is merely discussed "
+                    "later in the request or when the text only contains generic words such "
+                    "as research, wish, or a PR URL. For example, `使用 Auto Research，许愿……` "
+                    "takes the Auto Research route, while `评估是否应该使用 Auto Research` stays "
+                    "on the normal Goal route."
                 ),
                 _loopx_start_goal_arguments_instruction(
                     cli_bin=cli_bin,

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -54,17 +54,26 @@ def test_host_materialization_installs_generated_loopx_entry_skill(
     assert "surface the exact pasteable gate" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
     explicit_auto_research = (
-        "If the visible arguments explicitly request using or starting "
-        "`Auto Research`, or explicitly invoke the `auto-research` command"
+        "Use the Auto Research route only when the trimmed visible arguments "
+        "begin with `使用 Auto Research`"
     )
     assert explicit_auto_research in skill_text
+    for prefix in (
+        "`启动 Auto Research`",
+        "`Use Auto Research`",
+        "`Start Auto Research`",
+        "the literal `auto-research` command token",
+    ):
+        assert prefix in skill_text
     assert (
         '`loopx auto-research start "<complete visible $ARGUMENTS>" --execute`'
         in skill_text
     )
-    assert "Do not run `start-goal` first" in skill_text
-    assert "research, wish, or a PR URL alone" in skill_text
-    assert "`使用 Auto Research，许愿……` is an explicit Auto Research request" in skill_text
+    assert "Do not run `start-goal` first for that exact prefix" in skill_text
+    assert "Otherwise always use the normal `start-goal` route" in skill_text
+    assert "research, wish, or a PR URL" in skill_text
+    assert "`使用 Auto Research，许愿……` takes the Auto Research route" in skill_text
+    assert "`评估是否应该使用 Auto Research` stays on the normal Goal route" in skill_text
     assert skill_text.index(explicit_auto_research) < skill_text.index(
         "start-goal --guided"
     )
@@ -98,13 +107,14 @@ def test_host_materialization_can_bind_exact_managed_agent_surface(
     assert "never infer a route" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
     assert (
-        "If the visible arguments explicitly request using or starting "
-        "`Auto Research`, or explicitly invoke the `auto-research` command"
+        "Use the Auto Research route only when the trimmed visible arguments "
+        "begin with `使用 Auto Research`"
     ) in skill_text
     assert (
         '`loopx auto-research start "<complete visible $ARGUMENTS>" --execute`'
         in skill_text
     )
+    assert "Otherwise always use the normal `start-goal` route" in skill_text
     assert "current Todo evidence and the next executable Todo" not in skill_text
     assert "generic Todos remain scheduling records" not in skill_text
 

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -53,6 +53,21 @@ def test_host_materialization_installs_generated_loopx_entry_skill(
     assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
     assert "surface the exact pasteable gate" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
+    explicit_auto_research = (
+        "If the visible arguments explicitly request using or starting "
+        "`Auto Research`, or explicitly invoke the `auto-research` command"
+    )
+    assert explicit_auto_research in skill_text
+    assert (
+        '`loopx auto-research start "<complete visible $ARGUMENTS>" --execute`'
+        in skill_text
+    )
+    assert "Do not run `start-goal` first" in skill_text
+    assert "research, wish, or a PR URL alone" in skill_text
+    assert "`使用 Auto Research，许愿……` is an explicit Auto Research request" in skill_text
+    assert skill_text.index(explicit_auto_research) < skill_text.index(
+        "start-goal --guided"
+    )
     assert "reuse the packet's verified thread binding" not in skill_text
     assert "capability show <capability-id> --format json" not in skill_text
     assert "Chat/model summaries are not durable state" not in skill_text
@@ -82,6 +97,14 @@ def test_host_materialization_can_bind_exact_managed_agent_surface(
     assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
     assert "never infer a route" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
+    assert (
+        "If the visible arguments explicitly request using or starting "
+        "`Auto Research`, or explicitly invoke the `auto-research` command"
+    ) in skill_text
+    assert (
+        '`loopx auto-research start "<complete visible $ARGUMENTS>" --execute`'
+        in skill_text
+    )
     assert "current Todo evidence and the next executable Todo" not in skill_text
     assert "generic Todos remain scheduling records" not in skill_text
 


### PR DESCRIPTION
## Summary

- let built-in capabilities declare validated natural-language invocation aliases in the capability catalog
- map the Auto Research wish vocabulary, including `许愿`, to the canonical `loopx auto-research start ... --execute` multi-agent entrypoint
- resolve aliases at the `start-goal` CLI boundary before ordinary Goal selection, while leaving the ordinary Goal packet builder unchanged
- keep the generated `$loopx` skill generic: it only follows typed `capability_intent_route.entry_command` output and contains no Auto Research- or wish-specific vocabulary

## Root cause

The managed `$loopx` facade always entered generic `start-goal` planning. The Auto Research capability already owned a one-command multi-agent launcher, but there was no typed bridge from the user-facing wish vocabulary to that capability entrypoint. Agents could therefore create a normal single-agent Todo and manually assemble evidence/receipt commands without launching the Auto Research roles.

## Safety and compatibility

- only built-in capabilities may register global intent aliases; extensions cannot hijack `$loopx` routing
- matching is deterministic and limited to normalized clause prefixes
- explicit `--capability-route` overrides catalog aliases
- generic research requests and requests that merely discuss Auto Research remain on the existing Goal path
- command argv is schema-validated and must begin with `{cli_bin}` and contain exactly one `{goal_text}` token

## Validation

- related pytest suites: 115 passed
- Ruff: passed
- Auto Research user-contract smoke: passed
- bootstrap command-pack smoke: passed
- install-local smoke: passed
- control-plane maintainability ratchet: passed
- CLI output budget differential smoke: passed with permission to create its temporary Git worktree
- `loopx check`: 0 errors; two unrelated existing goal-state warnings
- premerge risk-profile checks all passed; aggregate remained red only because install-local exceeded the wrapper timeout and the CLI output differential could not create a parent-repo worktree under the sandbox before both checks passed standalone

## Future-facing pass

The reusable route contract lives in `loopx/capabilities/intent_route.py`; Auto Research owns only its aliases and argv template. No product-specific phrase or command is embedded in the shared `$loopx` skill or ordinary Goal state machine.