### PR TITLE
docs(release): extension doctor recovery guidance for GH-C04

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -28,7 +28,13 @@ loopx update check
 loopx update plan
 loopx update apply
 loopx doctor
+loopx extension doctor --all-enabled --execute
 ```
+
+After `loopx update apply`, revalidate enabled extensions with
+`loopx extension doctor --all-enabled --execute`. Stale extension readiness
+recovers on the next apply or doctor cycle; use per-extension doctor output for
+repair details. See [Extension lifecycle](../reference/extensions.md#runtime-lifecycle).
 
 For a pip or pipx distribution, apply delegates to that owner. For an archive
 snapshot, apply uses the public `stable` ref by default and preserves atomic
@@ -628,6 +634,8 @@ Treat these v0.x surfaces as stable enough for user guides, examples, and
 host integrations when their focused smokes pass:
 
 - `loopx doctor`, `loopx update`, `loopx check`, and the no-clone installer;
+- `loopx extension doctor` for enabled-extension readiness after install or
+  update apply;
 - project lifecycle commands: `bootstrap`, `connect`, `status`,
   `refresh-state`, `registry`, and `sync-global`;
 - todo lifecycle commands: `todo add`, `todo claim`, `todo update`,


### PR DESCRIPTION
## Summary
- Document `loopx extension doctor --all-enabled --execute` in the public install/update recovery path in `docs/product/release-readiness.md`.
- Add extension doctor to the stable surface list for post-install/update readiness (#3556).
- Contributor task **GH-C04**: most release-readiness validation already passes on `main`; this closes the remaining extension-readiness recovery gap without duplicating release-body optional-capability usage guidance.

## Test plan
- [x] `python3 examples/fresh-clone-quickstart-smoke.py`
- [x] `python3 examples/loopx-update-smoke.py`
- [x] `python3 examples/release/release-readiness-doc-smoke.py`
- [x] `python3 examples/release/release-version-contract-smoke.py`
- [x] `loopx check --scan-path docs/product/release-readiness.md --scan-path CONTRIBUTING.md`

Made with [Cursor](https://cursor.com)