### PR TITLE
docs: experimental planner-worker operator guide (GH-C75)

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,7 @@ Guides are task-oriented paths for people starting or operating LoopX.
 - [KunlunCode adapter guide (中文 HTML)](kunluncode-adapter.zh-CN.html)
 - [Auto-research command path](../../demo/auto_research/README.md)
 - [Multi-agent product recipe](multi-agent-product-recipe.md)
+- [Experimental planner-worker mode](planner-worker-experimental.md)
 - [Codex App multi-provider routing extension](../../packages/loopx-codex-provider-routing/README.md)
 - [Codex 多 App 隔离与运维最佳实践（中文）](codex-multi-app-best-practices.zh-CN.md)
 

--- a/docs/guides/planner-worker-experimental.md
+++ b/docs/guides/planner-worker-experimental.md
@@ -1,0 +1,67 @@
+# Experimental Planner-Worker Mode
+
+Status: **experimental**, opt-in, provider-neutral. This is not a resident
+scheduler and not LoopX's default multi-agent runtime. One call runs one
+bounded Planner → Worker → validation slice and returns a typed receipt.
+
+Use the shipped fake adapters in
+`examples/experiments/planner_worker/runtime-smoke.py` to learn the contract
+without a live model provider. TraeX is only one optional extension provider.
+
+## Operator contract
+
+| Rule | Requirement |
+| --- | --- |
+| Clean worktree | The workspace must be a git worktree with no dirty or untracked changes before Planner runs. |
+| Explicit model routes | Callers pass `model_routes` for `planner`, `cheap_worker`, and `strong_worker`. Missing routes fail closed. |
+| Caller-approved validation | Every `validation_commands` entry must appear in the caller allowlist. Unapproved commands stop before Worker writes. |
+| One-step receipt | Each `run_planner_worker_once` selects at most one executable step, runs it once, and returns `planner_worker_receipt_v0`. |
+| Incomplete cost | Receipts always set `cost.complete=false` until pricing is supplied; token `usage` may still be complete. |
+| Provider opt-in | Core owns the contract and fake runtime. Live providers (for example TraeX) stay optional and must be invoked explicitly. |
+| Stop | Do not restart or schedule another slice automatically. Read the receipt `status`/`reason` and exit; clean or reset the worktree before any later call. |
+
+## Fake runtime walkthrough
+
+```bash
+python3 examples/experiments/planner_worker/contract-smoke.py
+python3 examples/experiments/planner_worker/runtime-smoke.py
+```
+
+The runtime smoke builds a temporary clean git fixture, injects fake Planner and
+Worker adapters, allowlists `python3 verify.py`, and asserts a completed
+receipt with validation pass. It proves:
+
+- dirty worktrees are rejected at the observer boundary;
+- Worker sees the explicit cheap-worker model route;
+- validation runs only approved commands;
+- `usage.complete` can be true while `cost.complete` stays false.
+
+## Optional TraeX provider
+
+Only when you intentionally opt in to a live TraeX binary:
+
+```bash
+python3 scripts/experiments/traex_planner_worker_probe.py \
+  --cwd /path/to/clean/worktree \
+  --validation-command 'python3 -m pytest -q tests/test_target.py'
+```
+
+Pass every approved validation command explicitly. Keep the worktree clean
+before the probe. Treat TraeX output as one provider probe payload wrapping the
+same typed receipt—not as LoopX kernel writeback authority.
+
+## What this mode is not
+
+- Not a heartbeat, cron, or resident multi-agent scheduler.
+- Not a replacement for `loopx turn run-once` or host-mode connectors in the
+  [runtime connector catalog](../integrations/runtime-connector-catalog.md).
+- Not automatic quota spend, todo writeback, or default product orchestration.
+
+Stop after one receipt. Any follow-up slice is a new caller decision with a
+fresh clean worktree, explicit routes, and a fresh approved validation set.
+
+## Related surfaces
+
+- Contract and runtime: `loopx/experiments/planner_worker/`
+- Public smokes: `examples/experiments/planner_worker/`
+- Catalog index: [Runtime connector catalog](../integrations/runtime-connector-catalog.md)

--- a/docs/integrations/runtime-connector-catalog.md
+++ b/docs/integrations/runtime-connector-catalog.md
@@ -127,6 +127,24 @@ maintainer's local automation:
 - todo/writeback smokes cover the validated-work sequence and prove
   monitor-only or stop-only paths do not spend quota.
 
+## Experimental planner-worker mode
+
+Planner-worker is an **opt-in experimental** slice, not a catalog connector and
+not a resident scheduler. One call plans, executes at most one worker step, runs
+caller-approved validation, and returns a typed receipt. Model routes stay
+explicit; cost remains incomplete until pricing is supplied; live providers
+(such as TraeX) stay optional.
+
+Operator guide (provider-neutral fake runtime):
+[Experimental planner-worker mode](../guides/planner-worker-experimental.md).
+
+Public checks:
+
+```bash
+python3 examples/experiments/planner_worker/contract-smoke.py
+python3 examples/experiments/planner_worker/runtime-smoke.py
+```
+
 ## Related Contracts
 
 - [Host mode plan v0](../reference/protocols/host-mode-plan-v0.md)
@@ -138,3 +156,4 @@ maintainer's local automation:
 - [Session runtime to LoopX projection v0](../reference/protocols/session-runtime-loopx-projection-v0.md)
 - [Worker bridge install contract](worker-bridge-install-contract.md)
 - [Quota allocation](../quota-allocation.md)
+- [Experimental planner-worker mode](../guides/planner-worker-experimental.md)


### PR DESCRIPTION
## Summary
- Add a concise public operator guide for experimental planner-worker mode using the shipped provider-neutral fake runtime.
- Cover clean-worktree, explicit model routes, caller-approved validation, one-step typed receipt, incomplete-cost semantics, provider opt-in, and how to stop — without presenting the mode as a resident scheduler or default multi-agent runtime.
- Link the guide from the runtime connector catalog (experimental section) and the guides index.

Closes #3628

## Test plan
- [x] `python3 examples/experiments/planner_worker/contract-smoke.py`
- [x] `python3 examples/experiments/planner_worker/runtime-smoke.py`
- [x] `loopx check --scan-path docs/integrations/runtime-connector-catalog.md --scan-path docs/development/contributor-tasks.md`


Made with [Cursor](https://cursor.com)