### PR TITLE
fix(loopx): route wish intents through capabilities

### DIFF
--- a/loopx/capabilities/auto_research/README.md
+++ b/loopx/capabilities/auto_research/README.md
@@ -94,6 +94,16 @@ The contract also includes the next one-command launch surface:
 loopx auto-research start "<open question>" --execute
 ```
 
+The generic `/loopx` entry also recognizes the capability-owned clause-leading aliases
+`许愿`, `我许愿`, `使用 Auto Research`, `启动 Auto Research`, `Use Auto
+Research`, `Start Auto Research`, and `auto-research`. `start-goal` resolves
+those aliases from the capability catalog before ordinary Goal selection and
+returns a typed `capability_intent_route` containing the exact command above.
+Generic research requests and requests that only discuss Auto Research remain
+on the normal Goal route. Explicit Goal controls such as `--goal-id`,
+`--agent-id`, `--new-peer`, `--fine-grained`, or `--capability-route` also
+retain precedence over the alias.
+
 Without `--execute`, `start` returns the same contract-anchored runner packet as
 a dry-run preview. With `--execute`, it creates an isolated research frontier
 and starts the visible Codex TUI lanes through the generic multi-agent kernel.

--- a/loopx/capabilities/auto_research/catalog_entry.py
+++ b/loopx/capabilities/auto_research/catalog_entry.py
@@ -29,6 +29,29 @@ AUTO_RESEARCH_CATALOG_ENTRY: dict[str, Any] = {
         "history, evidence, and continuation contracts."
     ),
     "entry_command": "loopx auto-research <open-question>",
+    "intent_routes": [
+        {
+            "route_id": "wish",
+            "match_kind": "normalized_clause_prefix",
+            "aliases": [
+                "我许愿",
+                "许愿",
+                "使用 Auto Research",
+                "启动 Auto Research",
+                "Use Auto Research",
+                "Start Auto Research",
+                "auto-research",
+            ],
+            "command_argv": [
+                "{cli_bin}",
+                "auto-research",
+                "start",
+                "{goal_text}",
+                "--execute",
+            ],
+            "effect_class": "local_multi_agent_launch",
+        }
+    ],
     "commands": [
         {
             "command": "loopx auto-research <open-question>",

--- a/loopx/capabilities/intent_route.py
+++ b/loopx/capabilities/intent_route.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import re
+import shlex
+import unicodedata
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+CAPABILITY_INTENT_ROUTE_SCHEMA_VERSION = "loopx_capability_intent_route_v0"
+CAPABILITY_INTENT_GOAL_TEXT_TOKEN = "{goal_text}"
+CAPABILITY_INTENT_ROUTE_FIELDS = frozenset(
+    {
+        "route_id",
+        "match_kind",
+        "aliases",
+        "command_argv",
+        "effect_class",
+    }
+)
+CAPABILITY_INTENT_MATCH_KINDS = frozenset(
+    {"normalized_prefix", "normalized_clause_prefix"}
+)
+
+
+def _required_string(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def normalize_capability_intent_routes(
+    value: object,
+    *,
+    context: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValueError(f"{context} must be a list")
+    normalized_routes: list[dict[str, Any]] = []
+    seen_route_ids: set[str] = set()
+    for index, route_value in enumerate(value):
+        route_context = f"{context}[{index}]"
+        if not isinstance(route_value, Mapping):
+            raise ValueError(f"{route_context} must be a mapping")
+        unknown_fields = set(route_value) - CAPABILITY_INTENT_ROUTE_FIELDS
+        if unknown_fields:
+            raise ValueError(
+                f"{route_context} has unsupported fields: "
+                + ", ".join(sorted(str(field) for field in unknown_fields))
+            )
+        route_id = _required_string(
+            route_value.get("route_id"),
+            field=f"{route_context} route_id",
+        )
+        if route_id in seen_route_ids:
+            raise ValueError(f"{context} has duplicate route_id `{route_id}`")
+        seen_route_ids.add(route_id)
+        match_kind = _required_string(
+            route_value.get("match_kind"),
+            field=f"{route_context} match_kind",
+        )
+        if match_kind not in CAPABILITY_INTENT_MATCH_KINDS:
+            raise ValueError(
+                f"{route_context} has unsupported match_kind `{match_kind}`"
+            )
+        aliases = route_value.get("aliases")
+        if not isinstance(aliases, list) or not aliases:
+            raise ValueError(f"{route_context} requires non-empty aliases")
+        normalized_aliases = [
+            _required_string(alias, field=f"{route_context} alias")
+            for alias in aliases
+        ]
+        if len(set(normalized_aliases)) != len(normalized_aliases):
+            raise ValueError(f"{route_context} has duplicate aliases")
+        command_argv = route_value.get("command_argv")
+        if not isinstance(command_argv, list) or not command_argv:
+            raise ValueError(f"{route_context} requires non-empty command_argv")
+        normalized_argv = [
+            _required_string(argument, field=f"{route_context} argument")
+            for argument in command_argv
+        ]
+        if normalized_argv[0] != "{cli_bin}":
+            raise ValueError(
+                f"{route_context} command_argv must begin with `{{cli_bin}}`"
+            )
+        if normalized_argv.count(CAPABILITY_INTENT_GOAL_TEXT_TOKEN) != 1:
+            raise ValueError(
+                f"{route_context} command_argv must contain exactly one "
+                f"`{CAPABILITY_INTENT_GOAL_TEXT_TOKEN}`"
+            )
+        normalized_routes.append(
+            {
+                "route_id": route_id,
+                "match_kind": match_kind,
+                "aliases": normalized_aliases,
+                "command_argv": normalized_argv,
+                "effect_class": _required_string(
+                    route_value.get("effect_class") or "capability_entry",
+                    field=f"{route_context} effect_class",
+                ),
+            }
+        )
+    return normalized_routes
+
+
+def _normalized_text(value: object) -> str:
+    normalized = unicodedata.normalize("NFKC", str(value or "")).casefold()
+    return "\n".join(" ".join(line.split()) for line in normalized.splitlines()).strip()
+
+
+def _matches(text: str, *, alias: str, match_kind: str) -> bool:
+    if match_kind == "normalized_prefix":
+        return text.startswith(alias)
+    return any(
+        clause.strip().startswith(alias)
+        for clause in re.split(r"[。！？!?；;，,\n]+", text)
+    )
+
+
+def resolve_capability_intent_route_from_records(
+    goal_text: str,
+    *,
+    records: Iterable[Mapping[str, Any]],
+    cli_bin: str,
+    runtime_root: str | None = None,
+) -> dict[str, Any] | None:
+    original_text = str(goal_text or "").strip()
+    normalized_text = _normalized_text(original_text)
+    if not normalized_text:
+        return None
+    normalized_runtime_root = (
+        _required_string(runtime_root, field="runtime_root")
+        if runtime_root is not None
+        else None
+    )
+
+    matches: list[dict[str, Any]] = []
+    for record in records:
+        provider_state = record.get("provider_state")
+        if not isinstance(provider_state, Mapping) or provider_state.get("ready") is not True:
+            continue
+        for route in record.get("intent_routes") or []:
+            for raw_alias in route["aliases"]:
+                alias = _normalized_text(raw_alias)
+                if _matches(
+                    normalized_text,
+                    alias=alias,
+                    match_kind=route["match_kind"],
+                ):
+                    matches.append(
+                        {
+                            "capability_id": record["id"],
+                            "route_id": route["route_id"],
+                            "matched_alias": raw_alias,
+                            "normalized_alias": alias,
+                            "match_kind": route["match_kind"],
+                            "command_argv": route["command_argv"],
+                            "effect_class": route["effect_class"],
+                        }
+                    )
+    if not matches:
+        return None
+    capability_ids = sorted({str(match["capability_id"]) for match in matches})
+    if len(capability_ids) != 1:
+        raise ValueError(
+            "ambiguous capability intent route; matched capabilities: "
+            + ", ".join(capability_ids)
+        )
+    selected = max(matches, key=lambda match: len(str(match["normalized_alias"])))
+    command_argv: list[str] = []
+    for argument in selected["command_argv"]:
+        if argument == "{cli_bin}":
+            command_argv.append(str(cli_bin))
+            if normalized_runtime_root is not None:
+                command_argv.extend(["--runtime-root", normalized_runtime_root])
+        elif argument == CAPABILITY_INTENT_GOAL_TEXT_TOKEN:
+            command_argv.append(original_text)
+        else:
+            command_argv.append(str(argument))
+    return {
+        "schema_version": CAPABILITY_INTENT_ROUTE_SCHEMA_VERSION,
+        "capability_id": selected["capability_id"],
+        "route_id": selected["route_id"],
+        "selection_source": "capability_catalog_intent_alias",
+        "selection_reason_code": "explicit_capability_alias",
+        "match_kind": selected["match_kind"],
+        "matched_alias": selected["matched_alias"],
+        "entry_command": shlex.join(command_argv),
+        "effect_class": selected["effect_class"],
+        "bypasses_generic_goal_start": True,
+    }

--- a/loopx/capabilities/intent_route.py
+++ b/loopx/capabilities/intent_route.py
@@ -38,6 +38,7 @@ def normalize_capability_intent_routes(
         raise ValueError(f"{context} must be a list")
     normalized_routes: list[dict[str, Any]] = []
     seen_route_ids: set[str] = set()
+    seen_aliases: dict[str, str] = {}
     for index, route_value in enumerate(value):
         route_context = f"{context}[{index}]"
         if not isinstance(route_value, Mapping):
@@ -72,6 +73,15 @@ def normalize_capability_intent_routes(
         ]
         if len(set(normalized_aliases)) != len(normalized_aliases):
             raise ValueError(f"{route_context} has duplicate aliases")
+        for alias in normalized_aliases:
+            normalized_alias = _normalized_text(alias)
+            previous_route_id = seen_aliases.get(normalized_alias)
+            if previous_route_id is not None:
+                raise ValueError(
+                    f"{context} has duplicate normalized alias `{normalized_alias}` "
+                    f"across routes `{previous_route_id}` and `{route_id}`"
+                )
+            seen_aliases[normalized_alias] = route_id
         command_argv = route_value.get("command_argv")
         if not isinstance(command_argv, list) or not command_argv:
             raise ValueError(f"{route_context} requires non-empty command_argv")

--- a/loopx/capabilities/registry.py
+++ b/loopx/capabilities/registry.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Any
 
 from .documentation import normalize_documentation_contract
+from .intent_route import normalize_capability_intent_routes
 
 
 CAPABILITY_ORIGINS = frozenset({"builtin", "extension"})
@@ -111,6 +112,15 @@ class CapabilityRegistry:
         normalized["origin"] = origin
         normalized["visibility"] = visibility
         normalized["provider_id"] = provider_id
+        if record.get("intent_routes") is not None:
+            if origin != "builtin":
+                raise ValueError(
+                    f"{context} intent_routes are reserved for built-in capabilities"
+                )
+            normalized["intent_routes"] = normalize_capability_intent_routes(
+                record.get("intent_routes"),
+                context=f"{context} intent_routes",
+            )
         documentation_value = record.get("documentation")
         if documentation_value is None:
             if origin == "builtin" and visibility == "public":

--- a/loopx/cli_commands/start_goal.py
+++ b/loopx/cli_commands/start_goal.py
@@ -12,10 +12,13 @@ from ..bootstrap_command_pack import (
     build_start_goal_host_surface_selection_packet,
     render_start_goal_guided_markdown,
 )
+from ..capabilities.catalog import build_capability_registry
+from ..capabilities.intent_route import resolve_capability_intent_route_from_records
 from ..control_plane.effect_runtime import (
     EffectRuntimeStartupError,
     MINIMUM_NODE_VERSION_TEXT,
 )
+from ..paths import resolve_runtime_root
 from ._host_thread import current_host_thread_id
 
 PrintPayload = Callable[
@@ -105,13 +108,26 @@ def _render_start_goal_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _render_capability_intent_route(payload: dict[str, object]) -> str:
+    route = payload["capability_intent_route"]
+    assert isinstance(route, dict)
+    return (
+        "# LoopX Capability Intent Route\n\n"
+        f"- capability: `{route.get('capability_id')}`\n"
+        f"- route: `{route.get('route_id')}`\n"
+        f"- source: `{route.get('selection_source')}`\n"
+        f"- next: `{route.get('entry_command')}`\n"
+    )
+
+
 def add_capability_route_argument(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--capability-route",
         choices=START_GOAL_CAPABILITY_ROUTES,
         help=(
-            "Explicit product capability route for this goal start. Goal text never "
-            "selects a capability route."
+            "Explicit product capability route override for this goal start. Generic "
+            "goal wording never selects a route; a registered capability may declare "
+            "an exact invocation alias handled before generic Goal routing."
         ),
     )
 
@@ -284,6 +300,34 @@ def handle_start_goal_command(
         return 2
     try:
         goal_text, capability_route, fine_grained = _resolve_start_goal_input(args)
+        intent_route_runtime_root = None
+        if runtime_root_arg:
+            registry_path = (
+                Path(args.project).expanduser().resolve() / ".loopx" / "registry.json"
+            )
+            intent_route_runtime_root = str(
+                resolve_runtime_root(
+                    {},
+                    override=runtime_root_arg,
+                    registry_path=registry_path,
+                )
+            )
+        intent_route = (
+            resolve_capability_intent_route_from_records(
+                goal_text,
+                records=build_capability_registry().records(),
+                cli_bin=args.cli_bin,
+                runtime_root=intent_route_runtime_root,
+            )
+            if (
+                capability_route is None
+                and args.goal_id is None
+                and args.agent_id is None
+                and not bool(getattr(args, "new_peer", False))
+                and not fine_grained
+            )
+            else None
+        )
     except ValueError as exc:
         payload = {
             "ok": False,
@@ -296,6 +340,27 @@ def handle_start_goal_command(
         }
         print_payload(payload, args.format, _render_start_goal_markdown)
         return 2
+    if intent_route is not None:
+        payload = {
+            "ok": True,
+            "schema_version": "loopx_start_goal_capability_intent_route_v0",
+            "read_only": True,
+            "goal_text": goal_text,
+            "capability_intent_route": intent_route,
+            "recommended_next_step": {
+                "kind": "invoke_capability_entry",
+                "requires_user_confirmation": False,
+                "command": intent_route["entry_command"],
+            },
+            "safety_contract": {
+                "writes_registry": False,
+                "writes_state_file": False,
+                "creates_heartbeat": False,
+                "spends_quota": False,
+            },
+        }
+        print_payload(payload, args.format, _render_capability_intent_route)
+        return 0
     if not args.host_surface:
         try:
             payload = build_start_goal_host_surface_selection_packet(

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -83,8 +83,11 @@ def _loopx_start_goal_arguments_instruction(
         "unchanged as one value to "
         f'`{cli_bin} start-goal --guided --project . --slash-command-arguments='
         f'"<complete visible $ARGUMENTS>" --host-surface {selected_host}`. '
-        "The CLI, not the model, owns parsing supported leading switches and "
-        "preserving the remaining goal text. Never split or recompose the "
+        "The CLI, not the model, owns parsing supported leading switches, "
+        "resolving capability-owned intent aliases, and preserving the remaining "
+        "goal text. If the result contains a typed "
+        "`capability_intent_route`, execute its exact `entry_command` and do not "
+        "continue the generic Goal transaction. Never split or recompose the "
         "arguments, and never infer a route from issue/PR wording or URLs."
     )
     if host_surface is None:

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -11,6 +11,8 @@ from loopx.capabilities.catalog import (
     build_capability_detail_packet,
     build_capability_registry,
 )
+from loopx.capabilities.intent_route import resolve_capability_intent_route_from_records
+from loopx.capabilities.registry import CapabilityRegistry
 from loopx.capabilities.context_providers import (
     OpenVikingContextProvider,
     build_context_provider,
@@ -432,6 +434,196 @@ def test_active_explore_and_auto_research_records_point_to_real_smokes() -> None
             prefix = "python3 "
             assert command.startswith(prefix)
             assert (repository / command.removeprefix(prefix)).is_file()
+
+
+@pytest.mark.parametrize(
+    "goal_text",
+    [
+        "我许愿帮我在美股发现最近的机会",
+        "许愿在当前的美股市场发现机会",
+        "使用 Auto Research，许愿在当前的美股市场发现机会",
+        (
+            "https://github.com/huangruiteng/loopx/pull/3593 这个PR合入了。"
+            "那你用这个PR新增的能力，我许愿在美股给我挣钱！今天就要"
+        ),
+        (
+            "https://github.com/huangruiteng/loopx/pull/3593 这个PR合入了\n"
+            "我许愿在美股给我挣钱"
+        ),
+        "Start Auto Research to compare two hypotheses",
+    ],
+)
+def test_auto_research_catalog_routes_explicit_wish_intent(goal_text: str) -> None:
+    capability = build_capability_detail_packet("auto-research")["capability"]
+    route = resolve_capability_intent_route_from_records(
+        goal_text,
+        records=build_capability_registry().records(),
+        cli_bin="loopx",
+    )
+
+    assert capability["intent_routes"][0]["route_id"] == "wish"
+    assert "许愿" in capability["intent_routes"][0]["aliases"]
+    assert route is not None
+    assert route["schema_version"] == "loopx_capability_intent_route_v0"
+    assert route["capability_id"] == "auto-research"
+    assert route["route_id"] == "wish"
+    assert route["selection_source"] == "capability_catalog_intent_alias"
+    assert route["selection_reason_code"] == "explicit_capability_alias"
+    assert route["entry_command"].startswith("loopx auto-research start ")
+    assert route["entry_command"].endswith(" --execute")
+
+
+def test_capability_intent_route_preserves_typed_runtime_root() -> None:
+    route = resolve_capability_intent_route_from_records(
+        "我许愿比较两个假设",
+        records=build_capability_registry().records(),
+        cli_bin="loopx",
+        runtime_root="/tmp/runtime with spaces",
+    )
+
+    assert route is not None
+    assert route["entry_command"] == (
+        "loopx --runtime-root '/tmp/runtime with spaces' "
+        "auto-research start '我许愿比较两个假设' --execute"
+    )
+
+
+@pytest.mark.parametrize(
+    "goal_text",
+    [
+        "研究当前的美股市场",
+        "评估是否应该使用 Auto Research",
+        "总结 wish-to-artifact PR 的实现",
+        "修复普通 Goal 的路由",
+    ],
+)
+def test_capability_intent_route_does_not_capture_generic_goal_text(
+    goal_text: str,
+) -> None:
+    assert (
+        resolve_capability_intent_route_from_records(
+            goal_text,
+            records=build_capability_registry().records(),
+            cli_bin="loopx",
+        )
+        is None
+    )
+
+
+def test_capability_intent_route_rejects_ambiguous_capabilities() -> None:
+    route = {
+        "route_id": "wish",
+        "match_kind": "normalized_prefix",
+        "aliases": ["wish"],
+        "command_argv": ["{cli_bin}", "example", "{goal_text}"],
+        "effect_class": "local_execution",
+    }
+    records = [
+        {
+            "id": capability_id,
+            "provider_state": {"ready": True},
+            "intent_routes": [route],
+        }
+        for capability_id in ("first", "second")
+    ]
+
+    with pytest.raises(ValueError, match="ambiguous capability intent route"):
+        resolve_capability_intent_route_from_records(
+            "wish for something",
+            records=records,
+            cli_bin="loopx",
+        )
+
+
+@pytest.mark.parametrize(
+    ("intent_routes", "expected_error"),
+    [
+        ("wish", "intent_routes must be a list"),
+        (
+            [
+                {
+                    "route_id": "wish",
+                    "match_kind": "contains",
+                    "aliases": ["wish"],
+                    "command_argv": ["{cli_bin}", "{goal_text}"],
+                }
+            ],
+            "unsupported match_kind",
+        ),
+        (
+            [
+                {
+                    "route_id": "wish",
+                    "match_kind": "normalized_prefix",
+                    "aliases": ["wish"],
+                    "command_argv": ["{cli_bin}", "auto-research", "start"],
+                }
+            ],
+            "must contain exactly one `{goal_text}`",
+        ),
+        (
+            [
+                {
+                    "route_id": "wish",
+                    "match_kind": "normalized_prefix",
+                    "aliases": ["wish"],
+                    "command_argv": ["external-command", "{goal_text}"],
+                }
+            ],
+            "must begin with `{cli_bin}`",
+        ),
+    ],
+)
+def test_capability_registry_rejects_invalid_intent_routes(
+    intent_routes: object,
+    expected_error: str,
+) -> None:
+    registry = CapabilityRegistry()
+    registry.register_provider(
+        {
+            "id": "test-provider",
+            "origin": "builtin",
+            "declared": True,
+            "installed": True,
+            "enabled": True,
+            "ready": True,
+        }
+    )
+    with pytest.raises(ValueError, match=expected_error):
+        registry.register_capability(
+            {
+                "id": "test-capability",
+                "origin": "builtin",
+                "visibility": "internal",
+                "provider_id": "test-provider",
+                "title": "Test capability",
+                "status": "test",
+                "user_value": "Validate intent routes.",
+                "next_real_step": "Reject malformed configuration.",
+                "intent_routes": intent_routes,
+            }
+        )
+
+
+def test_extension_capability_cannot_claim_a_loopx_intent_alias(
+    tmp_path: Path,
+) -> None:
+    manifest = _write_manifest(tmp_path / "extension.toml")
+    manifest.write_text(
+        manifest.read_text(encoding="utf-8")
+        + """
+intent_routes = [
+  { route_id = "wish", match_kind = "normalized_prefix", aliases = ["wish"], command_argv = ["{cli_bin}", "{goal_text}"] }
+]
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="intent_routes are reserved for built-in capabilities",
+    ):
+        build_capability_catalog_packet([manifest])
 
 
 def test_issue_fix_capability_exposes_discovered_issue_promotion() -> None:

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -11,7 +11,10 @@ from loopx.capabilities.catalog import (
     build_capability_detail_packet,
     build_capability_registry,
 )
-from loopx.capabilities.intent_route import resolve_capability_intent_route_from_records
+from loopx.capabilities.intent_route import (
+    normalize_capability_intent_routes,
+    resolve_capability_intent_route_from_records,
+)
 from loopx.capabilities.registry import CapabilityRegistry
 from loopx.capabilities.context_providers import (
     OpenVikingContextProvider,
@@ -533,6 +536,89 @@ def test_capability_intent_route_rejects_ambiguous_capabilities() -> None:
             records=records,
             cli_bin="loopx",
         )
+
+
+def test_capability_registry_rejects_same_capability_route_alias_ambiguity() -> None:
+    registry = CapabilityRegistry()
+    registry.register_provider(
+        {
+            "id": "test-provider",
+            "origin": "builtin",
+            "declared": True,
+            "installed": True,
+            "enabled": True,
+            "ready": True,
+        }
+    )
+    with pytest.raises(ValueError, match="duplicate normalized alias `go`"):
+        registry.register_capability(
+            {
+                "id": "test-capability",
+                "origin": "builtin",
+                "visibility": "internal",
+                "provider_id": "test-provider",
+                "title": "Test capability",
+                "status": "test",
+                "user_value": "Reject ambiguous routes.",
+                "next_real_step": "Keep route aliases unique.",
+                "intent_routes": [
+                    {
+                        "route_id": "first",
+                        "match_kind": "normalized_prefix",
+                        "aliases": ["ＧＯ"],
+                        "command_argv": [
+                            "{cli_bin}",
+                            "first",
+                            "{goal_text}",
+                        ],
+                    },
+                    {
+                        "route_id": "second",
+                        "match_kind": "normalized_prefix",
+                        "aliases": ["go"],
+                        "command_argv": [
+                            "{cli_bin}",
+                            "second",
+                            "{goal_text}",
+                        ],
+                    },
+                ],
+            }
+        )
+
+
+def test_capability_intent_route_prefers_longest_distinct_alias() -> None:
+    record = {
+        "id": "test-capability",
+        "provider_state": {"ready": True},
+        "intent_routes": normalize_capability_intent_routes(
+            [
+                {
+                    "route_id": "short",
+                    "match_kind": "normalized_prefix",
+                    "aliases": ["go"],
+                    "command_argv": ["{cli_bin}", "short", "{goal_text}"],
+                },
+                {
+                    "route_id": "long",
+                    "match_kind": "normalized_prefix",
+                    "aliases": ["go deep"],
+                    "command_argv": ["{cli_bin}", "long", "{goal_text}"],
+                },
+            ],
+            context="test intent_routes",
+        ),
+    }
+
+    route = resolve_capability_intent_route_from_records(
+        "go deep into the evidence",
+        records=[record],
+        cli_bin="loopx",
+    )
+
+    assert route is not None
+    assert route["route_id"] == "long"
+    assert route["entry_command"] == "loopx long 'go deep into the evidence'"
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -609,7 +609,7 @@ def test_candidate_preflight_contract_describes_receipt_shapes() -> None:
         )
 
 
-def test_goal_text_never_selects_capability_route_without_switch(
+def test_generic_goal_text_never_selects_explicit_capability_route_without_switch(
     tmp_path: Path,
 ) -> None:
     project = _write_connected_project(tmp_path)
@@ -661,6 +661,211 @@ def test_goal_text_never_selects_capability_route_without_switch(
     route = explicit_route["guided_transaction"]["selected_capability_route"]
     assert route["selection_source"] == "explicit_capability_route"
     assert route["selection_reason_code"] == "capability_route_enabled"
+
+
+def test_wish_intent_routes_to_auto_research_before_goal_selection(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--host-surface",
+                "ark-managed-agent",
+                "--slash-command-arguments",
+                "我许愿帮我在美股发现最近的机会",
+            ]
+        )
+    payload = json.loads(output.getvalue())
+
+    assert exit_code == 0
+    route = payload["capability_intent_route"]
+    assert route["capability_id"] == "auto-research"
+    assert route["selection_source"] == "capability_catalog_intent_alias"
+    assert payload["recommended_next_step"] == {
+        "kind": "invoke_capability_entry",
+        "requires_user_confirmation": False,
+        "command": (
+            "loopx auto-research start "
+            "'我许愿帮我在美股发现最近的机会' --execute"
+        ),
+    }
+    assert "project_connection" not in payload
+    assert "goal_selection_gate" not in payload
+
+
+def test_wish_intent_routes_before_host_surface_selection(tmp_path: Path) -> None:
+    project = _write_connected_project(tmp_path)
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--slash-command-arguments",
+                "许愿在当前的美股市场发现机会",
+            ]
+        )
+    payload = json.loads(output.getvalue())
+
+    assert exit_code == 0
+    assert payload["recommended_next_step"]["kind"] == "invoke_capability_entry"
+    assert payload["capability_intent_route"]["capability_id"] == "auto-research"
+    assert "host_surface_selection_gate" not in payload
+
+
+def test_wish_intent_preserves_explicit_runtime_root(tmp_path: Path) -> None:
+    project = _write_connected_project(tmp_path)
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--runtime-root",
+                "explicit runtime",
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--slash-command-arguments",
+                "我许愿比较两个假设",
+            ]
+        )
+    payload = json.loads(output.getvalue())
+    entry_argv = shlex.split(payload["capability_intent_route"]["entry_command"])
+
+    assert exit_code == 0
+    assert entry_argv[:3] == [
+        "loopx",
+        "--runtime-root",
+        str(project / "explicit runtime"),
+    ]
+    assert entry_argv[3:] == [
+        "auto-research",
+        "start",
+        "我许愿比较两个假设",
+        "--execute",
+    ]
+
+
+def test_wish_clause_after_pr_context_routes_to_auto_research(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--host-surface",
+                "ark-managed-agent",
+                "--slash-command-arguments",
+                (
+                    "https://github.com/huangruiteng/loopx/pull/3593 这个PR合入了。"
+                    "那你用这个PR新增的能力，我许愿在美股给我挣钱！今天就要"
+                ),
+            ]
+        )
+    payload = json.loads(output.getvalue())
+
+    assert exit_code == 0
+    assert payload["capability_intent_route"]["capability_id"] == "auto-research"
+    assert payload["capability_intent_route"]["matched_alias"] == "我许愿"
+
+
+def test_wish_line_after_pr_context_routes_to_auto_research(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    output = io.StringIO()
+    with contextlib.redirect_stdout(output):
+        exit_code = cli_main(
+            [
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--host-surface",
+                "ark-managed-agent",
+                "--slash-command-arguments",
+                (
+                    "https://github.com/huangruiteng/loopx/pull/3593 这个PR合入了\n"
+                    "我许愿在美股给我挣钱"
+                ),
+            ]
+        )
+    payload = json.loads(output.getvalue())
+
+    assert exit_code == 0
+    assert payload["capability_intent_route"]["capability_id"] == "auto-research"
+    assert payload["capability_intent_route"]["matched_alias"] == "我许愿"
+
+
+def test_auto_research_discussion_remains_on_normal_goal_route(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    exit_code, payload = _invoke_ark_start_goal_cli(
+        project,
+        "--slash-command-arguments",
+        "评估是否应该使用 Auto Research",
+    )
+
+    assert exit_code == 0
+    assert "capability_intent_route" not in payload
+    assert payload["recommended_next_step"]["kind"] == "goal_plan_write_and_activate"
+
+
+def test_explicit_capability_switch_overrides_wish_intent_alias(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    exit_code, payload = _invoke_ark_start_goal_cli(
+        project,
+        "--capability-route",
+        "issue-fix",
+        "--goal-text",
+        "许愿修复指定 issue",
+    )
+
+    assert exit_code == 0
+    assert "capability_intent_route" not in payload
+    route = payload["guided_transaction"]["selected_capability_route"]
+    assert route["capability_id"] == "issue-fix"
+    assert route["selection_source"] == "explicit_capability_route"
+
+
+def test_explicit_goal_id_overrides_wish_intent_alias(tmp_path: Path) -> None:
+    project = _write_connected_project(tmp_path)
+    exit_code, payload = _invoke_ark_start_goal_cli(
+        project,
+        "--goal-text",
+        "我许愿继续现有研究目标",
+    )
+
+    assert exit_code == 0
+    assert "capability_intent_route" not in payload
+    assert payload["goal_id"] == GOAL_ID
+    assert payload["recommended_next_step"]["kind"] == "goal_plan_write_and_activate"
 
 
 def test_explicit_capability_route_survives_compact_detail_readback(

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -50,6 +50,10 @@ def test_host_materialization_installs_generated_loopx_entry_skill(
     assert "The CLI, not the model, owns parsing" in skill_text
     assert "Never split or recompose" in skill_text
     assert "never infer a route from issue/PR wording or URLs" in skill_text
+    assert "If the result contains a typed `capability_intent_route`" in skill_text
+    assert "execute its exact `entry_command`" in skill_text
+    assert "使用 Auto Research" not in skill_text
+    assert "许愿" not in skill_text
     assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
     assert "surface the exact pasteable gate" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
@@ -79,6 +83,9 @@ def test_host_materialization_can_bind_exact_managed_agent_surface(
     assert "--host-surface <exact-current-host>" not in skill_text
     assert "--slash-command-arguments" in skill_text
     assert "The CLI, not the model, owns parsing" in skill_text
+    assert "If the result contains a typed `capability_intent_route`" in skill_text
+    assert "使用 Auto Research" not in skill_text
+    assert "许愿" not in skill_text
     assert "`ordered_steps` and `goal_start_contract` as authoritative" in skill_text
     assert "never infer a route" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text


### PR DESCRIPTION
## Summary

- let built-in capabilities declare validated natural-language invocation aliases in the capability catalog
- map the Auto Research wish vocabulary, including `许愿`, to the canonical `loopx auto-research start ... --execute` multi-agent entrypoint
- resolve aliases at the `start-goal` CLI boundary before ordinary Goal selection, while leaving the ordinary Goal packet builder unchanged
- keep the generated `$loopx` skill generic: it only follows typed `capability_intent_route.entry_command` output and contains no Auto Research- or wish-specific vocabulary

Supersedes closed draft #3604.

## Root cause

The managed `$loopx` facade always entered generic `start-goal` planning. The Auto Research capability already owned a one-command multi-agent launcher, but there was no typed bridge from the user-facing wish vocabulary to that capability entrypoint. Agents could therefore create a normal single-agent Todo and manually assemble evidence/receipt commands without launching the Auto Research roles.

## Safety and compatibility

- only built-in capabilities may register global intent aliases; extensions cannot hijack `$loopx` routing
- matching is deterministic and limited to normalized clause prefixes
- explicit Goal controls (`--goal-id`, `--agent-id`, `--new-peer`, `--fine-grained`, or `--capability-route`) retain precedence over aliases
- generic research requests and requests that merely discuss Auto Research remain on the existing Goal path
- command argv is schema-validated and must begin with `{cli_bin}` and contain exactly one `{goal_text}` token

## Validation

- related pytest suites: 116 passed
- Ruff: passed
- Auto Research user-contract smoke: passed
- bootstrap command-pack smoke: passed
- install-local smoke: passed
- control-plane maintainability ratchet: passed
- CLI output budget differential smoke: passed with permission to create its temporary Git worktree
- `loopx check`: 0 errors; two unrelated existing goal-state warnings
- premerge risk-profile checks all passed; aggregate remained red only because install-local exceeded the wrapper timeout and the CLI output differential could not create a parent-repo worktree under the sandbox before both checks passed standalone

## Future-facing pass

The reusable route contract lives in `loopx/capabilities/intent_route.py`; Auto Research owns only its aliases and argv template. No product-specific phrase or command is embedded in the shared `$loopx` skill or ordinary Goal packet builder.