### PR TITLE
Fix botmux runtime doctor read race

### DIFF
--- a/loopx/control_plane/goals/botmux_runtime.py
+++ b/loopx/control_plane/goals/botmux_runtime.py
@@ -15,7 +15,8 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
-from ...file_lock import exclusive_file_lock
+from ...file_lock import LockAcquireTimeoutError, exclusive_file_lock
+from ...file_lock import lock_timeout_error_fields
 from ...paths import registry_project_root
 from ...registry import registry_goals
 
@@ -499,6 +500,23 @@ def _assert_public_packet(packet: Mapping[str, Any]) -> None:
     visit(packet)
 
 
+def _lock_timeout_packet(
+    *, goal_id: str, operation: str, execute: bool, error: LockAcquireTimeoutError
+) -> dict[str, Any]:
+    packet = _operation_packet(
+        ok=False,
+        goal_id=goal_id,
+        operation=operation,
+        execute=execute,
+        status="blocked",
+        blocker="botmux_runtime_lock_timeout",
+        public_summary="the botmux runtime binding is busy; inspect the lock holder and retry",
+    )
+    packet.update(lock_timeout_error_fields(error))
+    _assert_public_packet(packet)
+    return packet
+
+
 def _probe_botmux(
     *,
     binding: Mapping[str, Any],
@@ -721,67 +739,60 @@ def doctor_botmux_runtime(
     binding_path: Path,
     requester: JsonRequester = _request_json,
 ) -> dict[str, Any]:
-    with exclusive_file_lock(binding_path, operation="botmux_runtime_doctor"):
-        binding = botmux_binding_for_goal(
-            read_botmux_runtime_binding(binding_path),
-            goal_id,
-        )
-        if binding is None or binding.get("enabled") is not True:
+    try:
+        with exclusive_file_lock(binding_path, operation="botmux_runtime_doctor"):
+            binding = botmux_binding_for_goal(
+                read_botmux_runtime_binding(binding_path),
+                goal_id,
+            )
+            if binding is None or binding.get("enabled") is not True:
+                return _operation_packet(
+                    ok=False,
+                    goal_id=goal_id,
+                    operation="runtime_doctor",
+                    execute=False,
+                    status="blocked",
+                    blocker="botmux_binding_missing",
+                    public_summary="configure a botmux runtime binding for this goal",
+                )
+            try:
+                probe = _probe_botmux(binding=binding, requester=requester)
+            except (ValueError, BotmuxApiError, BotmuxTransportError) as exc:
+                if isinstance(exc, ValueError):
+                    blocker = (
+                        "botmux_auth_unavailable"
+                        if "token is unavailable" in str(exc)
+                        else "botmux_configuration_invalid"
+                    )
+                    summary = "the botmux runtime binding is not ready"
+                elif isinstance(exc, BotmuxApiError):
+                    blocker = "botmux_api_rejected"
+                    summary = "botmux rejected the runtime readiness probe"
+                else:
+                    blocker = "botmux_unreachable"
+                    summary = "the configured botmux daemon is unreachable"
+                return _operation_packet(
+                    ok=False,
+                    goal_id=goal_id,
+                    operation="runtime_doctor",
+                    execute=False,
+                    status="blocked",
+                    blocker=blocker,
+                    public_summary=summary,
+                )
             return _operation_packet(
-                ok=False,
+                ok=True,
                 goal_id=goal_id,
                 operation="runtime_doctor",
                 execute=False,
-                status="blocked",
-                blocker="botmux_binding_missing",
-                public_summary="configure a botmux runtime binding for this goal",
+                status="ready",
+                public_summary="the botmux runtime binding is ready",
+                readback_verified=True,
+                details=probe,
             )
-        try:
-            probe = _probe_botmux(binding=binding, requester=requester)
-        except ValueError as exc:
-            blocker = (
-                "botmux_auth_unavailable"
-                if "token is unavailable" in str(exc)
-                else "botmux_configuration_invalid"
-            )
-            return _operation_packet(
-                ok=False,
-                goal_id=goal_id,
-                operation="runtime_doctor",
-                execute=False,
-                status="blocked",
-                blocker=blocker,
-                public_summary="the botmux runtime binding is not ready",
-            )
-        except BotmuxApiError:
-            return _operation_packet(
-                ok=False,
-                goal_id=goal_id,
-                operation="runtime_doctor",
-                execute=False,
-                status="blocked",
-                blocker="botmux_api_rejected",
-                public_summary="botmux rejected the runtime readiness probe",
-            )
-        except BotmuxTransportError:
-            return _operation_packet(
-                ok=False,
-                goal_id=goal_id,
-                operation="runtime_doctor",
-                execute=False,
-                status="blocked",
-                blocker="botmux_unreachable",
-                public_summary="the configured botmux daemon is unreachable",
-            )
-        return _operation_packet(
-            ok=True,
-            goal_id=goal_id,
-            operation="runtime_doctor",
-            execute=False,
-            status="ready",
-            public_summary="the botmux runtime binding is ready",
-            readback_verified=True,
-            details=probe,
+    except LockAcquireTimeoutError as exc:
+        return _lock_timeout_packet(
+            goal_id=goal_id, operation="runtime_doctor", execute=False, error=exc
         )
 
 
@@ -1456,7 +1467,15 @@ def status_botmux_runtime(
     execute: bool = False,
     requester: JsonRequester = _request_json,
 ) -> dict[str, Any]:
-    if not execute:
+    if execute:
+        with exclusive_file_lock(binding_path, operation="botmux_runtime_status"):
+            return _status_botmux_runtime(
+                goal_id=goal_id,
+                binding_path=binding_path,
+                execute=True,
+                requester=requester,
+            )
+    try:
         with exclusive_file_lock(binding_path, operation="botmux_runtime_status"):
             return _status_botmux_runtime(
                 goal_id=goal_id,
@@ -1464,12 +1483,9 @@ def status_botmux_runtime(
                 execute=False,
                 requester=requester,
             )
-    with exclusive_file_lock(binding_path, operation="botmux_runtime_status"):
-        return _status_botmux_runtime(
-            goal_id=goal_id,
-            binding_path=binding_path,
-            execute=True,
-            requester=requester,
+    except LockAcquireTimeoutError as exc:
+        return _lock_timeout_packet(
+            goal_id=goal_id, operation="runtime_status", execute=False, error=exc
         )
 
 

--- a/loopx/control_plane/goals/botmux_runtime.py
+++ b/loopx/control_plane/goals/botmux_runtime.py
@@ -721,67 +721,68 @@ def doctor_botmux_runtime(
     binding_path: Path,
     requester: JsonRequester = _request_json,
 ) -> dict[str, Any]:
-    binding = botmux_binding_for_goal(
-        read_botmux_runtime_binding(binding_path),
-        goal_id,
-    )
-    if binding is None or binding.get("enabled") is not True:
+    with exclusive_file_lock(binding_path, operation="botmux_runtime_doctor"):
+        binding = botmux_binding_for_goal(
+            read_botmux_runtime_binding(binding_path),
+            goal_id,
+        )
+        if binding is None or binding.get("enabled") is not True:
+            return _operation_packet(
+                ok=False,
+                goal_id=goal_id,
+                operation="runtime_doctor",
+                execute=False,
+                status="blocked",
+                blocker="botmux_binding_missing",
+                public_summary="configure a botmux runtime binding for this goal",
+            )
+        try:
+            probe = _probe_botmux(binding=binding, requester=requester)
+        except ValueError as exc:
+            blocker = (
+                "botmux_auth_unavailable"
+                if "token is unavailable" in str(exc)
+                else "botmux_configuration_invalid"
+            )
+            return _operation_packet(
+                ok=False,
+                goal_id=goal_id,
+                operation="runtime_doctor",
+                execute=False,
+                status="blocked",
+                blocker=blocker,
+                public_summary="the botmux runtime binding is not ready",
+            )
+        except BotmuxApiError:
+            return _operation_packet(
+                ok=False,
+                goal_id=goal_id,
+                operation="runtime_doctor",
+                execute=False,
+                status="blocked",
+                blocker="botmux_api_rejected",
+                public_summary="botmux rejected the runtime readiness probe",
+            )
+        except BotmuxTransportError:
+            return _operation_packet(
+                ok=False,
+                goal_id=goal_id,
+                operation="runtime_doctor",
+                execute=False,
+                status="blocked",
+                blocker="botmux_unreachable",
+                public_summary="the configured botmux daemon is unreachable",
+            )
         return _operation_packet(
-            ok=False,
+            ok=True,
             goal_id=goal_id,
             operation="runtime_doctor",
             execute=False,
-            status="blocked",
-            blocker="botmux_binding_missing",
-            public_summary="configure a botmux runtime binding for this goal",
+            status="ready",
+            public_summary="the botmux runtime binding is ready",
+            readback_verified=True,
+            details=probe,
         )
-    try:
-        probe = _probe_botmux(binding=binding, requester=requester)
-    except ValueError as exc:
-        blocker = (
-            "botmux_auth_unavailable"
-            if "token is unavailable" in str(exc)
-            else "botmux_configuration_invalid"
-        )
-        return _operation_packet(
-            ok=False,
-            goal_id=goal_id,
-            operation="runtime_doctor",
-            execute=False,
-            status="blocked",
-            blocker=blocker,
-            public_summary="the botmux runtime binding is not ready",
-        )
-    except BotmuxApiError:
-        return _operation_packet(
-            ok=False,
-            goal_id=goal_id,
-            operation="runtime_doctor",
-            execute=False,
-            status="blocked",
-            blocker="botmux_api_rejected",
-            public_summary="botmux rejected the runtime readiness probe",
-        )
-    except BotmuxTransportError:
-        return _operation_packet(
-            ok=False,
-            goal_id=goal_id,
-            operation="runtime_doctor",
-            execute=False,
-            status="blocked",
-            blocker="botmux_unreachable",
-            public_summary="the configured botmux daemon is unreachable",
-        )
-    return _operation_packet(
-        ok=True,
-        goal_id=goal_id,
-        operation="runtime_doctor",
-        execute=False,
-        status="ready",
-        public_summary="the botmux runtime binding is ready",
-        readback_verified=True,
-        details=probe,
-    )
 
 
 def _disable_botmux_runtime(
@@ -1456,12 +1457,13 @@ def status_botmux_runtime(
     requester: JsonRequester = _request_json,
 ) -> dict[str, Any]:
     if not execute:
-        return _status_botmux_runtime(
-            goal_id=goal_id,
-            binding_path=binding_path,
-            execute=False,
-            requester=requester,
-        )
+        with exclusive_file_lock(binding_path, operation="botmux_runtime_status"):
+            return _status_botmux_runtime(
+                goal_id=goal_id,
+                binding_path=binding_path,
+                execute=False,
+                requester=requester,
+            )
     with exclusive_file_lock(binding_path, operation="botmux_runtime_status"):
         return _status_botmux_runtime(
             goal_id=goal_id,

--- a/tests/control_plane/test_botmux_goal_channel_runtime.py
+++ b/tests/control_plane/test_botmux_goal_channel_runtime.py
@@ -1070,3 +1070,58 @@ def test_concurrent_trigger_dispatches_provider_once(
         "already_dispatched",
         "queued",
     ]
+
+
+def test_doctor_waits_for_concurrent_setup_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    ready_to_probe = threading.Event()
+    allow_setup_to_finish = threading.Event()
+    doctor_result: dict[str, Any] = {}
+
+    def delayed_requester(**kwargs: Any) -> dict[str, Any]:
+        if kwargs["path"] == "/api/trigger" and kwargs["payload"]["options"].get("dryRun") is True:
+            ready_to_probe.set()
+            allow_setup_to_finish.wait(timeout=2.0)
+        return _requester([], tmp_path)(**kwargs)
+
+    def run_setup() -> None:
+        setup_botmux_runtime(
+            registry=registry,
+            registry_path=registry_path,
+            goal_id=GOAL_ID,
+            binding_path=binding_path,
+            endpoint="http://127.0.0.1:7891",
+            bot_id=BOT_ID,
+            chat_id=CHAT_ID,
+            token_env="BOTMUX_TEST_TOKEN",
+            execute=True,
+            requester=delayed_requester,
+        )
+
+    def run_doctor() -> None:
+        ready_to_probe.wait(timeout=2.0)
+        doctor_result.update(
+            doctor_botmux_runtime(
+                goal_id=GOAL_ID,
+                binding_path=binding_path,
+                requester=_requester([], tmp_path),
+            )
+        )
+
+    setup_thread = threading.Thread(target=run_setup)
+    doctor_thread = threading.Thread(target=run_doctor)
+    setup_thread.start()
+    doctor_thread.start()
+    ready_to_probe.wait(timeout=2.0)
+    time.sleep(0.05)
+    allow_setup_to_finish.set()
+    setup_thread.join()
+    doctor_thread.join()
+
+    assert doctor_result["ok"] is True
+    assert doctor_result["status"] == "ready"

--- a/tests/control_plane/test_botmux_goal_channel_runtime.py
+++ b/tests/control_plane/test_botmux_goal_channel_runtime.py
@@ -21,6 +21,7 @@ from loopx.control_plane.goals.botmux_runtime import (
     status_botmux_runtime,
     trigger_botmux_runtime,
 )
+from loopx.file_lock import LOCK_POLICIES, LockAcquisitionPolicy, LockPolicy
 
 
 GOAL_ID = "goal-public-fixture"
@@ -1125,3 +1126,92 @@ def test_doctor_waits_for_concurrent_setup_write(
 
     assert doctor_result["ok"] is True
     assert doctor_result["status"] == "ready"
+
+
+@pytest.mark.parametrize(
+    ("runtime_operation", "waiter_operation"),
+    [
+        ("runtime_doctor", "botmux_runtime_doctor"),
+        ("runtime_status", "botmux_runtime_status"),
+    ],
+)
+def test_runtime_reads_return_typed_packet_when_setup_lock_times_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runtime_operation: str,
+    waiter_operation: str,
+) -> None:
+    registry, registry_path = _registry(tmp_path)
+    binding_path = tmp_path / ".loopx" / "goal-channel-runtime.json"
+    monkeypatch.setenv("BOTMUX_TEST_TOKEN", "secret-public-fixture")
+    monkeypatch.setitem(
+        LOCK_POLICIES,
+        LockAcquisitionPolicy.MUTATION,
+        LockPolicy(
+            timeout_seconds=0.05,
+            poll_interval_seconds=0.005,
+            retry_mode="manual_after_holder_inspection",
+        ),
+    )
+    setup_holds_lock = threading.Event()
+    allow_setup_to_finish = threading.Event()
+    setup_result: dict[str, Any] = {}
+
+    def delayed_requester(**kwargs: Any) -> dict[str, Any]:
+        if (
+            kwargs["path"] == "/api/trigger"
+            and kwargs["payload"]["options"].get("dryRun") is True
+        ):
+            setup_holds_lock.set()
+            allow_setup_to_finish.wait(timeout=2.0)
+        return _requester([], tmp_path)(**kwargs)
+
+    def run_setup() -> None:
+        setup_result.update(
+            setup_botmux_runtime(
+                registry=registry,
+                registry_path=registry_path,
+                goal_id=GOAL_ID,
+                binding_path=binding_path,
+                endpoint="http://127.0.0.1:7891",
+                bot_id=BOT_ID,
+                chat_id=CHAT_ID,
+                token_env="BOTMUX_TEST_TOKEN",
+                execute=True,
+                requester=delayed_requester,
+            )
+        )
+
+    setup_thread = threading.Thread(target=run_setup)
+    setup_thread.start()
+    assert setup_holds_lock.wait(timeout=2.0)
+
+    try:
+        if runtime_operation == "runtime_doctor":
+            result = doctor_botmux_runtime(
+                goal_id=GOAL_ID,
+                binding_path=binding_path,
+                requester=_requester([], tmp_path),
+            )
+        else:
+            result = status_botmux_runtime(
+                goal_id=GOAL_ID,
+                binding_path=binding_path,
+                requester=_requester([], tmp_path),
+            )
+    finally:
+        allow_setup_to_finish.set()
+        setup_thread.join(timeout=2.0)
+
+    assert not setup_thread.is_alive()
+    assert setup_result["status"] == "configured"
+    assert result["ok"] is False
+    assert result["operation"] == runtime_operation
+    assert result["status"] == "blocked"
+    assert result["blocker"] == "botmux_runtime_lock_timeout"
+    assert result["error_code"] == "lock_acquire_timeout"
+    assert result["lock_timeout"]["holder"]["operation"] == "botmux_runtime_setup"
+    assert result["lock_timeout"]["waiter"]["operation"] == waiter_operation
+    assert result["operator_action"]["action"] == "inspect_lock_holder"
+    assert json.loads(json.dumps(result)) == result
+    _assert_public_packet(result)


### PR DESCRIPTION
## Summary
- serialize botmux runtime doctor reads with the runtime binding file lock
- do the same for non-executing runtime status reads to keep the binding state consistent under concurrent writes
- add a regression test covering concurrent setup + doctor execution

## Testing
- pytest -q tests/control_plane/test_botmux_goal_channel_runtime.py