### PR TITLE
feat(lark): add profile-bound multi-route inbox routing

### DIFF
--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -9,33 +9,32 @@ import sys
 import tempfile
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from loopx.extensions.lark.event_collector import (  # noqa: E402
+from loopx.cli_commands.lark_inbox import (
+    _collector_permissions,
+)
+from loopx.extensions.lark import (
+    LARK_COLLECTOR_PERMISSION,
+    LARK_REPLY_PERMISSION,
+)
+from loopx.extensions.lark.event_collector import (
     inspect_lark_event_collector,
     install_lark_event_collector,
     plan_lark_event_collector,
 )
-from loopx.extensions.lark.event_collector_runtime import (  # noqa: E402
+from loopx.extensions.lark.event_collector_runtime import (
     add_lark_event_received_reaction,
     enrich_lark_event_reply_context,
     lark_event_requires_reply_context_lookup,
     run_lark_event_collector,
 )
-from loopx.extensions.lark.event_inbox import (  # noqa: E402
+from loopx.extensions.lark.event_inbox import (
     project_lark_event_inbox_urgency,
 )
-from loopx.extensions.lark.inbox_reactions import (  # noqa: E402
+from loopx.extensions.lark.inbox_reactions import (
     lark_inbox_reaction_receipts,
-)
-from loopx.cli_commands.lark_inbox import (  # noqa: E402
-    _collector_permissions,
-)
-from loopx.extensions.lark import (  # noqa: E402
-    LARK_COLLECTOR_PERMISSION,
-    LARK_REPLY_PERMISSION,
 )
 
 
@@ -166,9 +165,9 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         )
         assert preview["status"] == "preview_ready", preview
         assert preview["would_write_service"] is True, preview
-        assert calls == [
-            [str(node), str(lark_cli), "event", "consume", "--help"]
-        ], calls
+        assert calls == [[str(node), str(lark_cli), "event", "consume", "--help"]], (
+            calls
+        )
 
         installed = install_lark_event_collector(
             project=project,
@@ -195,10 +194,12 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         assert service_argv[service_argv.index("--lark-cli-executable") + 1] == str(
             lark_cli
         ), service_argv
-        assert service_argv[service_argv.index("--node-executable") + 1] == str(
-            node
-        ), service_argv
-        assert "event" not in service_argv and "consume" not in service_argv, service_argv
+        assert service_argv[service_argv.index("--node-executable") + 1] == str(node), (
+            service_argv
+        )
+        assert "event" not in service_argv and "consume" not in service_argv, (
+            service_argv
+        )
 
         direct_event = {
             "message_id": "om_direct_fixture",
@@ -237,6 +238,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
             profile="project-review-bot",
             emoji_type="Get",
         )
+
         def timeout_runner(
             argv: list[str], **_: object
         ) -> subprocess.CompletedProcess[str]:
@@ -259,9 +261,9 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
             "reactions",
             "create",
         ], reaction_calls
-        assert json.loads(
-            reaction_calls[0][reaction_calls[0].index("--data") + 1]
-        ) == {"reaction_type": {"emoji_type": "Get"}}, reaction_calls
+        assert json.loads(reaction_calls[0][reaction_calls[0].index("--data") + 1]) == {
+            "reaction_type": {"emoji_type": "Get"}
+        }, reaction_calls
         invalid_inbox = json.loads(inbox_config.read_text())
         invalid_inbox["reply"]["enabled"] = False
         inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
@@ -315,7 +317,9 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         }
         lookup_calls: list[list[str]] = []
 
-        def lookup_runner(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        def lookup_runner(
+            argv: list[str], **_: object
+        ) -> subprocess.CompletedProcess[str]:
             lookup_calls.append(list(argv))
             message_id = argv[argv.index("--message-ids") + 1]
             return subprocess.CompletedProcess(
@@ -416,6 +420,7 @@ if "event" in args and "consume" in args:
             "message_id": "om_runtime_direct",
             "create_time": "2026-07-16T00:00:00Z",
             "content": "@Project Review Bot 能处理吗？",
+            "chat_id": "oc_private_fixture_chat",
         },
         {
             "schema_version": "lark_event_inbox_event_v0",
@@ -423,6 +428,7 @@ if "event" in args and "consume" in args:
             "message_id": "om_runtime_ordinary",
             "create_time": "2026-07-16T00:01:00Z",
             "content": "Project Review Bot 群里的普通问题为什么会这样？",
+            "chat_id": "oc_private_fixture_chat",
         },
         {
             "schema_version": "lark_event_inbox_event_v0",
@@ -430,6 +436,7 @@ if "event" in args and "consume" in args:
             "message_id": "om_runtime_reply",
             "create_time": "2026-07-16T00:02:00Z",
             "content": "这是不带 at 的回复",
+            "chat_id": "oc_private_fixture_chat",
         },
     ]
     for event in events:

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -6,21 +6,21 @@ import os
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from loopx.extensions.lark.event_inbox import (  # noqa: E402
+from loopx.extensions.lark.event_inbox import (
     acknowledge_lark_event_inbox,
     ingest_lark_event_inbox,
     inspect_lark_event_inbox,
     lark_event_inbox_contains_text,
     project_lark_event_inbox_urgency,
 )
-from loopx.extensions.lark.inbox_reply import reply_lark_event_inbox  # noqa: E402
+from loopx.extensions.lark.inbox_reply import reply_lark_event_inbox
 
 
 def main() -> None:
@@ -77,16 +77,22 @@ def main() -> None:
         )
         pending = inspect_lark_event_inbox(project=project, config_path=config)
         assert pending["thread_complete"] is True, pending
-        assert lark_event_inbox_contains_text(
-            project=project,
-            config_path=config,
-            text="record this feedback",
-        ) is True
-        assert lark_event_inbox_contains_text(
-            project=project,
-            config_path=config,
-            text="https://github.com/owner/repo/pull/404",
-        ) is False
+        assert (
+            lark_event_inbox_contains_text(
+                project=project,
+                config_path=config,
+                text="record this feedback",
+            )
+            is True
+        )
+        assert (
+            lark_event_inbox_contains_text(
+                project=project,
+                config_path=config,
+                text="https://github.com/owner/repo/pull/404",
+            )
+            is False
+        )
 
         imported = ingest_lark_event_inbox(
             project=project,
@@ -219,7 +225,7 @@ def main() -> None:
         urgency = project_lark_event_inbox_urgency(
             project=project,
             config_path=config,
-            now=datetime(2026, 7, 12, 10, 12, tzinfo=timezone.utc),
+            now=datetime(2026, 7, 12, 10, 12, tzinfo=UTC),
         )
         assert urgency["pending_count"] == 4, urgency
         assert urgency["direct_question_count"] == 1, urgency
@@ -265,6 +271,27 @@ def main() -> None:
             if args[3:6] == ["im", "chats", "get"]:
                 return {"returncode": 0, "stdout": "{}", "stderr": ""}
             if "+messages-reply" in args:
+                if "--dry-run" in args:
+                    reply_text = args[args.index("--text") + 1]
+                    return {
+                        "returncode": 0,
+                        "stdout": json.dumps(
+                            {
+                                "api": [
+                                    {
+                                        "body": {
+                                            "content": json.dumps(
+                                                {"text": reply_text},
+                                                ensure_ascii=False,
+                                            )
+                                        }
+                                    }
+                                ]
+                            },
+                            ensure_ascii=False,
+                        ),
+                        "stderr": "",
+                    }
                 return {
                     "returncode": 0,
                     "stdout": json.dumps({"message_id": "om_reply_1"}),
@@ -320,6 +347,8 @@ def main() -> None:
                 if args[3:6] == ["im", "chats", "get"]:
                     return {"returncode": 0, "stdout": "{}", "stderr": ""}
                 if "+messages-reply" in args:
+                    if "--dry-run" in args:
+                        return successful_runner(args)
                     return {
                         "returncode": 0,
                         "stdout": json.dumps({"message_id": "om_reply_mention"}),
@@ -360,9 +389,7 @@ def main() -> None:
 
             return run
 
-        mention_reply = (
-            '<at user_id="ou_reviewer_fixture">Reviewer</at> 已记录并修正。'
-        )
+        mention_reply = '<at user_id="ou_reviewer_fixture">Reviewer</at> 已记录并修正。'
         normalized_mention = reply_lark_event_inbox(
             project=project,
             config_path=config,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
+from ..capabilities.issue_fix.provider_hooks import IssueFixReviewerProviderHooks
+from ..control_plane.runtime.goal_project_route import resolve_goal_project_route
 from ..extensions.lark import (
     LARK_COLLECTOR_PERMISSION,
     LARK_EXTENSION_ID,
@@ -14,21 +16,6 @@ from ..extensions.lark import (
     LARK_REPLY_PERMISSION,
     LARK_REVIEWER_NOTIFICATION_PERMISSION,
 )
-from ..extensions.lark.event_inbox import (
-    acknowledge_lark_event_inbox,
-    ingest_lark_event_inbox,
-    inspect_lark_event_inbox,
-    lark_event_inbox_contains_text,
-    project_lark_event_inbox_urgency,
-)
-from ..extensions.lark.inbox_reply import reply_lark_event_inbox
-from ..extensions.lark.inbox_reactions import (
-    complete_lark_event_inbox_reactions,
-    mark_lark_event_inbox_processing,
-)
-from ..extensions.lark.reviewer_notification import (
-    lark_reviewer_notification_sink,
-)
 from ..extensions.lark.event_collector import (
     inspect_lark_event_collector,
     install_lark_event_collector,
@@ -36,12 +23,30 @@ from ..extensions.lark.event_collector import (
     plan_lark_event_collector,
 )
 from ..extensions.lark.event_collector_runtime import run_lark_event_collector
+from ..extensions.lark.event_inbox import (
+    acknowledge_lark_event_inbox,
+    inspect_lark_event_inbox,
+    lark_event_inbox_contains_text,
+)
+from ..extensions.lark.inbox_reactions import (
+    complete_lark_event_inbox_reactions,
+    mark_lark_event_inbox_processing,
+)
+from ..extensions.lark.inbox_reply import reply_lark_event_inbox
+from ..extensions.lark.reviewer_notification import (
+    lark_reviewer_notification_sink,
+)
+from ..extensions.lark.routed_inbox import (
+    acknowledge_routed_lark_event_inbox,
+    ingest_routed_lark_event_inbox,
+    inspect_routed_lark_event_inbox,
+    project_routed_lark_event_inbox_urgency,
+    resolve_routed_lark_inbox_config,
+)
 from ..extensions.runtime import (
     default_extension_state_file,
     resolve_extension_activation,
 )
-from ..capabilities.issue_fix.provider_hooks import IssueFixReviewerProviderHooks
-from ..control_plane.runtime.goal_project_route import resolve_goal_project_route
 
 
 def _goal_inbox_config(
@@ -130,6 +135,11 @@ def register_lark_inbox_commands(
     reply.add_argument("--agent-id")
     reply.add_argument("--message-id", required=True)
     reply.add_argument("--text", required=True)
+    reply.add_argument(
+        "--provider-preflight",
+        action="store_true",
+        help="Run identity, membership, and provider dry-run checks without sending.",
+    )
     reply.add_argument("--execute", action="store_true")
     processing = sub.add_parser(
         "processing",
@@ -232,7 +242,10 @@ def _collector_permissions(
         project=project,
         config_path=config_path,
     )
-    if config["inbox"]["reply"].get("received_reaction_emoji"):
+    if any(
+        route["inbox"]["reply"].get("received_reaction_emoji")
+        for route in config["routes"]
+    ):
         return (LARK_COLLECTOR_PERMISSION, LARK_REPLY_PERMISSION)
     return (LARK_COLLECTOR_PERMISSION,)
 
@@ -254,16 +267,14 @@ def build_lark_operator_inbox_urgency_projector(
 ) -> Callable[..., dict[str, object]]:
     """Compose activation proof with the extension-owned private config read."""
 
-    def project(
-        *, project: str | Path, config_path: str | Path
-    ) -> dict[str, object]:
+    def project(*, project: str | Path, config_path: str | Path) -> dict[str, object]:
         _resolve_lark_activation(
             "drain",
             runtime_root_arg=(
                 str(runtime_root_arg) if runtime_root_arg is not None else None
             ),
         )
-        return project_lark_event_inbox_urgency(
+        return project_routed_lark_event_inbox_urgency(
             project=project,
             config_path=config_path,
         )
@@ -368,42 +379,58 @@ def handle_lark_inbox_command(
                     required_permissions=required_permissions,
                 )
         if args.lark_inbox_command == "drain":
-            payload = inspect_lark_event_inbox(
+            payload = inspect_routed_lark_event_inbox(
                 project=project,
                 config_path=config_path,
                 limit=args.limit,
             )
         elif args.lark_inbox_command == "ack":
-            payload = acknowledge_lark_event_inbox(
+            payload = acknowledge_routed_lark_event_inbox(
                 project=project,
                 config_path=config_path,
                 message_ids=args.message_id,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "reply":
-            payload = reply_lark_event_inbox(
+            routed_config = resolve_routed_lark_inbox_config(
                 project=project,
                 config_path=config_path,
                 message_id=args.message_id,
+            )
+            payload = reply_lark_event_inbox(
+                project=project,
+                config_path=routed_config,
+                message_id=args.message_id,
                 text=args.text,
                 execute=args.execute,
+                provider_preflight=args.provider_preflight,
             )
         elif args.lark_inbox_command == "processing":
-            payload = mark_lark_event_inbox_processing(
+            routed_config = resolve_routed_lark_inbox_config(
                 project=project,
                 config_path=config_path,
+                message_id=args.message_id,
+            )
+            payload = mark_lark_event_inbox_processing(
+                project=project,
+                config_path=routed_config,
                 message_id=args.message_id,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "reaction-complete":
-            payload = complete_lark_event_inbox_reactions(
+            routed_config = resolve_routed_lark_inbox_config(
                 project=project,
                 config_path=config_path,
+                message_id=args.message_id,
+            )
+            payload = complete_lark_event_inbox_reactions(
+                project=project,
+                config_path=routed_config,
                 message_id=args.message_id,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "ingest":
-            payload = ingest_lark_event_inbox(
+            payload = ingest_routed_lark_event_inbox(
                 project=project,
                 config_path=config_path,
                 events=_read_stdin_events(),

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -9,28 +9,32 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from .agent_registry import normalize_registered_agents
 from .boundary_authority import (
     build_checkpointed_boundary_authority_entry,
     checkpointed_boundary_authority_summary,
 )
-from .agent_registry import normalize_registered_agents
 from .capabilities.change_quality.policy import (
     CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
     change_quality_goal_policy_summary,
 )
-from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .configuration_catalog import build_goal_configuration_catalog
-from .explore_graph import compact_explore_graph_policy
-from .orchestration import (
-    DEFAULT_ORCHESTRATION_MODE,
-    EXPLORE_HARNESS_PROFILES,
-    MULTI_SUBAGENT_ORCHESTRATION_MODE,
-    compact_orchestration_policy,
-    compact_peer_task_coordination_policy,
-    orchestration_policy_summary,
+from .control_plane import compact_control_plane_policy, control_plane_policy_summary
+from .control_plane.agents.legacy_migration import (
+    completed_peer_agent_runtime_migration,
+    legacy_agent_hierarchy_present,
+    migrate_coordination_to_peer_v1,
+    peer_agent_runtime_migration_completed,
+    peer_agent_runtime_migration_id,
 )
-from .quota import goal_quota_config
-from .registry import atomic_write_json, read_json, registry_goals
+from .control_plane.agents.profile import normalize_agent_profile
+from .control_plane.agents.runtime_model import (
+    AgentRuntimeModel,
+    agent_runtime_model_for_goal,
+)
+from .control_plane.agents.supervisor import normalize_peer_supervisor
+from .control_plane.agents.work_mode import normalize_agent_work_modes
+from .control_plane.operator_inbox_binding import local_private_config_digest
 from .control_plane.reward_memory import (
     reward_memory_goal_policy,
     reward_memory_goal_policy_summary,
@@ -44,21 +48,17 @@ from .execution_profile import (
     execution_profile_with_turn_granularity,
     normalize_turn_granularity,
 )
-from .control_plane.agents.legacy_migration import (
-    completed_peer_agent_runtime_migration,
-    legacy_agent_hierarchy_present,
-    migrate_coordination_to_peer_v1,
-    peer_agent_runtime_migration_completed,
-    peer_agent_runtime_migration_id,
+from .explore_graph import compact_explore_graph_policy
+from .orchestration import (
+    DEFAULT_ORCHESTRATION_MODE,
+    EXPLORE_HARNESS_PROFILES,
+    MULTI_SUBAGENT_ORCHESTRATION_MODE,
+    compact_orchestration_policy,
+    compact_peer_task_coordination_policy,
+    orchestration_policy_summary,
 )
-from .control_plane.agents.profile import normalize_agent_profile
-from .control_plane.agents.work_mode import normalize_agent_work_modes
-from .control_plane.agents.runtime_model import (
-    AgentRuntimeModel,
-    agent_runtime_model_for_goal,
-)
-from .control_plane.agents.supervisor import normalize_peer_supervisor
-
+from .quota import goal_quota_config
+from .registry import atomic_write_json, read_json, registry_goals
 
 WAITING_ON_CHOICES = (
     "codex",
@@ -121,8 +121,13 @@ def _lark_event_inbox_config_summary(goal: dict[str, Any]) -> dict[str, Any]:
     return {
         "enabled": inbox.get("enabled") is True or bool(enabled_agent_inboxes),
         "config_pointer_registered": bool(inbox.get("config_path"))
-        or any(bool(value.get("config_path")) for value in enabled_agent_inboxes.values()),
+        or any(
+            bool(value.get("config_path")) for value in enabled_agent_inboxes.values()
+        ),
         "agent_scoped_count": len(enabled_agent_inboxes),
+        "agent_scoped_bound_count": sum(
+            bool(value.get("config_digest")) for value in enabled_agent_inboxes.values()
+        ),
     }
 
 
@@ -152,8 +157,7 @@ def _local_private_config_path(
         or path.suffix != ".json"
     ):
         raise ValueError(
-            f"{label} must be a repo-relative JSON path "
-            "under .loopx/config/"
+            f"{label} must be a repo-relative JSON path under .loopx/config/"
         )
     return path.as_posix()
 
@@ -209,7 +213,9 @@ def _clean_registered_agents(values: list[str] | None) -> list[str] | None:
                 continue
             agent = normalize_todo_claimed_by(raw_agent)
             if not agent:
-                raise ValueError("registered agents must be public-safe tokens such as codex-main-control")
+                raise ValueError(
+                    "registered agents must be public-safe tokens such as codex-main-control"
+                )
             if agent not in agents:
                 agents.append(agent)
     return agents
@@ -231,7 +237,9 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
     quota = goal_quota_config(goal)
     control_plane = compact_control_plane_policy(goal.get("control_plane"))
     orchestration = compact_orchestration_policy(goal.get("spawn_policy"))
-    coordination = goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
+    coordination = (
+        goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
+    )
     agent_model = agent_runtime_model_for_goal(goal)
     registered_agents = normalize_registered_agents(
         coordination.get("registered_agents")
@@ -243,9 +251,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
             "window_hours": quota.get("window_hours"),
         },
         "control_plane": control_plane,
-        "issue_fix_reviewer_notification": _reviewer_notification_config_summary(
-            goal
-        ),
+        "issue_fix_reviewer_notification": _reviewer_notification_config_summary(goal),
         "lark_event_inbox": _lark_event_inbox_config_summary(goal),
         "lark_kanban_heartbeat_sync": _lark_kanban_heartbeat_config_summary(goal),
         "reward_memory": reward_memory_goal_policy_summary(goal),
@@ -254,7 +260,9 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "orchestration": orchestration,
         "waiting_on": goal.get("waiting_on"),
         "write_scope": _clean_write_scope(coordination.get("write_scope") or []) or [],
-        "checkpointed_boundary_authority": checkpointed_boundary_authority_summary(coordination),
+        "checkpointed_boundary_authority": checkpointed_boundary_authority_summary(
+            coordination
+        ),
         "registered_agents": registered_agents,
         "peer_task_coordination": deepcopy(
             compact_peer_task_coordination_policy(coordination)
@@ -479,13 +487,17 @@ def configure_goal(
             execution_turn_granularity
         )
     if clear_allowed_domains and allowed_domains:
-        raise ValueError("--clear-allowed-domains cannot be combined with --allowed-domain")
+        raise ValueError(
+            "--clear-allowed-domains cannot be combined with --allowed-domain"
+        )
     if clear_explore_harness_profile and explore_harness_profile:
         raise ValueError(
             "--clear-explore-harness-profile cannot be combined with --explore-harness-profile"
         )
     if clear_registered_agents and registered_agents:
-        raise ValueError("--clear-registered-agents cannot be combined with --registered-agent")
+        raise ValueError(
+            "--clear-registered-agents cannot be combined with --registered-agent"
+        )
     if clear_peer_task_coordinator and peer_task_coordinator:
         raise ValueError(
             "--clear-peer-task-coordinator cannot be combined with "
@@ -494,13 +506,15 @@ def configure_goal(
     if agent_model is not None:
         agent_model = str(agent_model).strip().lower()
         if agent_model not in AGENT_MODEL_CHOICES:
-            raise ValueError("--agent-model must be one of: " + ", ".join(AGENT_MODEL_CHOICES))
+            raise ValueError(
+                "--agent-model must be one of: " + ", ".join(AGENT_MODEL_CHOICES)
+            )
     if automation_prompt_migration_ack is not None:
-        automation_prompt_migration_ack = str(
-            automation_prompt_migration_ack
-        ).strip()
+        automation_prompt_migration_ack = str(automation_prompt_migration_ack).strip()
         if not automation_prompt_migration_ack:
-            raise ValueError("--ack-automation-prompt-migration requires a migration id")
+            raise ValueError(
+                "--ack-automation-prompt-migration requires a migration id"
+            )
         if registered_agents is not None or clear_registered_agents:
             raise ValueError(
                 "--ack-automation-prompt-migration cannot change registered agents; "
@@ -518,7 +532,9 @@ def configure_goal(
     if replace_write_scope and not write_scope:
         raise ValueError("--replace-write-scope requires --write-scope")
     if clear_write_scope and replace_write_scope:
-        raise ValueError("--clear-write-scope cannot be combined with --replace-write-scope")
+        raise ValueError(
+            "--clear-write-scope cannot be combined with --replace-write-scope"
+        )
     if clear_waiting_on and waiting_on:
         raise ValueError("--clear-waiting-on cannot be combined with --waiting-on")
     adding_boundary_authority = any(
@@ -532,7 +548,9 @@ def configure_goal(
         )
     )
     if clear_boundary_authority and adding_boundary_authority:
-        raise ValueError("--clear-boundary-authority cannot be combined with boundary authority fields")
+        raise ValueError(
+            "--clear-boundary-authority cannot be combined with boundary authority fields"
+        )
     if (
         clear_issue_fix_reviewer_notification_config
         and issue_fix_reviewer_notification_config
@@ -553,24 +571,34 @@ def configure_goal(
             "--lark-event-inbox-agent-id requires --lark-event-inbox-config "
             "or --clear-lark-event-inbox-config"
         )
-    if clear_reward_memory_config and (
-        reward_memory_config or reward_memory_agents
-    ):
+    if clear_reward_memory_config and (reward_memory_config or reward_memory_agents):
         raise ValueError(
             "--clear-reward-memory-config cannot be combined with "
             "--reward-memory-config or --reward-memory-agent"
         )
     if waiting_on and waiting_on not in WAITING_ON_CHOICES:
-        raise ValueError("--waiting-on must be one of: " + ", ".join(WAITING_ON_CHOICES))
-    if multi_subagent_feature is not None and multi_subagent_feature not in MULTI_SUBAGENT_FEATURE_CHOICES:
-        raise ValueError("--multi-subagent-feature must be one of: " + ", ".join(MULTI_SUBAGENT_FEATURE_CHOICES))
-    if multi_subagent_feature is not None and (orchestration_mode is not None or spawn_allowed is not None):
+        raise ValueError(
+            "--waiting-on must be one of: " + ", ".join(WAITING_ON_CHOICES)
+        )
+    if (
+        multi_subagent_feature is not None
+        and multi_subagent_feature not in MULTI_SUBAGENT_FEATURE_CHOICES
+    ):
+        raise ValueError(
+            "--multi-subagent-feature must be one of: "
+            + ", ".join(MULTI_SUBAGENT_FEATURE_CHOICES)
+        )
+    if multi_subagent_feature is not None and (
+        orchestration_mode is not None or spawn_allowed is not None
+    ):
         raise ValueError(
             "--multi-subagent-feature cannot be combined with --orchestration-mode or --spawn-allowed; "
             "use --max-children/--allowed-domain for bounded feature settings"
         )
     if explore_harness_profile is not None:
-        explore_harness_profile = str(explore_harness_profile).strip().lower().replace("_", "-")
+        explore_harness_profile = (
+            str(explore_harness_profile).strip().lower().replace("_", "-")
+        )
         if explore_harness_profile not in EXPLORE_HARNESS_PROFILES:
             raise ValueError(
                 "--explore-harness-profile must be one of: "
@@ -578,14 +606,20 @@ def configure_goal(
             )
 
     quota_compute = _non_negative_number(quota_compute, field="quota_compute")
-    quota_window_hours = _positive_number(quota_window_hours, field="quota_window_hours")
+    quota_window_hours = _positive_number(
+        quota_window_hours, field="quota_window_hours"
+    )
     max_children = _non_negative_int(max_children, field="max_children")
     allowed_domains = _clean_domains(allowed_domains)
     if multi_subagent_feature == "off":
         if max_children not in (None, 0):
-            raise ValueError("--multi-subagent-feature off cannot be combined with --max-children greater than 0")
+            raise ValueError(
+                "--multi-subagent-feature off cannot be combined with --max-children greater than 0"
+            )
         if allowed_domains:
-            raise ValueError("--multi-subagent-feature off cannot be combined with --allowed-domain")
+            raise ValueError(
+                "--multi-subagent-feature off cannot be combined with --allowed-domain"
+            )
     registered_agents = _clean_registered_agents(registered_agents)
     if peer_task_coordinator is not None:
         peer_task_coordinator = normalize_todo_claimed_by(peer_task_coordinator)
@@ -609,9 +643,7 @@ def configure_goal(
         lark_event_inbox_config,
         label="lark event inbox config",
     )
-    normalized_lark_inbox_agent = normalize_todo_claimed_by(
-        lark_event_inbox_agent_id
-    )
+    normalized_lark_inbox_agent = normalize_todo_claimed_by(lark_event_inbox_agent_id)
     if lark_event_inbox_agent_id and not normalized_lark_inbox_agent:
         raise ValueError(
             "--lark-event-inbox-agent-id must be a public-safe registered agent id"
@@ -628,9 +660,7 @@ def configure_goal(
         raise ValueError(f"goal_id not found in registry: {goal_id}")
 
     existing_coordination = (
-        goal.get("coordination")
-        if isinstance(goal.get("coordination"), dict)
-        else {}
+        goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
     )
     effective_registered_agents = (
         []
@@ -671,19 +701,15 @@ def configure_goal(
             )
         if not effective_reward_memory_agents:
             raise ValueError(
-                "enabling Reward Memory requires at least one "
-                "--reward-memory-agent"
+                "enabling Reward Memory requires at least one --reward-memory-agent"
             )
     unknown_reward_memory_agents = sorted(
         set(effective_reward_memory_agents) - set(effective_registered_agents)
     )
-    reward_memory_remains_enabled = (
-        not clear_reward_memory_config
-        and (
-            existing_reward_memory["enabled"]
-            or reward_memory_config is not None
-            or reward_memory_agents is not None
-        )
+    reward_memory_remains_enabled = not clear_reward_memory_config and (
+        existing_reward_memory["enabled"]
+        or reward_memory_config is not None
+        or reward_memory_agents is not None
     )
     if reward_memory_remains_enabled and unknown_reward_memory_agents:
         raise ValueError(
@@ -765,12 +791,17 @@ def configure_goal(
                 "automation prompt migration id does not match the current goal state; "
                 f"expected {expected_migration_id}"
             )
-    elif execute and legacy_hierarchy_before and not migration_completed_before and (
-        agent_model is not None
-        or registered_agents is not None
-        or peer_task_coordinator is not None
-        or clear_peer_task_coordinator
-        or clear_registered_agents
+    elif (
+        execute
+        and legacy_hierarchy_before
+        and not migration_completed_before
+        and (
+            agent_model is not None
+            or registered_agents is not None
+            or peer_task_coordinator is not None
+            or clear_peer_task_coordinator
+            or clear_registered_agents
+        )
     ):
         raise ValueError(
             "legacy agent hierarchy requires the one-time host automation migration first; "
@@ -793,13 +824,19 @@ def configure_goal(
         or self_repair_waiting_projection is not None
     ):
         control_plane = _mutable_control_plane(goal)
-        self_repair = control_plane.get("self_repair") if isinstance(control_plane.get("self_repair"), dict) else {}
+        self_repair = (
+            control_plane.get("self_repair")
+            if isinstance(control_plane.get("self_repair"), dict)
+            else {}
+        )
         if self_repair_enabled is not None:
             self_repair["enabled"] = self_repair_enabled
         if self_repair_health is not None:
             self_repair["allow_health_blocker_repair"] = self_repair_health
         if self_repair_waiting_projection is not None:
-            self_repair["allow_waiting_projection_repair"] = self_repair_waiting_projection
+            self_repair["allow_waiting_projection_repair"] = (
+                self_repair_waiting_projection
+            )
         control_plane["self_repair"] = self_repair
 
     if (
@@ -862,10 +899,17 @@ def configure_goal(
             if clear_lark_event_inbox_config:
                 agent_inboxes.pop(normalized_lark_inbox_agent, None)
             else:
-                agent_inboxes[normalized_lark_inbox_agent] = {
+                agent_inbox_binding: dict[str, Any] = {
                     "enabled": True,
                     "config_path": lark_event_inbox_config,
                 }
+                config_digest = local_private_config_digest(
+                    project=str(goal.get("repo") or ""),
+                    config_path=str(lark_event_inbox_config or ""),
+                )
+                if config_digest:
+                    agent_inbox_binding["config_digest"] = config_digest
+                agent_inboxes[normalized_lark_inbox_agent] = agent_inbox_binding
             if agent_inboxes:
                 control_plane["lark_event_inboxes"] = agent_inboxes
             else:
@@ -912,8 +956,7 @@ def configure_goal(
 
     if (
         multi_subagent_feature is not None
-        or
-        orchestration_mode is not None
+        or orchestration_mode is not None
         or spawn_allowed is not None
         or max_children is not None
         or allowed_domains is not None
@@ -922,12 +965,18 @@ def configure_goal(
         or explore_harness_profile is not None
         or clear_explore_harness_profile
     ):
-        spawn_policy = goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else {}
+        spawn_policy = (
+            goal.get("spawn_policy")
+            if isinstance(goal.get("spawn_policy"), dict)
+            else {}
+        )
         if multi_subagent_feature == "enabled":
             spawn_policy["mode"] = MULTI_SUBAGENT_ORCHESTRATION_MODE
             spawn_policy["allowed"] = True
             if max_children is None:
-                existing_children = int(compact_orchestration_policy(spawn_policy).get("max_children") or 0)
+                existing_children = int(
+                    compact_orchestration_policy(spawn_policy).get("max_children") or 0
+                )
                 spawn_policy["max_children"] = (
                     existing_children
                     if existing_children > 0
@@ -996,7 +1045,11 @@ def configure_goal(
         or clear_boundary_authority
         or adding_boundary_authority
     ):
-        coordination = goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
+        coordination = (
+            goal.get("coordination")
+            if isinstance(goal.get("coordination"), dict)
+            else {}
+        )
         effective_agent_model = AgentRuntimeModel.PEER_V1.value
         if clear_registered_agents:
             coordination.pop("registered_agents", None)
@@ -1109,8 +1162,7 @@ def configure_goal(
             else:
                 coordination.pop("agent_work_modes", None)
         if not clear_registered_agents and (
-            normalized_todo_lifecycle_authority
-            or clear_todo_lifecycle_authority
+            normalized_todo_lifecycle_authority or clear_todo_lifecycle_authority
         ):
             current_authority = normalize_todo_lifecycle_authority(
                 coordination.get("todo_lifecycle_authority"),
@@ -1135,7 +1187,10 @@ def configure_goal(
                 )
             else:
                 coordination.pop("todo_lifecycle_authority", None)
-        if automation_prompt_migration_ack is not None and not migration_already_completed:
+        if (
+            automation_prompt_migration_ack is not None
+            and not migration_already_completed
+        ):
             coordination = migrate_coordination_to_peer_v1(
                 coordination,
                 migration_id=automation_prompt_migration_ack,
@@ -1162,8 +1217,12 @@ def configure_goal(
             if replace_write_scope:
                 coordination["write_scope"] = write_scope
             else:
-                existing_write_scope = _clean_write_scope(coordination.get("write_scope") or []) or []
-                coordination["write_scope"] = _clean_write_scope([*existing_write_scope, *write_scope]) or []
+                existing_write_scope = (
+                    _clean_write_scope(coordination.get("write_scope") or []) or []
+                )
+                coordination["write_scope"] = (
+                    _clean_write_scope([*existing_write_scope, *write_scope]) or []
+                )
         if clear_boundary_authority:
             coordination.pop("checkpointed_boundary_authority", None)
         if adding_boundary_authority:
@@ -1203,7 +1262,9 @@ def configure_goal(
         atomic_write_json(registry_path, payload)
 
     feature_summary = {
-        "multi_subagent": _multi_subagent_feature_status(after.get("orchestration") or {}),
+        "multi_subagent": _multi_subagent_feature_status(
+            after.get("orchestration") or {}
+        ),
         "explore_graph": deepcopy(after.get("explore_graph") or {"enabled": False}),
         "explore_harness": deepcopy(
             (after.get("orchestration") or {}).get("explore_harness")
@@ -1246,8 +1307,12 @@ def configure_goal(
             ),
             "exactly_once_effect": True,
         },
-        "control_plane_summary": control_plane_policy_summary(after.get("control_plane")),
-        "orchestration_summary": orchestration_policy_summary(after.get("orchestration")),
+        "control_plane_summary": control_plane_policy_summary(
+            after.get("control_plane")
+        ),
+        "orchestration_summary": orchestration_policy_summary(
+            after.get("orchestration")
+        ),
         "feature_summary": feature_summary,
         "configuration_catalog": build_goal_configuration_catalog(
             goal_id=goal_id,
@@ -1319,7 +1384,9 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         lines.append(f"- orchestration: {payload.get('orchestration_summary')}")
     feature_summary = payload.get("feature_summary")
     if isinstance(feature_summary, dict):
-        lines.append(f"- feature_multi_subagent: `{feature_summary.get('multi_subagent')}`")
+        lines.append(
+            f"- feature_multi_subagent: `{feature_summary.get('multi_subagent')}`"
+        )
         graph = feature_summary.get("explore_graph")
         if isinstance(graph, dict):
             lines.append(
@@ -1378,9 +1445,7 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         for command in migration.get("commands") or []:
             if not isinstance(command, dict):
                 continue
-            lines.append(
-                f"  - {command.get('agent_id')}: `{command.get('command')}`"
-            )
+            lines.append(f"  - {command.get('agent_id')}: `{command.get('command')}`")
     supervisor_prompt = payload.get("supervisor_prompt")
     if isinstance(supervisor_prompt, dict):
         lines.append(f"- supervisor_prompt_status: `{supervisor_prompt.get('status')}`")

--- a/loopx/control_plane/operator_inbox_binding.py
+++ b/loopx/control_plane/operator_inbox_binding.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+BINDING_SCHEMA_VERSION = "operator_inbox_binding_v0"
+
+
+def local_private_config_digest(
+    *, project: str | Path, config_path: str | Path
+) -> str | None:
+    """Hash one project-local private config without returning its contents."""
+
+    root = Path(project).expanduser().resolve()
+    relative = PurePosixPath(str(config_path or "").strip().replace("\\", "/"))
+    if not relative.parts or relative.is_absolute() or ".." in relative.parts:
+        return None
+    path = (root / Path(*relative.parts)).resolve()
+    try:
+        path.relative_to(root)
+        content = path.read_bytes()
+    except (OSError, ValueError):
+        return None
+    return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
+
+def operator_inbox_binding(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    expected_digest: object = None,
+) -> dict[str, Any]:
+    """Return a public-safe config-binding status for one inbox owner lane."""
+
+    expected = str(expected_digest or "").strip()
+    actual = local_private_config_digest(project=project, config_path=config_path)
+    if not expected:
+        status = "unbound"
+    elif actual is None:
+        status = "unavailable"
+    elif actual != expected:
+        status = "drifted"
+    else:
+        status = "verified"
+    return {
+        "schema_version": BINDING_SCHEMA_VERSION,
+        "status": status,
+        "digest_recorded": bool(expected),
+        "config_available": actual is not None,
+        "binding_verified": status == "verified",
+        "attention_required": status in {"drifted", "unavailable"},
+        "private_config_returned": False,
+        "config_digest_returned": False,
+    }

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -6,8 +6,6 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
-from ..reward_memory import reward_memory_goal_policy
-
 from ...boundary_authority import checkpointed_boundary_authority_summary
 from ...execution_profile import execution_profile_outcome_floor
 from ...explore_graph import compact_explore_graph_policy
@@ -16,6 +14,8 @@ from ...orchestration import (
     compact_peer_task_coordination_policy,
 )
 from ...repository_identity import resolve_project_identity
+from ..operator_inbox_binding import operator_inbox_binding
+from ..reward_memory import reward_memory_goal_policy
 from ..todos.contract import (
     normalize_required_capabilities,
     normalize_required_write_scopes,
@@ -38,7 +38,9 @@ def quota_execution_profile_summary(value: Any) -> dict[str, Any] | None:
         else {}
     )
     if policy.get("small_scale_streak_threshold") is not None:
-        compact["small_scale_streak_threshold"] = policy.get("small_scale_streak_threshold")
+        compact["small_scale_streak_threshold"] = policy.get(
+            "small_scale_streak_threshold"
+        )
     floor = execution_profile_outcome_floor(value)
     if floor:
         outcome_markers = (
@@ -177,9 +179,7 @@ def _registry_boundary_projection(goal: Mapping[str, Any]) -> dict[str, Any]:
         boundary["available_capabilities"] = available_capabilities
     requires_approval_value = coordination.get("requires_parent_approval")
     requires_approval = (
-        requires_approval_value
-        if isinstance(requires_approval_value, list)
-        else []
+        requires_approval_value if isinstance(requires_approval_value, list) else []
     )
     if requires_approval:
         boundary["requires_parent_approval"] = [
@@ -205,9 +205,7 @@ def goal_boundary(
 ) -> dict[str, Any] | None:
     boundary = _registry_boundary_projection(goal)
     control_plane = (
-        goal.get("control_plane")
-        if isinstance(goal.get("control_plane"), dict)
-        else {}
+        goal.get("control_plane") if isinstance(goal.get("control_plane"), dict) else {}
     )
     issue_fix = (
         control_plane.get("issue_fix")
@@ -220,13 +218,9 @@ def goal_boundary(
         else {}
     )
     if reviewer_notification.get("enabled") is True:
-        boundary.setdefault("capabilities", {})[
-            "issue_fix_reviewer_notification"
-        ] = {
+        boundary.setdefault("capabilities", {})["issue_fix_reviewer_notification"] = {
             "enabled": True,
-            "config_pointer_registered": bool(
-                reviewer_notification.get("config_path")
-            ),
+            "config_pointer_registered": bool(reviewer_notification.get("config_path")),
         }
     agent_inboxes = (
         control_plane.get("lark_event_inboxes")
@@ -263,7 +257,25 @@ def goal_boundary(
         }
         project = Path(str(goal.get("repo") or "")).expanduser()
         config_path = str(lark_event_inbox.get("config_path") or "").strip()
-        if project.is_dir() and config_path and operator_inbox_urgency_projector:
+        binding = operator_inbox_binding(
+            project=project,
+            config_path=config_path,
+            expected_digest=lark_event_inbox.get("config_digest"),
+        )
+        inbox_capability["binding"] = binding
+        owner_binding_blocked = bool(
+            isinstance(agent_inbox, dict) and binding["attention_required"]
+        )
+        if owner_binding_blocked:
+            inbox_capability.pop("drain_command", None)
+            inbox_capability["urgency"] = {
+                "schema_version": "lark_event_inbox_urgency_v0",
+                "enabled": True,
+                "projection_status": "unavailable",
+                "blocker": "agent_lark_inbox_config_binding_drift",
+                "local_private_content_returned": False,
+            }
+        elif project.is_dir() and config_path and operator_inbox_urgency_projector:
             try:
                 urgency = operator_inbox_urgency_projector(
                     project=project,
@@ -340,9 +352,7 @@ def goal_boundary(
                 "config_runtime_route"
             )
             if isinstance(config_runtime_route, Mapping):
-                reward_capability["config_runtime_route"] = dict(
-                    config_runtime_route
-                )
+                reward_capability["config_runtime_route"] = dict(config_runtime_route)
         if agent_id is not None:
             reward_capability.update(
                 {
@@ -380,7 +390,9 @@ def goal_boundary(
         boundary["explore_graph"] = compact_explore_graph_policy(
             goal.get("explore_graph")
         )
-    spawn_policy = goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else None
+    spawn_policy = (
+        goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else None
+    )
     if spawn_policy is not None:
         orchestration = compact_orchestration_policy(spawn_policy)
         boundary["orchestration"] = orchestration
@@ -400,17 +412,23 @@ def goal_boundary(
         if not isinstance(policy_source, dict):
             continue
             break
-    if isinstance(project_asset_source, dict) and project_asset_source.get("project_asset"):
+    if isinstance(project_asset_source, dict) and project_asset_source.get(
+        "project_asset"
+    ):
         project_asset = project_asset_source.get("project_asset")
         if isinstance(project_asset, dict):
             if project_asset.get("stop_condition"):
                 boundary["stop_condition"] = project_asset.get("stop_condition")
             if isinstance(project_asset.get("execution_profile"), dict):
-                boundary["execution_profile"] = quota_execution_profile_boundary_summary(
-                    project_asset["execution_profile"]
+                boundary["execution_profile"] = (
+                    quota_execution_profile_boundary_summary(
+                        project_asset["execution_profile"]
+                    )
                 )
             if isinstance(project_asset.get("orchestration"), dict):
-                boundary["orchestration"] = compact_orchestration_policy(project_asset["orchestration"])
+                boundary["orchestration"] = compact_orchestration_policy(
+                    project_asset["orchestration"]
+                )
     if boundary:
         boundary["rule"] = "stay_in_scope_or_stop"
         return boundary

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -157,30 +157,50 @@ inbox config but owns host-only details such as the chat id and supervisor:
 
 ```json
 {
-  "schema_version": "lark_event_collector_config_v0",
+  "schema_version": "lark_event_collector_config_v1",
   "enabled": true,
   "service_name": "loopx-lark-feedback",
   "event_key": "im.message.receive_v1",
   "identity": "bot",
   "profile": "project-review-bot",
   "supervisor": "launchd",
-  "chat_id": "oc_<local-private-chat-id>",
   "consume_timeout": "30m",
   "lark_cli_bin": "lark-cli",
-  "event_inbox_config": ".loopx/config/lark/event-inbox.json"
+  "routes": [
+    {
+      "route_key": "requirements-a",
+      "chat_id": "oc_<local-private-chat-id-a>",
+      "event_inbox_config": ".loopx/config/lark/requirements-a.json"
+    },
+    {
+      "route_key": "requirements-b",
+      "chat_id": "oc_<local-private-chat-id-b>",
+      "event_inbox_config": ".loopx/config/lark/requirements-b.json"
+    }
+  ]
 }
 ```
 
-The packaged v0 lifecycle accepts only `im.message.receive_v1`, bot identity,
-an isolated `loopx-` service name, and `configured_chat_all`. These constraints
-match the canonical inbox schema, avoid collisions with unrelated user services,
-and make thread completeness explicit instead of pretending that an
-`addressed_only` consumer sees later unaddressed replies. Plan and install
-output never returns the chat id, local paths, generated jq, or credentials.
+The packaged lifecycle accepts only `im.message.receive_v1`, bot identity, an
+isolated `loopx-` service name, and `configured_chat_all`. Config v1 requires a
+unique lowercase public-safe `route_key` for each route, consumes one
+profile-bound event stream, and routes each configured chat into a distinct
+inbox config and inbox path. Missing, unsafe, or duplicate route keys, duplicate
+chat routes, shared inbox paths, reply chat mismatches, and route profile
+divergence fail closed. Each accepted event persists the configured route key,
+so aggregate drain gives the Agent a stable requirement-context identity without
+exposing a private chat id. A missing or mismatched persisted route key also
+fails closed instead of silently reclassifying an older message. Each inbox therefore
+retains independent pending/processed state and source-context reply placement
+while one Bot can serve several chats without competing consumers. The v0
+single-chat shape remains accepted and is normalized to one route. Plan,
+install, run, and status output expose only route and health counts; they never
+return profile values, chat ids, local paths, generated jq, or credentials.
 
 An enabled collector must bind an explicit non-default Lark CLI profile. When
-`profile` is omitted, LoopX may reuse the enabled inbox reply
-`sender_profile`; when both are present they must match. The generated service
+`profile` is omitted, LoopX may reuse the shared enabled inbox reply
+`sender_profile`; every routed reply profile must resolve to that same value.
+When both are present they must match. The generated service
 passes the profile-bound collector config to the LoopX runtime, which places
 `--profile` before both `event consume` and message readback calls. Collection,
 reply-target verification, and optional replies therefore cannot silently use
@@ -232,27 +252,39 @@ local host write and therefore requires explicit `--execute`. Status separates
 healthy before the first message, while acceptance of a real integration still
 requires one post-install event to appear in the inbox.
 
-Register the generic inbox pointer once at the goal boundary:
+Register one inbox or the v1 routed collector as the Agent-owned goal boundary.
+The latter keeps one authority and one Agent lane while exposing aggregate,
+content-free urgency across all configured chats:
 
 ```bash
 loopx configure-goal \
   --goal-id <goal-id> \
-  --lark-event-inbox-config .loopx/config/lark/event-inbox.json
+  --lark-event-inbox-agent-id <context-assistant-agent-id> \
+  --lark-event-inbox-config .loopx/config/lark/collector.json
 
 # Review the preview, then apply explicitly.
 loopx configure-goal \
   --goal-id <goal-id> \
-  --lark-event-inbox-config .loopx/config/lark/event-inbox.json \
+  --lark-event-inbox-agent-id <context-assistant-agent-id> \
+  --lark-event-inbox-config .loopx/config/lark/collector.json \
   --execute
+
+# Drain all configured chats through the same Agent lane. Each item retains
+# route-specific source-context reply guidance; message-scoped follow-up
+# commands resolve exactly one isolated inbox or fail closed.
+loopx lark-inbox drain \
+  --goal-id <goal-id> \
+  --agent-id <context-assistant-agent-id>
 ```
 
 The configuration catalog exposes this optional capability on demand. Quota
 projects `enabled`, `config_pointer_registered`, a local control command, and a
 content-free urgency summary; it never projects the private path, message ids,
 senders, or message bodies. The summary includes
-pending/direct-question/direct-mention/verified-bot-reply counts and the oldest
-pending age. A configured direct mention or verified reply to a message authored
-by the configured bot becomes a high-priority `lark_event_inbox` work lane
+pending/direct-question/direct-mention/verified-bot-reply counts, routed inbox
+counts, and the oldest pending age. It does not expose route chat ids or profile
+names. A configured direct mention or verified reply to a message authored by
+the configured bot becomes a high-priority `lark_event_inbox` work lane
 before ordinary monitor or advancement work. Generated heartbeat bodies run the
 actual goal-boundary `drain_command`;
 `loopx --registry <invoked-registry> lark-inbox drain --goal-id <goal-id>`

--- a/loopx/extensions/lark/event_collector.py
+++ b/loopx/extensions/lark/event_collector.py
@@ -8,17 +8,23 @@ import re
 import shlex
 import shutil
 import subprocess
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any
 
 from .event_inbox import (
+    ROUTE_KEY_PATTERN,
     SAFE_PROFILE_PATTERN,
     inspect_lark_event_inbox,
     load_lark_event_inbox_config,
 )
 
-
-CONFIG_SCHEMA_VERSION = "lark_event_collector_config_v0"
+CONFIG_SCHEMA_VERSION_V0 = "lark_event_collector_config_v0"
+CONFIG_SCHEMA_VERSION = "lark_event_collector_config_v1"
+SUPPORTED_CONFIG_SCHEMA_VERSIONS = {
+    CONFIG_SCHEMA_VERSION_V0,
+    CONFIG_SCHEMA_VERSION,
+}
 PLAN_SCHEMA_VERSION = "lark_event_collector_plan_v0"
 STATUS_SCHEMA_VERSION = "lark_event_collector_status_v0"
 INSTALL_SCHEMA_VERSION = "lark_event_collector_install_v0"
@@ -27,6 +33,7 @@ CHAT_RE = re.compile(r"^oc_[A-Za-z0-9_-]+$")
 TIMEOUT_RE = re.compile(r"^[1-9][0-9]*(?:s|m|h)$")
 SUPPORTED_SUPERVISORS = {"launchd", "systemd"}
 SUPPORTED_EVENT_KEY = "im.message.receive_v1"
+MAX_ROUTE_COUNT = 50
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 
@@ -80,51 +87,131 @@ def load_lark_event_collector_config(
         ) from exc
     if (
         not isinstance(payload, Mapping)
-        or payload.get("schema_version") != CONFIG_SCHEMA_VERSION
+        or payload.get("schema_version") not in SUPPORTED_CONFIG_SCHEMA_VERSIONS
     ):
         raise ValueError(
-            f"lark collector config schema_version must be {CONFIG_SCHEMA_VERSION}"
+            "lark collector config schema_version must be "
+            f"{CONFIG_SCHEMA_VERSION_V0} or {CONFIG_SCHEMA_VERSION}"
         )
+    schema_version = str(payload["schema_version"])
     enabled = payload.get("enabled") is True
     service_name = str(payload.get("service_name") or "loopx-lark-collector").strip()
     event_key = str(payload.get("event_key") or "im.message.receive_v1").strip()
     identity = str(payload.get("identity") or "bot").strip()
     supervisor = str(payload.get("supervisor") or "").strip()
-    chat_id = str(payload.get("chat_id") or "").strip()
     timeout = str(payload.get("consume_timeout") or "30m").strip()
     lark_cli_bin = str(payload.get("lark_cli_bin") or "lark-cli").strip()
     if not SERVICE_RE.fullmatch(service_name):
         raise ValueError("service_name must be a lowercase loopx- service token")
     if event_key != SUPPORTED_EVENT_KEY:
-        raise ValueError(
-            f"collector v0 event_key must be {SUPPORTED_EVENT_KEY}"
-        )
+        raise ValueError(f"collector event_key must be {SUPPORTED_EVENT_KEY}")
     if identity != "bot":
-        raise ValueError("collector v0 identity must be bot")
+        raise ValueError("collector identity must be bot")
     if supervisor not in SUPPORTED_SUPERVISORS:
         raise ValueError("supervisor must be launchd or systemd")
-    if not CHAT_RE.fullmatch(chat_id):
-        raise ValueError("chat_id must be a Lark oc_ chat id")
     if not TIMEOUT_RE.fullmatch(timeout):
         raise ValueError("consume_timeout must use a bounded duration such as 30m")
     if Path(lark_cli_bin).name != lark_cli_bin or not lark_cli_bin:
         raise ValueError("lark_cli_bin must be a command name, not a path")
-    inbox_config_ref, inbox_config_path = _relative_project_path(
-        root, payload.get("event_inbox_config"), "event_inbox_config"
-    )
-    inbox = load_lark_event_inbox_config(project=root, config_path=inbox_config_path)
-    if enabled and not inbox["enabled"]:
-        raise ValueError("enabled collector requires an enabled event inbox")
-    if enabled and not inbox["thread_complete"]:
+    if schema_version == CONFIG_SCHEMA_VERSION_V0:
+        raw_routes: object = [
+            {
+                "route_key": "default",
+                "chat_id": payload.get("chat_id"),
+                "event_inbox_config": payload.get("event_inbox_config"),
+            }
+        ]
+    else:
+        if "chat_id" in payload or "event_inbox_config" in payload:
+            raise ValueError(
+                "collector v1 uses routes instead of top-level chat_id or "
+                "event_inbox_config"
+            )
+        raw_routes = payload.get("routes")
+    if not isinstance(raw_routes, list) or not (
+        1 <= len(raw_routes) <= MAX_ROUTE_COUNT
+    ):
         raise ValueError(
-            "collector lifecycle currently requires configured_chat_all capture"
-    )
+            f"collector routes must contain 1-{MAX_ROUTE_COUNT} route objects"
+        )
+    routes: list[dict[str, Any]] = []
+    seen_route_keys: set[str] = set()
+    seen_chat_ids: set[str] = set()
+    seen_inbox_refs: set[str] = set()
+    seen_inbox_paths: set[Path] = set()
+    for index, raw_route in enumerate(raw_routes):
+        if not isinstance(raw_route, Mapping):
+            raise TypeError(f"collector route {index + 1} must be an object")
+        route_key = str(raw_route.get("route_key") or "").strip()
+        if not ROUTE_KEY_PATTERN.fullmatch(route_key):
+            raise ValueError(
+                f"collector route {index + 1} route_key must be a lowercase "
+                "public-safe token"
+            )
+        chat_id = str(raw_route.get("chat_id") or "").strip()
+        if not CHAT_RE.fullmatch(chat_id):
+            raise ValueError(
+                f"collector route {index + 1} chat_id must be a Lark oc_ chat id"
+            )
+        inbox_config_ref, inbox_config_path = _relative_project_path(
+            root,
+            raw_route.get("event_inbox_config"),
+            f"collector route {index + 1} event_inbox_config",
+        )
+        if route_key in seen_route_keys:
+            raise ValueError("collector routes must use unique route keys")
+        if chat_id in seen_chat_ids:
+            raise ValueError("collector routes must use unique chat ids")
+        if inbox_config_ref in seen_inbox_refs:
+            raise ValueError(
+                "collector routes must use independent event inbox configs and paths"
+            )
+        inbox = load_lark_event_inbox_config(
+            project=root,
+            config_path=inbox_config_path,
+        )
+        if enabled and not inbox["enabled"]:
+            raise ValueError("enabled collector requires enabled event inboxes")
+        if enabled and not inbox["thread_complete"]:
+            raise ValueError(
+                "collector lifecycle currently requires configured_chat_all capture"
+            )
+        reply_chat_id = str(inbox["reply"].get("chat_id") or "").strip()
+        if inbox["reply"].get("enabled") is True and reply_chat_id != chat_id:
+            raise ValueError(
+                "collector route chat_id must match the inbox reply chat_id"
+            )
+        inbox_path = inbox["inbox_path"]
+        if inbox_path is not None and inbox_path in seen_inbox_paths:
+            raise ValueError(
+                "collector routes must use independent event inbox configs and paths"
+            )
+        seen_route_keys.add(route_key)
+        seen_chat_ids.add(chat_id)
+        seen_inbox_refs.add(inbox_config_ref)
+        if inbox_path is not None:
+            seen_inbox_paths.add(inbox_path)
+        routes.append(
+            {
+                "route_key": route_key,
+                "chat_id": chat_id,
+                "event_inbox_config_ref": inbox_config_ref,
+                "inbox": inbox,
+            }
+        )
     configured_profile = str(payload.get("profile") or "").strip()
-    reply_profile = (
-        str(inbox["reply"].get("sender_profile") or "").strip()
-        if inbox["reply"].get("enabled") is True
-        else ""
-    )
+    reply_profiles = {
+        str(route["inbox"]["reply"].get("sender_profile") or "").strip()
+        for route in routes
+        if route["inbox"]["reply"].get("enabled") is True
+    }
+    reply_profiles.discard("")
+    if not configured_profile and len(reply_profiles) > 1:
+        raise ValueError(
+            "all collector route reply profiles must match one profile-bound "
+            "event stream"
+        )
+    reply_profile = next(iter(reply_profiles), "")
     profile = configured_profile or reply_profile
     profile_source = None
     if configured_profile:
@@ -132,18 +219,20 @@ def load_lark_event_collector_config(
     elif reply_profile:
         profile_source = "event_inbox_reply"
     if enabled and (
-        not SAFE_PROFILE_PATTERN.fullmatch(profile)
-        or profile.lower() == "default"
+        not SAFE_PROFILE_PATTERN.fullmatch(profile) or profile.lower() == "default"
     ):
         raise ValueError(
             "enabled lark collector requires an explicit non-default profile "
             "or an enabled inbox reply sender_profile"
         )
-    if configured_profile and reply_profile and configured_profile != reply_profile:
+    if configured_profile and any(
+        configured_profile != candidate for candidate in reply_profiles
+    ):
         raise ValueError(
-            "lark collector profile must match the inbox reply sender_profile"
+            "lark collector profile must match every inbox reply sender_profile"
         )
     return {
+        "schema_version": schema_version,
         "enabled": enabled,
         "project": root,
         "config_path": path,
@@ -153,18 +242,21 @@ def load_lark_event_collector_config(
         "profile": profile,
         "profile_source": profile_source,
         "supervisor": supervisor,
-        "chat_id": chat_id,
         "consume_timeout": timeout,
         "lark_cli_bin": lark_cli_bin,
-        "event_inbox_config_ref": inbox_config_ref,
-        "inbox": inbox,
+        "routes": routes,
     }
 
 
-def _jq_projection(chat_id: str) -> str:
-    chat_literal = json.dumps(chat_id, ensure_ascii=False)
+def _jq_projection(chat_ids: str | Sequence[str]) -> str:
+    values = [chat_ids] if isinstance(chat_ids, str) else list(chat_ids)
+    if not values:
+        raise ValueError("collector jq projection requires at least one chat id")
+    chat_filter = " or ".join(
+        f".chat_id == {json.dumps(chat_id, ensure_ascii=False)}" for chat_id in values
+    )
     return (
-        f"select(.chat_id == {chat_literal}) | "
+        f"select({chat_filter}) | "
         '{schema_version:"lark_event_inbox_event_v0",'
         "event_id:(.event_id // .message_id // .id),"
         "message_id:(.message_id // .id),"
@@ -282,8 +374,12 @@ def _plan(
             "profile_bound": bool(config.get("profile")),
             "profile_source": config["profile_source"],
             "profile_returned": False,
-            "capture_scope": config["inbox"]["capture_scope"],
-            "thread_complete": config["inbox"]["thread_complete"],
+            "capture_scope": "configured_chat_all",
+            "thread_complete": all(
+                route["inbox"]["thread_complete"] for route in config["routes"]
+            ),
+            "route_count": len(config["routes"]),
+            "multi_chat_routing": len(config["routes"]) > 1,
             "lark_cli_available": executable is not None,
             "install_hint": (
                 None
@@ -436,12 +532,19 @@ def inspect_lark_event_collector(
             ],
         )
         bus_healthy = bus.returncode == 0
-    inbox_status = inspect_lark_event_inbox(
-        project=config["project"],
-        config_path=config["event_inbox_config_ref"],
-        limit=1,
-    )
-    event_count = int(inbox_status.get("captured_count") or 0)
+    inbox_statuses = [
+        inspect_lark_event_inbox(
+            project=config["project"],
+            config_path=route["event_inbox_config_ref"],
+            limit=1,
+        )
+        for route in config["routes"]
+    ]
+    route_event_counts = [
+        int(inbox_status.get("captured_count") or 0) for inbox_status in inbox_statuses
+    ]
+    event_count = sum(route_event_counts)
+    routes_with_event_evidence = sum(count > 0 for count in route_event_counts)
     active = observed.returncode == 0 and (
         config["supervisor"] != "launchd" or "state = running" in observed.stdout
     )
@@ -471,7 +574,15 @@ def inspect_lark_event_collector(
         "event_bus_healthy": bus_healthy,
         "captured_event_count": event_count,
         "real_event_evidence_present": event_count > 0,
-        "thread_complete": config["inbox"]["thread_complete"],
+        "route_count": len(config["routes"]),
+        "multi_chat_routing": len(config["routes"]) > 1,
+        "routes_with_event_evidence_count": routes_with_event_evidence,
+        "all_routes_real_event_evidence_present": (
+            routes_with_event_evidence == len(config["routes"])
+        ),
+        "thread_complete": all(
+            route["inbox"]["thread_complete"] for route in config["routes"]
+        ),
         "local_paths_returned": False,
         "chat_id_returned": False,
         "credentials_returned": False,

--- a/loopx/extensions/lark/event_collector_runtime.py
+++ b/loopx/extensions/lark/event_collector_runtime.py
@@ -218,10 +218,7 @@ def _sender_identity(message: Mapping[str, Any]) -> tuple[str, str]:
         sender.get("sender_type") or message.get("sender_type") or ""
     ).strip()
     sender_id = str(
-        sender.get("id")
-        or sender.get("sender_id")
-        or message.get("sender_id")
-        or ""
+        sender.get("id") or sender.get("sender_id") or message.get("sender_id") or ""
     ).strip()
     return sender_type, sender_id
 
@@ -306,6 +303,7 @@ def enrich_lark_event_reply_context(
 def _consume_argv(
     config: Mapping[str, Any], command_prefix: Sequence[str]
 ) -> list[str]:
+    chat_ids = [str(route["chat_id"]) for route in config["routes"]]
     return [
         *command_prefix,
         "--profile",
@@ -318,7 +316,7 @@ def _consume_argv(
         "--timeout",
         str(config["consume_timeout"]),
         "--jq",
-        _jq_projection(str(config["chat_id"])),
+        _jq_projection(chat_ids),
         "--quiet",
     ]
 
@@ -443,6 +441,7 @@ def run_lark_event_collector(
         if node_executable
         else _executable_prefix(lark_cli_executable)
     )
+    routes_by_chat = {str(route["chat_id"]): route for route in config["routes"]}
     process = subprocess.Popen(
         _consume_argv(config, command_prefix),
         stdout=subprocess.PIPE,
@@ -462,6 +461,7 @@ def run_lark_event_collector(
     reply_to_bot_count = 0
     received_reaction_count = 0
     received_reaction_failure_count = 0
+    routed_chat_ids: set[str] = set()
     profile_app_id: str | None = None
     profile_identity_checked = False
     try:
@@ -473,11 +473,14 @@ def run_lark_event_collector(
                 continue
             if not isinstance(payload, Mapping):
                 continue
+            chat_id = str(payload.get("chat_id") or "").strip()
+            route = routes_by_chat.get(chat_id)
+            if route is None:
+                continue
+            inbox = route["inbox"]
             needs_reply_lookup = lark_event_requires_reply_context_lookup(
                 payload,
-                bot_display_name=str(
-                    config["inbox"]["reply"].get("bot_display_name") or ""
-                ),
+                bot_display_name=str(inbox["reply"].get("bot_display_name") or ""),
             )
             if not needs_reply_lookup:
                 enriched = {
@@ -500,7 +503,7 @@ def run_lark_event_collector(
                         command_prefix=command_prefix,
                         profile=str(config["profile"]),
                         profile_app_id=profile_app_id,
-                        configured_chat_id=str(config["chat_id"]),
+                        configured_chat_id=chat_id,
                     )
                     if profile_app_id is not None
                     else {
@@ -513,16 +516,17 @@ def run_lark_event_collector(
             if not MESSAGE_ID_PATTERN.fullmatch(message_id):
                 continue
             with lark_inbox_reaction_lock(
-                inbox=config["inbox"]["inbox_path"],
+                inbox=inbox["inbox_path"],
                 message_id=message_id,
             ):
                 result = ingest_lark_event_inbox(
                     project=config["project"],
-                    config_path=config["event_inbox_config_ref"],
+                    config_path=route["event_inbox_config_ref"],
                     events=[
                         {
                             "schema_version": "lark_event_inbox_event_v0",
                             **enriched,
+                            "route_key": route["route_key"],
                         }
                     ],
                     execute=True,
@@ -530,21 +534,16 @@ def run_lark_event_collector(
                 if int(result.get("accepted_count") or 0) == 0:
                     continue
                 captured_count += 1
-                verified_count += int(
-                    enriched.get("reply_context_verified") is True
-                )
+                routed_chat_ids.add(chat_id)
+                verified_count += int(enriched.get("reply_context_verified") is True)
                 reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
                 attention_kind = _event_attention_kind(
                     enriched,
-                    bot_display_name=str(
-                        config["inbox"]["reply"].get("bot_display_name")
-                        or ""
-                    ),
+                    bot_display_name=str(inbox["reply"].get("bot_display_name") or ""),
                     capture_scope="configured_chat_all",
                 )
                 received_reaction_emoji = str(
-                    config["inbox"]["reply"].get("received_reaction_emoji")
-                    or ""
+                    inbox["reply"].get("received_reaction_emoji") or ""
                 )
                 if attention_kind is not None and received_reaction_emoji:
                     reaction_id = _create_lark_event_received_reaction(
@@ -557,7 +556,7 @@ def run_lark_event_collector(
                     if reaction_id:
                         try:
                             record_lark_inbox_reaction(
-                                inbox=config["inbox"]["inbox_path"],
+                                inbox=inbox["inbox_path"],
                                 message_id=message_id,
                                 phase="received",
                                 reaction_id=reaction_id,
@@ -573,9 +572,7 @@ def run_lark_event_collector(
                             )
                             reaction_id = None
                     received_reaction_count += int(reaction_id is not None)
-                    received_reaction_failure_count += int(
-                        reaction_id is None
-                    )
+                    received_reaction_failure_count += int(reaction_id is None)
         returncode = process.wait()
     finally:
         if process.poll() is None:
@@ -589,9 +586,16 @@ def run_lark_event_collector(
             signal.signal(signum, handler)
     return {
         "ok": returncode == 0,
-        "schema_version": "lark_event_collector_run_v0",
+        "schema_version": (
+            "lark_event_collector_run_v1"
+            if config["schema_version"] == "lark_event_collector_config_v1"
+            else "lark_event_collector_run_v0"
+        ),
         "status": "completed" if returncode == 0 else "consumer_failed",
         "captured_count": captured_count,
+        "route_count": len(config["routes"]),
+        "routed_route_count": len(routed_chat_ids),
+        "multi_chat_routing": len(config["routes"]) > 1,
         "reply_context_verified_count": verified_count,
         "reply_to_bot_count": reply_to_bot_count,
         "received_reaction_count": received_reaction_count,
@@ -599,5 +603,7 @@ def run_lark_event_collector(
         "external_writes_performed": received_reaction_count > 0,
         "profile_identity_checked": profile_identity_checked,
         "profile_identity_verified": profile_app_id is not None,
+        "chat_ids_returned": False,
+        "local_paths_returned": False,
         "private_content_returned": False,
     }

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timezone
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
-from typing import Any, Mapping, Sequence
+from typing import Any
 
 from ...control_plane.work_items.operator_inbox import (
     OperatorInboxSourceContract,
@@ -23,6 +24,7 @@ CHAT_ID_PATTERN = re.compile(r"oc_[A-Za-z0-9_-]+")
 REACTION_EMOJI_PATTERN = re.compile(r"[A-Za-z0-9_]{1,64}")
 REPLY_PLACEMENT_POLICIES = {"source_thread", "source_context"}
 REPLY_EDITORIAL_STYLES = {"concise", "bullet_points_preferred"}
+ROUTE_KEY_PATTERN = re.compile(r"[a-z0-9][a-z0-9._-]{0,79}")
 LARK_OPERATOR_INBOX_SOURCE_CONTRACT = OperatorInboxSourceContract(
     config_schema_version=CONFIG_SCHEMA_VERSION,
     event_schema_version=EVENT_SCHEMA_VERSION,
@@ -201,6 +203,11 @@ def _event_from_payload(payload: object) -> dict[str, Any] | None:
         "create_time": str(payload.get("create_time") or "")[:40],
         "content": content,
     }
+    if "route_key" in payload:
+        route_key = str(payload.get("route_key") or "").strip()
+        if not ROUTE_KEY_PATTERN.fullmatch(route_key):
+            return None
+        event["route_key"] = route_key
     parent_id = str(payload.get("parent_id") or "").strip()
     root_id = str(payload.get("root_id") or "").strip()
     if MESSAGE_ID_PATTERN.fullmatch(parent_id):
@@ -477,7 +484,7 @@ def acknowledge_lark_event_inbox(
         payload = {
             "schema_version": PROCESSED_SCHEMA_VERSION,
             "message_ids": merged,
-            "last_processed_at": datetime.now(timezone.utc).isoformat(),
+            "last_processed_at": datetime.now(UTC).isoformat(),
         }
         temporary = processed_path.with_suffix(".json.tmp")
         temporary.write_text(

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -15,7 +15,6 @@ from .event_inbox import (
 )
 from .inbox_reactions import complete_lark_event_inbox_reactions
 
-
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
 
 AT_MENTION_PATTERN = re.compile(
@@ -24,15 +23,16 @@ AT_MENTION_PATTERN = re.compile(
     re.IGNORECASE,
 )
 MENTION_ID_KEYS = ("open_id", "user_id", "union_id")
+FENCED_CODE_PATTERN = re.compile(r"```.*?```", re.DOTALL)
 
 
 def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
     result = subprocess.run(
         list(args),
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         timeout=30,
+        check=False,
     )
     return {
         "returncode": result.returncode,
@@ -78,7 +78,11 @@ def _message(value: Any, message_id: str) -> Mapping[str, Any] | None:
         if str(value.get("message_id") or "") == message_id:
             return value
         return next(
-            (found for child in value.values() if (found := _message(child, message_id))),
+            (
+                found
+                for child in value.values()
+                if (found := _message(child, message_id))
+            ),
             None,
         )
     if isinstance(value, list):
@@ -144,18 +148,26 @@ def _canonical_expected_text(text: str) -> tuple[str, dict[str, str]]:
         )
         return token
 
-    return " ".join(AT_MENTION_PATTERN.sub(replace, text).split()), identity_tokens
+    replaced = AT_MENTION_PATTERN.sub(replace, text)
+    return _normalized_lines(replaced), identity_tokens
 
 
-def _readback_matches_reply(
-    *, reply_text: str, message: Mapping[str, Any]
-) -> bool:
+def _normalized_lines(value: Any) -> str:
+    lines = [" ".join(line.split()) for line in str(value or "").splitlines()]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    return "\n".join(lines)
+
+
+def _readback_matches_reply(*, reply_text: str, message: Mapping[str, Any]) -> bool:
     expected_text, identity_tokens = _canonical_expected_text(reply_text)
     actual_text = _message_text(message)
     if not actual_text:
         return False
     if not identity_tokens:
-        return " ".join(actual_text.split()) == expected_text
+        return _normalized_lines(actual_text) == expected_text
 
     mentions = message.get("mentions")
     if not isinstance(mentions, list):
@@ -204,16 +216,39 @@ def _readback_matches_reply(
         if len(rendered_candidates) != 1:
             return False
         actual_text = actual_text.replace(rendered_candidates[0], token)
-    return " ".join(actual_text.split()) == expected_text
+    return _normalized_lines(actual_text) == expected_text
 
 
 def _normalized_reply_text(value: Any) -> str:
-    lines = [" ".join(line.split()) for line in str(value or "").splitlines()]
-    while lines and not lines[0]:
-        lines.pop(0)
-    while lines and not lines[-1]:
-        lines.pop()
-    return "\n".join(lines)[:1200]
+    text = str(value or "").replace("\r\n", "\n").replace("\r", "\n")
+    outside_code = FENCED_CODE_PATTERN.sub("", text)
+    if r"\n" in outside_code:
+        raise ValueError(
+            "lark inbox reply contains a literal backslash-n outside fenced code; "
+            "pass real newlines"
+        )
+    return _normalized_lines(text)[:1200]
+
+
+def _provider_preview_matches_reply(
+    *, reply_text: str, payload: Mapping[str, Any]
+) -> bool:
+    data = payload.get("data")
+    api_calls = payload.get("api")
+    if not isinstance(api_calls, list) and isinstance(data, Mapping):
+        api_calls = data.get("api")
+    if not isinstance(api_calls, list):
+        return False
+    for call in api_calls:
+        if not isinstance(call, Mapping):
+            continue
+        body = call.get("body")
+        if not isinstance(body, Mapping):
+            continue
+        preview_text = _content_text(body)
+        if preview_text and _normalized_lines(preview_text) == reply_text:
+            return True
+    return False
 
 
 def _result(
@@ -230,6 +265,9 @@ def _result(
     reaction_cleanup_verified: bool = False,
     placement: str | None = None,
     blocker: str | None = None,
+    format_preflight_passed: bool = False,
+    provider_preview_performed: bool = False,
+    provider_preview_verified: bool = False,
 ) -> dict[str, Any]:
     packet: dict[str, Any] = {
         "ok": ok,
@@ -244,6 +282,9 @@ def _result(
         "reaction_cleanup_verified": reaction_cleanup_verified,
         "sender_identity_verified": identity_verified,
         "sender_chat_membership_verified": membership_verified,
+        "format_preflight_passed": format_preflight_passed,
+        "provider_preview_performed": provider_preview_performed,
+        "provider_preview_verified": provider_preview_verified,
         "private_sender_profile_captured": False,
         "private_chat_id_captured": False,
         "private_message_id_captured": False,
@@ -264,6 +305,7 @@ def reply_lark_event_inbox(
     message_id: str,
     text: str,
     execute: bool = False,
+    provider_preflight: bool = False,
     runner: CommandRunner = _default_runner,
 ) -> dict[str, Any]:
     """Reply with the explicit inbox-configured bot and placement policy."""
@@ -327,13 +369,14 @@ def reply_lark_event_inbox(
         ).encode("utf-8")
     ).hexdigest()
     receipt = f"sha256:{digest}"
-    if not execute:
+    if not execute and not provider_preflight:
         return _result(
             status="preview_ready",
             ok=True,
             execute=False,
             receipt=receipt,
             placement=placement,
+            format_preflight_passed=True,
         )
 
     base = ["lark-cli", "--profile", profile]
@@ -351,9 +394,10 @@ def reply_lark_event_inbox(
         return _result(
             status="gate_required",
             ok=False,
-            execute=True,
+            execute=execute,
             receipt=receipt,
             blocker="lark_inbox_reply_sender_identity_mismatch",
+            format_preflight_passed=True,
         )
 
     membership = _call(
@@ -375,10 +419,11 @@ def reply_lark_event_inbox(
         return _result(
             status="gate_required",
             ok=False,
-            execute=True,
+            execute=execute,
             receipt=receipt,
             identity_verified=True,
             blocker="lark_inbox_reply_sender_not_in_configured_chat",
+            format_preflight_passed=True,
         )
 
     destination = (
@@ -401,8 +446,7 @@ def reply_lark_event_inbox(
             "--reply-in-thread",
         ]
     )
-    send = _call(
-        runner,
+    provider_args = (
         base
         + destination
         + [
@@ -412,7 +456,46 @@ def reply_lark_event_inbox(
             "bot",
             "--format",
             "json",
-        ],
+        ]
+    )
+    preview = _call(runner, provider_args + ["--dry-run"])
+    provider_preview_verified = bool(
+        preview.get("returncode") == 0
+        and _provider_preview_matches_reply(
+            reply_text=reply_text,
+            payload=_json_object(preview.get("stdout")),
+        )
+    )
+    if not provider_preview_verified:
+        return _result(
+            status="gate_required",
+            ok=False,
+            execute=execute,
+            receipt=receipt,
+            identity_verified=True,
+            membership_verified=True,
+            placement=placement,
+            blocker="lark_inbox_reply_provider_preview_mismatch",
+            format_preflight_passed=True,
+            provider_preview_performed=True,
+        )
+    if not execute:
+        return _result(
+            status="preview_ready",
+            ok=True,
+            execute=False,
+            receipt=receipt,
+            identity_verified=True,
+            membership_verified=True,
+            placement=placement,
+            format_preflight_passed=True,
+            provider_preview_performed=True,
+            provider_preview_verified=True,
+        )
+
+    send = _call(
+        runner,
+        provider_args,
     )
     if send.get("returncode") != 0:
         return _result(
@@ -424,6 +507,9 @@ def reply_lark_event_inbox(
             membership_verified=True,
             placement=placement,
             blocker="lark_inbox_reply_provider_failed",
+            format_preflight_passed=True,
+            provider_preview_performed=True,
+            provider_preview_verified=True,
         )
 
     reply_message_id = _message_id(_json_object(send.get("stdout")))
@@ -438,6 +524,9 @@ def reply_lark_event_inbox(
             write_performed=True,
             placement=placement,
             blocker="lark_inbox_reply_not_verified",
+            format_preflight_passed=True,
+            provider_preview_performed=True,
+            provider_preview_verified=True,
         )
     readback = _call(
         runner,
@@ -504,4 +593,7 @@ def reply_lark_event_inbox(
             if verified
             else "lark_inbox_reply_not_verified"
         ),
+        format_preflight_passed=True,
+        provider_preview_performed=True,
+        provider_preview_verified=True,
     )

--- a/loopx/extensions/lark/routed_inbox.py
+++ b/loopx/extensions/lark/routed_inbox.py
@@ -216,11 +216,16 @@ def resolve_routed_lark_inbox_config(
     if kind == "inbox":
         return str(config_path)
     _, routes = _collector_routes(project=project, config_path=config_path)
-    matches = [
-        str(route["event_inbox_config_ref"])
-        for route in routes
-        if (route["inbox"]["inbox_path"] / f"{message_id}.json").is_file()
-    ]
+    matches: list[str] = []
+    for route in routes:
+        inbox_path = route["inbox"].get("inbox_path")
+        if inbox_path is None:
+            # A disabled route inbox has no addressable message store; it can
+            # never contain the requested message and must fail closed cleanly
+            # instead of raising on a None path.
+            continue
+        if (inbox_path / f"{message_id}.json").is_file():
+            matches.append(str(route["event_inbox_config_ref"]))
     if len(matches) != 1:
         raise ValueError(
             "message id must resolve to exactly one configured Lark inbox route"

--- a/loopx/extensions/lark/routed_inbox.py
+++ b/loopx/extensions/lark/routed_inbox.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .event_collector import (
+    SUPPORTED_CONFIG_SCHEMA_VERSIONS as COLLECTOR_SCHEMA_VERSIONS,
+)
+from .event_collector import load_lark_event_collector_config
+from .event_inbox import (
+    CONFIG_SCHEMA_VERSION as INBOX_SCHEMA_VERSION,
+)
+from .event_inbox import (
+    MESSAGE_ID_PATTERN,
+    acknowledge_lark_event_inbox,
+    ingest_lark_event_inbox,
+    inspect_lark_event_inbox,
+    load_lark_event_inbox_config,
+    project_lark_event_inbox_urgency,
+)
+
+
+def lark_inbox_config_kind(*, project: str | Path, config_path: str | Path) -> str:
+    """Classify one local-private inbox or routed collector config."""
+
+    root = Path(project).expanduser().resolve()
+    path = Path(config_path).expanduser()
+    path = (path if path.is_absolute() else root / path).resolve()
+    try:
+        path.relative_to(root)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(
+            "Lark inbox config must be readable inside the project"
+        ) from exc
+    schema_version = (
+        str(payload.get("schema_version") or "") if isinstance(payload, Mapping) else ""
+    )
+    if schema_version == INBOX_SCHEMA_VERSION:
+        load_lark_event_inbox_config(project=root, config_path=path)
+        return "inbox"
+    if schema_version in COLLECTOR_SCHEMA_VERSIONS:
+        load_lark_event_collector_config(project=root, config_path=path)
+        return "collector"
+    raise ValueError("Lark inbox config schema is unsupported")
+
+
+def _collector_routes(
+    *, project: str | Path, config_path: str | Path
+) -> tuple[Path, list[dict[str, Any]]]:
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=config_path,
+    )
+    return Path(config["project"]), list(config["routes"])
+
+
+def inspect_routed_lark_event_inbox(
+    *, project: str | Path, config_path: str | Path, limit: int = 20
+) -> dict[str, Any]:
+    """Drain one inbox or a collector's isolated route inboxes as one lane."""
+
+    kind = lark_inbox_config_kind(project=project, config_path=config_path)
+    if kind == "inbox":
+        return inspect_lark_event_inbox(
+            project=project,
+            config_path=config_path,
+            limit=limit,
+        )
+    root, routes = _collector_routes(project=project, config_path=config_path)
+    items: list[dict[str, Any]] = []
+    statuses: list[dict[str, Any]] = []
+    for route in routes:
+        route_key = str(route["route_key"])
+        status = inspect_lark_event_inbox(
+            project=root,
+            config_path=route["event_inbox_config_ref"],
+            limit=100,
+        )
+        statuses.append(status)
+        guidance = status.get("reply_guidance")
+        for raw_item in status.get("items") or []:
+            if isinstance(raw_item, Mapping):
+                item = dict(raw_item)
+                if item.get("route_key") != route_key:
+                    raise ValueError(
+                        "routed Lark inbox item route_key must match its configured route"
+                    )
+                if isinstance(guidance, Mapping):
+                    item["reply_guidance"] = dict(guidance)
+                items.append(item)
+    items.sort(
+        key=lambda item: (
+            str(item.get("create_time") or ""),
+            str(item.get("message_id") or ""),
+        )
+    )
+    bounded = items[: max(1, min(int(limit), 100))]
+    pending_count = sum(int(status.get("pending_count") or 0) for status in statuses)
+    return {
+        "ok": True,
+        "schema_version": "lark_event_inbox_projection_v1",
+        "enabled": all(status.get("enabled") is True for status in statuses),
+        "configured": True,
+        "capture_scope": "configured_chat_all",
+        "thread_complete": all(
+            status.get("thread_complete") is True for status in statuses
+        ),
+        "route_count": len(routes),
+        "routes_with_pending_count": sum(
+            int(status.get("pending_count") or 0) > 0 for status in statuses
+        ),
+        "pending_count": pending_count,
+        "captured_count": sum(
+            int(status.get("captured_count") or 0) for status in statuses
+        ),
+        "returned_count": len(bounded),
+        "processed_count": sum(
+            int(status.get("processed_count") or 0) for status in statuses
+        ),
+        "invalid_count": sum(
+            int(status.get("invalid_count") or 0) for status in statuses
+        ),
+        "items": bounded,
+        "local_private_content_returned": bool(bounded),
+        "external_reads_performed": False,
+        "chat_ids_returned": False,
+        "route_keys_returned": bool(bounded),
+        "profiles_returned": False,
+        "instruction": (
+            "Use each item's route_key to bind it to the stable requirement "
+            "context, then process it through the same Agent lane. Message-scoped reply, "
+            "reaction, and ACK commands resolve the unique routed inbox while "
+            "preserving the item's source-context guidance."
+        ),
+    }
+
+
+def project_routed_lark_event_inbox_urgency(
+    *, project: str | Path, config_path: str | Path
+) -> dict[str, Any]:
+    """Aggregate route urgency without returning messages or route identities."""
+
+    kind = lark_inbox_config_kind(project=project, config_path=config_path)
+    if kind == "inbox":
+        return project_lark_event_inbox_urgency(
+            project=project,
+            config_path=config_path,
+        )
+    root, routes = _collector_routes(project=project, config_path=config_path)
+    projections = [
+        project_lark_event_inbox_urgency(
+            project=root,
+            config_path=route["event_inbox_config_ref"],
+        )
+        for route in routes
+    ]
+    oldest_values = [
+        str(projection.get("oldest_pending_at"))
+        for projection in projections
+        if projection.get("oldest_pending_at")
+    ]
+    age_values = [
+        int(projection["oldest_pending_age_seconds"])
+        for projection in projections
+        if projection.get("oldest_pending_age_seconds") is not None
+    ]
+    count_fields = (
+        "pending_count",
+        "direct_question_count",
+        "direct_mention_count",
+        "reply_to_bot_count",
+        "attention_required_count",
+    )
+    result: dict[str, Any] = {
+        "schema_version": "lark_event_inbox_urgency_v1",
+        "enabled": all(projection.get("enabled") is True for projection in projections),
+        "thread_complete": all(
+            projection.get("thread_complete") is True for projection in projections
+        ),
+        "route_count": len(routes),
+        "routes_with_pending_count": sum(
+            int(projection.get("pending_count") or 0) > 0 for projection in projections
+        ),
+        "oldest_pending_at": min(oldest_values) if oldest_values else None,
+        "oldest_pending_age_seconds": max(age_values) if age_values else None,
+        "reply_due": any(
+            projection.get("reply_due") is True for projection in projections
+        ),
+        "local_private_content_returned": False,
+        "chat_ids_returned": False,
+        "profiles_returned": False,
+    }
+    result.update(
+        {
+            field: sum(int(projection.get(field) or 0) for projection in projections)
+            for field in count_fields
+        }
+    )
+    return result
+
+
+def resolve_routed_lark_inbox_config(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    message_id: str,
+) -> str:
+    """Resolve one message to exactly one inbox without exposing route identity."""
+
+    if not MESSAGE_ID_PATTERN.fullmatch(str(message_id or "").strip()):
+        raise ValueError("routed Lark inbox lookup requires a valid message id")
+    kind = lark_inbox_config_kind(project=project, config_path=config_path)
+    if kind == "inbox":
+        return str(config_path)
+    _, routes = _collector_routes(project=project, config_path=config_path)
+    matches = [
+        str(route["event_inbox_config_ref"])
+        for route in routes
+        if (route["inbox"]["inbox_path"] / f"{message_id}.json").is_file()
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            "message id must resolve to exactly one configured Lark inbox route"
+        )
+    return matches[0]
+
+
+def acknowledge_routed_lark_event_inbox(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    message_ids: Sequence[str],
+    execute: bool = False,
+) -> dict[str, Any]:
+    """ACK messages across isolated routes only after all routes resolve."""
+
+    kind = lark_inbox_config_kind(project=project, config_path=config_path)
+    if kind == "inbox":
+        return acknowledge_lark_event_inbox(
+            project=project,
+            config_path=config_path,
+            message_ids=message_ids,
+            execute=execute,
+        )
+    grouped: dict[str, list[str]] = {}
+    for message_id in message_ids:
+        route_config = resolve_routed_lark_inbox_config(
+            project=project,
+            config_path=config_path,
+            message_id=message_id,
+        )
+        grouped.setdefault(route_config, []).append(message_id)
+    receipts = [
+        acknowledge_lark_event_inbox(
+            project=project,
+            config_path=route_config,
+            message_ids=values,
+            execute=execute,
+        )
+        for route_config, values in grouped.items()
+    ]
+    return {
+        "ok": all(receipt.get("ok") is True for receipt in receipts),
+        "schema_version": "lark_event_inbox_ack_v1",
+        "execute": execute,
+        "requested_count": len(message_ids),
+        "new_count": sum(int(receipt.get("new_count") or 0) for receipt in receipts),
+        "already_acknowledged_count": sum(
+            int(receipt.get("already_acknowledged_count") or 0) for receipt in receipts
+        ),
+        "write_performed": any(
+            receipt.get("write_performed") is True for receipt in receipts
+        ),
+        "message_ids": list(message_ids),
+        "route_count": len(grouped),
+        "local_private_content_captured": False,
+        "external_writes_performed": False,
+        "chat_ids_returned": False,
+        "profiles_returned": False,
+    }
+
+
+def ingest_routed_lark_event_inbox(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    events: Sequence[object],
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Backfill collector events by configured chat without cross-route fallback."""
+
+    kind = lark_inbox_config_kind(project=project, config_path=config_path)
+    if kind == "inbox":
+        return ingest_lark_event_inbox(
+            project=project,
+            config_path=config_path,
+            events=events,
+            execute=execute,
+        )
+    _, routes = _collector_routes(project=project, config_path=config_path)
+    by_chat = {str(route["chat_id"]): route for route in routes}
+    grouped: dict[str, list[object]] = {}
+    invalid_count = 0
+    for event in events:
+        chat_id = (
+            str(event.get("chat_id") or "").strip()
+            if isinstance(event, Mapping)
+            else ""
+        )
+        route = by_chat.get(chat_id)
+        if route is None:
+            invalid_count += 1
+            continue
+        grouped.setdefault(str(route["event_inbox_config_ref"]), []).append(
+            {**event, "route_key": route["route_key"]}
+        )
+    receipts = [
+        ingest_lark_event_inbox(
+            project=project,
+            config_path=route_config,
+            events=values,
+            execute=execute,
+        )
+        for route_config, values in grouped.items()
+    ]
+    return {
+        "ok": True,
+        "schema_version": "lark_event_inbox_ingest_v1",
+        "execute": execute,
+        "requested_count": len(events),
+        "accepted_count": sum(
+            int(receipt.get("accepted_count") or 0) for receipt in receipts
+        ),
+        "invalid_count": invalid_count
+        + sum(int(receipt.get("invalid_count") or 0) for receipt in receipts),
+        "duplicate_count": sum(
+            int(receipt.get("duplicate_count") or 0) for receipt in receipts
+        ),
+        "write_performed": any(
+            receipt.get("write_performed") is True for receipt in receipts
+        ),
+        "route_count": len(grouped),
+        "local_private_content_returned": False,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "chat_ids_returned": False,
+        "profiles_returned": False,
+    }

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli_commands import lark_inbox
+from loopx.extensions.lark.event_collector import (
+    _jq_projection,
+    load_lark_event_collector_config,
+    plan_lark_event_collector,
+)
+from loopx.extensions.lark.event_collector_runtime import run_lark_event_collector
+from loopx.extensions.lark.event_inbox import inspect_lark_event_inbox
+from loopx.extensions.lark.routed_inbox import (
+    acknowledge_routed_lark_event_inbox,
+    ingest_routed_lark_event_inbox,
+    inspect_routed_lark_event_inbox,
+    project_routed_lark_event_inbox_urgency,
+    resolve_routed_lark_inbox_config,
+)
+
+
+def _project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(["git", "init", "-q", str(project)], check=True)
+    (project / ".gitignore").write_text(".loopx/\n", encoding="utf-8")
+    return project
+
+
+def _write_inbox(
+    project: Path,
+    *,
+    name: str,
+    chat_id: str,
+    profile: str = "shared-context-bot",
+) -> str:
+    relative = f".loopx/config/lark/{name}.json"
+    path = project / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": f".loopx/inbox/{name}",
+                "capture_scope": "configured_chat_all",
+                "reply": {
+                    "enabled": True,
+                    "sender_profile": profile,
+                    "sender_identity": "bot",
+                    "bot_display_name": "Shared Context Bot",
+                    "chat_id": chat_id,
+                    "placement_policy": "source_context",
+                    "editorial_style": "bullet_points_preferred",
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return relative
+
+
+def _write_collector(
+    project: Path,
+    *,
+    routes: list[dict[str, str]],
+    schema_version: str = "lark_event_collector_config_v1",
+) -> Path:
+    path = project / ".loopx/config/lark/collector.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "enabled": True,
+        "service_name": "loopx-shared-context",
+        "event_key": "im.message.receive_v1",
+        "identity": "bot",
+        "supervisor": "systemd",
+        "consume_timeout": "30m",
+        "lark_cli_bin": "lark-cli",
+    }
+    if schema_version == "lark_event_collector_config_v0":
+        payload.update(routes[0])
+    else:
+        payload["routes"] = routes
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+    return path
+
+
+def _two_route_config(tmp_path: Path) -> tuple[Path, Path, str, str]:
+    project = _project(tmp_path)
+    first_chat = "oc_public_fixture_alpha"
+    second_chat = "oc_public_fixture_beta"
+    first = _write_inbox(
+        project,
+        name="requirements-alpha",
+        chat_id=first_chat,
+    )
+    second = _write_inbox(
+        project,
+        name="requirements-beta",
+        chat_id=second_chat,
+    )
+    collector = _write_collector(
+        project,
+        routes=[
+            {
+                "route_key": "requirements-alpha",
+                "chat_id": first_chat,
+                "event_inbox_config": first,
+            },
+            {
+                "route_key": "requirements-beta",
+                "chat_id": second_chat,
+                "event_inbox_config": second,
+            },
+        ],
+    )
+    return project, collector, first_chat, second_chat
+
+
+def test_v1_plan_binds_one_profile_to_isolated_multi_chat_routes(
+    tmp_path: Path,
+) -> None:
+    project, collector, first_chat, second_chat = _two_route_config(tmp_path)
+
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=collector,
+    )
+    plan = plan_lark_event_collector(project=project, config_path=collector)
+
+    assert config["schema_version"] == "lark_event_collector_config_v1"
+    assert len(config["routes"]) == 2
+    assert [route["route_key"] for route in config["routes"]] == [
+        "requirements-alpha",
+        "requirements-beta",
+    ]
+    assert config["profile"] == "shared-context-bot"
+    assert config["profile_source"] == "event_inbox_reply"
+    assert len({route["inbox"]["inbox_path"] for route in config["routes"]}) == 2
+    assert plan["route_count"] == 2
+    assert plan["multi_chat_routing"] is True
+    assert plan["thread_complete"] is True
+    assert plan["profile_returned"] is False
+    assert plan["chat_id_returned"] is False
+    serialized = json.dumps(plan)
+    assert first_chat not in serialized
+    assert second_chat not in serialized
+    assert "shared-context-bot" not in serialized
+    assert str(project) not in serialized
+
+
+def test_v0_config_is_normalized_to_one_route(tmp_path: Path) -> None:
+    project = _project(tmp_path)
+    chat_id = "oc_public_fixture_single"
+    inbox = _write_inbox(project, name="requirements-single", chat_id=chat_id)
+    collector = _write_collector(
+        project,
+        schema_version="lark_event_collector_config_v0",
+        routes=[{"chat_id": chat_id, "event_inbox_config": inbox}],
+    )
+
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=collector,
+    )
+    plan = plan_lark_event_collector(project=project, config_path=collector)
+
+    assert len(config["routes"]) == 1
+    assert config["routes"][0]["route_key"] == "default"
+    assert config["routes"][0]["chat_id"] == chat_id
+    assert plan["route_count"] == 1
+    assert plan["multi_chat_routing"] is False
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error"),
+    [
+        ("duplicate_chat", "unique chat ids"),
+        ("missing_route_key", "public-safe token"),
+        ("duplicate_route_key", "unique route keys"),
+        ("unsafe_route_key", "public-safe token"),
+        ("duplicate_inbox", "independent event inbox"),
+        ("reply_chat_mismatch", "must match the inbox reply chat_id"),
+        ("profile_mismatch", "must match one profile-bound event stream"),
+    ],
+)
+def test_multi_chat_routes_fail_closed_on_ambiguous_bindings(
+    tmp_path: Path,
+    mutation: str,
+    error: str,
+) -> None:
+    project, collector, first_chat, _ = _two_route_config(tmp_path)
+    payload = json.loads(collector.read_text(encoding="utf-8"))
+    if mutation == "duplicate_chat":
+        payload["routes"][1]["chat_id"] = first_chat
+    elif mutation == "missing_route_key":
+        payload["routes"][0].pop("route_key")
+    elif mutation == "duplicate_route_key":
+        payload["routes"][1]["route_key"] = payload["routes"][0]["route_key"]
+    elif mutation == "unsafe_route_key":
+        payload["routes"][0]["route_key"] = "Private Requirement Group"
+    elif mutation == "duplicate_inbox":
+        payload["routes"][1]["event_inbox_config"] = payload["routes"][0][
+            "event_inbox_config"
+        ]
+    elif mutation == "reply_chat_mismatch":
+        first_inbox = project / payload["routes"][0]["event_inbox_config"]
+        inbox_payload = json.loads(first_inbox.read_text(encoding="utf-8"))
+        inbox_payload["reply"]["chat_id"] = "oc_public_fixture_other"
+        first_inbox.write_text(json.dumps(inbox_payload), encoding="utf-8")
+    else:
+        second_inbox = project / payload["routes"][1]["event_inbox_config"]
+        inbox_payload = json.loads(second_inbox.read_text(encoding="utf-8"))
+        inbox_payload["reply"]["sender_profile"] = "different-context-bot"
+        second_inbox.write_text(json.dumps(inbox_payload), encoding="utf-8")
+    collector.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=error):
+        load_lark_event_collector_config(
+            project=project,
+            config_path=collector,
+        )
+
+
+def test_jq_projection_filters_one_stream_to_all_configured_chats() -> None:
+    projection = _jq_projection(["oc_public_fixture_alpha", "oc_public_fixture_beta"])
+
+    assert '.chat_id == "oc_public_fixture_alpha"' in projection
+    assert '.chat_id == "oc_public_fixture_beta"' in projection
+    assert " or " in projection
+    assert "chat_id:.chat_id" in projection
+
+
+def test_cli_drain_accepts_routed_collector_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, collector, first_chat, second_chat = _two_route_config(tmp_path)
+    receipt = ingest_routed_lark_event_inbox(
+        project=project,
+        config_path=collector,
+        events=[
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "message_id": "om_public_alpha",
+                "content": "alpha request",
+                "chat_id": first_chat,
+            },
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "message_id": "om_public_beta",
+                "content": "beta request",
+                "chat_id": second_chat,
+            },
+        ],
+        execute=True,
+    )
+    monkeypatch.setattr(
+        lark_inbox,
+        "_resolve_lark_activation",
+        lambda *_args, **_kwargs: {"enabled": True},
+    )
+    rendered: list[dict[str, object]] = []
+    args = argparse.Namespace(
+        command="lark-inbox",
+        lark_inbox_command="drain",
+        project=str(project),
+        config=str(collector),
+        goal_id=None,
+        agent_id=None,
+        limit=20,
+    )
+
+    code = lark_inbox.handle_lark_inbox_command(
+        args,
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        output_format=lambda _args: "json",
+        print_payload=lambda payload, *_args: rendered.append(payload),
+    )
+
+    assert receipt["accepted_count"] == 2
+    assert code == 0
+    assert rendered[0]["route_count"] == 2
+    assert rendered[0]["pending_count"] == 2
+    assert [item["route_key"] for item in rendered[0]["items"]] == [
+        "requirements-alpha",
+        "requirements-beta",
+    ]
+    assert rendered[0]["extension_activation"] == {"enabled": True}
+
+
+def test_runtime_consumes_once_and_routes_each_chat_to_its_own_inbox(
+    tmp_path: Path,
+) -> None:
+    project, collector, first_chat, second_chat = _two_route_config(tmp_path)
+    events = [
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-alpha",
+            "message_id": "om_public_alpha",
+            "create_time": "2026-08-25T00:00:00Z",
+            "content": "alpha request",
+            "chat_id": first_chat,
+            "mentioned": True,
+        },
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-beta",
+            "message_id": "om_public_beta",
+            "create_time": "2026-08-25T00:01:00Z",
+            "content": "beta request",
+            "chat_id": second_chat,
+            "mentioned": True,
+        },
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-unconfigured",
+            "message_id": "om_public_unconfigured",
+            "create_time": "2026-08-25T00:02:00Z",
+            "content": "unconfigured request",
+            "chat_id": "oc_public_fixture_unconfigured",
+            "mentioned": True,
+        },
+    ]
+    runtime_cli = tmp_path / "runtime-lark-cli"
+    runtime_cli.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        "import sys\n"
+        f"events = {events!r}\n"
+        "args = sys.argv[1:]\n"
+        "if args.count('consume') != 1:\n"
+        "    raise SystemExit(2)\n"
+        "projection = args[args.index('--jq') + 1]\n"
+        f"if {first_chat!r} not in projection or {second_chat!r} not in projection:\n"
+        "    raise SystemExit(3)\n"
+        "for event in events:\n"
+        "    print(json.dumps(event), flush=True)\n",
+        encoding="utf-8",
+    )
+    runtime_cli.chmod(0o755)
+
+    def unexpected_runner(
+        argv: list[str], **_: object
+    ) -> subprocess.CompletedProcess[str]:
+        raise AssertionError(f"unexpected provider lookup: {argv}")
+
+    result = run_lark_event_collector(
+        project=project,
+        config_path=collector,
+        lark_cli_executable=str(runtime_cli),
+        runner=unexpected_runner,
+    )
+
+    assert result == {
+        "ok": True,
+        "schema_version": "lark_event_collector_run_v1",
+        "status": "completed",
+        "captured_count": 2,
+        "route_count": 2,
+        "routed_route_count": 2,
+        "multi_chat_routing": True,
+        "reply_context_verified_count": 0,
+        "reply_to_bot_count": 0,
+        "received_reaction_count": 0,
+        "received_reaction_failure_count": 0,
+        "external_writes_performed": False,
+        "profile_identity_checked": False,
+        "profile_identity_verified": False,
+        "chat_ids_returned": False,
+        "local_paths_returned": False,
+        "private_content_returned": False,
+    }
+    first = inspect_lark_event_inbox(
+        project=project,
+        config_path=".loopx/config/lark/requirements-alpha.json",
+        limit=10,
+    )
+    second = inspect_lark_event_inbox(
+        project=project,
+        config_path=".loopx/config/lark/requirements-beta.json",
+        limit=10,
+    )
+    assert [item["message_id"] for item in first["items"]] == ["om_public_alpha"]
+    assert [item["message_id"] for item in second["items"]] == ["om_public_beta"]
+    assert first["items"][0]["route_key"] == "requirements-alpha"
+    assert second["items"][0]["route_key"] == "requirements-beta"
+    aggregate = inspect_routed_lark_event_inbox(
+        project=project,
+        config_path=collector,
+        limit=10,
+    )
+    assert aggregate["route_count"] == 2
+    assert aggregate["routes_with_pending_count"] == 2
+    assert aggregate["pending_count"] == 2
+    assert [item["message_id"] for item in aggregate["items"]] == [
+        "om_public_alpha",
+        "om_public_beta",
+    ]
+    assert all("reply_guidance" in item for item in aggregate["items"])
+    assert [item["route_key"] for item in aggregate["items"]] == [
+        "requirements-alpha",
+        "requirements-beta",
+    ]
+    assert aggregate["route_keys_returned"] is True
+    urgency = project_routed_lark_event_inbox_urgency(
+        project=project,
+        config_path=collector,
+    )
+    assert urgency["route_count"] == 2
+    assert urgency["routes_with_pending_count"] == 2
+    assert urgency["pending_count"] == 2
+    assert urgency["local_private_content_returned"] is False
+    assert first_chat not in json.dumps(urgency)
+    assert second_chat not in json.dumps(urgency)
+    assert (
+        resolve_routed_lark_inbox_config(
+            project=project,
+            config_path=collector,
+            message_id="om_public_beta",
+        )
+        == ".loopx/config/lark/requirements-beta.json"
+    )
+
+    acknowledged = acknowledge_routed_lark_event_inbox(
+        project=project,
+        config_path=collector,
+        message_ids=["om_public_alpha"],
+        execute=True,
+    )
+    assert acknowledged["new_count"] == 1
+    assert (
+        inspect_lark_event_inbox(
+            project=project,
+            config_path=".loopx/config/lark/requirements-alpha.json",
+            limit=10,
+        )["pending_count"]
+        == 0
+    )
+    assert (
+        inspect_lark_event_inbox(
+            project=project,
+            config_path=".loopx/config/lark/requirements-beta.json",
+            limit=10,
+        )["pending_count"]
+        == 1
+    )
+
+
+@pytest.mark.parametrize("tampered_route_key", [None, "requirements-beta"])
+def test_routed_drain_fails_closed_on_missing_or_mismatched_persisted_route_key(
+    tmp_path: Path,
+    tampered_route_key: str | None,
+) -> None:
+    project, collector, first_chat, _ = _two_route_config(tmp_path)
+    receipt = ingest_routed_lark_event_inbox(
+        project=project,
+        config_path=collector,
+        events=[
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "message_id": "om_public_alpha",
+                "content": "alpha request",
+                "chat_id": first_chat,
+            }
+        ],
+        execute=True,
+    )
+    assert receipt["accepted_count"] == 1
+    event_path = project / ".loopx/inbox/requirements-alpha/om_public_alpha.json"
+    payload = json.loads(event_path.read_text(encoding="utf-8"))
+    if tampered_route_key is None:
+        payload.pop("route_key")
+    else:
+        payload["route_key"] = tampered_route_key
+    event_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="route_key must match"):
+        inspect_routed_lark_event_inbox(
+            project=project,
+            config_path=collector,
+            limit=10,
+        )

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -490,3 +490,59 @@ def test_routed_drain_fails_closed_on_missing_or_mismatched_persisted_route_key(
             config_path=collector,
             limit=10,
         )
+
+
+def test_disabled_route_inbox_message_resolution_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """A disabled route inbox has no message store; resolving a message id on a
+    paused collector must fail closed with a clean error, not raise on a None
+    inbox path.
+    """
+
+    project = _project(tmp_path)
+    disabled_inbox = ".loopx/config/lark/disabled.json"
+    path = project / disabled_inbox
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": False,
+                "inbox_dir": ".loopx/inbox/disabled",
+                "capture_scope": "configured_chat_all",
+                "reply": {
+                    "enabled": False,
+                    "sender_profile": "disabled-context-bot",
+                    "sender_identity": "bot",
+                    "bot_display_name": "Disabled Context Bot",
+                    "chat_id": "oc_public_fixture_disabled",
+                },
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    collector = _write_collector(
+        project,
+        routes=[
+            {
+                "route_key": "requirements-disabled",
+                "chat_id": "oc_public_fixture_disabled",
+                "event_inbox_config": disabled_inbox,
+            },
+        ],
+    )
+    payload = json.loads(collector.read_text(encoding="utf-8"))
+    payload["enabled"] = False
+    collector.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match="must resolve to exactly one configured Lark inbox route",
+    ):
+        resolve_routed_lark_inbox_config(
+            project=project,
+            config_path=collector,
+            message_id="om_public_fixture_disabled",
+        )

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -91,7 +91,22 @@ def _reply_runner(state: dict[str, Any]):
             payload = {"data": {"chat_id": "oc_public_fixture"}}
         elif "+messages-reply" in args:
             state["reply_text"] = args[args.index("--text") + 1]
-            payload = {"data": {"message_id": "om_reply_fixture"}}
+            payload = (
+                {
+                    "api": [
+                        {
+                            "body": {
+                                "content": json.dumps(
+                                    {"text": state["reply_text"]},
+                                    ensure_ascii=False,
+                                )
+                            }
+                        }
+                    ]
+                }
+                if "--dry-run" in args
+                else {"data": {"message_id": "om_reply_fixture"}}
+            )
         elif "+messages-mget" in args:
             payload = {
                 "data": {
@@ -163,9 +178,7 @@ def test_mention_uses_existing_inbox_reply_and_ack_path(tmp_path: Path) -> None:
     assert result["ok"] is True
     assert result["status"] == "replied_and_acknowledged"
     assert result["goal_id"] == "goal-alpha"
-    assert answers == [
-        ("goal-alpha", "@linkmacbot 你现在 loopx 的版本是什么")
-    ]
+    assert answers == [("goal-alpha", "@linkmacbot 你现在 loopx 的版本是什么")]
     assert state["reply_text"] == "当前运行的是 LoopX 开发版。"
     reply_call = next(call for call in state["calls"] if "+messages-reply" in call)
     assert reply_call[:3] == ["lark-cli", "--profile", "mew"]
@@ -505,7 +518,9 @@ def test_bound_topic_reuses_one_goal_chat_session(tmp_path: Path) -> None:
     assert "只生成预览" in runtime.submit_calls[0]["message"]
 
 
-def test_runtime_service_uses_one_consumer_for_reused_app_profile(tmp_path: Path) -> None:
+def test_runtime_service_uses_one_consumer_for_reused_app_profile(
+    tmp_path: Path,
+) -> None:
     from loopx.extensions.lark.goal_topic_runtime import LarkGoalTopicRuntimeService
 
     started = threading.Event()
@@ -539,7 +554,10 @@ def test_runtime_service_uses_one_consumer_for_reused_app_profile(tmp_path: Path
                     "enabled": True,
                     "target_ref": "mew-product",
                     "topic": {"root_message_id": f"om_{goal_id}"},
-                    "routing": {"incoming_mode": "mentions", "reply_mode": "topic_reply"},
+                    "routing": {
+                        "incoming_mode": "mentions",
+                        "reply_mode": "topic_reply",
+                    },
                 }
             },
         }
@@ -706,7 +724,9 @@ def test_runtime_service_records_safe_failure_code_for_listener_exception(
     service.close()
 
 
-def test_profile_stream_keeps_one_consumer_open_between_messages(tmp_path: Path) -> None:
+def test_profile_stream_keeps_one_consumer_open_between_messages(
+    tmp_path: Path,
+) -> None:
     from loopx.extensions.lark.goal_topic_runtime import stream_lark_goal_topic_profile
 
     captured: dict[str, Any] = {}
@@ -786,7 +806,9 @@ def test_profile_stream_keeps_one_consumer_open_between_messages(tmp_path: Path)
     }
 
 
-def test_profile_poll_routes_provider_event_through_existing_reply_path(tmp_path: Path) -> None:
+def test_profile_poll_routes_provider_event_through_existing_reply_path(
+    tmp_path: Path,
+) -> None:
     from loopx.extensions.lark.goal_topic_runtime import (
         poll_lark_goal_topic_profile_once,
     )
@@ -820,7 +842,10 @@ def test_profile_poll_routes_provider_event_through_existing_reply_path(tmp_path
                     "enabled": True,
                     "target_ref": "mew-product",
                     "topic": {"root_message_id": "om_topic_alpha"},
-                    "routing": {"incoming_mode": "mentions", "reply_mode": "topic_reply"},
+                    "routing": {
+                        "incoming_mode": "mentions",
+                        "reply_mode": "topic_reply",
+                    },
                 }
             },
         }
@@ -847,7 +872,9 @@ def test_profile_poll_routes_provider_event_through_existing_reply_path(tmp_path
         state["consume_args"] = list(args)
         return {"returncode": 0, "stdout": json.dumps(event) + "\n", "stderr": ""}
 
-    def provider_runner(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def provider_runner(
+        args: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
         raise AssertionError(f"event routing must not query message history: {args}")
 
     result = poll_lark_goal_topic_profile_once(
@@ -1006,7 +1033,10 @@ def test_profile_poll_routes_the_only_goal_in_a_chat_without_querying_message_hi
                         "enabled": True,
                         "target_ref": "mew-product",
                         "topic": {"root_message_id": "om_topic_alpha"},
-                        "routing": {"incoming_mode": "all", "reply_mode": "topic_reply"},
+                        "routing": {
+                            "incoming_mode": "all",
+                            "reply_mode": "topic_reply",
+                        },
                     }
                 },
             }
@@ -1019,7 +1049,9 @@ def test_profile_poll_routes_the_only_goal_in_a_chat_without_querying_message_hi
         "content": "hello",
     }
 
-    def provider_runner(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def provider_runner(
+        args: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
         raise AssertionError(f"event routing must not query message history: {args}")
 
     result = poll_lark_goal_topic_profile_once(
@@ -1077,7 +1109,10 @@ def test_profile_poll_reports_ambiguous_topic_context_without_querying_message_h
                     "enabled": True,
                     "target_ref": "mew-product",
                     "topic": {"root_message_id": topic_root},
-                    "routing": {"incoming_mode": "mentions", "reply_mode": "topic_reply"},
+                    "routing": {
+                        "incoming_mode": "mentions",
+                        "reply_mode": "topic_reply",
+                    },
                 }
             },
         }
@@ -1088,7 +1123,9 @@ def test_profile_poll_reports_ambiguous_topic_context_without_querying_message_h
         "content": "hello",
     }
 
-    def provider_runner(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+    def provider_runner(
+        args: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
         raise AssertionError(f"event routing must not query message history: {args}")
 
     result = poll_lark_goal_topic_profile_once(
@@ -1108,7 +1145,9 @@ def test_profile_poll_reports_ambiguous_topic_context_without_querying_message_h
             "stderr": "",
         },
         provider_runner=provider_runner,
-        reply_runner=lambda _args: (_ for _ in ()).throw(AssertionError("must not reply")),
+        reply_runner=lambda _args: (_ for _ in ()).throw(
+            AssertionError("must not reply")
+        ),
     )
 
     assert result["event_count"] == 1
@@ -1147,7 +1186,10 @@ def test_profile_poll_does_not_reply_or_invoke_agent_when_message_mentions_other
                     "enabled": True,
                     "target_ref": "mew-product",
                     "topic": {"root_message_id": "om_topic_alpha"},
-                    "routing": {"incoming_mode": "mentions", "reply_mode": "topic_reply"},
+                    "routing": {
+                        "incoming_mode": "mentions",
+                        "reply_mode": "topic_reply",
+                    },
                 }
             },
         }
@@ -1187,7 +1229,9 @@ def test_profile_poll_does_not_reply_or_invoke_agent_when_message_mentions_other
             "stderr": "",
         },
         provider_runner=lambda _args: subprocess.CompletedProcess([], 0, "", ""),
-        reply_runner=lambda _args: (_ for _ in ()).throw(AssertionError("must not reply")),
+        reply_runner=lambda _args: (_ for _ in ()).throw(
+            AssertionError("must not reply")
+        ),
     )
 
     assert result_other["event_count"] == 1
@@ -1222,7 +1266,9 @@ def test_profile_poll_does_not_reply_or_invoke_agent_when_message_mentions_other
             "stderr": "",
         },
         provider_runner=lambda _args: subprocess.CompletedProcess([], 0, "", ""),
-        reply_runner=lambda _args: (_ for _ in ()).throw(AssertionError("must not reply")),
+        reply_runner=lambda _args: (_ for _ in ()).throw(
+            AssertionError("must not reply")
+        ),
     )
 
     assert result_all["event_count"] == 1

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -8,13 +8,13 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
 from loopx.extensions.lark.inbox_reactions import (
     complete_lark_event_inbox_reactions,
     lark_inbox_reaction_receipts,
     mark_lark_event_inbox_processing,
     record_lark_inbox_reaction,
 )
-from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
 from loopx.extensions.lark.inbox_reply import reply_lark_event_inbox
 
 
@@ -155,6 +155,29 @@ class ReplyRunner:
         if call[3:6] == ["im", "chats", "get"]:
             return {"returncode": 0, "stdout": "{}", "stderr": ""}
         if "+messages-reply" in call or "+messages-send" in call:
+            if "--dry-run" in call:
+                reply_text = call[call.index("--text") + 1]
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "data": {
+                                "api": [
+                                    {
+                                        "body": {
+                                            "content": json.dumps(
+                                                {"text": reply_text},
+                                                ensure_ascii=False,
+                                            )
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        ensure_ascii=False,
+                    ),
+                    "stderr": "",
+                }
             return {
                 "returncode": 0,
                 "stdout": json.dumps({"message_id": "om_reply_fixture"}),
@@ -184,9 +207,7 @@ class ReplyRunner:
         if "reactions" in call and "delete" in call:
             return {
                 "returncode": int(self.fail_reaction_delete),
-                "stdout": json.dumps(
-                    {"ok": not self.fail_reaction_delete}
-                ),
+                "stdout": json.dumps({"ok": not self.fail_reaction_delete}),
                 "stderr": "",
             }
         if "reactions" in call and "list" in call:
@@ -351,9 +372,10 @@ def test_completion_removes_only_recorded_bot_reactions(tmp_path: Path) -> None:
     assert result["status"] == "completed"
     assert result["deleted_count"] == 2
     assert all("delete" in call for call in runner.calls)
-    assert {
-        call[call.index("--reaction-id") + 1] for call in runner.calls
-    } == {"reaction_Get", "reaction_OnIt"}
+    assert {call[call.index("--reaction-id") + 1] for call in runner.calls} == {
+        "reaction_Get",
+        "reaction_OnIt",
+    }
     assert (
         lark_inbox_reaction_receipts(
             inbox=inbox,
@@ -407,9 +429,7 @@ def test_verified_reply_removes_processing_reaction(tmp_path: Path) -> None:
     assert result["reaction_cleanup_verified"] is True
     assert result["placement"] == "source_thread"
     delete_call = next(call for call in runner.calls if "delete" in call)
-    assert delete_call[delete_call.index("--reaction-id") + 1] == (
-        "reaction_OnIt"
-    )
+    assert delete_call[delete_call.index("--reaction-id") + 1] == ("reaction_OnIt")
     assert (
         lark_inbox_reaction_receipts(
             inbox=inbox,
@@ -443,8 +463,18 @@ def test_source_context_reply_uses_chat_root_for_top_level_message(
     )
 
     assert result["ok"] is True
+    assert result["format_preflight_passed"] is True
+    assert result["provider_preview_verified"] is True
     assert result["placement"] == "chat_root"
-    send_call = next(call for call in runner.calls if "+messages-send" in call)
+    preview_call = next(call for call in runner.calls if "--dry-run" in call)
+    assert preview_call[preview_call.index("--text") + 1] == (
+        "进展：\n- 第一项\n- 第二项"
+    )
+    send_call = next(
+        call
+        for call in runner.calls
+        if "+messages-send" in call and "--dry-run" not in call
+    )
     assert "--reply-in-thread" not in send_call
     assert send_call[send_call.index("--chat-id") + 1] == "oc_project_review"
     assert send_call[send_call.index("--text") + 1] == "进展：\n- 第一项\n- 第二项"
@@ -478,6 +508,75 @@ def test_source_context_reply_stays_in_existing_topic(tmp_path: Path) -> None:
     assert not any("+messages-send" in call for call in runner.calls)
 
 
+def test_reply_preview_verifies_provider_without_writing(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(readback_text="line one\nline two")
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="line one\nline two",
+        execute=False,
+        provider_preflight=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "preview_ready"
+    assert result["external_write_performed"] is False
+    assert result["sender_identity_verified"] is True
+    assert result["sender_chat_membership_verified"] is True
+    assert result["provider_preview_performed"] is True
+    assert result["provider_preview_verified"] is True
+    provider_calls = [
+        call
+        for call in runner.calls
+        if "+messages-reply" in call or "+messages-send" in call
+    ]
+    assert len(provider_calls) == 1
+    assert "--dry-run" in provider_calls[0]
+
+
+def test_reply_rejects_literal_backslash_n_before_provider(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner()
+
+    try:
+        reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_reaction_fixture",
+            text=r"status:\n- first\n- second",
+            execute=False,
+            runner=runner,
+        )
+    except ValueError as exc:
+        assert "literal backslash-n" in str(exc)
+    else:
+        raise AssertionError("literal backslash-n must fail before provider calls")
+    assert runner.calls == []
+
+
+def test_multiline_readback_must_preserve_line_structure(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(readback_text="line one line two")
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="line one\nline two",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "sent_unverified"
+    assert result["provider_preview_verified"] is True
+    assert result["reply_verified"] is False
+
+
 def test_verified_reply_accepts_provider_token_or_rendered_mention_name(
     tmp_path: Path,
 ) -> None:
@@ -502,8 +601,7 @@ def test_verified_reply_accepts_provider_token_or_rendered_mention_name(
             config_path=config,
             message_id="om_reaction_fixture",
             text=(
-                '<at open_id="ou_public_reviewer">Public Reviewer</at> '
-                "please review"
+                '<at open_id="ou_public_reviewer">Public Reviewer</at> please review'
             ),
             execute=True,
             runner=runner,
@@ -533,10 +631,7 @@ def test_rendered_mention_name_does_not_override_identity_mismatch(
         project=project,
         config_path=config,
         message_id="om_reaction_fixture",
-        text=(
-            '<at open_id="ou_public_reviewer">Public Reviewer</at> '
-            "please review"
-        ),
+        text=('<at open_id="ou_public_reviewer">Public Reviewer</at> please review'),
         execute=True,
         runner=runner,
     )

--- a/tests/extensions/test_lark_urgency_composition.py
+++ b/tests/extensions/test_lark_urgency_composition.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 from loopx.cli_commands import lark_inbox
 from loopx.configure_goal import configure_goal
 from loopx.control_plane.quota.goal_boundary import goal_boundary
+from loopx.extensions.lark.routed_inbox import (
+    project_routed_lark_event_inbox_urgency,
+)
 
 
 def _goal(project: Path) -> dict[str, object]:
@@ -36,7 +40,11 @@ def test_lark_urgency_projection_checks_activation_before_private_config(
         return {"schema_version": "lark_event_inbox_urgency_v0"}
 
     monkeypatch.setattr(lark_inbox, "_resolve_lark_activation", resolve)
-    monkeypatch.setattr(lark_inbox, "project_lark_event_inbox_urgency", project)
+    monkeypatch.setattr(
+        lark_inbox,
+        "project_routed_lark_event_inbox_urgency",
+        project,
+    )
 
     projector = lark_inbox.build_lark_operator_inbox_urgency_projector(
         runtime_root_arg=tmp_path / "runtime"
@@ -62,7 +70,11 @@ def test_disabled_lark_extension_cannot_schedule_from_private_config(
         return {}
 
     monkeypatch.setattr(lark_inbox, "_resolve_lark_activation", disabled)
-    monkeypatch.setattr(lark_inbox, "project_lark_event_inbox_urgency", project)
+    monkeypatch.setattr(
+        lark_inbox,
+        "project_routed_lark_event_inbox_urgency",
+        project,
+    )
 
     boundary = goal_boundary(
         _goal(tmp_path),
@@ -100,6 +112,18 @@ def test_agent_scoped_inbox_is_registered_and_projected_only_for_its_agent(
         ),
         encoding="utf-8",
     )
+    inbox_config = tmp_path / ".loopx" / "config" / "lark" / "agent-alpha.json"
+    inbox_config.parent.mkdir(parents=True)
+    inbox_config.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/lark/agent-alpha",
+            }
+        ),
+        encoding="utf-8",
+    )
 
     configured = configure_goal(
         registry_path=registry_path,
@@ -111,6 +135,12 @@ def test_agent_scoped_inbox_is_registered_and_projected_only_for_its_agent(
 
     assert configured["written"] is True
     goal = json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0]
+    binding = goal["control_plane"]["lark_event_inboxes"]["agent-alpha"]
+    assert binding["config_digest"].startswith("sha256:")
+    assert (
+        configured["feature_summary"]["lark_event_inbox"]["agent_scoped_bound_count"]
+        == 1
+    )
     assert (
         lark_inbox._goal_inbox_config(goal, agent_id="agent-alpha")
         == ".loopx/config/lark/agent-alpha.json"
@@ -118,5 +148,117 @@ def test_agent_scoped_inbox_is_registered_and_projected_only_for_its_agent(
     assert lark_inbox._goal_inbox_config(goal, agent_id="agent-beta") is None
     alpha = goal_boundary(goal, agent_id="agent-alpha", registry_path=registry_path)
     beta = goal_boundary(goal, agent_id="agent-beta", registry_path=registry_path)
-    assert "--agent-id agent-alpha" in alpha["capabilities"]["lark_event_inbox"]["drain_command"]
+    assert (
+        "--agent-id agent-alpha"
+        in alpha["capabilities"]["lark_event_inbox"]["drain_command"]
+    )
+    assert alpha["capabilities"]["lark_event_inbox"]["binding"] == {
+        "schema_version": "operator_inbox_binding_v0",
+        "status": "verified",
+        "digest_recorded": True,
+        "config_available": True,
+        "binding_verified": True,
+        "attention_required": False,
+        "private_config_returned": False,
+        "config_digest_returned": False,
+    }
     assert beta is None or "lark_event_inbox" not in beta.get("capabilities", {})
+
+    inbox_config.write_text(
+        inbox_config.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+    drifted = goal_boundary(
+        goal,
+        agent_id="agent-alpha",
+        registry_path=registry_path,
+    )["capabilities"]["lark_event_inbox"]
+    assert drifted["binding"]["status"] == "drifted"
+    assert drifted["binding"]["attention_required"] is True
+    assert "drain_command" not in drifted
+    assert drifted["urgency"]["blocker"] == ("agent_lark_inbox_config_binding_drift")
+
+
+def test_agent_scoped_binding_accepts_one_multi_chat_collector_authority(
+    tmp_path: Path,
+) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / ".gitignore").write_text(".loopx/\n", encoding="utf-8")
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir()
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "goal-shared-context",
+                        "repo": str(tmp_path),
+                        "coordination": {"registered_agents": ["agent-shared-context"]},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    config_dir = tmp_path / ".loopx" / "config" / "lark"
+    config_dir.mkdir(parents=True)
+    routes = []
+    for suffix in ("alpha", "beta"):
+        inbox_relative = f".loopx/config/lark/{suffix}.json"
+        (tmp_path / inbox_relative).write_text(
+            json.dumps(
+                {
+                    "schema_version": "lark_event_inbox_config_v0",
+                    "enabled": True,
+                    "inbox_dir": f".loopx/inbox/{suffix}",
+                    "capture_scope": "configured_chat_all",
+                }
+            ),
+            encoding="utf-8",
+        )
+        routes.append(
+            {
+                "route_key": f"requirements-{suffix}",
+                "chat_id": f"oc_public_fixture_{suffix}",
+                "event_inbox_config": inbox_relative,
+            }
+        )
+    collector_relative = ".loopx/config/lark/collector.json"
+    (tmp_path / collector_relative).write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_collector_config_v1",
+                "enabled": True,
+                "service_name": "loopx-shared-context",
+                "profile": "shared-context-bot",
+                "supervisor": "systemd",
+                "routes": routes,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    configured = configure_goal(
+        registry_path=registry_path,
+        goal_id="goal-shared-context",
+        lark_event_inbox_config=collector_relative,
+        lark_event_inbox_agent_id="agent-shared-context",
+        execute=True,
+    )
+    goal = json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0]
+    capability = goal_boundary(
+        goal,
+        agent_id="agent-shared-context",
+        registry_path=registry_path,
+        operator_inbox_urgency_projector=project_routed_lark_event_inbox_urgency,
+    )["capabilities"]["lark_event_inbox"]
+
+    assert configured["written"] is True
+    assert capability["binding"]["status"] == "verified"
+    assert capability["urgency"]["route_count"] == 2
+    assert capability["urgency"]["pending_count"] == 0
+    assert capability["urgency"]["local_private_content_returned"] is False
+    assert "--agent-id agent-shared-context" in capability["drain_command"]
+    serialized = json.dumps(capability)
+    assert "oc_public_fixture_alpha" not in serialized
+    assert "oc_public_fixture_beta" not in serialized


### PR DESCRIPTION
## Summary

- add profile-bound multi-route Lark inbox configuration with a stable Agent-visible `route_key`
- route ACK, processing, reply, and reaction operations to the exact inbox and fail closed on missing or mismatched bindings
- bind Goal quota projection to a content-free collector/inbox digest so private configuration drift pauses inbox work
- preserve legacy single-route behavior and harden reply preview/readback for Bot identity, membership, placement, and multiline formatting

## Validation

- `pytest -q tests/extensions` (`479 passed`)
- focused routing suite after the final rebase (`53 passed`)
- `python3 examples/lark-event-collector-lifecycle-smoke.py`
- `python3 examples/lark-event-inbox-smoke.py`
- risk-based pre-merge canary (`18/18` selected checks passed)
- changed-file and repository public-boundary scans

Closes #3598
