### PR TITLE
fix(smokes): repair full public suite drift

### DIFF
--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -56,7 +56,10 @@ next_real_step = "Keep explicit enablement bounded."
     )
 
     baseline = run_cli(runtime_root, "capability", "list")
-    assert [item["id"] for item in baseline["capabilities"]] == [
+    builtin_capabilities = [
+        item for item in baseline["capabilities"] if item["origin"] == "builtin"
+    ]
+    assert [item["id"] for item in builtin_capabilities] == [
         "benchmark-toolkit",
         "integration-branch-reconcile",
         "repository-change-window",
@@ -74,10 +77,11 @@ next_real_step = "Keep explicit enablement bounded."
         "value-connectors",
         "explore",
         "auto-research",
+        "deep-research",
         "public-safe-outbound",
         "connector-registry",
     ]
-    assert all(item["provider_id"] == "loopx-core" for item in baseline["capabilities"])
+    assert all(item["provider_id"] == "loopx-core" for item in builtin_capabilities)
     value_summary = next(
         item for item in baseline["capabilities"] if item["id"] == "value-connectors"
     )

--- a/examples/control_plane/stale-primary-successor-model-behavior-qualification.py
+++ b/examples/control_plane/stale-primary-successor-model-behavior-qualification.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Qualify that the live weak/default model leaves a stale open primary."""
+"""Qualify that the live weak/default model leaves a stale open primary.
+
+This is a credentialed live qualification, not a public smoke-suite check.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +11,10 @@ import sys
 import tempfile
 from pathlib import Path
 
-from loopx.control_plane.testing.selected_todo_tool_behavior import (
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.testing.selected_todo_tool_behavior import (  # noqa: E402
     SELECTED_TODO_TOOL_FIXTURE_TODO_ID,
     DoubaoSelectedTodoToolBehaviorActor,
 )
@@ -36,7 +42,7 @@ def main() -> int:
         for receipt in receipts
     )
     summary = {
-        "schema_version": "stale_primary_successor_model_behavior_smoke_v0",
+        "schema_version": "stale_primary_successor_model_behavior_qualification_v0",
         "qualification_passed": passed,
         "attempts_required": ATTEMPTS_REQUIRED,
         "attempts_completed": len(receipts),

--- a/examples/control_plane/work-lane-contract-smoke.py
+++ b/examples/control_plane/work-lane-contract-smoke.py
@@ -2190,9 +2190,17 @@ def assert_active_next_action_todo_survives_compact_candidate_limits() -> None:
         "agent_todo_summary.active_next_action_executable_items"
     ), next_action
     assert guard["recommended_action"] == target_action, guard
-    primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
-    assert primary_action.startswith("todo_skillsbench_lifecycle:"), guard
-    assert "Debug SkillsBench product-mode lifecycle" in primary_action, guard
+    selected_todo = guard["selected_todo"]
+    assert selected_todo["todo_id"] == "todo_skillsbench_lifecycle", guard
+    portfolio = guard["action_portfolio"]
+    assert portfolio["primary"]["todo_id"] == "todo_skillsbench_lifecycle", guard
+    assert portfolio["suggested_actions"][0]["todo_id"] == (
+        "todo_skillsbench_lifecycle"
+    ), portfolio
+    agent_channel = guard["interaction_contract"]["agent_channel"]
+    assert agent_channel["selection_required"] is True, agent_channel
+    assert agent_channel["delivery_allowed"] is False, agent_channel
+    assert agent_channel["action_portfolio_ref"] == "$.action_portfolio", agent_channel
     markdown = render_quota_should_run_markdown(guard)
     assert "agent_lane_next_action: todo_id=todo_skillsbench_lifecycle" in markdown, markdown
 

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -237,7 +237,17 @@ def main() -> int:
         assert codex_only["summary"]["codex_prompt_dir"] is None, codex_only
         assert codex_only["summary"]["codex_skill_dir"] == str(root / "codex-only" / "skills"), codex_only
         assert codex_only["summary"]["claude_skill_dir"] is None, codex_only
-        assert codex_only["summary"]["status_counts"]["unsupported_host_surface"] == 10, codex_only
+        codex_skill_commands = {
+            item["command"]
+            for item in codex_only["installed"]
+            if item["mechanism"] == "codex_explicit_skills"
+        }
+        unsupported_native_commands = {
+            item["command"]
+            for item in codex_only["installed"]
+            if item["status"] == "unsupported_host_surface"
+        }
+        assert unsupported_native_commands == codex_skill_commands, codex_only
 
         legacy_codex_home = root / "legacy-codex"
         legacy_claude_home = root / "legacy-claude"

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
 from pathlib import Path
 
 from ..capabilities.explore.composition_frontier import (
@@ -43,17 +42,9 @@ from ..control_plane.quota.settlement_cli import (
     render_existing_heartbeat_receipt_payload,
 )
 from ..control_plane.quota.turn_envelope import build_turn_envelope
-from ..control_plane.runtime.status_projection_cache import (
-    load_status_projection_cache,
-    resolve_status_projection_cache_runtime_root,
-    write_status_projection_cache,
-)
 from ..control_plane.scheduler.execution_context import (
     GUIDED_START_TURN_RUNTIME_PROFILES,
     SchedulerExecutionContextResolution,
-    SchedulerRuntimeProfile,
-    scheduler_execution_context_for_runtime_profile,
-    scheduler_runtime_profile_for_execution_context,
 )
 from ..control_plane.todos.contract import normalize_todo_id
 from ..file_lock import lock_timeout_error_fields
@@ -78,20 +69,13 @@ from ..quota import (
     spend_quota_slot,
     void_quota_slot,
 )
-from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
-from ..turn_identity import mint_turn_instance_id, normalize_turn_instance_id
+from ..status import collect_status
 from ..upgrade import resolve_codex_app_automation_rrule
-from .lark_inbox import build_lark_operator_inbox_urgency_projector
+from .quota_context import QuotaCommandContext, prepare_quota_command_context
 from .quota_host_poll import attach_host_poll_receipt
 from .quota_monitor_poll import record_quota_monitor_poll_for_cli
 from .quota_registration import (
     register_quota_command as register_quota_command,  # noqa: PLC0414
-)
-from .quota_request import (
-    QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
-    QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
-    quota_detail_sections_from_args,
-    validate_quota_command_request,
 )
 
 PrintPayload = Callable[
@@ -108,229 +92,12 @@ QUOTA_EVENT_KINDS = {
     "spend-slot": "quota_spend",
     "void-slot": "quota_void",
 }
-QUOTA_SCHEDULER_COMMANDS = frozenset(
-    {
-        "should-run",
-        "monitor-poll",
-        "scheduler-ack",
-        "scheduler-ack-current",
-        "scheduler-fail-current",
-        "spend-slot",
-    }
-)
-
-
-@dataclass(frozen=True, slots=True)
-class _QuotaCommandContext:
-    runtime_root: Path
-    scan_roots: list[Path]
-    status_limit: int
-    status_goal_id: str | None
-    status_payload: dict[str, object]
-    cache_metadata: dict[str, object] | None
-    scheduler_context: Mapping[str, object] | SchedulerExecutionContextResolution | None
-    operator_inbox_urgency_projector: Callable[..., dict[str, object]]
-    detail_sections: frozenset[str]
-    heartbeat_turn_id: str | None
-
-
 def _heartbeat_receipt_settlement_bindings(
     event: Mapping[str, object],
 ) -> tuple[str | None, str | None]:
     return (
         heartbeat_receipt_settlement_todo_id(event),
         heartbeat_receipt_settlement_replan_obligation_id(event),
-    )
-
-
-def _scheduler_execution_context_from_args(
-    args: argparse.Namespace,
-) -> Mapping[str, object] | SchedulerExecutionContextResolution | None:
-    explicit_scheduler_fields = (
-        args.host_surface,
-        args.scheduler_owner,
-        args.execution_mode,
-    )
-    if args.codex_app and (args.runtime_profile or any(explicit_scheduler_fields)):
-        raise QuotaCommandValidationError(
-            "--codex-app cannot be combined with --runtime-profile, "
-            "--host-surface, --scheduler-owner, or --execution-mode"
-        )
-    if args.runtime_profile and any(explicit_scheduler_fields):
-        raise QuotaCommandValidationError(
-            "--runtime-profile cannot be combined with --host-surface, "
-            "--scheduler-owner, or --execution-mode"
-        )
-    runtime_profile = (
-        SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT.value
-        if args.codex_app
-        else args.runtime_profile
-    )
-    if runtime_profile:
-        return scheduler_execution_context_for_runtime_profile(runtime_profile)
-    if any(explicit_scheduler_fields):
-        return {
-            "host_surface": args.host_surface,
-            "scheduler_owner": args.scheduler_owner,
-            "execution_mode": args.execution_mode,
-            "source": "quota_cli_invocation",
-        }
-    return None
-
-
-def _prepare_quota_command_context(
-    args: argparse.Namespace,
-    *,
-    registry_path: Path,
-    runtime_root_arg: str | None,
-) -> _QuotaCommandContext:
-    command = args.quota_command
-    if bool(getattr(args, "turn_envelope", False)) and command != "should-run":
-        raise QuotaCommandValidationError(
-            "--turn-envelope is only valid with `quota should-run`"
-        )
-    requested_details = set(getattr(args, "include_details", None) or ())
-    if requested_details and command not in {"should-run", "monitor-poll"}:
-        raise QuotaCommandValidationError(
-            "--include-detail is only valid with `quota should-run` or "
-            "`quota monitor-poll`"
-        )
-    if requested_details and "all" not in requested_details:
-        allowed_details = set(
-            QUOTA_MONITOR_POLL_DETAIL_SECTIONS
-            if command == "monitor-poll"
-            else QUOTA_SHOULD_RUN_DETAIL_SECTIONS
-        )
-        unsupported_details = sorted(requested_details - allowed_details)
-        if unsupported_details:
-            raise QuotaCommandValidationError(
-                f"`quota {command}` does not accept --include-detail "
-                f"{', '.join(unsupported_details)}"
-            )
-    if (
-        bool(getattr(args, "include_scheduler_detail", False))
-        and command != "should-run"
-    ):
-        raise QuotaCommandValidationError(
-            "--include-scheduler-detail is only valid with `quota should-run`"
-        )
-    if bool(getattr(args, "record_host_poll", False)) and command != "should-run":
-        raise QuotaCommandValidationError(
-            "--record-host-poll is only valid with `quota should-run`"
-        )
-
-    begin_turn = bool(getattr(args, "begin_turn", False))
-    try:
-        heartbeat_turn_id = normalize_turn_instance_id(
-            getattr(args, "turn_instance_id", None)
-        )
-    except ValueError as exc:
-        raise QuotaCommandValidationError(str(exc)) from exc
-    if heartbeat_turn_id and command not in {
-        "should-run",
-        "monitor-poll",
-        "spend-slot",
-    }:
-        raise QuotaCommandValidationError(
-            "--turn-instance-id is only valid with `quota should-run`, "
-            "`quota monitor-poll`, or `quota spend-slot`"
-        )
-    if getattr(args, "replan_obligation_id", None) and command != "spend-slot":
-        raise QuotaCommandValidationError(
-            "--replan-obligation-id is only valid with `quota spend-slot`"
-        )
-    if getattr(args, "replan_obligation_id", None) and getattr(args, "todo_id", None):
-        raise QuotaCommandValidationError(
-            "--replan-obligation-id cannot be combined with --todo-id"
-        )
-    if heartbeat_turn_id and not args.agent_id:
-        raise QuotaCommandValidationError(
-            "turn-scoped quota settlement requires --agent-id"
-        )
-    scheduler_context = (
-        _scheduler_execution_context_from_args(args)
-        if command in QUOTA_SCHEDULER_COMMANDS
-        else None
-    )
-    validate_quota_command_request(args)
-    if begin_turn:
-        profile = scheduler_runtime_profile_for_execution_context(scheduler_context)
-        if profile not in GUIDED_START_TURN_RUNTIME_PROFILES:
-            raise QuotaCommandValidationError(
-                "--begin-turn requires runtime-profile codex_app_heartbeat "
-                "or codex_app_ssh_goal"
-            )
-        heartbeat_turn_id = mint_turn_instance_id(prefix="guided-start")
-    if heartbeat_turn_id and command == "should-run" and bool(args.dry_run):
-        raise QuotaCommandValidationError(
-            "turn-scoped `quota should-run` cannot use --dry-run"
-        )
-
-    scan_roots = [Path(item).expanduser() for item in args.scan_path]
-    if not scan_roots:
-        scan_roots = [Path(args.scan_root).expanduser()]
-    status_limit = max(0, args.limit)
-    if command in QUOTA_SCHEDULER_COMMANDS:
-        status_limit = max(status_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
-    runtime_root = resolve_status_projection_cache_runtime_root(
-        registry_path=registry_path,
-        runtime_root_override=runtime_root_arg,
-    )
-    operator_inbox_urgency_projector = build_lark_operator_inbox_urgency_projector(
-        runtime_root_arg=runtime_root,
-    )
-    status_goal_id = args.goal_id if command not in {"status", "plan"} else None
-    projection_cache_ttl_seconds = int(
-        getattr(args, "projection_cache_ttl_seconds", 120)
-    )
-    status_payload = None
-    cache_metadata = None
-    if bool(getattr(args, "use_projection_cache", False)):
-        status_payload, cache_metadata = load_status_projection_cache(
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            scan_roots=scan_roots,
-            limit=status_limit,
-            include_task_graph=False,
-            goal_id=status_goal_id,
-            max_age_seconds=projection_cache_ttl_seconds,
-            available_capabilities=args.available_capabilities,
-        )
-    if status_payload is None:
-        status_payload = collect_status(
-            registry_path=registry_path,
-            runtime_root_override=runtime_root_arg,
-            scan_roots=scan_roots,
-            limit=status_limit,
-            goal_id=status_goal_id,
-            available_capabilities=args.available_capabilities,
-        )
-        if bool(getattr(args, "write_projection_cache", False)):
-            cache_metadata = write_status_projection_cache(
-                registry_path=registry_path,
-                runtime_root=runtime_root,
-                scan_roots=scan_roots,
-                limit=status_limit,
-                include_task_graph=False,
-                goal_id=status_goal_id,
-                payload=status_payload,
-                max_age_seconds=projection_cache_ttl_seconds,
-                available_capabilities=args.available_capabilities,
-            )
-    elif isinstance(status_payload.get("projection_cache"), dict):
-        cache_metadata = dict(status_payload["projection_cache"])
-
-    return _QuotaCommandContext(
-        runtime_root=runtime_root,
-        scan_roots=scan_roots,
-        status_limit=status_limit,
-        status_goal_id=status_goal_id,
-        status_payload=status_payload,
-        cache_metadata=cache_metadata,
-        scheduler_context=scheduler_context,
-        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
-        detail_sections=quota_detail_sections_from_args(args),
-        heartbeat_turn_id=heartbeat_turn_id,
     )
 
 
@@ -643,9 +410,9 @@ def handle_quota_command(
     heartbeat_receipt_ready = False
     heartbeat_stall_observation = "not_evaluated"
     detail_sections: frozenset[str] = frozenset()
-    context: _QuotaCommandContext | None = None
+    context: QuotaCommandContext | None = None
     try:
-        context = _prepare_quota_command_context(
+        context = prepare_quota_command_context(
             args,
             registry_path=registry_path,
             runtime_root_arg=runtime_root_arg,

--- a/loopx/cli_commands/quota_context.py
+++ b/loopx/cli_commands/quota_context.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..control_plane.quota.error_codes import QuotaCommandValidationError
+from ..control_plane.runtime.status_projection_cache import (
+    load_status_projection_cache,
+    resolve_status_projection_cache_runtime_root,
+    write_status_projection_cache,
+)
+from ..control_plane.scheduler.execution_context import (
+    GUIDED_START_TURN_RUNTIME_PROFILES,
+    SchedulerExecutionContextResolution,
+    SchedulerRuntimeProfile,
+    scheduler_execution_context_for_runtime_profile,
+    scheduler_runtime_profile_for_execution_context,
+)
+from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
+from ..turn_identity import mint_turn_instance_id, normalize_turn_instance_id
+from .lark_inbox import build_lark_operator_inbox_urgency_projector
+from .quota_request import (
+    QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
+    QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
+    quota_detail_sections_from_args,
+    validate_quota_command_request,
+)
+
+QUOTA_SCHEDULER_COMMANDS = frozenset(
+    {
+        "should-run",
+        "monitor-poll",
+        "scheduler-ack",
+        "scheduler-ack-current",
+        "scheduler-fail-current",
+        "spend-slot",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class QuotaCommandContext:
+    runtime_root: Path
+    scan_roots: list[Path]
+    status_limit: int
+    status_goal_id: str | None
+    status_payload: dict[str, object]
+    cache_metadata: dict[str, object] | None
+    scheduler_context: Mapping[str, object] | SchedulerExecutionContextResolution | None
+    operator_inbox_urgency_projector: Callable[..., dict[str, object]]
+    detail_sections: frozenset[str]
+    heartbeat_turn_id: str | None
+
+
+def _scheduler_execution_context_from_args(
+    args: argparse.Namespace,
+) -> Mapping[str, object] | SchedulerExecutionContextResolution | None:
+    explicit_scheduler_fields = (
+        args.host_surface,
+        args.scheduler_owner,
+        args.execution_mode,
+    )
+    if args.codex_app and (args.runtime_profile or any(explicit_scheduler_fields)):
+        raise QuotaCommandValidationError(
+            "--codex-app cannot be combined with --runtime-profile, "
+            "--host-surface, --scheduler-owner, or --execution-mode"
+        )
+    if args.runtime_profile and any(explicit_scheduler_fields):
+        raise QuotaCommandValidationError(
+            "--runtime-profile cannot be combined with --host-surface, "
+            "--scheduler-owner, or --execution-mode"
+        )
+    runtime_profile = (
+        SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT.value
+        if args.codex_app
+        else args.runtime_profile
+    )
+    if runtime_profile:
+        return scheduler_execution_context_for_runtime_profile(runtime_profile)
+    if any(explicit_scheduler_fields):
+        return {
+            "host_surface": args.host_surface,
+            "scheduler_owner": args.scheduler_owner,
+            "execution_mode": args.execution_mode,
+            "source": "quota_cli_invocation",
+        }
+    return None
+
+
+def prepare_quota_command_context(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> QuotaCommandContext:
+    command = args.quota_command
+    if bool(getattr(args, "turn_envelope", False)) and command != "should-run":
+        raise QuotaCommandValidationError(
+            "--turn-envelope is only valid with `quota should-run`"
+        )
+    requested_details = set(getattr(args, "include_details", None) or ())
+    if requested_details and command not in {"should-run", "monitor-poll"}:
+        raise QuotaCommandValidationError(
+            "--include-detail is only valid with `quota should-run` or "
+            "`quota monitor-poll`"
+        )
+    if requested_details and "all" not in requested_details:
+        allowed_details = set(
+            QUOTA_MONITOR_POLL_DETAIL_SECTIONS
+            if command == "monitor-poll"
+            else QUOTA_SHOULD_RUN_DETAIL_SECTIONS
+        )
+        unsupported_details = sorted(requested_details - allowed_details)
+        if unsupported_details:
+            raise QuotaCommandValidationError(
+                f"`quota {command}` does not accept --include-detail "
+                f"{', '.join(unsupported_details)}"
+            )
+    if (
+        bool(getattr(args, "include_scheduler_detail", False))
+        and command != "should-run"
+    ):
+        raise QuotaCommandValidationError(
+            "--include-scheduler-detail is only valid with `quota should-run`"
+        )
+    if bool(getattr(args, "record_host_poll", False)) and command != "should-run":
+        raise QuotaCommandValidationError(
+            "--record-host-poll is only valid with `quota should-run`"
+        )
+
+    begin_turn = bool(getattr(args, "begin_turn", False))
+    try:
+        heartbeat_turn_id = normalize_turn_instance_id(
+            getattr(args, "turn_instance_id", None)
+        )
+    except ValueError as exc:
+        raise QuotaCommandValidationError(str(exc)) from exc
+    if heartbeat_turn_id and command not in {
+        "should-run",
+        "monitor-poll",
+        "spend-slot",
+    }:
+        raise QuotaCommandValidationError(
+            "--turn-instance-id is only valid with `quota should-run`, "
+            "`quota monitor-poll`, or `quota spend-slot`"
+        )
+    if getattr(args, "replan_obligation_id", None) and command != "spend-slot":
+        raise QuotaCommandValidationError(
+            "--replan-obligation-id is only valid with `quota spend-slot`"
+        )
+    if getattr(args, "replan_obligation_id", None) and getattr(args, "todo_id", None):
+        raise QuotaCommandValidationError(
+            "--replan-obligation-id cannot be combined with --todo-id"
+        )
+    if heartbeat_turn_id and not args.agent_id:
+        raise QuotaCommandValidationError(
+            "turn-scoped quota settlement requires --agent-id"
+        )
+    scheduler_context = (
+        _scheduler_execution_context_from_args(args)
+        if command in QUOTA_SCHEDULER_COMMANDS
+        else None
+    )
+    validate_quota_command_request(args)
+    if begin_turn:
+        profile = scheduler_runtime_profile_for_execution_context(scheduler_context)
+        if profile not in GUIDED_START_TURN_RUNTIME_PROFILES:
+            raise QuotaCommandValidationError(
+                "--begin-turn requires runtime-profile codex_app_heartbeat "
+                "or codex_app_ssh_goal"
+            )
+        heartbeat_turn_id = mint_turn_instance_id(prefix="guided-start")
+    if heartbeat_turn_id and command == "should-run" and bool(args.dry_run):
+        raise QuotaCommandValidationError(
+            "turn-scoped `quota should-run` cannot use --dry-run"
+        )
+
+    scan_roots = [Path(item).expanduser() for item in args.scan_path]
+    if not scan_roots:
+        scan_roots = [Path(args.scan_root).expanduser()]
+    status_limit = max(0, args.limit)
+    if command in QUOTA_SCHEDULER_COMMANDS:
+        status_limit = max(status_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
+    runtime_root = resolve_status_projection_cache_runtime_root(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_arg,
+    )
+    operator_inbox_urgency_projector = build_lark_operator_inbox_urgency_projector(
+        runtime_root_arg=runtime_root,
+    )
+    status_goal_id = args.goal_id if command not in {"status", "plan"} else None
+    projection_cache_ttl_seconds = int(
+        getattr(args, "projection_cache_ttl_seconds", 120)
+    )
+    status_payload = None
+    cache_metadata = None
+    if bool(getattr(args, "use_projection_cache", False)):
+        status_payload, cache_metadata = load_status_projection_cache(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            scan_roots=scan_roots,
+            limit=status_limit,
+            include_task_graph=False,
+            goal_id=status_goal_id,
+            max_age_seconds=projection_cache_ttl_seconds,
+            available_capabilities=args.available_capabilities,
+        )
+    if status_payload is None:
+        status_payload = collect_status(
+            registry_path=registry_path,
+            runtime_root_override=runtime_root_arg,
+            scan_roots=scan_roots,
+            limit=status_limit,
+            goal_id=status_goal_id,
+            available_capabilities=args.available_capabilities,
+        )
+        if bool(getattr(args, "write_projection_cache", False)):
+            cache_metadata = write_status_projection_cache(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                scan_roots=scan_roots,
+                limit=status_limit,
+                include_task_graph=False,
+                goal_id=status_goal_id,
+                payload=status_payload,
+                max_age_seconds=projection_cache_ttl_seconds,
+                available_capabilities=args.available_capabilities,
+            )
+    elif isinstance(status_payload.get("projection_cache"), dict):
+        cache_metadata = dict(status_payload["projection_cache"])
+
+    return QuotaCommandContext(
+        runtime_root=runtime_root,
+        scan_roots=scan_roots,
+        status_limit=status_limit,
+        status_goal_id=status_goal_id,
+        status_payload=status_payload,
+        cache_metadata=cache_metadata,
+        scheduler_context=scheduler_context,
+        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+        detail_sections=quota_detail_sections_from_args(args),
+        heartbeat_turn_id=heartbeat_turn_id,
+    )

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import argparse
-from collections.abc import Callable
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 from ..agent_registry import (
@@ -11,16 +11,6 @@ from ..agent_registry import (
     registered_agent_ids_from_registry,
     require_registered_agent_id,
 )
-from ..execution_profile import execution_profile_turn_granularity
-from ..heartbeat_prompt import (
-    build_heartbeat_prompt,
-    build_heartbeat_prompt_error_payload,
-    render_heartbeat_prompt_markdown,
-)
-from ..heartbeat_prequota import (
-    render_heartbeat_pre_quota_markdown,
-    run_heartbeat_pre_quota,
-)
 from ..chat_server import (
     DEFAULT_CHAT_HOST,
     DEFAULT_CHAT_PORT,
@@ -28,6 +18,16 @@ from ..chat_server import (
 )
 from ..control_plane.scheduler.execution_context import SchedulerRuntimeProfile
 from ..dashboard_launcher import launch_dashboard
+from ..execution_profile import execution_profile_turn_granularity
+from ..heartbeat_prequota import (
+    render_heartbeat_pre_quota_markdown,
+    run_heartbeat_pre_quota,
+)
+from ..heartbeat_prompt import (
+    build_heartbeat_prompt,
+    build_heartbeat_prompt_error_payload,
+    render_heartbeat_prompt_markdown,
+)
 from ..paths import default_public_scan_root
 from ..presentation.renderers.status_markdown import render_status_markdown
 from ..promotion_gate import (
@@ -58,10 +58,6 @@ from ..status_server import (
     serve_status,
 )
 from ..upgrade import build_upgrade_plan, render_upgrade_plan_markdown
-from .support_control_registry import (
-    explicit_global_registry,
-    resolve_heartbeat_active_state,
-)
 from .support_control_backup import (
     handle_backup_state_command,
     register_backup_state_command,
@@ -70,12 +66,18 @@ from .support_control_chat_endpoint import (
     handle_chat_endpoint_command,
     register_chat_endpoint_command,
 )
+from .support_control_heartbeat_registration import (
+    register_heartbeat_control_commands,
+)
+from .support_control_registry import (
+    explicit_global_registry,
+    resolve_heartbeat_active_state,
+)
 from .support_control_supervisor import (
     SUPERVISOR_CONTROL_COMMANDS,
     handle_supervisor_control_command,
     register_supervisor_control_commands,
 )
-
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -106,164 +108,7 @@ def register_support_control_commands(
     add_subcommand_format: AddFormat,
 ) -> None:
     register_backup_state_command(subparsers, add_subcommand_format)
-
-    heartbeat_prompt_parser = subparsers.add_parser(
-        "heartbeat-prompt",
-        help="Generate a guarded heartbeat or visible-goal host-loop task body.",
-    )
-    add_subcommand_format(heartbeat_prompt_parser)
-    heartbeat_prompt_parser.add_argument(
-        "--goal-id", required=True, help="Stable LoopX goal id."
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--active-state",
-        help="Active goal state file the heartbeat should read and write back. Defaults to the registry goal state_file.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--material-rule",
-        help="Optional project-specific material queue rule appended to the task body.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--permission-rule",
-        help="Optional trusted-session permission rule appended to the task body.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--cli-bin",
-        default="loopx",
-        help="Command name embedded in generated preflight/guard/spend commands. Use loopx-canary for gray rollout targets.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--agent-id",
-        help="Optional public-safe automation agent id, such as codex-main-control or codex-side-bypass.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--turn-instance-id",
-        help=(
-            "Optional exact public-safe heartbeat receipt id. Requires an exact "
-            "agent id and a receipt-producing runtime profile."
-        ),
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--agent-scope",
-        dest="agent_scopes",
-        action="append",
-        help="Optional natural-language scope for this automation agent. Repeat for multiple scope lines.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--available-capability",
-        dest="available_capabilities",
-        action="append",
-        help=(
-            "Declare a capability available in this host loop, such as network or "
-            "external_evidence_poll. Repeat for multiple capabilities; generated "
-            "quota guard and spend commands preserve the declaration."
-        ),
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--runtime-profile",
-        choices=[profile.value for profile in SchedulerRuntimeProfile],
-        help=(
-            "Embed one explicit scheduler runtime profile in the generated quota "
-            "guard. Cannot be combined with the explicit scheduler context fields."
-        ),
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--codex-app",
-        action="store_true",
-        help=(
-            "Compact explicit alias for --runtime-profile "
-            "codex_app_heartbeat in generated heartbeat commands."
-        ),
-    )
-    heartbeat_prompt_parser.add_argument(
-        "--visible-goal-host",
-        choices=["traex-cli"],
-        help=(
-            "Render the visible Goal task contract for an explicitly verified "
-            "host while preserving its scheduler runtime profile."
-        ),
-    )
-    heartbeat_prompt_parser.add_argument(
-        "-H",
-        "--host-surface",
-        choices=[
-            "ark_managed_agent",
-            "codex_app",
-            "codex_app_ssh",
-            "codex_cli",
-            "generic_cli",
-            "claude_code",
-            "kunluncode",
-            "local_scheduler",
-        ],
-        help="Host surface embedded in the generated quota guard.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "-O",
-        "--scheduler-owner",
-        choices=[
-            "host_automation",
-            "agent_cli_loop",
-            "goal_runtime",
-            "outer_controller",
-            "none",
-        ],
-        help="Cadence owner embedded in the generated quota guard.",
-    )
-    heartbeat_prompt_parser.add_argument(
-        "-M",
-        "--execution-mode",
-        choices=["interactive", "isolated_headless", "hosted_automation"],
-        help="Execution mode embedded in the generated quota guard.",
-    )
-    heartbeat_style_group = heartbeat_prompt_parser.add_mutually_exclusive_group()
-    heartbeat_style_group.add_argument(
-        "--full",
-        action="store_true",
-        help="Generate the expanded audit body. The default installed heartbeat body is thin.",
-    )
-    heartbeat_style_group.add_argument(
-        "--compact",
-        action="store_true",
-        help="Generate a shorter automation body that points edge cases back to the expanded lifecycle contract.",
-    )
-    heartbeat_style_group.add_argument(
-        "--brief",
-        action="store_true",
-        help="Generate a minimal installed automation body that delegates details to the compact lifecycle contract.",
-    )
-    heartbeat_style_group.add_argument(
-        "--thin",
-        action="store_true",
-        help="Generate the thinnest generic dispatcher body for trusted agents that inspect LoopX state themselves.",
-    )
-
-    heartbeat_prequota_parser = subparsers.add_parser(
-        "heartbeat-prequota",
-        help=(
-            "Run best-effort kernel reconciliation hooks before heartbeat quota "
-            "selection without spending quota."
-        ),
-    )
-    add_subcommand_format(heartbeat_prequota_parser)
-    heartbeat_prequota_parser.add_argument(
-        "-g",
-        "--goal-id",
-        required=True,
-        help="Stable LoopX goal id.",
-    )
-    heartbeat_prequota_parser.add_argument(
-        "-a",
-        "--agent-id",
-        required=True,
-        help="Registered heartbeat lifecycle actor.",
-    )
-    heartbeat_prequota_parser.add_argument(
-        "--fetch-timeout-seconds",
-        type=int,
-        default=10,
-        help="Timeout for each bounded compact external metadata fetch.",
-    )
+    register_heartbeat_control_commands(subparsers, add_subcommand_format)
 
     register_supervisor_control_commands(subparsers, add_subcommand_format)
 

--- a/loopx/cli_commands/support_control_heartbeat_registration.py
+++ b/loopx/cli_commands/support_control_heartbeat_registration.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..control_plane.scheduler.execution_context import SchedulerRuntimeProfile
+
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_heartbeat_control_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    heartbeat_prompt_parser = subparsers.add_parser(
+        "heartbeat-prompt",
+        help="Generate a guarded heartbeat or visible-goal host-loop task body.",
+    )
+    add_subcommand_format(heartbeat_prompt_parser)
+    heartbeat_prompt_parser.add_argument(
+        "--goal-id", required=True, help="Stable LoopX goal id."
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--active-state",
+        help="Active goal state file the heartbeat should read and write back. Defaults to the registry goal state_file.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--material-rule",
+        help="Optional project-specific material queue rule appended to the task body.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--permission-rule",
+        help="Optional trusted-session permission rule appended to the task body.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="Command name embedded in generated preflight/guard/spend commands. Use loopx-canary for gray rollout targets.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--agent-id",
+        help="Optional public-safe automation agent id, such as codex-main-control or codex-side-bypass.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--turn-instance-id",
+        help=(
+            "Optional exact public-safe heartbeat receipt id. Requires an exact "
+            "agent id and a receipt-producing runtime profile."
+        ),
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--agent-scope",
+        dest="agent_scopes",
+        action="append",
+        help="Optional natural-language scope for this automation agent. Repeat for multiple scope lines.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Declare a capability available in this host loop, such as network or "
+            "external_evidence_poll. Repeat for multiple capabilities; generated "
+            "quota guard and spend commands preserve the declaration."
+        ),
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--runtime-profile",
+        choices=[profile.value for profile in SchedulerRuntimeProfile],
+        help=(
+            "Embed one explicit scheduler runtime profile in the generated quota "
+            "guard. Cannot be combined with the explicit scheduler context fields."
+        ),
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--codex-app",
+        action="store_true",
+        help=(
+            "Compact explicit alias for --runtime-profile "
+            "codex_app_heartbeat in generated heartbeat commands."
+        ),
+    )
+    heartbeat_prompt_parser.add_argument(
+        "--visible-goal-host",
+        choices=["traex-cli"],
+        help=(
+            "Render the visible Goal task contract for an explicitly verified "
+            "host while preserving its scheduler runtime profile."
+        ),
+    )
+    heartbeat_prompt_parser.add_argument(
+        "-H",
+        "--host-surface",
+        choices=[
+            "ark_managed_agent",
+            "codex_app",
+            "codex_app_ssh",
+            "codex_cli",
+            "generic_cli",
+            "claude_code",
+            "kunluncode",
+            "local_scheduler",
+        ],
+        help="Host surface embedded in the generated quota guard.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "-O",
+        "--scheduler-owner",
+        choices=[
+            "host_automation",
+            "agent_cli_loop",
+            "goal_runtime",
+            "outer_controller",
+            "none",
+        ],
+        help="Cadence owner embedded in the generated quota guard.",
+    )
+    heartbeat_prompt_parser.add_argument(
+        "-M",
+        "--execution-mode",
+        choices=["interactive", "isolated_headless", "hosted_automation"],
+        help="Execution mode embedded in the generated quota guard.",
+    )
+    heartbeat_style_group = heartbeat_prompt_parser.add_mutually_exclusive_group()
+    heartbeat_style_group.add_argument(
+        "--full",
+        action="store_true",
+        help="Generate the expanded audit body. The default installed heartbeat body is thin.",
+    )
+    heartbeat_style_group.add_argument(
+        "--compact",
+        action="store_true",
+        help="Generate a shorter automation body that points edge cases back to the expanded lifecycle contract.",
+    )
+    heartbeat_style_group.add_argument(
+        "--brief",
+        action="store_true",
+        help="Generate a minimal installed automation body that delegates details to the compact lifecycle contract.",
+    )
+    heartbeat_style_group.add_argument(
+        "--thin",
+        action="store_true",
+        help="Generate the thinnest generic dispatcher body for trusted agents that inspect LoopX state themselves.",
+    )
+
+    heartbeat_prequota_parser = subparsers.add_parser(
+        "heartbeat-prequota",
+        help=(
+            "Run best-effort kernel reconciliation hooks before heartbeat quota "
+            "selection without spending quota."
+        ),
+    )
+    add_subcommand_format(heartbeat_prequota_parser)
+    heartbeat_prequota_parser.add_argument(
+        "-g",
+        "--goal-id",
+        required=True,
+        help="Stable LoopX goal id.",
+    )
+    heartbeat_prequota_parser.add_argument(
+        "-a",
+        "--agent-id",
+        required=True,
+        help="Registered heartbeat lifecycle actor.",
+    )
+    heartbeat_prequota_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for each bounded compact external metadata fetch.",
+    )

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -260,6 +260,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {"command": "loopx auto-research", "purpose": "Project public-safe research frontiers."},
             {
+                "command": "loopx deepresearch",
+                "purpose": "Run a bounded, citation-auditable research ledger and report workflow.",
+            },
+            {
                 "command": "loopx agent-turn-recall",
                 "purpose": "Prepare goal-scoped memory guidance for one admitted autonomous agent turn.",
             },

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -225,6 +225,9 @@ Resolve a portable weekly profile, evaluate report triggers, and compose provide
 \fBloopx auto\-research\fR
 Project public\-safe research frontiers.
 .TP
+\fBloopx deepresearch\fR
+Run a bounded, citation\-auditable research ledger and report workflow.
+.TP
 \fBloopx agent\-turn\-recall\fR
 Prepare goal\-scoped memory guidance for one admitted autonomous agent turn.
 .TP


### PR DESCRIPTION
## Summary

- keep credentialed live model qualification out of automatic public-smoke discovery
- update work-lane, capability-registry, slash-install, and help/manpage checks to current semantic contracts
- split oversized quota and support-control command modules along existing ownership boundaries

## Validation

- repository-local `canary smoke-suite`: 5/5 repaired public checks passed after rebasing onto current `origin/main`
- public suite discovery: credentialed qualification absent from all 505 public smokes
- standard premerge: all 18 catalog, risk-profile, and public-boundary checks passed
- capability registry tests: 18 passed
- changed Python compile, `git diff --check`, and public/private boundary scan passed
- change-quality receipt: `cqr_7c10fceece73ef57cb3d`

## Scope pass

The related future-facing pass was applied: cohesive context preparation and heartbeat parser registration moved out of oversized command modules without changing their caller-facing contracts. No broader migration was needed.