### PR TITLE
fix(quota): restore CLI composition seams

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -72,6 +72,7 @@ from ..quota import (
 from ..status import collect_status
 from ..upgrade import resolve_codex_app_automation_rrule
 from .quota_context import QuotaCommandContext, prepare_quota_command_context
+from .lark_inbox import build_lark_operator_inbox_urgency_projector
 from .quota_host_poll import attach_host_poll_receipt
 from .quota_monitor_poll import record_quota_monitor_poll_for_cli
 from .quota_registration import (
@@ -416,6 +417,10 @@ def handle_quota_command(
             args,
             registry_path=registry_path,
             runtime_root_arg=runtime_root_arg,
+            status_collector=collect_status,
+            operator_inbox_urgency_projector=build_lark_operator_inbox_urgency_projector(
+                runtime_root_arg=runtime_root_arg,
+            ),
         )
         heartbeat_turn_id = context.heartbeat_turn_id
         detail_sections = context.detail_sections

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -418,8 +418,8 @@ def handle_quota_command(
             registry_path=registry_path,
             runtime_root_arg=runtime_root_arg,
             status_collector=collect_status,
-            operator_inbox_urgency_projector=build_lark_operator_inbox_urgency_projector(
-                runtime_root_arg=runtime_root_arg,
+            operator_inbox_urgency_projector_factory=(
+                build_lark_operator_inbox_urgency_projector
             ),
         )
         heartbeat_turn_id = context.heartbeat_turn_id

--- a/loopx/cli_commands/quota_context.py
+++ b/loopx/cli_commands/quota_context.py
@@ -20,7 +20,6 @@ from ..control_plane.scheduler.execution_context import (
 )
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..turn_identity import mint_turn_instance_id, normalize_turn_instance_id
-from .lark_inbox import build_lark_operator_inbox_urgency_projector
 from .quota_request import (
     QUOTA_MONITOR_POLL_DETAIL_SECTIONS,
     QUOTA_SHOULD_RUN_DETAIL_SECTIONS,
@@ -94,6 +93,8 @@ def prepare_quota_command_context(
     *,
     registry_path: Path,
     runtime_root_arg: str | None,
+    status_collector: Callable[..., dict[str, object]] | None = None,
+    operator_inbox_urgency_projector: Callable[..., dict[str, object]],
 ) -> QuotaCommandContext:
     command = args.quota_command
     if bool(getattr(args, "turn_envelope", False)) and command != "should-run":
@@ -180,15 +181,16 @@ def prepare_quota_command_context(
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
     if not scan_roots:
         scan_roots = [Path(args.scan_root).expanduser()]
-    status_limit = max(0, args.limit)
+    try:
+        requested_limit = int(getattr(args, "limit", 0))
+    except (TypeError, ValueError):
+        requested_limit = 0
+    status_limit = max(0, requested_limit)
     if command in QUOTA_SCHEDULER_COMMANDS:
         status_limit = max(status_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
     runtime_root = resolve_status_projection_cache_runtime_root(
         registry_path=registry_path,
         runtime_root_override=runtime_root_arg,
-    )
-    operator_inbox_urgency_projector = build_lark_operator_inbox_urgency_projector(
-        runtime_root_arg=runtime_root,
     )
     status_goal_id = args.goal_id if command not in {"status", "plan"} else None
     projection_cache_ttl_seconds = int(
@@ -208,7 +210,8 @@ def prepare_quota_command_context(
             available_capabilities=args.available_capabilities,
         )
     if status_payload is None:
-        status_payload = collect_status(
+        collector = status_collector or collect_status
+        status_payload = collector(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
             scan_roots=scan_roots,

--- a/loopx/cli_commands/quota_context.py
+++ b/loopx/cli_commands/quota_context.py
@@ -94,7 +94,9 @@ def prepare_quota_command_context(
     registry_path: Path,
     runtime_root_arg: str | None,
     status_collector: Callable[..., dict[str, object]] | None = None,
-    operator_inbox_urgency_projector: Callable[..., dict[str, object]],
+    operator_inbox_urgency_projector_factory: Callable[
+        ..., Callable[..., dict[str, object]]
+    ],
 ) -> QuotaCommandContext:
     command = args.quota_command
     if bool(getattr(args, "turn_envelope", False)) and command != "should-run":
@@ -242,7 +244,9 @@ def prepare_quota_command_context(
         status_payload=status_payload,
         cache_metadata=cache_metadata,
         scheduler_context=scheduler_context,
-        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+        operator_inbox_urgency_projector=operator_inbox_urgency_projector_factory(
+            runtime_root_arg=runtime_root
+        ),
         detail_sections=quota_detail_sections_from_args(args),
         heartbeat_turn_id=heartbeat_turn_id,
     )

--- a/tests/control_plane/test_scheduler_ack_current_host_binding.py
+++ b/tests/control_plane/test_scheduler_ack_current_host_binding.py
@@ -133,8 +133,19 @@ def test_quota_should_run_ignores_cross_agent_scheduler_state(tmp_path: Path) ->
     assert app["stateful_backoff"]["apply_needed"] is True
 
 
-def test_scheduler_ack_collects_the_periodic_should_run_lookback(monkeypatch) -> None:
+def test_scheduler_ack_collects_the_periodic_should_run_lookback(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     seen: dict[str, object] = {}
+
+    runtime_root = tmp_path / "runtime"
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir()
+    registry_path.write_text(
+        json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+        encoding="utf-8",
+    )
 
     def fake_collect_status(**kwargs):
         seen["limit"] = kwargs.get("limit")
@@ -150,7 +161,16 @@ def test_scheduler_ack_collects_the_periodic_should_run_lookback(monkeypatch) ->
         seen["output_format"] = output_format
         seen["renderer"] = renderer
 
+    def fake_build_lark_projector(*, runtime_root_arg):
+        seen["lark_runtime_root"] = runtime_root_arg
+        return lambda **_kwargs: {}
+
     monkeypatch.setattr(quota_command, "collect_status", fake_collect_status)
+    monkeypatch.setattr(
+        quota_command,
+        "build_lark_operator_inbox_urgency_projector",
+        fake_build_lark_projector,
+    )
     monkeypatch.setattr(
         quota_command,
         "record_quota_scheduler_ack",
@@ -198,7 +218,7 @@ def test_scheduler_ack_collects_the_periodic_should_run_lookback(monkeypatch) ->
 
     result = quota_command.handle_quota_command(
         args,
-        registry_path=Path(".loopx/registry.json"),
+        registry_path=registry_path,
         runtime_root_arg=None,
         print_payload=fake_print_payload,
         append_cli_rollout_event=lambda **_: {},
@@ -206,6 +226,7 @@ def test_scheduler_ack_collects_the_periodic_should_run_lookback(monkeypatch) ->
 
     assert result == 0
     assert seen["limit"] == AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK
+    assert seen["lark_runtime_root"] == runtime_root
     assert seen["payload"] == {
         "ok": True,
         "mode": "scheduler-ack",


### PR DESCRIPTION
## Summary
- restore the quota CLI composition boundary after the quota command-module split
- keep Lark urgency provider ownership in `loopx.cli_commands.quota`
- inject the status collector through the CLI boundary so scheduler and diagnostic paths use the composed collector
- normalize missing or invalid quota limits before scheduler lookback calculation
- preserve the existing Python CLI contract and the TypeScript control-plane authority boundary
## Issue Or Task
-  N/A
## Root cause
The quota command was split into `quota.py` and `quota_context.py`, but the extracted context module retained ownership of the Lark urgency provider. This left the CLI composition boundary inconsistent with the architecture contract.
The extracted context builder also called its own imported `collect_status`, so replacing the collector at the CLI command boundary did not affect scheduler acknowledgement and quota diagnostic paths. In addition, scheduler commands could receive a missing or invalid `limit` value before applying the periodic lookback floor.
## Safety and compatibility
- Lark urgency remains composed by the quota CLI and is injected into the context builder.
- `quota_context.py` no longer owns the Lark provider dependency.
- Existing quota commands, Python CLI arguments, and output payload shapes remain unchanged.
- Scheduler commands continue to enforce the periodic lookback minimum.
- Invalid or missing limits fail closed to a bounded non-negative value.
- No new capability, extension, provider, or product-specific routing authority is introduced.
- No TypeScript control-plane authority is duplicated in Python.
## Validation
- [x] related pytest suites
- [x] `loopx check --scan-root .`: 0 errors
- [x] TypeScript/control-plane premerge canary
- [x] Python compilation for the changed quota modules
- [x] CLI output boundary and import-boundary checks

## Future-facing pass
The change keeps provider composition at the CLI boundary and makes the extracted quota context consume injected capabilities instead of importing provider implementations itself. This removes duplicate ownership and leaves the next control-plane migration step localized to the existing typed runtime boundary.
No product-specific vocabulary, provider implementation, or second business-rule authority was added to the generic quota context or ordinary Goal path. 翻译