### PR TITLE
fix(benchmark): reap native isolation subprocesses

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -50,7 +50,9 @@ task workspace at the returned `host-visible` alias, and an optional formal Loop
 profile at its verified absolute path. The surrounding host root, original task
 path, ambient host `/tmp`, nested host mounts, symlinked work children, and
 `/proc/1/root` escape path are absent. The helper requires unprivileged user, mount,
-and PID namespaces plus `pivot_root` and fails closed when its roots overlap.
+and PID namespaces, `pivot_root`, and `tini`. It runs `tini` as the isolated PID 1
+so long-lived workers reap orphaned command subprocesses, and fails closed when
+its roots overlap or the init resolves from a mutable task/profile/work root.
 
 ```python
 from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (

--- a/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
@@ -50,7 +50,8 @@ work_dir=$3
 profile_root=$4
 executable=$5
 setpriv_bin=$6
-shift 6
+init_bin=$7
+shift 7
 
 mount --make-rprivate /
 sandbox_root="$work_dir/.sandbox-root"
@@ -125,23 +126,29 @@ if [ -n "$profile_root" ]; then
     mount --bind "$profile_root" "$sandbox_root$profile_root"
 fi
 
-# A test launcher or alternate Codex binary may live outside the shared system
-# runtime, work directory, or formal profile.  Re-expose only the resolved file.
-bind_executable=1
-case "$executable" in
-    /usr/*|/bin/*|/sbin/*|/lib/*|/lib64/*|"$work_dir"/*) bind_executable=0 ;;
-esac
-if [ -n "$profile_root" ]; then
-    case "$executable" in
-        "$profile_root"/*) bind_executable=0 ;;
+# A test launcher, alternate Codex binary, or init may live outside the shared
+# system runtime, work directory, or formal profile.  Re-expose only each
+# resolved file.
+bind_runtime_file() {
+    runtime_file=$1
+    bind_file=1
+    case "$runtime_file" in
+        /usr/*|/bin/*|/sbin/*|/lib/*|/lib64/*|"$work_dir"/*) bind_file=0 ;;
     esac
-fi
-if [ "$bind_executable" = 1 ]; then
-    mkdir -p "$sandbox_root$(dirname "$executable")"
-    touch "$sandbox_root$executable"
-    mount --bind "$executable" "$sandbox_root$executable"
-    mount -o remount,bind,ro "$sandbox_root$executable"
-fi
+    if [ -n "$profile_root" ]; then
+        case "$runtime_file" in
+            "$profile_root"/*) bind_file=0 ;;
+        esac
+    fi
+    if [ "$bind_file" = 1 ]; then
+        mkdir -p "$sandbox_root$(dirname "$runtime_file")"
+        touch "$sandbox_root$runtime_file"
+        mount --bind "$runtime_file" "$sandbox_root$runtime_file"
+        mount -o remount,bind,ro "$sandbox_root$runtime_file"
+    fi
+}
+bind_runtime_file "$executable"
+bind_runtime_file "$init_bin"
 
 mkdir -p "$sandbox_root/.old-root"
 cd "$sandbox_root"
@@ -157,7 +164,9 @@ cd "$work_dir"
 
 # Capabilities exist only inside the fresh user namespace so Codex can install
 # its nested workspace/network sandbox.  They cannot reach the host namespace.
-exec "$setpriv_bin" --no-new-privs "$executable" "$@"
+# Keep a real init as PID 1 so orphaned command subprocesses are reaped during
+# long-running Goal workers instead of accumulating as defunct processes.
+exec "$init_bin" -s -- "$setpriv_bin" --no-new-privs "$executable" "$@"
 """
 
 
@@ -456,6 +465,7 @@ def build_native_codex_isolation_envelope(
     unshare = _resolve_executable("unshare", error="native_codex_unshare_missing")
     setpriv = _resolve_executable("setpriv", error="native_codex_setpriv_missing")
     shell = _resolve_executable("sh", error="native_codex_shell_missing")
+    init = _resolve_executable("tini", error="native_codex_init_missing")
     resolved_executable = _resolve_executable(
         executable, error="native_codex_executable_missing"
     )
@@ -470,6 +480,15 @@ def build_native_codex_isolation_envelope(
         raise NativeCodexIsolationError(
             "native_codex_executable_inside_workspace_source"
         )
+    if init == resolved_private_root or resolved_private_root in init.parents:
+        raise NativeCodexIsolationError("native_codex_init_inside_private_root")
+    mutable_roots = [resolved_work_dir]
+    if resolved_workspace is not None:
+        mutable_roots.append(resolved_workspace)
+    if resolved_profile is not None:
+        mutable_roots.append(resolved_profile)
+    if any(init == root or root in init.parents for root in mutable_roots):
+        raise NativeCodexIsolationError("native_codex_init_inside_mutable_root")
     if workspace_alias is not None:
         workspace_alias.mkdir(parents=True, exist_ok=True)
 
@@ -491,6 +510,7 @@ def build_native_codex_isolation_envelope(
         profile_raw,
         str(resolved_executable),
         str(setpriv),
+        str(init),
         *(str(value) for value in process_args),
     )
     return NativeCodexIsolationEnvelope(

--- a/tests/capabilities/test_native_codex_isolation.py
+++ b/tests/capabilities/test_native_codex_isolation.py
@@ -40,6 +40,10 @@ def _namespace_mounts_supported() -> bool:
     return probe.returncode == 0
 
 
+def _native_codex_isolation_supported() -> bool:
+    return _namespace_mounts_supported() and shutil.which("tini") is not None
+
+
 def test_native_codex_isolation_rejects_overlapping_authority_roots(
     tmp_path: Path,
 ) -> None:
@@ -229,8 +233,8 @@ def test_native_codex_loopx_state_rebase_requires_complete_registry_pair(
 
 
 @pytest.mark.skipif(
-    not _namespace_mounts_supported(),
-    reason="unprivileged user/mount namespaces are unavailable",
+    not _native_codex_isolation_supported(),
+    reason="native Codex isolation prerequisites are unavailable",
 )
 def test_native_codex_isolation_exposes_only_workspace_profile_and_work_children(
     tmp_path: Path,
@@ -306,8 +310,8 @@ def test_native_codex_isolation_exposes_only_workspace_profile_and_work_children
 
 
 @pytest.mark.skipif(
-    not _namespace_mounts_supported(),
-    reason="unprivileged user/mount namespaces are unavailable",
+    not _native_codex_isolation_supported(),
+    reason="native Codex isolation prerequisites are unavailable",
 )
 def test_native_codex_isolation_hides_runner_provider_authority_from_shell_probe(
     tmp_path: Path,
@@ -358,7 +362,7 @@ def test_native_codex_isolation_hides_runner_provider_authority_from_shell_probe
         profile_root=profile_root,
     )
     isolated_env = {
-        "PATH": "/usr/bin:/bin",
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
         "HOME": str(home),
         "CODEX_HOME": str(codex_home),
         "LOOPX_MODEL_PROVIDER_SENTINEL": "runner-owned-gateway-no-upstream-secret",
@@ -381,8 +385,8 @@ def test_native_codex_isolation_hides_runner_provider_authority_from_shell_probe
 
 
 @pytest.mark.skipif(
-    not _namespace_mounts_supported(),
-    reason="unprivileged user/mount namespaces are unavailable",
+    not _native_codex_isolation_supported(),
+    reason="native Codex isolation prerequisites are unavailable",
 )
 def test_native_codex_isolation_rejects_symlinked_work_children(
     tmp_path: Path,
@@ -407,3 +411,69 @@ def test_native_codex_isolation_rejects_symlinked_work_children(
     )
 
     assert completed.returncode == 64
+
+
+@pytest.mark.skipif(
+    not _native_codex_isolation_supported(),
+    reason="native Codex isolation prerequisites are unavailable",
+)
+def test_native_codex_isolation_reaps_orphaned_command_processes(
+    tmp_path: Path,
+) -> None:
+    private_root = tmp_path / "controller-private"
+    private_root.mkdir()
+    work_dir = tmp_path / "run-work"
+    work_dir.mkdir()
+    probe = textwrap.dedent(
+        """
+        import os
+        import time
+
+        child = os.fork()
+        if child == 0:
+            grandchild = os.fork()
+            if grandchild == 0:
+                time.sleep(0.05)
+                os._exit(0)
+            os._exit(0)
+        os.waitpid(child, 0)
+        time.sleep(0.5)
+
+        zombies = []
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            try:
+                fields = {}
+                with open(f"/proc/{entry}/status", encoding="utf-8") as handle:
+                    for line in handle:
+                        if ":" in line:
+                            key, value = line.split(":", 1)
+                            fields[key] = value.strip()
+                if (
+                    fields.get("PPid") == "1"
+                    and fields.get("State", "").startswith("Z")
+                ):
+                    zombies.append(entry)
+            except (FileNotFoundError, ProcessLookupError, PermissionError):
+                pass
+        print(len(zombies))
+        """
+    )
+    envelope = build_native_codex_isolation_envelope(
+        executable="python3",
+        process_args=["-c", probe],
+        work_dir=work_dir,
+        private_root=private_root,
+    )
+
+    completed = subprocess.run(
+        envelope.process_command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "0\n"


### PR DESCRIPTION
## Summary

- run `tini` as PID 1 inside the native Codex isolation namespace so orphaned command subprocesses are reaped
- fail closed when the init is missing or resolves from a mutable task, profile, or work root
- document the runtime prerequisite and add a real namespace regression that double-forks and asserts zero PID-1 zombies

## Why

A native Goal worker can launch many command subprocesses over a long run. When the app-server itself is PID 1, orphaned descendants remain defunct for the worker lifetime because the app-server is not an init/reaper. This can gradually consume the process table.

## Validation

- `ruff check` on the changed Python files
- `python -m pytest -q tests/capabilities/test_benchmark_toolkit.py tests/capabilities/test_native_codex_isolation.py benchmark/tests/test_native_codex_goal.py` (114 passed)
- `loopx canary premerge --from-git-diff --format json`: 18/18 selected checks passed, public-boundary scan clean, no failures or skips

## Review hold

The canary correctly classifies this as benchmark-sensitive and requires maintainer review. This PR does not change scoring, task semantics, permissions, or launch benchmark jobs.