### PR TITLE
Derive goal display_name from /loopx goal text

### DIFF
--- a/examples/control_plane/start-goal-display-name-smoke.py
+++ b/examples/control_plane/start-goal-display-name-smoke.py
@@ -86,8 +86,8 @@ def main() -> int:
 
         payload = json.loads(guided.stdout)
         connect_command = payload["guided_transaction"]["ordered_steps"][1]["command"]
-        assert "--display-name" in connect_command, connect_command
-        assert GOAL_TEXT in connect_command, connect_command
+        assert "--display-name" not in connect_command, connect_command
+        assert connect_command.count(GOAL_TEXT) == 1, connect_command
 
     print("ok: start-goal display_name smoke passed")
     return 0

--- a/examples/control_plane/start-goal-display-name-smoke.py
+++ b/examples/control_plane/start-goal-display-name-smoke.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke: guided /loopx goal starts persist a public-safe display_name."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_TEXT = "Fix dashboard goal title fallback for guided start"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-display-name-smoke-") as tmp:
+        project = Path(tmp) / "project"
+        project.mkdir()
+        (project / "README.md").write_text("# demo\n", encoding="utf-8")
+
+        bootstrap = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "bootstrap",
+                "--project",
+                str(project),
+                "--goal-id",
+                "demo-display-name-goal",
+                "--objective",
+                GOAL_TEXT,
+                "--no-onboarding-scan",
+                "--codex-app-heartbeat",
+                "no",
+                "--no-global-sync",
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if bootstrap.returncode != 0:
+            print(bootstrap.stdout)
+            print(bootstrap.stderr, file=sys.stderr)
+            return bootstrap.returncode
+
+        registry_path = project / ".loopx" / "registry.json"
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        goal = next(
+            item for item in registry["goals"] if item["id"] == "demo-display-name-goal"
+        )
+        assert goal.get("display_name") == GOAL_TEXT, goal
+
+        guided = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "start-goal",
+                "--guided",
+                "--project",
+                str(project),
+                "--goal-id",
+                "demo-display-name-goal",
+                "--agent-id",
+                "smoke-display-name-agent",
+                "--host-surface",
+                "cursor-agent",
+                "--goal-text",
+                GOAL_TEXT,
+            ],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if guided.returncode != 0:
+            print(guided.stdout)
+            print(guided.stderr, file=sys.stderr)
+            return guided.returncode
+
+        payload = json.loads(guided.stdout)
+        connect_command = payload["guided_transaction"]["ordered_steps"][1]["command"]
+        assert "--display-name" in connect_command, connect_command
+        assert GOAL_TEXT in connect_command, connect_command
+
+    print("ok: start-goal display_name smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -6,6 +6,7 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from .control_plane.runtime.public_safety import public_safe_compact_text
 from .control_plane.runtime.time import now_local_iso
 from .control_plane.todos.active_state_editing import (
     TODO_SECTION_HEADINGS,
@@ -39,6 +40,22 @@ from .todos import add_todo_to_lines
 
 DEFAULT_OBJECTIVE = "Improve this project through bounded, verified goal segments."
 DEFAULT_DOMAIN = "project-goal-control-plane"
+GOAL_DISPLAY_NAME_LIMIT = 120
+
+
+def derive_public_goal_display_name(
+    objective: str | None,
+    *,
+    explicit: str | None = None,
+) -> str | None:
+    """Return a public-safe dashboard title derived from goal text."""
+
+    candidate = str(explicit or "").strip() or str(objective or "").strip()
+    if not candidate:
+        return None
+    return public_safe_compact_text(candidate, limit=GOAL_DISPLAY_NAME_LIMIT)
+
+
 GENERIC_ONBOARDING_ADAPTER_KINDS = frozenset(
     {"generic_project_goal_v0", "read_only_project_map_v0"}
 )
@@ -741,6 +758,10 @@ def bootstrap_project(
     if runtime_root:
         registry["common_runtime_root"] = str(runtime_root)
 
+    resolved_display_name = derive_public_goal_display_name(
+        objective,
+        explicit=display_name,
+    )
     goal_entry = build_goal_entry(
         project=project,
         goal_id=goal_id,
@@ -757,7 +778,7 @@ def bootstrap_project(
         allowed_domains=allowed_domains or [],
         write_scope=write_scope or [],
         execution_profile=execution_profile,
-        display_name=display_name,
+        display_name=resolved_display_name,
     )
     registry, registry_goal_action = merge_goal(registry, goal_entry, force=force)
 
@@ -957,6 +978,7 @@ def bootstrap_project(
         "dry_run": dry_run,
         "project": str(project),
         "goal_id": goal_id,
+        "display_name": resolved_display_name,
         "registry": str(registry_path),
         "state_file": str(state_file),
         "goal_doc": str(goal_doc) if goal_doc else None,

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -681,7 +681,7 @@ def bootstrap_project(
     registry_path: Path,
     runtime_root: Path | None,
     goal_id: str | None,
-    objective: str,
+    objective: str | None,
     domain: str,
     role: str,
     parent_goal_id: str | None,
@@ -729,6 +729,7 @@ def bootstrap_project(
         state_file = project / state_file
     goal_doc = resolve_project_path(project, goal_doc)
     runtime_root = runtime_root.expanduser() if runtime_root else DEFAULT_RUNTIME_ROOT
+    state_objective = objective or DEFAULT_OBJECTIVE
     updated_at = now_iso()
     execution_profile = build_execution_profile(
         minimum_scale=execution_minimum_scale,
@@ -947,7 +948,7 @@ def bootstrap_project(
                     project=project,
                     goal_id=goal_id,
                     adapter_kind=adapter_kind,
-                    objective=objective,
+                    objective=state_objective,
                     updated_at=updated_at,
                     goal_doc=goal_doc,
                     execution_profile=execution_profile,

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -908,11 +908,7 @@ def build_loopx_bootstrap_command_pack(
         cli_bin=cli_bin,
         runtime_root=command_runtime_root,
         fine_grained=fine_grained,
-        display_name=(
-            derive_public_goal_display_name(None, explicit=display_name)
-            if display_name and display_name.strip()
-            else None
-        ),
+        display_name=derive_public_goal_display_name(None, explicit=display_name) if display_name else None,
     )
     goal_start_plan_prompt = build_goal_start_prompt(
         goal_text=normalized_goal_text,

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .agent_registry import registered_agent_ids_for_goal
-from .bootstrap import default_goal_id
+from .bootstrap import default_goal_id, derive_public_goal_display_name
 from .capabilities.issue_fix.candidate_preflight import (
     candidate_preflight_input_contract,
 )
@@ -685,6 +685,7 @@ def _goal_start_bootstrap_command(
     cli_bin: str,
     runtime_root: str | None,
     fine_grained: bool,
+    display_name: str | None = None,
 ) -> str:
     objective = goal_text or "<exact /loopx goal text>"
     lines = [
@@ -693,11 +694,17 @@ def _goal_start_bootstrap_command(
         "  --project . \\",
         f"  --goal-id {shell_arg(goal_id)} \\",
         f"  --objective {shell_arg(objective)} \\",
-        f"  --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)} \\",
-        f"  --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)} \\",
-        "  --no-onboarding-scan \\",
-        "  --codex-app-heartbeat ask",
     ]
+    if display_name:
+        lines.append(f"  --display-name {shell_arg(display_name)} \\")
+    lines.extend(
+        [
+            f"  --adapter-kind {shell_arg(DEFAULT_HANDOFF_ADAPTER_KIND)} \\",
+            f"  --adapter-status {shell_arg(DEFAULT_HANDOFF_ADAPTER_STATUS)} \\",
+            "  --no-onboarding-scan \\",
+            "  --codex-app-heartbeat ask",
+        ]
+    )
     if fine_grained:
         lines[-1] += " \\"
         lines.append("  --fine-grained")
@@ -766,6 +773,7 @@ def build_loopx_bootstrap_command_pack(
     available_capabilities: list[str] | None = None,
     capability_route: str | None = None,
     fine_grained: bool = False,
+    display_name: str | None = None,
     resolve_linked_worktree_alias: bool = True,
     runtime_root_arg: str | None = None,
 ) -> dict[str, Any]:
@@ -900,6 +908,10 @@ def build_loopx_bootstrap_command_pack(
         cli_bin=cli_bin,
         runtime_root=command_runtime_root,
         fine_grained=fine_grained,
+        display_name=derive_public_goal_display_name(
+            normalized_goal_text,
+            explicit=display_name,
+        ),
     )
     goal_start_plan_prompt = build_goal_start_prompt(
         goal_text=normalized_goal_text,
@@ -1395,6 +1407,7 @@ def build_start_goal_guided_packet(
     available_capabilities: list[str] | None = None,
     capability_route: str | None = None,
     fine_grained: bool = False,
+    display_name: str | None = None,
     include_command_pack_detail: bool = False,
     runtime_root_arg: str | None = None,
 ) -> dict[str, Any]:
@@ -1427,6 +1440,7 @@ def build_start_goal_guided_packet(
         available_capabilities=available_capabilities,
         capability_route=capability_route,
         fine_grained=fine_grained,
+        display_name=display_name,
         resolve_linked_worktree_alias=False,
         runtime_root_arg=runtime_root_arg,
     )

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -908,9 +908,10 @@ def build_loopx_bootstrap_command_pack(
         cli_bin=cli_bin,
         runtime_root=command_runtime_root,
         fine_grained=fine_grained,
-        display_name=derive_public_goal_display_name(
-            normalized_goal_text,
-            explicit=display_name,
+        display_name=(
+            derive_public_goal_display_name(None, explicit=display_name)
+            if display_name and display_name.strip()
+            else None
         ),
     )
     goal_start_plan_prompt = build_goal_start_prompt(

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from ..bootstrap import (
     DEFAULT_DOMAIN,
-    DEFAULT_OBJECTIVE,
     bootstrap_project,
     render_bootstrap_markdown,
 )
@@ -28,7 +27,11 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
         "--fork-goal",
         help="Create a new forked goal id instead of reusing an existing global goal route.",
     )
-    bootstrap_parser.add_argument("--objective", default=DEFAULT_OBJECTIVE, help="Initial goal objective.")
+    bootstrap_parser.add_argument(
+        "--objective",
+        default=None,
+        help="Initial goal objective. Defaults to the internal objective in active state when omitted.",
+    )
     bootstrap_parser.add_argument(
         "--display-name",
         help=(

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -29,6 +29,13 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
         help="Create a new forked goal id instead of reusing an existing global goal route.",
     )
     bootstrap_parser.add_argument("--objective", default=DEFAULT_OBJECTIVE, help="Initial goal objective.")
+    bootstrap_parser.add_argument(
+        "--display-name",
+        help=(
+            "Public-safe dashboard title for this goal. Defaults to a scrubbed "
+            "summary of --objective when omitted."
+        ),
+    )
     bootstrap_parser.add_argument("--domain", default=DEFAULT_DOMAIN, help="Goal domain label.")
     bootstrap_parser.add_argument("--role", choices=["controller", "subagent"], default="controller")
     bootstrap_parser.add_argument("--parent-goal-id", help="Parent goal id when --role subagent.")
@@ -223,6 +230,7 @@ def handle_bootstrap_connect_command(
             onboarding_max_status_paths=args.onboarding_max_status_paths,
             onboarding_max_top_level_files=args.onboarding_max_top_level_files,
             preserve_todos=bool(args.preserve_todos),
+            display_name=args.display_name,
             force=args.force,
             dry_run=args.dry_run,
             sync_global=not bool(args.no_global_sync),

--- a/loopx/cli_commands/start_goal.py
+++ b/loopx/cli_commands/start_goal.py
@@ -176,6 +176,13 @@ def register_start_goal_command(subparsers: argparse._SubParsersAction) -> None:
             "Todos executed in coherent evidence-driven turn slices."
         ),
     )
+    start_goal_parser.add_argument(
+        "--display-name",
+        help=(
+            "Public-safe dashboard title for this goal. Defaults to a scrubbed "
+            "summary of the goal text when connect/bootstrap runs."
+        ),
+    )
     goal_input_group = start_goal_parser.add_mutually_exclusive_group(required=True)
     goal_input_group.add_argument(
         "--goal-text",
@@ -331,6 +338,7 @@ def handle_start_goal_command(
             available_capabilities=args.available_capabilities,
             capability_route=capability_route,
             fine_grained=fine_grained,
+            display_name=getattr(args, "display_name", None),
             include_command_pack_detail=bool(args.include_command_pack_detail),
             runtime_root_arg=runtime_root_arg,
         )

--- a/tests/test_goal_display_name.py
+++ b/tests/test_goal_display_name.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loopx.bootstrap import bootstrap_project, derive_public_goal_display_name
+from loopx.bootstrap_command_pack import build_start_goal_guided_packet
+
+
+def test_derive_public_goal_display_name_prefers_explicit_override() -> None:
+    assert derive_public_goal_display_name(
+        "Fix scheduler state path override problem",
+        explicit="Fix scheduler override",
+    ) == "Fix scheduler override"
+
+
+def test_derive_public_goal_display_name_rejects_local_paths() -> None:
+    assert (
+        derive_public_goal_display_name(
+            "Repair /Users/example/project/.loopx/registry drift"
+        )
+        is None
+    )
+
+
+def test_bootstrap_project_persists_display_name_from_objective(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    registry_path = project / ".loopx" / "registry.json"
+    objective = "Fix guided start goal title for dashboard projection"
+
+    result = bootstrap_project(
+        project=project,
+        registry_path=registry_path,
+        runtime_root=tmp_path / "runtime",
+        goal_id="display-name-goal",
+        objective=objective,
+        domain="project-goal-control-plane",
+        role="controller",
+        parent_goal_id=None,
+        state_file=None,
+        goal_doc=None,
+        adapter_kind="generic_project_goal_v0",
+        adapter_status="connected",
+        next_probe=None,
+        spawn_allowed=False,
+        max_children=0,
+        allowed_domains=[],
+        write_scope=[],
+        onboarding_scan_enabled=False,
+        force=False,
+        dry_run=False,
+        sync_global=False,
+    )
+
+    assert result["ok"] is True
+    assert result["display_name"] == objective
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    goal = next(item for item in registry["goals"] if item["id"] == "display-name-goal")
+    assert goal["display_name"] == objective
+
+
+def test_guided_start_connect_command_includes_display_name(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    state_file = project / ".codex" / "goals" / "guided-goal" / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": "guided-goal",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/guided-goal/ACTIVE_GOAL_STATE.md",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    goal_text = "Repair dashboard goal title fallback"
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id="guided-goal",
+        agent_id="cursor-display-name-agent",
+        cli_bin="loopx",
+        host_surface="cursor-agent",
+        goal_text=goal_text,
+    )
+    connect_command = payload["guided_transaction"]["ordered_steps"][1]["command"]
+    assert "--display-name" in connect_command
+    assert goal_text in connect_command

--- a/tests/test_goal_display_name.py
+++ b/tests/test_goal_display_name.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 from loopx.bootstrap import bootstrap_project, derive_public_goal_display_name
@@ -58,6 +60,49 @@ def test_bootstrap_project_persists_display_name_from_objective(tmp_path: Path) 
     registry = json.loads(registry_path.read_text(encoding="utf-8"))
     goal = next(item for item in registry["goals"] if item["id"] == "display-name-goal")
     assert goal["display_name"] == objective
+
+
+def test_bootstrap_without_objective_does_not_persist_default_display_name(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    goal_id = "plain-bootstrap-goal"
+    state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "bootstrap",
+            "--project",
+            str(project),
+            "--goal-id",
+            goal_id,
+            "--state-file",
+            str(state_file),
+            "--no-onboarding-scan",
+            "--no-global-sync",
+            "--codex-app-heartbeat",
+            "no",
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["display_name"] is None
+    registry = json.loads((project / ".loopx" / "registry.json").read_text(encoding="utf-8"))
+    goal = next(item for item in registry["goals"] if item["id"] == goal_id)
+    assert goal.get("display_name") is None
 
 
 def test_guided_start_connect_command_includes_display_name(tmp_path: Path) -> None:

--- a/tests/test_goal_display_name.py
+++ b/tests/test_goal_display_name.py
@@ -105,7 +105,7 @@ def test_bootstrap_without_objective_does_not_persist_default_display_name(
     assert goal.get("display_name") is None
 
 
-def test_guided_start_connect_command_includes_display_name(tmp_path: Path) -> None:
+def test_guided_start_connect_command_omits_derived_display_name(tmp_path: Path) -> None:
     project = tmp_path / "project"
     state_file = project / ".codex" / "goals" / "guided-goal" / "ACTIVE_GOAL_STATE.md"
     state_file.parent.mkdir(parents=True)
@@ -139,5 +139,47 @@ def test_guided_start_connect_command_includes_display_name(tmp_path: Path) -> N
         goal_text=goal_text,
     )
     connect_command = payload["guided_transaction"]["ordered_steps"][1]["command"]
-    assert "--display-name" in connect_command
-    assert goal_text in connect_command
+    assert "--display-name" not in connect_command
+    assert connect_command.count(goal_text) == 1
+
+
+def test_guided_start_connect_command_includes_explicit_display_name(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    state_file = project / ".codex" / "goals" / "guided-goal" / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Active Goal State\n", encoding="utf-8")
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "goals": [
+                    {
+                        "id": "guided-goal",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/guided-goal/ACTIVE_GOAL_STATE.md",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    goal_text = "Repair dashboard goal title fallback"
+    display_name = "Repair dashboard title"
+    payload = build_start_goal_guided_packet(
+        project=project,
+        goal_id="guided-goal",
+        agent_id="cursor-display-name-agent",
+        cli_bin="loopx",
+        host_surface="cursor-agent",
+        goal_text=goal_text,
+        display_name=f"  {display_name}  ",
+    )
+    connect_command = payload["guided_transaction"]["ordered_steps"][1]["command"]
+    assert f"--display-name '{display_name}'" in connect_command
+    assert connect_command.count(goal_text) == 1


### PR DESCRIPTION
## Summary
- Derive and persist a public-safe `display_name` from `/loopx` / `start-goal` goal text during bootstrap/connect, with optional `--display-name` override on `bootstrap`, `connect`, and `start-goal`.
- Wire the guided start connect command to pass the derived title into registry state so dashboard projection prefers task intent over project-name fallback.
- Add focused unit coverage and a public smoke for the bootstrap + guided start contract.

Closes #3577.

## Test plan
- [x] `python3 examples/control_plane/start-goal-display-name-smoke.py`
- [x] `PYTHONPATH=. python3 tests/test_goal_display_name.py` (inline function run)
- [x] `python3 -m py_compile loopx/bootstrap.py loopx/bootstrap_command_pack.py loopx/cli_commands/bootstrap_connect.py loopx/cli_commands/start_goal.py`