### PR TITLE
feat(quota): GH-C95 typed per-run usage ingest for cost ledger

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -2187,14 +2187,31 @@ captured. There is no second usage ledger — run history plus this typed row is
 the single source of truth.
 
 Hosts and writers ingest usage through
-`loopx.control_plane.quota.usage_collector.ingest_usage_into_run_record` (wired
-into `write_reserved_run_artifacts`). Cumulative host snapshots are converted to
-non-negative deltas at that producer boundary and bound to
-`usage.source_snapshot_id` so replay of the same snapshot identity is idempotent.
-Missing optional measurements stay omitted (unknown) rather than zero-filled.
-Malformed, negative, reset, or out-of-order observations fail closed with a typed
-`UsageRowError`; they are never clamped or silently dropped. Quota/attempt
-accounting rows are not reinterpreted as token or dollar usage.
+`loopx.control_plane.quota.usage_collector.ingest_usage_into_run_record`, wired
+into `write_reserved_run_artifacts` and into the `refresh-state` run-write
+path. The first shipped measurement source is the Codex CLI session rollout:
+`loopx refresh-state --usage-codex-session <rollout.jsonl>` reads only the
+newest aggregate `token_count` totals, the model id, the session id, and event
+timestamps — never prompts, completions, or tool output. The session must be
+bound explicitly; there is no automatic session discovery, because guessing a
+concurrent session risks attributing one session's spend to another run. A
+host that measures usage itself can instead pass one finished per-run
+measurement with `--usage-json`. Without either flag, usage stays unknown.
+
+Cumulative host snapshots are converted to non-negative deltas at that
+producer boundary: the last accepted cumulative observation (all counters plus
+`provider`/`model`) is persisted as the goal's private
+`runs/usage_snapshot.json` state and used as the next delta basis, and each
+observation is bound to `usage.source_snapshot_id`. Replaying the same
+snapshot identity with an identical observation is an idempotent zero delta;
+the same identity carrying any different counter or binding label fails closed
+instead of silently zeroing real usage. A new session starts a fresh absolute
+observation rather than a bogus reset error. Missing optional measurements
+stay omitted (unknown) rather than zero-filled. Malformed, negative, reset, or
+out-of-order observations fail closed with a typed `UsageRowError`; they are
+never clamped or silently dropped, and a failed usage observation blocks the
+whole refresh append. Quota/attempt accounting rows are not reinterpreted as
+token or dollar usage.
 
 The typed compact usage row currently reports:
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -2199,22 +2199,28 @@ host that measures usage itself can instead pass one finished per-run
 measurement with `--usage-json`. Without either flag, usage stays unknown.
 
 Cumulative host snapshots are converted to non-negative deltas at that
-producer boundary: each session's last accepted cumulative observation (all
-counters plus `provider`/`model`) is persisted, keyed by session id, in the
-goal's private `runs/usage_snapshot.json` state (`goal_usage_snapshot_v1`) and
-used as that session's next delta basis, and each observation is bound to
-`usage.source_snapshot_id`. Baselines are per session, so interleaved sessions
-never rebase against each other: a returning session books only its own
-increment instead of re-booking its full cumulative total. Replaying the same
-snapshot identity with an identical observation is an idempotent zero delta;
-the same identity carrying any different counter or binding label fails closed
-instead of silently zeroing real usage. A new session starts a fresh absolute
-observation rather than a bogus reset error. Missing optional measurements
-stay omitted (unknown) rather than zero-filled. Malformed, negative,
-non-finite (`NaN`/`Infinity`, rejected both at the typed builder and at the
-strict-JSON `--usage-json` boundary), reset, or out-of-order observations fail
-closed with a typed `UsageRowError`; they are never clamped or silently
-dropped, and a failed usage observation blocks the whole refresh append.
+producer boundary, and the run index append is the single commit point: each
+session's delta basis is reconstructed from its own already-booked rows
+(telescoping absolute + delta sums per session id), not from a second state
+file, so a crash or retry can never leave the basis behind the ledger.
+Baselines are per session and each observation is bound to
+`usage.source_snapshot_id`, so interleaved sessions never rebase against each
+other: a returning session books only its own increment instead of re-booking
+its full cumulative total. Basis read and row append happen under a per-goal
+usage booking lock, so concurrent refreshes cannot fund two deltas from one
+stale basis. Replaying the same snapshot identity with an identical
+observation is an idempotent zero delta; the same identity carrying any
+different counter or binding label fails closed instead of silently zeroing
+real usage. A new session starts a fresh absolute observation rather than a
+bogus reset error. Missing optional measurements stay omitted (unknown)
+rather than zero-filled. Malformed, negative, non-finite (`NaN`/`Infinity`,
+rejected at the typed builder, at the strict-JSON `--usage-json` boundary,
+and again at durable serialization, which forbids non-standard JSON
+constants), reset, or out-of-order observations fail closed with a typed
+`UsageRowError`; they are never clamped or silently dropped, and a failed
+usage observation blocks the whole refresh append. Rollout parsing tolerates
+only a torn final line (concurrent-write noise); a malformed line with valid
+events after it fails closed instead of booking a stale cumulative snapshot.
 Quota/attempt accounting rows are not reinterpreted as token or dollar usage.
 
 The typed compact usage row currently reports:

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -498,11 +498,12 @@ first-screen UI are `ok`, `contract`, and `attention_queue`.
 `promotion_gate`, `decision_freshness_summary`, and `usage_summary` are optional and should be
 treated as compact protocol or run-history projections, not as the ledger
 itself, authoritative billing telemetry, or a release operation source.
-`usage_summary` carries aggregate token/cost/duration when runs report usage,
-but it remains a run-history proxy, not billing of record. A
-missing `status_contract` means an older status producer; loopback dashboards
-should surface that as a daemon freshness warning rather than silently hiding
-newer panels.
+`usage_summary` carries aggregate token/cost/duration when runs report a typed
+`run_usage_v0` usage row, but it remains a run-history proxy, not billing of
+record. Malformed or negative usage fails closed at ingest/read rather than
+appearing as zeros. A missing `status_contract` means an older status producer;
+loopback dashboards should surface that as a daemon freshness warning rather
+than silently hiding newer panels.
 
 ## Interface Budget Cadence
 
@@ -2176,12 +2177,34 @@ projection and cannot clear the warning.
 ## Usage Summary
 
 `usage_summary` is an optional dashboard-friendly proxy derived from the same
-compact run history. When a run reports usage, the summary carries aggregate
-input/output/cache token counts, an estimated cost, and wall-time duration for
-the goal; runs that report nothing contribute nothing. It remains a proxy, not
-billing telemetry: it still excludes raw thread logs, local project paths,
-private artifact contents, or anything that would require reading a Codex
-session transcript. Only aggregate numeric usage is captured.
+compact run history. When a run carries a typed `run_usage_v0` usage row, the
+summary aggregates input/output token counts and, when measured, cache tokens,
+estimated cost, and wall-time duration for the goal; runs that report nothing
+contribute nothing. It remains a proxy, not billing telemetry: it still excludes
+raw thread logs, local project paths, private artifact contents, or anything that
+would require reading a Codex session transcript. Only aggregate numeric usage is
+captured. There is no second usage ledger — run history plus this typed row is
+the single source of truth.
+
+Hosts and writers ingest usage through
+`loopx.control_plane.quota.usage_collector.ingest_usage_into_run_record` (wired
+into `write_reserved_run_artifacts`). Cumulative host snapshots are converted to
+non-negative deltas at that producer boundary and bound to
+`usage.source_snapshot_id` so replay of the same snapshot identity is idempotent.
+Missing optional measurements stay omitted (unknown) rather than zero-filled.
+Malformed, negative, reset, or out-of-order observations fail closed with a typed
+`UsageRowError`; they are never clamped or silently dropped. Quota/attempt
+accounting rows are not reinterpreted as token or dollar usage.
+
+The typed compact usage row currently reports:
+
+- `schema_version`: must be `run_usage_v0`
+- `measurement_kind`: `absolute` or `delta`
+- `source_snapshot_id`: stable host/runtime snapshot identity for idempotent
+  replay
+- `input_tokens` / `output_tokens`: required non-negative whole numbers
+- `cache_tokens` / `cost_usd` / `duration_ms`: optional; omitted when unmeasured
+- `provider` / `model`: public-safe runtime labels
 
 The summary currently reports:
 
@@ -2201,12 +2224,13 @@ The summary currently reports:
   blocker, or gate signal.
 - `input_tokens_24h` / `input_tokens_7d`, `output_tokens_24h` /
   `output_tokens_7d`, `cache_tokens_24h` / `cache_tokens_7d`: aggregate token
-  counts for runs that report a normalized `usage` block. Metric fields are
-  omitted for a window with no normalized usage sample; a 24h field can be
-  absent while the corresponding 7d field remains present.
+  counts for runs that report a typed `run_usage_v0` block. Metric fields are
+  omitted for a window (or optional metric) with no measured sample; a 24h field
+  can be absent while the corresponding 7d field remains present.
 - `cost_usd_24h` / `cost_usd_7d`: aggregate estimated cost in USD, rounded to
-  six decimals, computed by the reporting runtime.
-- `duration_ms_24h` / `duration_ms_7d`: aggregate wall-time in milliseconds.
+  six decimals, computed by the reporting runtime when measured.
+- `duration_ms_24h` / `duration_ms_7d`: aggregate wall-time in milliseconds when
+  measured.
 - `project_share_24h`: per-goal share of observed 24h runs, rounded to three
   decimals.
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -500,7 +500,7 @@ treated as compact protocol or run-history projections, not as the ledger
 itself, authoritative billing telemetry, or a release operation source.
 `usage_summary` carries aggregate token/cost/duration when runs report a typed
 `run_usage_v0` usage row, but it remains a run-history proxy, not billing of
-record. Malformed or negative usage fails closed at ingest/read rather than
+record. Malformed, negative, or non-finite usage fails closed at ingest/read rather than
 appearing as zeros. A missing `status_contract` means an older status producer;
 loopback dashboards should surface that as a daemon freshness warning rather
 than silently hiding newer panels.
@@ -2199,19 +2199,23 @@ host that measures usage itself can instead pass one finished per-run
 measurement with `--usage-json`. Without either flag, usage stays unknown.
 
 Cumulative host snapshots are converted to non-negative deltas at that
-producer boundary: the last accepted cumulative observation (all counters plus
-`provider`/`model`) is persisted as the goal's private
-`runs/usage_snapshot.json` state and used as the next delta basis, and each
-observation is bound to `usage.source_snapshot_id`. Replaying the same
+producer boundary: each session's last accepted cumulative observation (all
+counters plus `provider`/`model`) is persisted, keyed by session id, in the
+goal's private `runs/usage_snapshot.json` state (`goal_usage_snapshot_v1`) and
+used as that session's next delta basis, and each observation is bound to
+`usage.source_snapshot_id`. Baselines are per session, so interleaved sessions
+never rebase against each other: a returning session books only its own
+increment instead of re-booking its full cumulative total. Replaying the same
 snapshot identity with an identical observation is an idempotent zero delta;
 the same identity carrying any different counter or binding label fails closed
 instead of silently zeroing real usage. A new session starts a fresh absolute
 observation rather than a bogus reset error. Missing optional measurements
-stay omitted (unknown) rather than zero-filled. Malformed, negative, reset, or
-out-of-order observations fail closed with a typed `UsageRowError`; they are
-never clamped or silently dropped, and a failed usage observation blocks the
-whole refresh append. Quota/attempt accounting rows are not reinterpreted as
-token or dollar usage.
+stay omitted (unknown) rather than zero-filled. Malformed, negative,
+non-finite (`NaN`/`Infinity`, rejected both at the typed builder and at the
+strict-JSON `--usage-json` boundary), reset, or out-of-order observations fail
+closed with a typed `UsageRowError`; they are never clamped or silently
+dropped, and a failed usage observation blocks the whole refresh append.
+Quota/attempt accounting rows are not reinterpreted as token or dollar usage.
 
 The typed compact usage row currently reports:
 

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -179,6 +179,14 @@ def _inline_agent_vision_packet(args: argparse.Namespace) -> dict[str, object] |
     return packet
 
 
+def _reject_non_standard_json_constant(name: str) -> object:
+    # json.loads would otherwise accept NaN/Infinity/-Infinity, which json.dump
+    # then re-emits as non-standard JSON that breaks strict ledger consumers.
+    raise ValueError(
+        f"--usage-json must be strict JSON; non-standard constant {name} is not allowed"
+    )
+
+
 def _inline_progress_observation(
     args: argparse.Namespace,
 ) -> dict[str, object] | None:
@@ -470,8 +478,9 @@ def register_project_lifecycle_commands(
             "Inline JSON object with a provider-neutral per-run usage "
             "measurement: input_tokens, output_tokens, provider, model, "
             "source_snapshot_id, plus optional cache_tokens/cost_usd/"
-            "duration_ms. Malformed or negative usage fails the refresh "
-            "closed. Cannot be combined with --usage-codex-session."
+            "duration_ms. Must be strict JSON; malformed, negative, or "
+            "non-finite usage fails the refresh closed. Cannot be combined "
+            "with --usage-codex-session."
         ),
     )
     refresh_state_parser.add_argument(
@@ -660,7 +669,10 @@ def handle_project_lifecycle_command(
             progress_observation = _inline_progress_observation(args)
             usage_measurement: dict[str, object] | None = None
             if getattr(args, "usage_json", None):
-                loaded_usage = json.loads(args.usage_json)
+                loaded_usage = json.loads(
+                    args.usage_json,
+                    parse_constant=_reject_non_standard_json_constant,
+                )
                 if not isinstance(loaded_usage, dict):
                     raise ValueError("--usage-json must be a JSON object")
                 usage_measurement = loaded_usage

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -454,6 +454,27 @@ def register_project_lifecycle_commands(
         ),
     )
     refresh_state_parser.add_argument(
+        "--usage-codex-session",
+        help=(
+            "Path to the local Codex session rollout JSONL that produced this "
+            "run. Only aggregate token_count totals, the model id, and event "
+            "timestamps are read; prompts, completions, and tool output never "
+            "enter run history. The session must be bound explicitly; when the "
+            "rollout is unknown, omit the flag and usage stays unknown. Cannot "
+            "be combined with --usage-json."
+        ),
+    )
+    refresh_state_parser.add_argument(
+        "--usage-json",
+        help=(
+            "Inline JSON object with a provider-neutral per-run usage "
+            "measurement: input_tokens, output_tokens, provider, model, "
+            "source_snapshot_id, plus optional cache_tokens/cost_usd/"
+            "duration_ms. Malformed or negative usage fails the refresh "
+            "closed. Cannot be combined with --usage-codex-session."
+        ),
+    )
+    refresh_state_parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print the refresh payload without appending.",
@@ -637,6 +658,12 @@ def handle_project_lifecycle_command(
                 agent_vision_packet = inline_agent_vision_packet
                 merge_agent_vision_patch = True
             progress_observation = _inline_progress_observation(args)
+            usage_measurement: dict[str, object] | None = None
+            if getattr(args, "usage_json", None):
+                loaded_usage = json.loads(args.usage_json)
+                if not isinstance(loaded_usage, dict):
+                    raise ValueError("--usage-json must be a JSON object")
+                usage_measurement = loaded_usage
         except Exception as exc:
             payload = {
                 "ok": False,
@@ -684,6 +711,12 @@ def handle_project_lifecycle_command(
                 merge_agent_vision_patch=merge_agent_vision_patch,
                 vision_unchanged_reason=args.vision_unchanged_reason,
                 progress_observation=progress_observation,
+                usage_measurement=usage_measurement,
+                usage_codex_session=(
+                    Path(args.usage_codex_session).expanduser()
+                    if getattr(args, "usage_codex_session", None)
+                    else None
+                ),
                 dry_run=bool(args.dry_run),
                 sync_global=not bool(args.no_global_sync),
             )

--- a/loopx/control_plane/quota/codex_session_usage.py
+++ b/loopx/control_plane/quota/codex_session_usage.py
@@ -17,7 +17,10 @@ Cumulative-to-delta conversion happens at the run-write boundary: the caller
 persists each accepted observation with :func:`store_usage_snapshot` and
 passes it back through :func:`previous_snapshot_for_observation` so an
 unchanged rollout replays as a zero delta and a grown rollout books only the
-non-negative increment. Missing optional metrics stay unknown, never zero.
+non-negative increment. Baselines are kept per session id: interleaved
+sessions (A, then B, then A again) each rebase against their own last
+accepted cumulative snapshot, so a returning session never re-books its full
+total as new spend. Missing optional metrics stay unknown, never zero.
 """
 
 from __future__ import annotations
@@ -30,7 +33,7 @@ from typing import Any, Mapping
 from .usage_collector import UsageRowError
 
 CODEX_USAGE_PROVIDER = "codex"
-USAGE_SNAPSHOT_SCHEMA_VERSION = "goal_usage_snapshot_v0"
+USAGE_SNAPSHOT_SCHEMA_VERSION = "goal_usage_snapshot_v1"
 USAGE_SNAPSHOT_FILENAME = "usage_snapshot.json"
 _SNAPSHOT_FIELDS = (
     "session_id",
@@ -155,10 +158,12 @@ def usage_snapshot_path(runs_dir: Path) -> Path:
 
 
 def load_usage_snapshot(runs_dir: Path) -> dict[str, Any] | None:
-    """Return the persisted previous cumulative observation, if any.
+    """Return the persisted per-session cumulative baselines, if any.
 
-    A missing snapshot means first observation (absolute intake). A corrupt or
-    unknown-schema snapshot fails closed instead of silently rebasing spend.
+    A missing snapshot means no session has been booked yet, so any session's
+    first observation is an absolute intake. A corrupt or unknown-schema
+    snapshot fails closed instead of silently rebasing spend; the file is
+    private per-goal state and may be deleted to restart absolute intake.
     """
     path = usage_snapshot_path(runs_dir)
     try:
@@ -174,24 +179,36 @@ def load_usage_snapshot(runs_dir: Path) -> dict[str, Any] | None:
     if (
         not isinstance(data, dict)
         or str(data.get("schema_version") or "") != USAGE_SNAPSHOT_SCHEMA_VERSION
+        or not isinstance(data.get("sessions"), dict)
     ):
         raise CodexSessionUsageError(f"usage snapshot state has an unknown schema: {path}")
     return data
 
 
 def store_usage_snapshot(runs_dir: Path, observation: Mapping[str, Any]) -> Path:
-    """Persist the full cumulative observation as the next delta basis.
+    """Persist the observation as its own session's next delta basis.
 
-    The snapshot keeps every counter and binding label (not only the id) so
-    replay of the same identity can be verified field by field.
+    Baselines are grouped by session id: a single shared slot would be
+    overwritten by an interleaved session, making a returning session look
+    brand new and re-booking its full cumulative total as fresh spend. Each
+    entry keeps every counter and binding label (not only the id) so replay
+    of the same identity can be verified field by field.
     """
-    path = usage_snapshot_path(runs_dir)
-    record: dict[str, Any] = {"schema_version": USAGE_SNAPSHOT_SCHEMA_VERSION}
+    session_id = str(observation.get("session_id") or "").strip()
+    if not session_id:
+        raise CodexSessionUsageError("usage observation has no session id to persist")
+    state = load_usage_snapshot(runs_dir) or {
+        "schema_version": USAGE_SNAPSHOT_SCHEMA_VERSION,
+        "sessions": {},
+    }
+    record: dict[str, Any] = {}
     for field in _SNAPSHOT_FIELDS:
         record[field] = observation.get(field)
+    state["sessions"][session_id] = record
+    path = usage_snapshot_path(runs_dir)
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     tmp_path.write_text(
-        json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
     )
     tmp_path.replace(path)
     return path
@@ -201,14 +218,17 @@ def previous_snapshot_for_observation(
     snapshot: Mapping[str, Any] | None,
     observation: Mapping[str, Any],
 ) -> Mapping[str, Any] | None:
-    """Return the delta basis only when it belongs to the same Codex session.
+    """Return the stored delta basis for the observation's own session.
 
-    A new session restarts its cumulative counters from zero, so its first
-    observation must be booked as an absolute intake rather than raising a
-    bogus reset error against another session's basis.
+    Each Codex session counts cumulatively from zero, so the basis must come
+    from the same session: a new session's first observation is an absolute
+    intake, and a returning session rebases against its own last accepted
+    snapshot even when other sessions were booked in between.
     """
     if snapshot is None:
         return None
-    if str(snapshot.get("session_id") or "") != str(observation.get("session_id") or ""):
+    sessions = snapshot.get("sessions")
+    if not isinstance(sessions, Mapping):
         return None
-    return snapshot
+    basis = sessions.get(str(observation.get("session_id") or ""))
+    return basis if isinstance(basis, Mapping) else None

--- a/loopx/control_plane/quota/codex_session_usage.py
+++ b/loopx/control_plane/quota/codex_session_usage.py
@@ -13,39 +13,34 @@ cwd and mtime) risks attributing one concurrent session's spend to another
 run, and a wrong attribution is worse than an unknown one. Automatic
 discovery, if ever added, needs its own explicitly reviewed contract.
 
-Cumulative-to-delta conversion happens at the run-write boundary: the caller
-persists each accepted observation with :func:`store_usage_snapshot` and
-passes it back through :func:`previous_snapshot_for_observation` so an
-unchanged rollout replays as a zero delta and a grown rollout books only the
-non-negative increment. Baselines are kept per session id: interleaved
-sessions (A, then B, then A again) each rebase against their own last
-accepted cumulative snapshot, so a returning session never re-books its full
-total as new spend. Missing optional metrics stay unknown, never zero.
+Cumulative-to-delta conversion happens at the run-write boundary. The delta
+basis is not a second state file: :func:`session_usage_baseline` reconstructs
+each session's last accepted cumulative observation from the run index itself
+(telescoping absolute + delta sums per session id), so the durable row append
+is the single commit point that also advances the basis. A crash or retry can
+never leave the basis behind the ledger — replaying the same rollout books an
+idempotent zero delta, a grown rollout books only the non-negative increment,
+and interleaved sessions (A, then B, then A again) each rebase against their
+own baseline. Callers must hold the per-goal usage booking lock (see
+:func:`usage_booking_lock_target`) across basis read + row append so two
+concurrent bookings cannot fund two deltas from one stale basis. Missing
+optional metrics stay unknown, never zero.
 """
 
 from __future__ import annotations
 
 import json
+import math
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
-from .usage_collector import UsageRowError
+from ..runtime.run_index_duplicates import index_identity
+from .usage_collector import UsageRowError, ingest_usage_into_run_record
 
 CODEX_USAGE_PROVIDER = "codex"
-USAGE_SNAPSHOT_SCHEMA_VERSION = "goal_usage_snapshot_v1"
-USAGE_SNAPSHOT_FILENAME = "usage_snapshot.json"
-_SNAPSHOT_FIELDS = (
-    "session_id",
-    "source_snapshot_id",
-    "input_tokens",
-    "output_tokens",
-    "cache_tokens",
-    "cost_usd",
-    "duration_ms",
-    "provider",
-    "model",
-)
+USAGE_BOOKING_LOCK_TARGET = "usage_booking"
+_BASELINE_INT_FIELDS = ("input_tokens", "output_tokens", "cache_tokens", "duration_ms")
 
 
 class CodexSessionUsageError(UsageRowError):
@@ -86,16 +81,24 @@ def read_codex_session_usage(rollout_path: Path) -> dict[str, Any]:
     model = ""
     last_totals: Mapping[str, Any] | None = None
     last_totals_at = ""
-    for line in raw_text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
+    lines = [
+        (number, text)
+        for number, text in enumerate(raw_text.splitlines(), start=1)
+        if text.strip()
+    ]
+    for position, (line_number, line) in enumerate(lines):
         try:
-            item = json.loads(line)
-        except json.JSONDecodeError:
-            # The Codex CLI appends to the rollout while sessions run; a torn
-            # trailing line is not an integrity failure for earlier events.
-            continue
+            item = json.loads(line.strip())
+        except json.JSONDecodeError as exc:
+            if position == len(lines) - 1:
+                # The Codex CLI appends to the rollout while sessions run; only
+                # a torn final line is concurrent-write noise. A malformed line
+                # with valid events after it means the file itself is damaged,
+                # and parsing on could book a stale cumulative snapshot.
+                continue
+            raise CodexSessionUsageError(
+                f"codex session rollout line {line_number} is corrupt: {path}"
+            ) from exc
         if not isinstance(item, dict):
             continue
         kind = str(item.get("type") or "")
@@ -153,82 +156,127 @@ def read_codex_session_usage(rollout_path: Path) -> dict[str, Any]:
     return observation
 
 
-def usage_snapshot_path(runs_dir: Path) -> Path:
-    return Path(runs_dir) / USAGE_SNAPSHOT_FILENAME
+def usage_booking_lock_target(runs_dir: Path) -> Path:
+    """Return the per-goal lock target serializing usage basis read + append."""
+    return Path(runs_dir) / USAGE_BOOKING_LOCK_TARGET
 
 
-def load_usage_snapshot(runs_dir: Path) -> dict[str, Any] | None:
-    """Return the persisted per-session cumulative baselines, if any.
+def book_codex_session_usage(
+    record: MutableMapping[str, Any],
+    rollout_path: Path,
+    index_path: Path,
+    *,
+    index_record: MutableMapping[str, Any] | None = None,
+) -> None:
+    """Read the rollout and ingest its typed usage row onto the run record.
 
-    A missing snapshot means no session has been booked yet, so any session's
-    first observation is an absolute intake. A corrupt or unknown-schema
-    snapshot fails closed instead of silently rebasing spend; the file is
-    private per-goal state and may be deleted to restart absolute intake.
+    The delta basis is the session's ledger baseline from ``index_path``.
+    Callers must hold the usage booking lock across this call and the run row
+    append it funds, so concurrent bookings serialize on one basis.
     """
-    path = usage_snapshot_path(runs_dir)
+    observation = read_codex_session_usage(rollout_path)
+    ingest_usage_into_run_record(
+        record,
+        {key: value for key, value in observation.items() if key != "session_id"},
+        previous_snapshot=session_usage_baseline(
+            index_path, str(observation.get("session_id") or "")
+        ),
+        index_record=index_record,
+    )
+
+
+def _booked_usage_number(
+    value: Any, *, field: str, line_number: int, index_path: Path
+) -> int | float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or value < 0
+    ):
+        raise CodexSessionUsageError(
+            f"run index row {line_number} has an invalid booked usage.{field}: {index_path}"
+        )
+    return value
+
+
+def session_usage_baseline(
+    index_path: Path, session_id: str
+) -> dict[str, Any] | None:
+    """Reconstruct the session's last accepted cumulative observation.
+
+    The run index append is the ledger's single commit point: a usage booking
+    exists exactly when its row is durable. Summing the session's absolute and
+    delta rows telescopes back to the last accepted cumulative observation, so
+    there is no second basis state that a crash between writes could leave
+    stale. ``None`` means the session has never been booked (absolute intake).
+    Corrupt index rows fail closed: skipping a booked row would shrink the
+    basis and double-book real spend. Callers must hold the usage booking lock
+    while reading the basis and appending the row it funds.
+    """
+    sid = str(session_id or "").strip()
+    if not sid:
+        raise CodexSessionUsageError("usage observation has no session id")
+    prefix = f"{CODEX_USAGE_PROVIDER}:{sid}:"
     try:
-        raw = path.read_text(encoding="utf-8")
+        raw = index_path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return None
     except OSError as exc:
-        raise CodexSessionUsageError(f"usage snapshot state is unreadable: {path}") from exc
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise CodexSessionUsageError(f"usage snapshot state is corrupt: {path}") from exc
-    if (
-        not isinstance(data, dict)
-        or str(data.get("schema_version") or "") != USAGE_SNAPSHOT_SCHEMA_VERSION
-        or not isinstance(data.get("sessions"), dict)
-    ):
-        raise CodexSessionUsageError(f"usage snapshot state has an unknown schema: {path}")
-    return data
+        raise CodexSessionUsageError(
+            f"cannot read run index for the usage basis: {exc}"
+        ) from exc
 
-
-def store_usage_snapshot(runs_dir: Path, observation: Mapping[str, Any]) -> Path:
-    """Persist the observation as its own session's next delta basis.
-
-    Baselines are grouped by session id: a single shared slot would be
-    overwritten by an interleaved session, making a returning session look
-    brand new and re-booking its full cumulative total as fresh spend. Each
-    entry keeps every counter and binding label (not only the id) so replay
-    of the same identity can be verified field by field.
-    """
-    session_id = str(observation.get("session_id") or "").strip()
-    if not session_id:
-        raise CodexSessionUsageError("usage observation has no session id to persist")
-    state = load_usage_snapshot(runs_dir) or {
-        "schema_version": USAGE_SNAPSHOT_SCHEMA_VERSION,
-        "sessions": {},
+    int_totals: dict[str, int | None] = {field: None for field in _BASELINE_INT_FIELDS}
+    cost_total: float | None = None
+    last_usage: Mapping[str, Any] | None = None
+    seen_rows: set[tuple[str, str, str]] = set()
+    for line_number, line in enumerate(raw.splitlines(), start=1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise CodexSessionUsageError(
+                f"run index row {line_number} is corrupt: {index_path}"
+            ) from exc
+        if not isinstance(row, dict):
+            continue
+        usage = row.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        if not str(usage.get("source_snapshot_id") or "").startswith(prefix):
+            continue
+        identity = index_identity(row)
+        if identity in seen_rows:
+            continue
+        seen_rows.add(identity)
+        for field in _BASELINE_INT_FIELDS:
+            value = usage.get(field)
+            if value is None:
+                continue
+            booked = _booked_usage_number(
+                value, field=field, line_number=line_number, index_path=index_path
+            )
+            int_totals[field] = int(int_totals[field] or 0) + int(booked)
+        cost = usage.get("cost_usd")
+        if cost is not None:
+            booked_cost = _booked_usage_number(
+                cost, field="cost_usd", line_number=line_number, index_path=index_path
+            )
+            cost_total = float(cost_total or 0.0) + float(booked_cost)
+        last_usage = usage
+    if last_usage is None:
+        return None
+    return {
+        "session_id": sid,
+        "source_snapshot_id": str(last_usage.get("source_snapshot_id") or ""),
+        "input_tokens": int_totals["input_tokens"],
+        "output_tokens": int_totals["output_tokens"],
+        "cache_tokens": int_totals["cache_tokens"],
+        "cost_usd": cost_total,
+        "duration_ms": int_totals["duration_ms"],
+        "provider": last_usage.get("provider"),
+        "model": last_usage.get("model"),
     }
-    record: dict[str, Any] = {}
-    for field in _SNAPSHOT_FIELDS:
-        record[field] = observation.get(field)
-    state["sessions"][session_id] = record
-    path = usage_snapshot_path(runs_dir)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(
-        json.dumps(state, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
-    )
-    tmp_path.replace(path)
-    return path
-
-
-def previous_snapshot_for_observation(
-    snapshot: Mapping[str, Any] | None,
-    observation: Mapping[str, Any],
-) -> Mapping[str, Any] | None:
-    """Return the stored delta basis for the observation's own session.
-
-    Each Codex session counts cumulatively from zero, so the basis must come
-    from the same session: a new session's first observation is an absolute
-    intake, and a returning session rebases against its own last accepted
-    snapshot even when other sessions were booked in between.
-    """
-    if snapshot is None:
-        return None
-    sessions = snapshot.get("sessions")
-    if not isinstance(sessions, Mapping):
-        return None
-    basis = sessions.get(str(observation.get("session_id") or ""))
-    return basis if isinstance(basis, Mapping) else None

--- a/loopx/control_plane/quota/codex_session_usage.py
+++ b/loopx/control_plane/quota/codex_session_usage.py
@@ -1,0 +1,214 @@
+"""Codex session rollout usage producer for the ``run_usage_v0`` ledger seam.
+
+This is the first shipped measurement source behind
+``ingest_usage_into_run_record``: it reads one locally stored Codex CLI
+session rollout (JSONL) and returns the session-cumulative token usage as a
+provider-neutral observation. Only aggregate ``token_count`` totals, the model
+id, the session id, and event timestamps are read; prompts, completions, tool
+output, and any other conversational content never enter the measurement.
+
+The rollout must be bound explicitly by the caller. This module performs no
+session discovery under ``CODEX_HOME``: guessing the session (for example by
+cwd and mtime) risks attributing one concurrent session's spend to another
+run, and a wrong attribution is worse than an unknown one. Automatic
+discovery, if ever added, needs its own explicitly reviewed contract.
+
+Cumulative-to-delta conversion happens at the run-write boundary: the caller
+persists each accepted observation with :func:`store_usage_snapshot` and
+passes it back through :func:`previous_snapshot_for_observation` so an
+unchanged rollout replays as a zero delta and a grown rollout books only the
+non-negative increment. Missing optional metrics stay unknown, never zero.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Mapping
+
+from .usage_collector import UsageRowError
+
+CODEX_USAGE_PROVIDER = "codex"
+USAGE_SNAPSHOT_SCHEMA_VERSION = "goal_usage_snapshot_v0"
+USAGE_SNAPSHOT_FILENAME = "usage_snapshot.json"
+_SNAPSHOT_FIELDS = (
+    "session_id",
+    "source_snapshot_id",
+    "input_tokens",
+    "output_tokens",
+    "cache_tokens",
+    "cost_usd",
+    "duration_ms",
+    "provider",
+    "model",
+)
+
+
+class CodexSessionUsageError(UsageRowError):
+    """Fail-closed diagnostic for unreadable or unusable Codex rollouts."""
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def read_codex_session_usage(rollout_path: Path) -> dict[str, Any]:
+    """Return one cumulative usage observation from a Codex session rollout.
+
+    Counters are the session-cumulative totals from the newest ``token_count``
+    event. ``source_snapshot_id`` binds the observation to the session id plus
+    that event's timestamp, so replaying an unchanged rollout keeps the same
+    identity (idempotent zero delta) while a grown rollout produces a new
+    identity whose delta is taken against the stored previous observation.
+    """
+    path = Path(rollout_path).expanduser()
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CodexSessionUsageError(
+            f"cannot read codex session rollout: {exc}"
+        ) from exc
+
+    session_id = ""
+    session_started_at: datetime | None = None
+    model = ""
+    last_totals: Mapping[str, Any] | None = None
+    last_totals_at = ""
+    for line in raw_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            # The Codex CLI appends to the rollout while sessions run; a torn
+            # trailing line is not an integrity failure for earlier events.
+            continue
+        if not isinstance(item, dict):
+            continue
+        kind = str(item.get("type") or "")
+        payload = item.get("payload") if isinstance(item.get("payload"), dict) else {}
+        if kind == "session_meta":
+            session_id = str(
+                payload.get("session_id") or payload.get("id") or ""
+            ).strip()
+            session_started_at = _parse_timestamp(
+                payload.get("timestamp") or item.get("timestamp")
+            )
+        elif kind == "turn_context":
+            model_text = str(payload.get("model") or "").strip()
+            if model_text:
+                model = model_text
+        elif kind == "event_msg" and str(payload.get("type") or "") == "token_count":
+            info = payload.get("info") if isinstance(payload.get("info"), dict) else {}
+            totals = info.get("total_token_usage")
+            if isinstance(totals, Mapping):
+                last_totals = totals
+                last_totals_at = str(item.get("timestamp") or "").strip()
+
+    if not session_id:
+        raise CodexSessionUsageError(
+            f"codex session rollout has no session_meta id: {path}"
+        )
+    if last_totals is None:
+        raise CodexSessionUsageError(
+            f"codex session rollout has no token_count usage events: {path}"
+        )
+    if not model:
+        raise CodexSessionUsageError(
+            f"codex session rollout has no turn_context model id: {path}"
+        )
+
+    duration_ms: int | None = None
+    observed_at = _parse_timestamp(last_totals_at)
+    if session_started_at is not None and observed_at is not None:
+        elapsed_seconds = (observed_at - session_started_at).total_seconds()
+        if elapsed_seconds >= 0:
+            duration_ms = int(elapsed_seconds * 1000)
+
+    observation: dict[str, Any] = {
+        "input_tokens": last_totals.get("input_tokens"),
+        "output_tokens": last_totals.get("output_tokens"),
+        "cache_tokens": last_totals.get("cached_input_tokens"),
+        "provider": CODEX_USAGE_PROVIDER,
+        "model": model,
+        "session_id": session_id,
+        "source_snapshot_id": f"codex:{session_id}:{last_totals_at or 'unanchored'}",
+        "measurement_kind": "absolute",
+    }
+    if duration_ms is not None:
+        observation["duration_ms"] = duration_ms
+    return observation
+
+
+def usage_snapshot_path(runs_dir: Path) -> Path:
+    return Path(runs_dir) / USAGE_SNAPSHOT_FILENAME
+
+
+def load_usage_snapshot(runs_dir: Path) -> dict[str, Any] | None:
+    """Return the persisted previous cumulative observation, if any.
+
+    A missing snapshot means first observation (absolute intake). A corrupt or
+    unknown-schema snapshot fails closed instead of silently rebasing spend.
+    """
+    path = usage_snapshot_path(runs_dir)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise CodexSessionUsageError(f"usage snapshot state is unreadable: {path}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CodexSessionUsageError(f"usage snapshot state is corrupt: {path}") from exc
+    if (
+        not isinstance(data, dict)
+        or str(data.get("schema_version") or "") != USAGE_SNAPSHOT_SCHEMA_VERSION
+    ):
+        raise CodexSessionUsageError(f"usage snapshot state has an unknown schema: {path}")
+    return data
+
+
+def store_usage_snapshot(runs_dir: Path, observation: Mapping[str, Any]) -> Path:
+    """Persist the full cumulative observation as the next delta basis.
+
+    The snapshot keeps every counter and binding label (not only the id) so
+    replay of the same identity can be verified field by field.
+    """
+    path = usage_snapshot_path(runs_dir)
+    record: dict[str, Any] = {"schema_version": USAGE_SNAPSHOT_SCHEMA_VERSION}
+    for field in _SNAPSHOT_FIELDS:
+        record[field] = observation.get(field)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+    tmp_path.replace(path)
+    return path
+
+
+def previous_snapshot_for_observation(
+    snapshot: Mapping[str, Any] | None,
+    observation: Mapping[str, Any],
+) -> Mapping[str, Any] | None:
+    """Return the delta basis only when it belongs to the same Codex session.
+
+    A new session restarts its cumulative counters from zero, so its first
+    observation must be booked as an absolute intake rather than raising a
+    bogus reset error against another session's basis.
+    """
+    if snapshot is None:
+        return None
+    if str(snapshot.get("session_id") or "") != str(observation.get("session_id") or ""):
+        return None
+    return snapshot

--- a/loopx/control_plane/quota/codex_session_usage.py
+++ b/loopx/control_plane/quota/codex_session_usage.py
@@ -30,13 +30,16 @@ optional metrics stay unknown, never zero.
 from __future__ import annotations
 
 import json
-import math
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from typing import Any, Mapping, MutableMapping, cast
 
 from ..runtime.run_index_duplicates import index_identity
-from .usage_collector import UsageRowError, ingest_usage_into_run_record
+from .usage_collector import (
+    UsageRowError,
+    ingest_usage_into_run_record,
+    normalize_compact_usage_row,
+)
 
 CODEX_USAGE_PROVIDER = "codex"
 USAGE_BOOKING_LOCK_TARGET = "usage_booking"
@@ -185,21 +188,6 @@ def book_codex_session_usage(
     )
 
 
-def _booked_usage_number(
-    value: Any, *, field: str, line_number: int, index_path: Path
-) -> int | float:
-    if (
-        isinstance(value, bool)
-        or not isinstance(value, (int, float))
-        or not math.isfinite(float(value))
-        or value < 0
-    ):
-        raise CodexSessionUsageError(
-            f"run index row {line_number} has an invalid booked usage.{field}: {index_path}"
-        )
-    return value
-
-
 def session_usage_baseline(
     index_path: Path, session_id: str
 ) -> dict[str, Any] | None:
@@ -243,11 +231,25 @@ def session_usage_baseline(
             ) from exc
         if not isinstance(row, dict):
             continue
-        usage = row.get("usage")
-        if not isinstance(usage, dict):
+        raw_usage = row.get("usage")
+        if not isinstance(raw_usage, dict):
             continue
-        if not str(usage.get("source_snapshot_id") or "").startswith(prefix):
+        if not str(raw_usage.get("source_snapshot_id") or "").startswith(prefix):
             continue
+        try:
+            usage = normalize_compact_usage_row(raw_usage)
+        except UsageRowError as exc:
+            raise CodexSessionUsageError(
+                f"run index row {line_number} has invalid usage: {index_path}: {exc}"
+            ) from exc
+        if usage["provider"] != CODEX_USAGE_PROVIDER:
+            raise CodexSessionUsageError(
+                f"run index row {line_number} usage.provider must be codex: {index_path}"
+            )
+        if not str(usage["source_snapshot_id"]).startswith(prefix):
+            raise CodexSessionUsageError(
+                f"run index row {line_number} usage source does not match session: {index_path}"
+            )
         identity = index_identity(row)
         if identity in seen_rows:
             continue
@@ -256,16 +258,10 @@ def session_usage_baseline(
             value = usage.get(field)
             if value is None:
                 continue
-            booked = _booked_usage_number(
-                value, field=field, line_number=line_number, index_path=index_path
-            )
-            int_totals[field] = int(int_totals[field] or 0) + int(booked)
+            int_totals[field] = (int_totals[field] or 0) + cast(int, value)
         cost = usage.get("cost_usd")
         if cost is not None:
-            booked_cost = _booked_usage_number(
-                cost, field="cost_usd", line_number=line_number, index_path=index_path
-            )
-            cost_total = float(cost_total or 0.0) + float(booked_cost)
+            cost_total = (cost_total or 0.0) + cast(float, cost)
         last_usage = usage
     if last_usage is None:
         return None

--- a/loopx/control_plane/quota/usage_collector.py
+++ b/loopx/control_plane/quota/usage_collector.py
@@ -198,7 +198,29 @@ def build_compact_usage_row(
     if previous_snapshot is not None:
         previous_id = str(previous_snapshot.get("source_snapshot_id") or "").strip()
         if previous_id and previous_id == snapshot_id:
-            # Idempotent replay of the same cumulative snapshot identity.
+            # Same snapshot identity is only an idempotent replay when the full
+            # cumulative observation (counters and binding labels) is unchanged.
+            # A reused, corrupt, or out-of-order identity carrying different
+            # numbers must fail closed instead of silently zeroing real usage.
+            prior = _snapshot_counters(previous_snapshot, label="previous_snapshot")
+            mismatched = sorted(
+                field
+                for field in (*_REQUIRED_TOKEN_FIELDS, *_OPTIONAL_INT_FIELDS, *_OPTIONAL_FLOAT_FIELDS)
+                if current[field] != prior[field]
+            )
+            prior_labels = {
+                field: str(previous_snapshot.get(field) or "").strip()
+                for field in _LABEL_FIELDS
+            }
+            if prior_labels["provider"] != provider_label:
+                mismatched.append("provider")
+            if prior_labels["model"] != model_label:
+                mismatched.append("model")
+            if mismatched:
+                raise UsageRowError(
+                    "usage.source_snapshot_id replayed with a different cumulative "
+                    "observation (" + ", ".join(mismatched) + ")"
+                )
             kind = "delta"
             current = {
                 "input_tokens": 0,

--- a/loopx/control_plane/quota/usage_collector.py
+++ b/loopx/control_plane/quota/usage_collector.py
@@ -12,13 +12,14 @@ This module owns both sides of the seam described in
   remains the single source of truth; there is no second usage store.
 
 Missing measurements stay omitted (unknown), never coerced to zero.
-Malformed, negative, reset, or out-of-order observations fail closed with a
-typed error. Prompts, completions, tool output, credentials, provider payloads,
+Malformed, negative, non-finite, reset, or out-of-order observations fail
+closed with a typed error. Prompts, completions, tool output, credentials, provider payloads,
 and anything that reconstructs a conversation are never captured.
 """
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any, Mapping, MutableMapping
 
@@ -58,6 +59,8 @@ class UsageSample:
 def _require_non_negative_int(value: Any, *, field: str) -> int:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise UsageRowError(f"usage.{field} must be a non-negative number")
+    if isinstance(value, float) and not math.isfinite(value):
+        raise UsageRowError(f"usage.{field} must be finite")
     if float(value) != int(value):
         raise UsageRowError(f"usage.{field} must be a whole number")
     coerced = int(value)
@@ -78,6 +81,8 @@ def _optional_non_negative_float(value: Any, *, field: str) -> float | None:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise UsageRowError(f"usage.{field} must be a non-negative number")
     coerced = float(value)
+    if not math.isfinite(coerced):
+        raise UsageRowError(f"usage.{field} must be finite")
     if coerced < 0:
         raise UsageRowError(f"usage.{field} must be non-negative")
     return coerced

--- a/loopx/control_plane/quota/usage_collector.py
+++ b/loopx/control_plane/quota/usage_collector.py
@@ -1,83 +1,349 @@
-"""Provider-neutral usage capture seam for per-goal token/cost/duration.
+"""Provider-neutral usage capture and ingest for per-goal token/cost/duration.
 
-This module is the capture layer described in
-``docs/architecture/rfcs/goal-usage-token-cost-v0.md``. It defines the
-normalized, public-safe per-run usage shape and the consumption side of the
-seam: ``collect_usage_for_run`` reads a normalized ``usage`` block off a run
-dict for the aggregate loop in ``usage_summary``. It is provider-agnostic and
-performs no file IO.
+This module owns both sides of the seam described in
+``docs/architecture/rfcs/goal-usage-token-cost-v0.md`` and GH-C95 / #3163:
 
-The ingestion side (writing a ``usage`` block onto each runtime's run records)
-is a follow-up slice and lands together with its callers and tests.
+- **Producer** (``build_compact_usage_row`` / ``ingest_usage_into_run_record``):
+  emit a versioned, provider-neutral compact ``run_usage_v0`` row into existing
+  run-history records. Cumulative host snapshots become non-negative deltas at
+  this boundary and bind to ``source_snapshot_id`` so replay is idempotent.
+- **Reader** (``collect_usage_for_run``): consume only that typed row for the
+  aggregate loop in ``usage_summary``. The ledger (run history + this seam)
+  remains the single source of truth; there is no second usage store.
 
-Only aggregate numeric usage lives here. Prompts, completions, tool output,
-credentials, and anything that reconstructs a conversation are never captured.
+Missing measurements stay omitted (unknown), never coerced to zero.
+Malformed, negative, reset, or out-of-order observations fail closed with a
+typed error. Prompts, completions, tool output, credentials, provider payloads,
+and anything that reconstructs a conversation are never captured.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Mapping, MutableMapping
+
+
+RUN_USAGE_SCHEMA_VERSION = "run_usage_v0"
+_MEASUREMENT_KINDS = frozenset({"absolute", "delta"})
+_REQUIRED_TOKEN_FIELDS = ("input_tokens", "output_tokens")
+_OPTIONAL_INT_FIELDS = ("cache_tokens", "duration_ms")
+_OPTIONAL_FLOAT_FIELDS = ("cost_usd",)
+_LABEL_FIELDS = ("provider", "model")
+
+
+class UsageRowError(ValueError):
+    """Fail-closed diagnostic for malformed or illegal usage observations."""
 
 
 @dataclass(frozen=True)
 class UsageSample:
     """Normalized, public-safe per-run LLM usage.
 
-    Every field is aggregate numeric metadata. ``cost_usd`` and
-    ``duration_ms`` may be zero when a runtime cannot measure them; the caller
-    (the ingestion side) is responsible for filling them when the model id and
-    wall-time are known.
+    Token counts are always present once a typed row is accepted. Optional
+    aggregates stay ``None`` when the producer did not measure them so callers
+    can treat absence as unknown rather than zero.
     """
 
     input_tokens: int
     output_tokens: int
-    cache_tokens: int
-    cost_usd: float
-    duration_ms: int
+    cache_tokens: int | None
+    cost_usd: float | None
+    duration_ms: int | None
     provider: str
     model: str
+    source_snapshot_id: str
+    measurement_kind: str
 
 
-def _coerce_int(value: Any) -> int | None:
-    if isinstance(value, bool):
+def _require_non_negative_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise UsageRowError(f"usage.{field} must be a non-negative number")
+    if float(value) != int(value):
+        raise UsageRowError(f"usage.{field} must be a whole number")
+    coerced = int(value)
+    if coerced < 0:
+        raise UsageRowError(f"usage.{field} must be non-negative")
+    return coerced
+
+
+def _optional_non_negative_int(value: Any, *, field: str) -> int | None:
+    if value is None:
         return None
-    if isinstance(value, (int, float)):
-        coerced = int(value)
-        return coerced if coerced >= 0 else None
-    return None
+    return _require_non_negative_int(value, field=field)
 
 
-def _coerce_float(value: Any) -> float | None:
-    if isinstance(value, bool):
+def _optional_non_negative_float(value: Any, *, field: str) -> float | None:
+    if value is None:
         return None
-    if isinstance(value, (int, float)):
-        coerced = float(value)
-        return coerced if coerced >= 0 else None
-    return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise UsageRowError(f"usage.{field} must be a non-negative number")
+    coerced = float(value)
+    if coerced < 0:
+        raise UsageRowError(f"usage.{field} must be non-negative")
+    return coerced
+
+
+def _require_label(value: Any, *, field: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise UsageRowError(f"usage.{field} is required")
+    if len(text) > 120:
+        raise UsageRowError(f"usage.{field} exceeds 120 characters")
+    return text
+
+
+def _require_snapshot_id(value: Any) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise UsageRowError("usage.source_snapshot_id is required")
+    if len(text) > 240:
+        raise UsageRowError("usage.source_snapshot_id exceeds 240 characters")
+    return text
+
+
+def _snapshot_counters(snapshot: Mapping[str, Any], *, label: str) -> dict[str, int | float | None]:
+    if not isinstance(snapshot, Mapping):
+        raise UsageRowError(f"{label} must be a mapping")
+    return {
+        "input_tokens": _require_non_negative_int(
+            snapshot.get("input_tokens"), field=f"{label}.input_tokens"
+        ),
+        "output_tokens": _require_non_negative_int(
+            snapshot.get("output_tokens"), field=f"{label}.output_tokens"
+        ),
+        "cache_tokens": _optional_non_negative_int(
+            snapshot.get("cache_tokens"), field=f"{label}.cache_tokens"
+        ),
+        "cost_usd": _optional_non_negative_float(
+            snapshot.get("cost_usd"), field=f"{label}.cost_usd"
+        ),
+        "duration_ms": _optional_non_negative_int(
+            snapshot.get("duration_ms"), field=f"{label}.duration_ms"
+        ),
+    }
+
+
+def _delta_optional_int(
+    current: int | None,
+    previous: int | None,
+    *,
+    field: str,
+) -> int | None:
+    if current is None:
+        return None
+    if previous is None:
+        return current
+    delta = current - previous
+    if delta < 0:
+        raise UsageRowError(
+            f"usage.{field} reset or out-of-order cumulative observation"
+        )
+    return delta
+
+
+def _delta_optional_float(
+    current: float | None,
+    previous: float | None,
+    *,
+    field: str,
+) -> float | None:
+    if current is None:
+        return None
+    if previous is None:
+        return current
+    delta = current - previous
+    if delta < 0:
+        raise UsageRowError(
+            f"usage.{field} reset or out-of-order cumulative observation"
+        )
+    return delta
+
+
+def build_compact_usage_row(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    source_snapshot_id: str,
+    provider: str,
+    model: str,
+    cache_tokens: int | None = None,
+    cost_usd: float | None = None,
+    duration_ms: int | None = None,
+    measurement_kind: str = "absolute",
+    previous_snapshot: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a versioned compact usage row for run history.
+
+    When ``previous_snapshot`` is supplied, counters are converted to a
+    non-negative delta against that cumulative basis. Replaying the same
+    ``source_snapshot_id`` as the previous snapshot returns the prior absolute
+    zero-delta row without inventing new spend (idempotent replay).
+    """
+    kind = str(measurement_kind or "").strip()
+    if kind not in _MEASUREMENT_KINDS:
+        raise UsageRowError("usage.measurement_kind must be absolute or delta")
+
+    snapshot_id = _require_snapshot_id(source_snapshot_id)
+    provider_label = _require_label(provider, field="provider")
+    model_label = _require_label(model, field="model")
+
+    current = {
+        "input_tokens": _require_non_negative_int(input_tokens, field="input_tokens"),
+        "output_tokens": _require_non_negative_int(output_tokens, field="output_tokens"),
+        "cache_tokens": _optional_non_negative_int(cache_tokens, field="cache_tokens"),
+        "cost_usd": _optional_non_negative_float(cost_usd, field="cost_usd"),
+        "duration_ms": _optional_non_negative_int(duration_ms, field="duration_ms"),
+    }
+
+    if previous_snapshot is not None:
+        previous_id = str(previous_snapshot.get("source_snapshot_id") or "").strip()
+        if previous_id and previous_id == snapshot_id:
+            # Idempotent replay of the same cumulative snapshot identity.
+            kind = "delta"
+            current = {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_tokens": 0 if previous_snapshot.get("cache_tokens") is not None else None,
+                "cost_usd": 0.0 if previous_snapshot.get("cost_usd") is not None else None,
+                "duration_ms": 0 if previous_snapshot.get("duration_ms") is not None else None,
+            }
+        else:
+            prior = _snapshot_counters(previous_snapshot, label="previous_snapshot")
+            kind = "delta"
+            current = {
+                "input_tokens": _delta_optional_int(
+                    current["input_tokens"],
+                    prior["input_tokens"],
+                    field="input_tokens",
+                ),
+                "output_tokens": _delta_optional_int(
+                    current["output_tokens"],
+                    prior["output_tokens"],
+                    field="output_tokens",
+                ),
+                "cache_tokens": _delta_optional_int(
+                    current["cache_tokens"],
+                    prior["cache_tokens"],
+                    field="cache_tokens",
+                ),
+                "cost_usd": _delta_optional_float(
+                    current["cost_usd"],
+                    prior["cost_usd"],
+                    field="cost_usd",
+                ),
+                "duration_ms": _delta_optional_int(
+                    current["duration_ms"],
+                    prior["duration_ms"],
+                    field="duration_ms",
+                ),
+            }
+
+    if current["input_tokens"] is None or current["output_tokens"] is None:
+        raise UsageRowError("usage.input_tokens and usage.output_tokens are required")
+
+    row: dict[str, Any] = {
+        "schema_version": RUN_USAGE_SCHEMA_VERSION,
+        "measurement_kind": kind,
+        "source_snapshot_id": snapshot_id,
+        "input_tokens": current["input_tokens"],
+        "output_tokens": current["output_tokens"],
+        "provider": provider_label,
+        "model": model_label,
+    }
+    if current["cache_tokens"] is not None:
+        row["cache_tokens"] = current["cache_tokens"]
+    if current["cost_usd"] is not None:
+        row["cost_usd"] = current["cost_usd"]
+    if current["duration_ms"] is not None:
+        row["duration_ms"] = current["duration_ms"]
+    return row
+
+
+def normalize_compact_usage_row(usage: Any) -> dict[str, Any]:
+    """Validate a compact usage mapping and return a normalized ``run_usage_v0`` row."""
+    if not isinstance(usage, Mapping):
+        raise UsageRowError("usage must be a mapping")
+    if str(usage.get("schema_version") or "") != RUN_USAGE_SCHEMA_VERSION:
+        raise UsageRowError(
+            f"usage.schema_version must be {RUN_USAGE_SCHEMA_VERSION}"
+        )
+    return build_compact_usage_row(
+        input_tokens=usage.get("input_tokens"),  # type: ignore[arg-type]
+        output_tokens=usage.get("output_tokens"),  # type: ignore[arg-type]
+        cache_tokens=usage.get("cache_tokens"),
+        cost_usd=usage.get("cost_usd"),
+        duration_ms=usage.get("duration_ms"),
+        provider=str(usage.get("provider") or ""),
+        model=str(usage.get("model") or ""),
+        source_snapshot_id=str(usage.get("source_snapshot_id") or ""),
+        measurement_kind=str(usage.get("measurement_kind") or "absolute"),
+    )
+
+
+def ingest_usage_into_run_record(
+    record: MutableMapping[str, Any],
+    measurement: Mapping[str, Any] | None = None,
+    *,
+    previous_snapshot: Mapping[str, Any] | None = None,
+    index_record: MutableMapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Producer call site: attach a typed usage row onto a run-history record.
+
+    ``measurement`` may be a finished ``run_usage_v0`` row or raw absolute
+    counters plus labels. When omitted, any existing ``record["usage"]`` is
+    normalized in place. Returns the attached row, or ``None`` when neither the
+    record nor the caller supplied usage.
+    """
+    raw = measurement if measurement is not None else record.get("usage")
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise UsageRowError("usage must be a mapping")
+
+    if str(raw.get("schema_version") or "") == RUN_USAGE_SCHEMA_VERSION and previous_snapshot is None:
+        row = normalize_compact_usage_row(raw)
+    else:
+        row = build_compact_usage_row(
+            input_tokens=raw.get("input_tokens"),  # type: ignore[arg-type]
+            output_tokens=raw.get("output_tokens"),  # type: ignore[arg-type]
+            cache_tokens=raw.get("cache_tokens"),
+            cost_usd=raw.get("cost_usd"),
+            duration_ms=raw.get("duration_ms"),
+            provider=str(raw.get("provider") or ""),
+            model=str(raw.get("model") or ""),
+            source_snapshot_id=str(
+                raw.get("source_snapshot_id")
+                or record.get("run_id")
+                or record.get("generated_at")
+                or ""
+            ),
+            measurement_kind=str(raw.get("measurement_kind") or "absolute"),
+            previous_snapshot=previous_snapshot,
+        )
+    record["usage"] = row
+    if index_record is not None:
+        index_record["usage"] = dict(row)
+    return row
 
 
 def collect_usage_for_run(run: dict[str, Any]) -> UsageSample | None:
     """Return normalized usage for a run, or ``None`` if the run reports none.
 
-    Reads an optional ``usage`` block on the run dict. Runtimes that have not
-    yet been wired to report usage contribute nothing, so the aggregate
-    degrades gracefully to the prior run-history behavior.
+    Absent usage contributes nothing. A present but illegal usage block fails
+    closed instead of clamping, zero-filling, or silently dropping fields.
     """
     usage = run.get("usage")
-    if not isinstance(usage, dict):
+    if usage is None:
         return None
-    input_tokens = _coerce_int(usage.get("input_tokens"))
-    output_tokens = _coerce_int(usage.get("output_tokens"))
-    # A run claiming zero input and zero output has nothing aggregate-worthy.
-    if input_tokens is None and output_tokens is None:
-        return None
+    row = normalize_compact_usage_row(usage)
     return UsageSample(
-        input_tokens=input_tokens or 0,
-        output_tokens=output_tokens or 0,
-        cache_tokens=_coerce_int(usage.get("cache_tokens")) or 0,
-        cost_usd=_coerce_float(usage.get("cost_usd")) or 0.0,
-        duration_ms=_coerce_int(usage.get("duration_ms")) or 0,
-        provider=str(usage.get("provider") or "unknown"),
-        model=str(usage.get("model") or "unknown"),
+        input_tokens=int(row["input_tokens"]),
+        output_tokens=int(row["output_tokens"]),
+        cache_tokens=row.get("cache_tokens"),
+        cost_usd=row.get("cost_usd"),
+        duration_ms=row.get("duration_ms"),
+        provider=str(row["provider"]),
+        model=str(row["model"]),
+        source_snapshot_id=str(row["source_snapshot_id"]),
+        measurement_kind=str(row["measurement_kind"]),
     )

--- a/loopx/control_plane/quota/usage_summary.py
+++ b/loopx/control_plane/quota/usage_summary.py
@@ -79,12 +79,35 @@ def blank_usage_goal(goal_id: str) -> dict[str, Any]:
     }
 
 
-def _accumulate_usage(bucket: dict[str, Any], sample: UsageSample, suffix: str) -> None:
-    bucket[f"input_tokens_{suffix}"] += sample.input_tokens
-    bucket[f"output_tokens_{suffix}"] += sample.output_tokens
-    bucket[f"cache_tokens_{suffix}"] += sample.cache_tokens
-    bucket[f"cost_usd_{suffix}"] += sample.cost_usd
-    bucket[f"duration_ms_{suffix}"] += sample.duration_ms
+def _accumulate_usage(
+    bucket: dict[str, Any],
+    sample: UsageSample,
+    suffix: str,
+    observed_metrics: set[str],
+) -> None:
+    bucket[f"input_tokens_{suffix}"] = (
+        int(bucket.get(f"input_tokens_{suffix}") or 0) + sample.input_tokens
+    )
+    bucket[f"output_tokens_{suffix}"] = (
+        int(bucket.get(f"output_tokens_{suffix}") or 0) + sample.output_tokens
+    )
+    observed_metrics.add(f"input_tokens_{suffix}")
+    observed_metrics.add(f"output_tokens_{suffix}")
+    if sample.cache_tokens is not None:
+        bucket[f"cache_tokens_{suffix}"] = (
+            int(bucket.get(f"cache_tokens_{suffix}") or 0) + sample.cache_tokens
+        )
+        observed_metrics.add(f"cache_tokens_{suffix}")
+    if sample.cost_usd is not None:
+        bucket[f"cost_usd_{suffix}"] = (
+            float(bucket.get(f"cost_usd_{suffix}") or 0.0) + sample.cost_usd
+        )
+        observed_metrics.add(f"cost_usd_{suffix}")
+    if sample.duration_ms is not None:
+        bucket[f"duration_ms_{suffix}"] = (
+            int(bucket.get(f"duration_ms_{suffix}") or 0) + sample.duration_ms
+        )
+        observed_metrics.add(f"duration_ms_{suffix}")
 
 
 def _round_cost(bucket: dict[str, Any]) -> None:
@@ -94,15 +117,15 @@ def _round_cost(bucket: dict[str, Any]) -> None:
             bucket[key] = round(float(bucket[key]), 6)
 
 
-def _strip_unobserved_usage_windows(
+def _strip_unobserved_usage_metrics(
     bucket: dict[str, Any],
-    observed_windows: set[str],
+    observed_metrics: set[str],
 ) -> None:
     for suffix in ("24h", "7d"):
-        if suffix in observed_windows:
-            continue
         for metric_name in USAGE_METRIC_NAMES:
-            bucket.pop(f"{metric_name}_{suffix}", None)
+            key = f"{metric_name}_{suffix}"
+            if key not in observed_metrics:
+                bucket.pop(key, None)
 
 
 def build_usage_summary(
@@ -134,8 +157,8 @@ def build_usage_summary(
         "duration_ms_7d": 0,
     }
     goals: dict[str, dict[str, Any]] = {}
-    observed_usage_windows: set[str] = set()
-    goal_usage_windows: dict[str, set[str]] = {}
+    observed_usage_metrics: set[str] = set()
+    goal_usage_metrics: dict[str, set[str]] = {}
     sample_count = 0
 
     for run in history.get("runs") or []:
@@ -150,7 +173,9 @@ def build_usage_summary(
         slots = quota_spend_slots(run)
         automation_event = is_automation_run(run)
         progress_signal = is_progress_signal_run(run)
+        # Present-but-illegal usage fails closed inside collect_usage_for_run.
         usage_sample = collect_usage_for_run(run)
+        goal_metrics = goal_usage_metrics.setdefault(goal_id, set())
 
         if generated_at >= cutoff_7d:
             totals["runs_7d"] += 1
@@ -164,10 +189,8 @@ def build_usage_summary(
                 totals["progress_signal_run_count_7d"] += 1
                 goal["progress_signal_run_count_7d"] += 1
             if usage_sample is not None:
-                _accumulate_usage(totals, usage_sample, "7d")
-                _accumulate_usage(goal, usage_sample, "7d")
-                observed_usage_windows.add("7d")
-                goal_usage_windows.setdefault(goal_id, set()).add("7d")
+                _accumulate_usage(totals, usage_sample, "7d", observed_usage_metrics)
+                _accumulate_usage(goal, usage_sample, "7d", goal_metrics)
         if generated_at >= cutoff_24h:
             totals["runs_24h"] += 1
             goal["runs_24h"] += 1
@@ -180,10 +203,8 @@ def build_usage_summary(
                 totals["progress_signal_run_count_24h"] += 1
                 goal["progress_signal_run_count_24h"] += 1
             if usage_sample is not None:
-                _accumulate_usage(totals, usage_sample, "24h")
-                _accumulate_usage(goal, usage_sample, "24h")
-                observed_usage_windows.add("24h")
-                goal_usage_windows.setdefault(goal_id, set()).add("24h")
+                _accumulate_usage(totals, usage_sample, "24h", observed_usage_metrics)
+                _accumulate_usage(goal, usage_sample, "24h", goal_metrics)
 
     if totals["runs_24h"]:
         for goal in goals.values():
@@ -198,18 +219,18 @@ def build_usage_summary(
         key=lambda item: (
             item["runs_24h"],
             item["quota_spend_slots_24h"],
-            item["cost_usd_24h"],
-            item["input_tokens_24h"],
+            float(item.get("cost_usd_24h") or 0.0),
+            int(item.get("input_tokens_24h") or 0),
             item["runs_7d"],
             item["goal_id"],
         ),
         reverse=True,
     )
-    _strip_unobserved_usage_windows(totals, observed_usage_windows)
+    _strip_unobserved_usage_metrics(totals, observed_usage_metrics)
     for goal in goal_rows:
-        _strip_unobserved_usage_windows(
+        _strip_unobserved_usage_metrics(
             goal,
-            goal_usage_windows.get(str(goal.get("goal_id") or ""), set()),
+            goal_usage_metrics.get(str(goal.get("goal_id") or ""), set()),
         )
     return {
         "available": True,

--- a/loopx/control_plane/quota/usage_summary.py
+++ b/loopx/control_plane/quota/usage_summary.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import math
 from datetime import timedelta
 from typing import Any, Callable
 
 from .spend_sources import VISIBLE_GOAL_SLOT_SPEND_SOURCE
-from .usage_collector import UsageSample, collect_usage_for_run
+from .usage_collector import UsageRowError, UsageSample, collect_usage_for_run
 from ..runtime.time import now_utc
 
 USAGE_PROXY_NOTE = (
@@ -99,10 +100,12 @@ def _accumulate_usage(
         )
         observed_metrics.add(f"cache_tokens_{suffix}")
     if sample.cost_usd is not None:
-        bucket[f"cost_usd_{suffix}"] = (
-            float(bucket.get(f"cost_usd_{suffix}") or 0.0) + sample.cost_usd
-        )
-        observed_metrics.add(f"cost_usd_{suffix}")
+        key = f"cost_usd_{suffix}"
+        accumulated_cost = float(bucket.get(key) or 0.0) + sample.cost_usd
+        if not math.isfinite(accumulated_cost):
+            raise UsageRowError(f"usage summary {key} must be finite")
+        bucket[key] = accumulated_cost
+        observed_metrics.add(key)
     if sample.duration_ms is not None:
         bucket[f"duration_ms_{suffix}"] = (
             int(bucket.get(f"duration_ms_{suffix}") or 0) + sample.duration_ms
@@ -114,7 +117,10 @@ def _round_cost(bucket: dict[str, Any]) -> None:
     for suffix in ("24h", "7d"):
         key = f"cost_usd_{suffix}"
         if key in bucket:
-            bucket[key] = round(float(bucket[key]), 6)
+            rounded_cost = round(float(bucket[key]), 6)
+            if not math.isfinite(rounded_cost):
+                raise UsageRowError(f"usage summary {key} must be finite")
+            bucket[key] = rounded_cost
 
 
 def _strip_unobserved_usage_metrics(

--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -107,6 +107,7 @@ RUN_BASE_COMPACT_FIELDS = (
     "project_map",
     "json_exists",
     "markdown_exists",
+    "usage",
 )
 
 CompactProjection = Callable[[Any], Optional[dict[str, Any]]]

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -118,10 +118,13 @@ def write_reserved_run_artifacts(
     payload["index_path"] = str(index_path)
     if isinstance(record.get("usage"), dict):
         payload["usage"] = dict(record["usage"])
-    json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    json_path.write_text(
+        json.dumps(record, ensure_ascii=False, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
     markdown_path.write_text(render_markdown(payload) + "\n", encoding="utf-8")
     with index_path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        f.write(json.dumps(index_record, ensure_ascii=False, allow_nan=False) + "\n")
 
 
 def validate_goal_id_path_segment(goal_id: str) -> str:

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -103,6 +103,12 @@ def write_reserved_run_artifacts(
     payload: dict[str, Any],
     render_markdown: Callable[[dict[str, Any]], str],
 ) -> None:
+    from .control_plane.quota.usage_collector import ingest_usage_into_run_record
+
+    # Producer call site for GH-C95: normalize any compact usage measurement onto
+    # the durable run record and its index row before append. Fail closed here so
+    # malformed or negative usage never enters run history.
+    ingest_usage_into_run_record(record, index_record=index_record)
     json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)
     index_path = runs_dir / "index.jsonl"
     index_record["json_path"] = str(json_path)
@@ -110,6 +116,8 @@ def write_reserved_run_artifacts(
     payload["json_path"] = str(json_path)
     payload["markdown_path"] = str(markdown_path)
     payload["index_path"] = str(index_path)
+    if isinstance(record.get("usage"), dict):
+        payload["usage"] = dict(record["usage"])
     json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     markdown_path.write_text(render_markdown(payload) + "\n", encoding="utf-8")
     with index_path.open("a", encoding="utf-8") as f:

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -28,6 +28,13 @@ from .control_plane.quota.settlement import (
     resolve_settlement_delivery_workspace_causality,
     settlement_result_payload,
 )
+from .control_plane.quota.codex_session_usage import (
+    load_usage_snapshot,
+    previous_snapshot_for_observation,
+    read_codex_session_usage,
+    store_usage_snapshot,
+)
+from .control_plane.quota.usage_collector import ingest_usage_into_run_record
 from .control_plane.work_items.repair_delta import (
     REPAIR_DELTA_CONTRACT_SCHEMA_VERSION as REPAIR_DELTA_CONTRACT_SCHEMA_VERSION,
     REPAIR_DELTA_KIND_CHOICES as REPAIR_DELTA_KIND_CHOICES,
@@ -864,11 +871,15 @@ def refresh_state_run(
     progress_observation: dict[str, Any] | None = None,
     completion_todo_id: str | None = None,
     completion_turn_key: str | None = None,
+    usage_measurement: dict[str, Any] | None = None,
+    usage_codex_session: Path | None = None,
     dry_run: bool,
     sync_global: bool = True,
 ) -> dict[str, Any]:
     safe_goal_id = validate_goal_id_path_segment(goal_id)
     validate_public_safe_text("classification", classification)
+    if usage_measurement is not None and usage_codex_session is not None:
+        raise ValueError("--usage-json cannot be combined with --usage-codex-session")
     normalized_agent_id = (agent_id or "").strip()
     normalized_agent_lane = (agent_lane or "").strip()
     normalized_replan_obligation_id = normalize_todo_replan_obligation_id(
@@ -1308,6 +1319,30 @@ def refresh_state_run(
         dry_run=dry_run,
         autonomous_replan_recorded_requested=bool(autonomous_replan_recorded),
     )
+    # GH-C95 producer boundary: attach the typed run_usage_v0 row before the
+    # durable record and index rows are written, so malformed or negative usage
+    # fails the whole refresh instead of entering run history.
+    usage_observation: dict[str, Any] | None = None
+    if usage_codex_session is not None:
+        usage_observation = read_codex_session_usage(usage_codex_session)
+        ingest_usage_into_run_record(
+            record,
+            {
+                key: value
+                for key, value in usage_observation.items()
+                if key != "session_id"
+            },
+            previous_snapshot=previous_snapshot_for_observation(
+                load_usage_snapshot(runs_dir), usage_observation
+            ),
+            index_record=index_record,
+        )
+    elif usage_measurement is not None:
+        ingest_usage_into_run_record(
+            record, usage_measurement, index_record=index_record
+        )
+    if isinstance(record.get("usage"), dict):
+        payload["usage"] = dict(record["usage"])
     if dry_run:
         expected_write_scopes = ["runtime_history"]
         if active_state_next_action_update and active_state_next_action_update.get("would_update"):
@@ -1365,6 +1400,10 @@ def refresh_state_run(
         markdown_path.write_text(render_state_refresh_markdown(payload) + "\n", encoding="utf-8")
         with index_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        if usage_observation is not None:
+            # Persist the accepted cumulative observation as the next delta
+            # basis only after the run row it funded is durably appended.
+            store_usage_snapshot(runs_dir, usage_observation)
     if sync_global and route_status in {"missing", "ambiguous"}:
         payload["ok"] = False
         payload["partial_write"] = not dry_run

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any
 
@@ -29,10 +30,8 @@ from .control_plane.quota.settlement import (
     settlement_result_payload,
 )
 from .control_plane.quota.codex_session_usage import (
-    load_usage_snapshot,
-    previous_snapshot_for_observation,
-    read_codex_session_usage,
-    store_usage_snapshot,
+    book_codex_session_usage,
+    usage_booking_lock_target,
 )
 from .control_plane.quota.usage_collector import ingest_usage_into_run_record
 from .control_plane.work_items.repair_delta import (
@@ -1321,89 +1320,86 @@ def refresh_state_run(
     )
     # GH-C95 producer boundary: attach the typed run_usage_v0 row before the
     # durable record and index rows are written, so malformed or negative usage
-    # fails the whole refresh instead of entering run history.
-    usage_observation: dict[str, Any] | None = None
-    if usage_codex_session is not None:
-        usage_observation = read_codex_session_usage(usage_codex_session)
-        ingest_usage_into_run_record(
-            record,
-            {
-                key: value
-                for key, value in usage_observation.items()
-                if key != "session_id"
-            },
-            previous_snapshot=previous_snapshot_for_observation(
-                load_usage_snapshot(runs_dir), usage_observation
-            ),
-            index_record=index_record,
-        )
-    elif usage_measurement is not None:
-        ingest_usage_into_run_record(
-            record, usage_measurement, index_record=index_record
-        )
-    if isinstance(record.get("usage"), dict):
-        payload["usage"] = dict(record["usage"])
-    if dry_run:
-        expected_write_scopes = ["runtime_history"]
-        if active_state_next_action_update and active_state_next_action_update.get("would_update"):
-            expected_write_scopes.insert(0, "active_state")
-        if sync_global and route_status in {"resolved", "single_runtime"}:
-            expected_write_scopes.append("global_registry")
-        if shared_runtime_root:
-            expected_write_scopes.append("shared_runtime_projection")
-        patch_parts = [f"append refresh-state run classification={classification}"]
-        if active_state_next_action_update:
-            if active_state_next_action_update.get("would_update"):
-                patch_parts.append("preview active-state Next Action update")
-            else:
-                patch_parts.append("preserve active-state Next Action")
-        if sync_global and route_status in {"resolved", "single_runtime"}:
-            patch_parts.append("sync public-safe registry projection")
-        elif sync_global:
-            patch_parts.append(f"block global sync on {route_status} runtime projection route")
-        if shared_runtime_root:
-            patch_parts.append("project compact refresh to registered shared runtime")
-        payload["local_state_write_correctness"] = build_local_state_write_correctness_dry_run_packet(
-            goal_id=safe_goal_id,
-            writer_id=normalized_agent_id or "loopx.refresh-state",
-            write_class="refresh_state",
-            state_text=expected_write_state_text,
-            target_refs={
-                "state_file_ref": "registry.goal.state_file",
-                "run_history_ref": "runtime.goal.runs",
-                "index_ref": "runtime.goal.runs.index",
-                "global_registry_ref": (
-                    "runtime.registry.global"
-                    if sync_global and route_status in {"resolved", "single_runtime"}
-                    else None
-                ),
-                "shared_runtime_projection_ref": (
-                    "shared_runtime.goal.runs.index" if shared_runtime_root else None
-                ),
-            },
-            patch_summary="; ".join(patch_parts),
-            expected_write_scopes=expected_write_scopes,
-            lease_ref=None,
-            projection_status_surface=f"refresh-state dry-run: {classification}",
-        )
-    if not dry_run:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)
-        index_record["json_path"] = str(json_path)
-        index_record["markdown_path"] = str(markdown_path)
-        payload["json_path"] = str(json_path)
-        payload["markdown_path"] = str(markdown_path)
-        json_path.write_text(
-            json.dumps(record, ensure_ascii=False, indent=2) + "\n",
-            encoding="utf-8",
-        )
-        markdown_path.write_text(render_state_refresh_markdown(payload) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-        if usage_observation is not None:
-            # Persist the accepted cumulative observation as the next delta
-            # basis only after the run row it funded is durably appended.
-            store_usage_snapshot(runs_dir, usage_observation)
+    # fails the whole refresh instead of entering run history. The booking lock
+    # spans ledger-basis read + row append so concurrent refreshes cannot fund
+    # two deltas from one stale basis; the appended row advances the basis.
+    with ExitStack() as usage_booking_guard:
+        if usage_codex_session is not None:
+            if not dry_run:
+                runs_dir.mkdir(parents=True, exist_ok=True)
+                usage_booking_guard.enter_context(
+                    exclusive_file_lock(
+                        usage_booking_lock_target(runs_dir),
+                        agent_id=normalized_agent_id or None,
+                        operation="refresh-state-usage-booking",
+                    )
+                )
+            book_codex_session_usage(
+                record, usage_codex_session, index_path, index_record=index_record
+            )
+        elif usage_measurement is not None:
+            ingest_usage_into_run_record(
+                record, usage_measurement, index_record=index_record
+            )
+        if isinstance(record.get("usage"), dict):
+            payload["usage"] = dict(record["usage"])
+        if dry_run:
+            expected_write_scopes = ["runtime_history"]
+            if active_state_next_action_update and active_state_next_action_update.get("would_update"):
+                expected_write_scopes.insert(0, "active_state")
+            if sync_global and route_status in {"resolved", "single_runtime"}:
+                expected_write_scopes.append("global_registry")
+            if shared_runtime_root:
+                expected_write_scopes.append("shared_runtime_projection")
+            patch_parts = [f"append refresh-state run classification={classification}"]
+            if active_state_next_action_update:
+                if active_state_next_action_update.get("would_update"):
+                    patch_parts.append("preview active-state Next Action update")
+                else:
+                    patch_parts.append("preserve active-state Next Action")
+            if sync_global and route_status in {"resolved", "single_runtime"}:
+                patch_parts.append("sync public-safe registry projection")
+            elif sync_global:
+                patch_parts.append(f"block global sync on {route_status} runtime projection route")
+            if shared_runtime_root:
+                patch_parts.append("project compact refresh to registered shared runtime")
+            payload["local_state_write_correctness"] = build_local_state_write_correctness_dry_run_packet(
+                goal_id=safe_goal_id,
+                writer_id=normalized_agent_id or "loopx.refresh-state",
+                write_class="refresh_state",
+                state_text=expected_write_state_text,
+                target_refs={
+                    "state_file_ref": "registry.goal.state_file",
+                    "run_history_ref": "runtime.goal.runs",
+                    "index_ref": "runtime.goal.runs.index",
+                    "global_registry_ref": (
+                        "runtime.registry.global"
+                        if sync_global and route_status in {"resolved", "single_runtime"}
+                        else None
+                    ),
+                    "shared_runtime_projection_ref": (
+                        "shared_runtime.goal.runs.index" if shared_runtime_root else None
+                    ),
+                },
+                patch_summary="; ".join(patch_parts),
+                expected_write_scopes=expected_write_scopes,
+                lease_ref=None,
+                projection_status_surface=f"refresh-state dry-run: {classification}",
+            )
+        if not dry_run:
+            runs_dir.mkdir(parents=True, exist_ok=True)
+            json_path, markdown_path = reserve_unique_run_paths(runs_dir, generated_at)
+            index_record["json_path"] = str(json_path)
+            index_record["markdown_path"] = str(markdown_path)
+            payload["json_path"] = str(json_path)
+            payload["markdown_path"] = str(markdown_path)
+            json_path.write_text(
+                json.dumps(record, ensure_ascii=False, indent=2, allow_nan=False) + "\n",
+                encoding="utf-8",
+            )
+            markdown_path.write_text(render_state_refresh_markdown(payload) + "\n", encoding="utf-8")
+            with index_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(index_record, ensure_ascii=False, allow_nan=False) + "\n")
     if sync_global and route_status in {"missing", "ambiguous"}:
         payload["ok"] = False
         payload["partial_write"] = not dry_run

--- a/tests/cli_commands/test_project_lifecycle_goal_channel.py
+++ b/tests/cli_commands/test_project_lifecycle_goal_channel.py
@@ -192,6 +192,43 @@ def test_refresh_state_forwards_external_sink_suppression(
     assert captured_kwargs["external_sink_delivery_authorized"] is False
 
 
+@pytest.mark.parametrize(
+    "constant", ["NaN", "Infinity", "-Infinity"]
+)
+def test_refresh_state_rejects_non_standard_usage_json_constants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    constant: str,
+) -> None:
+    """--usage-json is strict JSON: NaN/Infinity must fail before any refresh."""
+    captured: dict[str, Any] = {}
+    refresh_calls: list[dict[str, Any]] = []
+
+    def _record_refresh(**kwargs: Any) -> dict[str, Any]:
+        refresh_calls.append(kwargs)
+        return {"ok": True, "appended": True, "dry_run": False}
+
+    monkeypatch.setattr(project_lifecycle, "refresh_state_run", _record_refresh)
+
+    args = _args()
+    args.usage_json = (
+        '{"input_tokens": 1, "output_tokens": 1, "provider": "p", '
+        '"model": "m", "source_snapshot_id": "s", "cost_usd": ' + constant + "}"
+    )
+    result = project_lifecycle.handle_project_lifecycle_command(
+        args,
+        registry_path=tmp_path / ".loopx" / "registry.json",
+        print_payload=lambda payload, fmt, renderer: captured.update(payload),
+        output_format=lambda args: "json",
+        append_cli_rollout_event=lambda *a, **kw: {},
+    )
+
+    assert result == 1
+    assert captured["ok"] is False
+    assert "strict JSON" in captured["error"]
+    assert refresh_calls == []
+
+
 def test_refresh_state_redacts_goal_channel_exception_details(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/control_plane/test_codex_session_usage.py
+++ b/tests/control_plane/test_codex_session_usage.py
@@ -1,0 +1,421 @@
+"""End-to-end producer regression for the GH-C95 cost ledger.
+
+Proves that a shipped host measurement source (a Codex session rollout) lands
+as a typed ``run_usage_v0`` row on the real ``refresh-state`` run-write path,
+that the goal's ``usage_summary`` becomes non-zero, that replaying the same
+cumulative snapshot never double-counts, and that a grown rollout books only
+the non-negative increment.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.control_plane.quota.codex_session_usage import (
+    CodexSessionUsageError,
+    load_usage_snapshot,
+    previous_snapshot_for_observation,
+    read_codex_session_usage,
+    store_usage_snapshot,
+    usage_snapshot_path,
+)
+from loopx.control_plane.quota.usage_summary import build_usage_summary
+from loopx.control_plane.runtime.time import parse_timestamp
+from loopx.state_refresh import refresh_state_run
+
+GOAL_ID = "codex-usage-fixture"
+SESSION_ID = "019f0000-aaaa-bbbb-cccc-000000000001"
+MODEL = "gpt-fixture-1"
+
+
+def _rollout_event(
+    timestamp: str,
+    *,
+    input_tokens: int,
+    cached_input_tokens: int,
+    output_tokens: int,
+) -> str:
+    totals = {
+        "input_tokens": input_tokens,
+        "cached_input_tokens": cached_input_tokens,
+        "cache_write_input_tokens": 0,
+        "output_tokens": output_tokens,
+        "reasoning_output_tokens": 0,
+        "total_tokens": input_tokens + output_tokens,
+    }
+    return json.dumps(
+        {
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": totals,
+                    "last_token_usage": totals,
+                    "model_context_window": 400000,
+                },
+            },
+        }
+    )
+
+
+def _rollout_header() -> list[str]:
+    return [
+        json.dumps(
+            {
+                "timestamp": "2026-08-26T01:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "session_id": SESSION_ID,
+                    "timestamp": "2026-08-26T01:00:00.000Z",
+                    "cwd": "/tmp/fixture-project",
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "timestamp": "2026-08-26T01:00:01.000Z",
+                "type": "turn_context",
+                "payload": {"turn_id": "turn-1", "model": MODEL},
+            }
+        ),
+    ]
+
+
+def _write_rollout(path: Path, lines: list[str]) -> Path:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _fixture_rollout(tmp_path: Path) -> Path:
+    lines = [
+        *_rollout_header(),
+        _rollout_event(
+            "2026-08-26T01:05:00.000Z",
+            input_tokens=1200,
+            cached_input_tokens=200,
+            output_tokens=300,
+        ),
+    ]
+    return _write_rollout(tmp_path / "rollout-fixture.jsonl", lines)
+
+
+def test_read_codex_session_usage_extracts_cumulative_totals(tmp_path: Path) -> None:
+    observation = read_codex_session_usage(_fixture_rollout(tmp_path))
+    assert observation["input_tokens"] == 1200
+    assert observation["output_tokens"] == 300
+    assert observation["cache_tokens"] == 200
+    assert observation["provider"] == "codex"
+    assert observation["model"] == MODEL
+    assert observation["session_id"] == SESSION_ID
+    assert observation["source_snapshot_id"] == (
+        f"codex:{SESSION_ID}:2026-08-26T01:05:00.000Z"
+    )
+    assert observation["measurement_kind"] == "absolute"
+    assert observation["duration_ms"] == 300_000
+    assert "cost_usd" not in observation  # unmeasured stays unknown, not zero
+
+
+def test_read_codex_session_usage_tolerates_torn_trailing_line(tmp_path: Path) -> None:
+    lines = [
+        *_rollout_header(),
+        _rollout_event(
+            "2026-08-26T01:05:00.000Z",
+            input_tokens=10,
+            cached_input_tokens=0,
+            output_tokens=5,
+        ),
+        '{"timestamp":"2026-08-26T01:06:00.000Z","type":"event_msg","payl',
+    ]
+    observation = read_codex_session_usage(
+        _write_rollout(tmp_path / "rollout-torn.jsonl", lines)
+    )
+    assert observation["input_tokens"] == 10
+
+
+def test_read_codex_session_usage_fails_closed_without_token_counts(
+    tmp_path: Path,
+) -> None:
+    path = _write_rollout(tmp_path / "rollout-empty.jsonl", _rollout_header())
+    with pytest.raises(CodexSessionUsageError, match="no token_count"):
+        read_codex_session_usage(path)
+
+
+def test_read_codex_session_usage_fails_closed_without_session_meta(
+    tmp_path: Path,
+) -> None:
+    lines = [
+        _rollout_event(
+            "2026-08-26T01:05:00.000Z",
+            input_tokens=10,
+            cached_input_tokens=0,
+            output_tokens=5,
+        )
+    ]
+    path = _write_rollout(tmp_path / "rollout-no-meta.jsonl", lines)
+    with pytest.raises(CodexSessionUsageError, match="session_meta"):
+        read_codex_session_usage(path)
+
+
+def test_read_codex_session_usage_fails_closed_on_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(CodexSessionUsageError, match="cannot read"):
+        read_codex_session_usage(tmp_path / "missing.jsonl")
+
+
+def test_usage_snapshot_roundtrip_and_session_scoping(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    assert load_usage_snapshot(runs_dir) is None
+    observation = read_codex_session_usage(_fixture_rollout(tmp_path))
+    store_usage_snapshot(runs_dir, observation)
+    snapshot = load_usage_snapshot(runs_dir)
+    assert snapshot is not None
+    assert snapshot["input_tokens"] == 1200
+    assert snapshot["provider"] == "codex"
+    assert snapshot["model"] == MODEL
+    assert previous_snapshot_for_observation(snapshot, observation) is snapshot
+    other_session = dict(observation, session_id="other-session")
+    assert previous_snapshot_for_observation(snapshot, other_session) is None
+
+
+def test_corrupt_usage_snapshot_fails_closed(tmp_path: Path) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    usage_snapshot_path(runs_dir).write_text("{not json", encoding="utf-8")
+    with pytest.raises(CodexSessionUsageError, match="corrupt"):
+        load_usage_snapshot(runs_dir)
+
+
+def _goal_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    project = tmp_path / "project"
+    state = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state.parent.mkdir(parents=True)
+    state.write_text("# Active Goal State\n", encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state.relative_to(project)),
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    return registry_path, project, runtime_root
+
+
+def _refresh(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path,
+    usage_codex_session: Path | None = None,
+    usage_measurement: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return refresh_state_run(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime_root),
+        goal_id=GOAL_ID,
+        project=project,
+        state_file=None,
+        classification="state_refreshed",
+        recommended_action="Observe the usage fixture.",
+        usage_codex_session=usage_codex_session,
+        usage_measurement=usage_measurement,
+        dry_run=False,
+        sync_global=False,
+    )
+
+
+def _index_runs(runtime_root: Path) -> list[dict[str, Any]]:
+    index_path = runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    return [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _summary_totals(runtime_root: Path) -> dict[str, Any]:
+    runs = _index_runs(runtime_root)
+    for run in runs:
+        run.setdefault("goal_id", GOAL_ID)
+    summary = build_usage_summary({"runs": runs}, parse_timestamp=parse_timestamp)
+    return summary["totals"]
+
+
+def test_refresh_state_codex_session_produces_non_zero_usage_summary(
+    tmp_path: Path,
+) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    rollout = _fixture_rollout(tmp_path)
+
+    payload = _refresh(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        usage_codex_session=rollout,
+    )
+    assert payload["ok"] is True
+    assert payload["usage"]["schema_version"] == "run_usage_v0"
+
+    runs = _index_runs(runtime_root)
+    assert len(runs) == 1
+    usage = runs[0]["usage"]
+    assert usage["input_tokens"] == 1200
+    assert usage["output_tokens"] == 300
+    assert usage["cache_tokens"] == 200
+    assert usage["provider"] == "codex"
+    assert usage["model"] == MODEL
+
+    totals = _summary_totals(runtime_root)
+    assert totals["input_tokens_24h"] == 1200
+    assert totals["output_tokens_24h"] == 300
+    assert totals["cache_tokens_24h"] == 200
+    assert totals["duration_ms_24h"] == 300_000
+
+
+def test_refresh_state_replaying_same_snapshot_does_not_double_count(
+    tmp_path: Path,
+) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    rollout = _fixture_rollout(tmp_path)
+
+    for _ in range(2):
+        payload = _refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            usage_codex_session=rollout,
+        )
+        assert payload["ok"] is True
+
+    runs = _index_runs(runtime_root)
+    assert len(runs) == 2
+    replay_usage = runs[1]["usage"]
+    assert replay_usage["measurement_kind"] == "delta"
+    assert replay_usage["input_tokens"] == 0
+    assert replay_usage["output_tokens"] == 0
+
+    totals = _summary_totals(runtime_root)
+    assert totals["input_tokens_24h"] == 1200
+    assert totals["output_tokens_24h"] == 300
+
+
+def test_refresh_state_books_only_the_cumulative_increment(tmp_path: Path) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    rollout = _fixture_rollout(tmp_path)
+    _refresh(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        usage_codex_session=rollout,
+    )
+
+    with rollout.open("a", encoding="utf-8") as handle:
+        handle.write(
+            _rollout_event(
+                "2026-08-26T01:10:00.000Z",
+                input_tokens=2000,
+                cached_input_tokens=350,
+                output_tokens=450,
+            )
+            + "\n"
+        )
+    _refresh(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        usage_codex_session=rollout,
+    )
+
+    runs = _index_runs(runtime_root)
+    increment = runs[1]["usage"]
+    assert increment["measurement_kind"] == "delta"
+    assert increment["input_tokens"] == 800
+    assert increment["output_tokens"] == 150
+    assert increment["cache_tokens"] == 150
+    assert increment["duration_ms"] == 300_000
+
+    totals = _summary_totals(runtime_root)
+    assert totals["input_tokens_24h"] == 2000
+    assert totals["output_tokens_24h"] == 450
+
+
+def test_refresh_state_without_usage_flags_keeps_usage_unknown(
+    tmp_path: Path,
+) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    payload = _refresh(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+    )
+    assert payload["ok"] is True
+    assert "usage" not in payload
+    runs = _index_runs(runtime_root)
+    assert "usage" not in runs[0]
+    assert not usage_snapshot_path(
+        runtime_root / "goals" / GOAL_ID / "runs"
+    ).exists()
+
+
+def test_refresh_state_accepts_typed_host_measurement(tmp_path: Path) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    payload = _refresh(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        usage_measurement={
+            "input_tokens": 42,
+            "output_tokens": 7,
+            "provider": "fixture-host",
+            "model": "fixture-model",
+            "source_snapshot_id": "host-measured-1",
+        },
+    )
+    assert payload["ok"] is True
+    runs = _index_runs(runtime_root)
+    assert runs[0]["usage"]["input_tokens"] == 42
+    assert runs[0]["usage"]["provider"] == "fixture-host"
+
+
+def test_refresh_state_rejects_combined_usage_inputs(tmp_path: Path) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            usage_codex_session=_fixture_rollout(tmp_path),
+            usage_measurement={"input_tokens": 1, "output_tokens": 1},
+        )
+
+
+def test_refresh_state_fails_closed_on_malformed_rollout_without_appending(
+    tmp_path: Path,
+) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    bad_rollout = _write_rollout(
+        tmp_path / "rollout-bad.jsonl", _rollout_header()
+    )
+    with pytest.raises(CodexSessionUsageError, match="no token_count"):
+        _refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            usage_codex_session=bad_rollout,
+        )
+    index_path = runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    assert not index_path.exists()

--- a/tests/control_plane/test_codex_session_usage.py
+++ b/tests/control_plane/test_codex_session_usage.py
@@ -10,18 +10,17 @@ the non-negative increment.
 from __future__ import annotations
 
 import json
+import threading
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+import loopx.state_refresh as state_refresh_module
 from loopx.control_plane.quota.codex_session_usage import (
     CodexSessionUsageError,
-    load_usage_snapshot,
-    previous_snapshot_for_observation,
     read_codex_session_usage,
-    store_usage_snapshot,
-    usage_snapshot_path,
+    session_usage_baseline,
 )
 from loopx.control_plane.quota.usage_collector import UsageRowError
 from loopx.control_plane.quota.usage_summary import build_usage_summary
@@ -139,6 +138,32 @@ def test_read_codex_session_usage_tolerates_torn_trailing_line(tmp_path: Path) -
     assert observation["input_tokens"] == 10
 
 
+def test_read_codex_session_usage_fails_closed_on_corrupt_middle_line(
+    tmp_path: Path,
+) -> None:
+    # A malformed line followed by valid events is file damage, not a torn
+    # tail: parsing on could silently accept a stale cumulative snapshot.
+    lines = [
+        *_rollout_header(),
+        _rollout_event(
+            "2026-08-26T01:05:00.000Z",
+            input_tokens=100,
+            cached_input_tokens=0,
+            output_tokens=10,
+        ),
+        '{"timestamp":"2026-08-26T01:06:00.000Z","type":"event_msg","payl',
+        _rollout_event(
+            "2026-08-26T01:07:00.000Z",
+            input_tokens=200,
+            cached_input_tokens=0,
+            output_tokens=20,
+        ),
+    ]
+    path = _write_rollout(tmp_path / "rollout-corrupt-middle.jsonl", lines)
+    with pytest.raises(CodexSessionUsageError, match="line 4 is corrupt"):
+        read_codex_session_usage(path)
+
+
 def test_read_codex_session_usage_fails_closed_without_token_counts(
     tmp_path: Path,
 ) -> None:
@@ -168,64 +193,107 @@ def test_read_codex_session_usage_fails_closed_on_missing_file(tmp_path: Path) -
         read_codex_session_usage(tmp_path / "missing.jsonl")
 
 
-def test_usage_snapshot_roundtrip_and_session_scoping(tmp_path: Path) -> None:
-    runs_dir = tmp_path / "runs"
-    runs_dir.mkdir()
-    assert load_usage_snapshot(runs_dir) is None
-    observation = read_codex_session_usage(_fixture_rollout(tmp_path))
-    store_usage_snapshot(runs_dir, observation)
-    snapshot = load_usage_snapshot(runs_dir)
-    assert snapshot is not None
-    basis = previous_snapshot_for_observation(snapshot, observation)
-    assert basis is not None
-    assert basis["input_tokens"] == 1200
-    assert basis["provider"] == "codex"
-    assert basis["model"] == MODEL
-    other_session = dict(observation, session_id="other-session")
-    assert previous_snapshot_for_observation(snapshot, other_session) is None
+def _index_row(
+    *,
+    generated_at: str,
+    source_snapshot_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    measurement_kind: str,
+    cache_tokens: int | None = None,
+    duration_ms: int | None = None,
+) -> str:
+    usage: dict[str, Any] = {
+        "schema_version": "run_usage_v0",
+        "measurement_kind": measurement_kind,
+        "source_snapshot_id": source_snapshot_id,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "provider": "codex",
+        "model": MODEL,
+    }
+    if cache_tokens is not None:
+        usage["cache_tokens"] = cache_tokens
+    if duration_ms is not None:
+        usage["duration_ms"] = duration_ms
+    return json.dumps(
+        {
+            "generated_at": generated_at,
+            "classification": "state_refreshed",
+            "json_path": f"runs/{generated_at}.json",
+            "markdown_path": f"runs/{generated_at}.md",
+            "usage": usage,
+        }
+    )
 
 
-def test_usage_snapshot_keeps_independent_per_session_baselines(
+def test_session_usage_baseline_missing_index_means_first_observation(
     tmp_path: Path,
 ) -> None:
-    runs_dir = tmp_path / "runs"
-    runs_dir.mkdir()
-    session_a = read_codex_session_usage(_fixture_rollout(tmp_path))
-    session_b = dict(session_a, session_id=OTHER_SESSION_ID, input_tokens=50)
-    store_usage_snapshot(runs_dir, session_a)
-    store_usage_snapshot(runs_dir, session_b)
-    snapshot = load_usage_snapshot(runs_dir)
-    basis_a = previous_snapshot_for_observation(snapshot, session_a)
-    basis_b = previous_snapshot_for_observation(snapshot, session_b)
-    assert basis_a is not None and basis_a["input_tokens"] == 1200
-    assert basis_b is not None and basis_b["input_tokens"] == 50
+    assert session_usage_baseline(tmp_path / "index.jsonl", SESSION_ID) is None
 
 
-def test_corrupt_usage_snapshot_fails_closed(tmp_path: Path) -> None:
-    runs_dir = tmp_path / "runs"
-    runs_dir.mkdir()
-    usage_snapshot_path(runs_dir).write_text("{not json", encoding="utf-8")
-    with pytest.raises(CodexSessionUsageError, match="corrupt"):
-        load_usage_snapshot(runs_dir)
-
-
-def test_single_slot_legacy_usage_snapshot_fails_closed(tmp_path: Path) -> None:
-    # The pre-release single-slot layout cannot express per-session baselines;
-    # rebasing against it could double-count, so it must not be read silently.
-    runs_dir = tmp_path / "runs"
-    runs_dir.mkdir()
-    usage_snapshot_path(runs_dir).write_text(
-        json.dumps(
-            {
-                "schema_version": "goal_usage_snapshot_v0",
-                "session_id": SESSION_ID,
-                "input_tokens": 1200,
-            }
-        ),
+def test_session_usage_baseline_telescopes_only_its_own_session_rows(
+    tmp_path: Path,
+) -> None:
+    index_path = tmp_path / "index.jsonl"
+    index_path.write_text(
+        "\n".join(
+            [
+                _index_row(
+                    generated_at="2026-08-26T01:05:00",
+                    source_snapshot_id=f"codex:{SESSION_ID}:t1",
+                    measurement_kind="absolute",
+                    input_tokens=100,
+                    output_tokens=10,
+                    cache_tokens=20,
+                    duration_ms=1000,
+                ),
+                _index_row(
+                    generated_at="2026-08-26T01:06:00",
+                    source_snapshot_id=f"codex:{OTHER_SESSION_ID}:t1",
+                    measurement_kind="absolute",
+                    input_tokens=50,
+                    output_tokens=5,
+                ),
+                _index_row(
+                    generated_at="2026-08-26T01:07:00",
+                    source_snapshot_id=f"codex:{SESSION_ID}:t2",
+                    measurement_kind="delta",
+                    input_tokens=40,
+                    output_tokens=4,
+                    cache_tokens=10,
+                    duration_ms=500,
+                ),
+                json.dumps({"generated_at": "2026-08-26T01:08:00"}),
+            ]
+        )
+        + "\n",
         encoding="utf-8",
     )
-    with pytest.raises(CodexSessionUsageError, match="unknown schema"):
-        load_usage_snapshot(runs_dir)
+    basis = session_usage_baseline(index_path, SESSION_ID)
+    assert basis is not None
+    assert basis["input_tokens"] == 140
+    assert basis["output_tokens"] == 14
+    assert basis["cache_tokens"] == 30
+    assert basis["duration_ms"] == 1500
+    assert basis["cost_usd"] is None
+    assert basis["source_snapshot_id"] == f"codex:{SESSION_ID}:t2"
+    assert basis["provider"] == "codex"
+    assert basis["model"] == MODEL
+
+    other = session_usage_baseline(index_path, OTHER_SESSION_ID)
+    assert other is not None
+    assert other["input_tokens"] == 50
+
+
+def test_session_usage_baseline_fails_closed_on_corrupt_index_row(
+    tmp_path: Path,
+) -> None:
+    index_path = tmp_path / "index.jsonl"
+    index_path.write_text('{"generated_at": "2026-08-26T01:05:00"\n', encoding="utf-8")
+    with pytest.raises(CodexSessionUsageError, match="row 1 is corrupt"):
+        session_usage_baseline(index_path, SESSION_ID)
 
 
 def _goal_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
@@ -349,6 +417,10 @@ def test_refresh_state_replaying_same_snapshot_does_not_double_count(
     totals = _summary_totals(runtime_root)
     assert totals["input_tokens_24h"] == 1200
     assert totals["output_tokens_24h"] == 300
+    # The appended index row is the basis advancement itself: there is no
+    # second snapshot state file that a crash between writes could leave stale.
+    runs_dir = runtime_root / "goals" / GOAL_ID / "runs"
+    assert not (runs_dir / "usage_snapshot.json").exists()
 
 
 def test_refresh_state_books_only_the_cumulative_increment(tmp_path: Path) -> None:
@@ -457,6 +529,86 @@ def test_refresh_state_interleaved_sessions_do_not_double_count(
     assert totals["output_tokens_24h"] == 20
 
 
+def test_refresh_state_concurrent_same_session_bookings_do_not_double_count(
+    tmp_path: Path,
+) -> None:
+    """The booking lock serializes basis read + append: exactly one non-zero booking."""
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    rollout = _fixture_rollout(tmp_path)
+    errors: list[Exception] = []
+    barrier = threading.Barrier(2)
+
+    def _book() -> None:
+        try:
+            barrier.wait(timeout=10)
+            _refresh(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                project=project,
+                usage_codex_session=rollout,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced via assertion below
+            errors.append(exc)
+
+    workers = [threading.Thread(target=_book) for _ in range(2)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=30)
+    assert errors == []
+
+    runs = _index_runs(runtime_root)
+    assert len(runs) == 2
+    booked_inputs = sorted(run["usage"]["input_tokens"] for run in runs)
+    assert booked_inputs == [0, 1200]  # one absolute intake, one zero-delta replay
+
+    totals = _summary_totals(runtime_root)
+    assert totals["input_tokens_24h"] == 1200
+    assert totals["output_tokens_24h"] == 300
+
+
+def test_refresh_state_never_persists_non_finite_usage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Durable run rows are strict JSON even if a future producer bug slips NaN through."""
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+
+    def _inject_nan(
+        record: dict[str, Any],
+        measurement: dict[str, Any] | None = None,
+        *,
+        previous_snapshot: Any = None,
+        index_record: dict[str, Any] | None = None,
+    ) -> None:
+        poisoned = {
+            "schema_version": "run_usage_v0",
+            "measurement_kind": "absolute",
+            "source_snapshot_id": "poisoned",
+            "input_tokens": 1,
+            "output_tokens": 1,
+            "provider": "codex",
+            "model": MODEL,
+            "cost_usd": float("nan"),
+        }
+        record["usage"] = poisoned
+        if index_record is not None:
+            index_record["usage"] = dict(poisoned)
+
+    monkeypatch.setattr(
+        state_refresh_module, "ingest_usage_into_run_record", _inject_nan
+    )
+    with pytest.raises(ValueError, match="JSON compliant"):
+        _refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            usage_measurement={"input_tokens": 1, "output_tokens": 1},
+        )
+    index_path = runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    assert not index_path.exists()
+
+
 def test_refresh_state_rejects_non_finite_measurement(tmp_path: Path) -> None:
     registry_path, project, runtime_root = _goal_fixture(tmp_path)
     with pytest.raises(UsageRowError, match="finite"):
@@ -490,9 +642,6 @@ def test_refresh_state_without_usage_flags_keeps_usage_unknown(
     assert "usage" not in payload
     runs = _index_runs(runtime_root)
     assert "usage" not in runs[0]
-    assert not usage_snapshot_path(
-        runtime_root / "goals" / GOAL_ID / "runs"
-    ).exists()
 
 
 def test_refresh_state_accepts_typed_host_measurement(tmp_path: Path) -> None:

--- a/tests/control_plane/test_codex_session_usage.py
+++ b/tests/control_plane/test_codex_session_usage.py
@@ -23,12 +23,14 @@ from loopx.control_plane.quota.codex_session_usage import (
     store_usage_snapshot,
     usage_snapshot_path,
 )
+from loopx.control_plane.quota.usage_collector import UsageRowError
 from loopx.control_plane.quota.usage_summary import build_usage_summary
 from loopx.control_plane.runtime.time import parse_timestamp
 from loopx.state_refresh import refresh_state_run
 
 GOAL_ID = "codex-usage-fixture"
 SESSION_ID = "019f0000-aaaa-bbbb-cccc-000000000001"
+OTHER_SESSION_ID = "019f0000-aaaa-bbbb-cccc-000000000002"
 MODEL = "gpt-fixture-1"
 
 
@@ -63,14 +65,14 @@ def _rollout_event(
     )
 
 
-def _rollout_header() -> list[str]:
+def _rollout_header(session_id: str = SESSION_ID) -> list[str]:
     return [
         json.dumps(
             {
                 "timestamp": "2026-08-26T01:00:00.000Z",
                 "type": "session_meta",
                 "payload": {
-                    "session_id": SESSION_ID,
+                    "session_id": session_id,
                     "timestamp": "2026-08-26T01:00:00.000Z",
                     "cwd": "/tmp/fixture-project",
                 },
@@ -174,12 +176,29 @@ def test_usage_snapshot_roundtrip_and_session_scoping(tmp_path: Path) -> None:
     store_usage_snapshot(runs_dir, observation)
     snapshot = load_usage_snapshot(runs_dir)
     assert snapshot is not None
-    assert snapshot["input_tokens"] == 1200
-    assert snapshot["provider"] == "codex"
-    assert snapshot["model"] == MODEL
-    assert previous_snapshot_for_observation(snapshot, observation) is snapshot
+    basis = previous_snapshot_for_observation(snapshot, observation)
+    assert basis is not None
+    assert basis["input_tokens"] == 1200
+    assert basis["provider"] == "codex"
+    assert basis["model"] == MODEL
     other_session = dict(observation, session_id="other-session")
     assert previous_snapshot_for_observation(snapshot, other_session) is None
+
+
+def test_usage_snapshot_keeps_independent_per_session_baselines(
+    tmp_path: Path,
+) -> None:
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    session_a = read_codex_session_usage(_fixture_rollout(tmp_path))
+    session_b = dict(session_a, session_id=OTHER_SESSION_ID, input_tokens=50)
+    store_usage_snapshot(runs_dir, session_a)
+    store_usage_snapshot(runs_dir, session_b)
+    snapshot = load_usage_snapshot(runs_dir)
+    basis_a = previous_snapshot_for_observation(snapshot, session_a)
+    basis_b = previous_snapshot_for_observation(snapshot, session_b)
+    assert basis_a is not None and basis_a["input_tokens"] == 1200
+    assert basis_b is not None and basis_b["input_tokens"] == 50
 
 
 def test_corrupt_usage_snapshot_fails_closed(tmp_path: Path) -> None:
@@ -187,6 +206,25 @@ def test_corrupt_usage_snapshot_fails_closed(tmp_path: Path) -> None:
     runs_dir.mkdir()
     usage_snapshot_path(runs_dir).write_text("{not json", encoding="utf-8")
     with pytest.raises(CodexSessionUsageError, match="corrupt"):
+        load_usage_snapshot(runs_dir)
+
+
+def test_single_slot_legacy_usage_snapshot_fails_closed(tmp_path: Path) -> None:
+    # The pre-release single-slot layout cannot express per-session baselines;
+    # rebasing against it could double-count, so it must not be read silently.
+    runs_dir = tmp_path / "runs"
+    runs_dir.mkdir()
+    usage_snapshot_path(runs_dir).write_text(
+        json.dumps(
+            {
+                "schema_version": "goal_usage_snapshot_v0",
+                "session_id": SESSION_ID,
+                "input_tokens": 1200,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(CodexSessionUsageError, match="unknown schema"):
         load_usage_snapshot(runs_dir)
 
 
@@ -351,6 +389,92 @@ def test_refresh_state_books_only_the_cumulative_increment(tmp_path: Path) -> No
     totals = _summary_totals(runtime_root)
     assert totals["input_tokens_24h"] == 2000
     assert totals["output_tokens_24h"] == 450
+
+
+def test_refresh_state_interleaved_sessions_do_not_double_count(
+    tmp_path: Path,
+) -> None:
+    """A returning session must rebase against its own baseline (A, B, A)."""
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    rollout_a = _write_rollout(
+        tmp_path / "rollout-a.jsonl",
+        [
+            *_rollout_header(),
+            _rollout_event(
+                "2026-08-26T01:05:00.000Z",
+                input_tokens=100,
+                cached_input_tokens=0,
+                output_tokens=10,
+            ),
+        ],
+    )
+    rollout_b = _write_rollout(
+        tmp_path / "rollout-b.jsonl",
+        [
+            *_rollout_header(session_id=OTHER_SESSION_ID),
+            _rollout_event(
+                "2026-08-26T01:06:00.000Z",
+                input_tokens=50,
+                cached_input_tokens=0,
+                output_tokens=5,
+            ),
+        ],
+    )
+
+    for rollout in (rollout_a, rollout_b):
+        _refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            usage_codex_session=rollout,
+        )
+    with rollout_a.open("a", encoding="utf-8") as handle:
+        handle.write(
+            _rollout_event(
+                "2026-08-26T01:10:00.000Z",
+                input_tokens=150,
+                cached_input_tokens=0,
+                output_tokens=15,
+            )
+            + "\n"
+        )
+    _refresh(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        usage_codex_session=rollout_a,
+    )
+
+    runs = _index_runs(runtime_root)
+    assert len(runs) == 3
+    returning = runs[2]["usage"]
+    assert returning["measurement_kind"] == "delta"
+    assert returning["input_tokens"] == 50  # 150 cumulative - 100 own baseline
+    assert returning["output_tokens"] == 5
+
+    totals = _summary_totals(runtime_root)
+    assert totals["input_tokens_24h"] == 200  # 150 (A) + 50 (B), never 300
+    assert totals["output_tokens_24h"] == 20
+
+
+def test_refresh_state_rejects_non_finite_measurement(tmp_path: Path) -> None:
+    registry_path, project, runtime_root = _goal_fixture(tmp_path)
+    with pytest.raises(UsageRowError, match="finite"):
+        _refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            usage_measurement={
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "provider": "fixture-host",
+                "model": "fixture-model",
+                "source_snapshot_id": "host-measured-nan",
+                "cost_usd": float("nan"),
+            },
+        )
+    index_path = runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    assert not index_path.exists()
 
 
 def test_refresh_state_without_usage_flags_keeps_usage_unknown(

--- a/tests/control_plane/test_codex_session_usage.py
+++ b/tests/control_plane/test_codex_session_usage.py
@@ -19,6 +19,7 @@ import pytest
 import loopx.state_refresh as state_refresh_module
 from loopx.control_plane.quota.codex_session_usage import (
     CodexSessionUsageError,
+    book_codex_session_usage,
     read_codex_session_usage,
     session_usage_baseline,
 )
@@ -294,6 +295,62 @@ def test_session_usage_baseline_fails_closed_on_corrupt_index_row(
     index_path.write_text('{"generated_at": "2026-08-26T01:05:00"\n', encoding="utf-8")
     with pytest.raises(CodexSessionUsageError, match="row 1 is corrupt"):
         session_usage_baseline(index_path, SESSION_ID)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "error_match"),
+    [
+        ({"input_tokens": 1200.5}, "input_tokens must be a whole number"),
+        ({"duration_ms": 300_000.5}, "duration_ms must be a whole number"),
+        ({"schema_version": None}, "schema_version"),
+        ({"measurement_kind": "estimate"}, "measurement_kind"),
+        ({"provider": "other-provider"}, "provider must be codex"),
+    ],
+    ids=[
+        "fractional-token",
+        "fractional-duration",
+        "missing-schema",
+        "illegal-measurement-kind",
+        "wrong-provider",
+    ],
+)
+def test_book_codex_session_usage_fails_closed_on_invalid_baseline_without_appending(
+    tmp_path: Path,
+    mutation: dict[str, Any],
+    error_match: str,
+) -> None:
+    rollout = _fixture_rollout(tmp_path)
+    index_path = tmp_path / "index.jsonl"
+    persisted_row = json.loads(
+        _index_row(
+            generated_at="2026-08-26T01:05:00",
+            source_snapshot_id=f"codex:{SESSION_ID}:2026-08-26T01:05:00.000Z",
+            measurement_kind="absolute",
+            input_tokens=1200,
+            output_tokens=300,
+            cache_tokens=200,
+            duration_ms=300_000,
+        )
+    )
+    persisted_row["usage"].update(mutation)
+    if "schema_version" in mutation and mutation["schema_version"] is None:
+        persisted_row["usage"].pop("schema_version", None)
+    index_path.write_text(json.dumps(persisted_row) + "\n", encoding="utf-8")
+    index_before_retry = index_path.read_bytes()
+    record: dict[str, Any] = {}
+    index_record: dict[str, Any] = {}
+
+    with pytest.raises(CodexSessionUsageError, match=error_match):
+        book_codex_session_usage(
+            record,
+            rollout,
+            index_path,
+            index_record=index_record,
+        )
+
+    assert index_path.read_bytes() == index_before_retry
+    assert "usage" not in record
+    assert "usage" not in index_record
 
 
 def _goal_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -483,6 +483,40 @@ def test_build_compact_usage_row_same_snapshot_id_without_prior_labels_fails_clo
         )
 
 
+@pytest.mark.parametrize(
+    "bad_cost", [float("nan"), float("inf"), float("-inf")], ids=["nan", "inf", "-inf"]
+)
+def test_build_compact_usage_row_rejects_non_finite_cost(bad_cost: float) -> None:
+    # NaN/Infinity would survive json.dumps as non-standard JSON and poison
+    # aggregation, so they must fail closed at intake instead.
+    with pytest.raises(UsageRowError, match="cost_usd must be finite"):
+        build_compact_usage_row(
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=bad_cost,
+            provider="codex",
+            model="codex-1",
+            source_snapshot_id="snap-nonfinite-cost",
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_tokens", [float("nan"), float("inf")], ids=["nan", "inf"]
+)
+def test_build_compact_usage_row_rejects_non_finite_token_counts(
+    bad_tokens: float,
+) -> None:
+    # Must raise the typed UsageRowError, not leak int()'s ValueError/OverflowError.
+    with pytest.raises(UsageRowError, match="input_tokens must be finite"):
+        build_compact_usage_row(
+            input_tokens=bad_tokens,  # type: ignore[arg-type]
+            output_tokens=5,
+            provider="codex",
+            model="codex-1",
+            source_snapshot_id="snap-nonfinite-tokens",
+        )
+
+
 def test_build_compact_usage_row_fails_closed_on_cumulative_reset() -> None:
     previous = {
         "source_snapshot_id": "snap-1",

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -377,6 +377,8 @@ def test_build_compact_usage_row_idempotent_replay_same_snapshot() -> None:
         "cache_tokens": 10,
         "cost_usd": 0.1,
         "duration_ms": 1000,
+        "provider": "codex",
+        "model": "codex-1",
     }
     row = build_compact_usage_row(
         input_tokens=100,
@@ -395,6 +397,90 @@ def test_build_compact_usage_row_idempotent_replay_same_snapshot() -> None:
     assert row["cache_tokens"] == 0
     assert row["cost_usd"] == 0.0
     assert row["duration_ms"] == 0
+
+
+def test_build_compact_usage_row_same_snapshot_id_different_counters_fails_closed() -> None:
+    previous = {
+        "source_snapshot_id": "snap-9",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "cache_tokens": 10,
+        "cost_usd": 0.1,
+        "duration_ms": 1000,
+        "provider": "codex",
+        "model": "codex-1",
+    }
+    with pytest.raises(UsageRowError, match="different cumulative observation.*input_tokens"):
+        build_compact_usage_row(
+            input_tokens=150,
+            output_tokens=40,
+            cache_tokens=10,
+            cost_usd=0.1,
+            duration_ms=1000,
+            provider="codex",
+            model="codex-1",
+            source_snapshot_id="snap-9",
+            previous_snapshot=previous,
+        )
+
+
+def test_build_compact_usage_row_same_snapshot_id_optional_presence_change_fails_closed() -> None:
+    previous = {
+        "source_snapshot_id": "snap-9",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "cache_tokens": 10,
+        "provider": "codex",
+        "model": "codex-1",
+    }
+    with pytest.raises(UsageRowError, match="different cumulative observation.*cache_tokens"):
+        build_compact_usage_row(
+            input_tokens=100,
+            output_tokens=40,
+            cache_tokens=None,
+            provider="codex",
+            model="codex-1",
+            source_snapshot_id="snap-9",
+            previous_snapshot=previous,
+        )
+
+
+def test_build_compact_usage_row_same_snapshot_id_different_labels_fails_closed() -> None:
+    previous = {
+        "source_snapshot_id": "snap-9",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "provider": "codex",
+        "model": "codex-1",
+    }
+    with pytest.raises(UsageRowError, match="different cumulative observation.*model"):
+        build_compact_usage_row(
+            input_tokens=100,
+            output_tokens=40,
+            provider="codex",
+            model="codex-2",
+            source_snapshot_id="snap-9",
+            previous_snapshot=previous,
+        )
+
+
+def test_build_compact_usage_row_same_snapshot_id_without_prior_labels_fails_closed() -> None:
+    # A same-id basis that never recorded its binding labels cannot prove the
+    # replay is identical, so it must not be treated as a zero-delta replay.
+    previous = {
+        "source_snapshot_id": "snap-9",
+        "input_tokens": 100,
+        "output_tokens": 40,
+    }
+    with pytest.raises(UsageRowError, match="different cumulative observation"):
+        build_compact_usage_row(
+            input_tokens=100,
+            output_tokens=40,
+            provider="codex",
+            model="codex-1",
+            source_snapshot_id="snap-9",
+            previous_snapshot=previous,
+        )
 
 
 def test_build_compact_usage_row_fails_closed_on_cumulative_reset() -> None:

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -91,6 +91,23 @@ def test_collect_usage_for_run_fails_closed_without_schema_version() -> None:
         )
 
 
+def test_collect_usage_for_run_fails_closed_on_non_finite_cost() -> None:
+    with pytest.raises(UsageRowError, match="cost_usd must be finite"):
+        collect_usage_for_run({"usage": _usage(cost_usd=float("nan"))})
+
+
+def test_build_usage_summary_fails_closed_on_non_finite_persisted_cost() -> None:
+    # A non-finite value that somehow reached a persisted row must abort
+    # aggregation, never propagate into summary totals.
+    run = _run(
+        "g1",
+        generated_at=datetime.now(timezone.utc),
+        usage=_usage(cost_usd=float("inf")),
+    )
+    with pytest.raises(UsageRowError, match="cost_usd must be finite"):
+        build_usage_summary({"runs": [run]}, parse_timestamp=_identity_parse)
+
+
 def test_collect_usage_for_run_normalizes_fields() -> None:
     sample = collect_usage_for_run({"usage": _usage()})
     assert sample == UsageSample(

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -3,14 +3,50 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import pytest
+
 from loopx.control_plane.quota.usage_collector import (
+    RUN_USAGE_SCHEMA_VERSION,
+    UsageRowError,
     UsageSample,
+    build_compact_usage_row,
     collect_usage_for_run,
+    ingest_usage_into_run_record,
 )
 from loopx.control_plane.quota.usage_summary import (
     blank_usage_goal,
     build_usage_summary,
 )
+
+
+def _usage(
+    *,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_tokens: int | None = 20,
+    cost_usd: float | None = 0.2,
+    duration_ms: int | None = 5000,
+    provider: str = "codex",
+    model: str = "codex-1",
+    source_snapshot_id: str = "snap-1",
+    measurement_kind: str = "absolute",
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "schema_version": RUN_USAGE_SCHEMA_VERSION,
+        "measurement_kind": measurement_kind,
+        "source_snapshot_id": source_snapshot_id,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "provider": provider,
+        "model": model,
+    }
+    if cache_tokens is not None:
+        row["cache_tokens"] = cache_tokens
+    if cost_usd is not None:
+        row["cost_usd"] = cost_usd
+    if duration_ms is not None:
+        row["duration_ms"] = duration_ms
+    return row
 
 
 def _run(
@@ -41,29 +77,49 @@ def test_blank_usage_goal_has_usage_fields() -> None:
 
 def test_collect_usage_for_run_returns_none_without_usage_block() -> None:
     assert collect_usage_for_run({"goal_id": "g1"}) is None
-    assert collect_usage_for_run({"goal_id": "g1", "usage": "not-a-dict"}) is None
 
 
-def test_collect_usage_for_run_returns_none_when_no_tokens() -> None:
-    # cost alone, with no tokens, is not aggregate-worthy.
-    assert collect_usage_for_run({"usage": {"cost_usd": 0.1}}) is None
+def test_collect_usage_for_run_fails_closed_on_non_mapping_usage() -> None:
+    with pytest.raises(UsageRowError, match="usage must be a mapping"):
+        collect_usage_for_run({"goal_id": "g1", "usage": "not-a-dict"})
+
+
+def test_collect_usage_for_run_fails_closed_without_schema_version() -> None:
+    with pytest.raises(UsageRowError, match="schema_version"):
+        collect_usage_for_run(
+            {"usage": {"input_tokens": 1, "output_tokens": 1, "provider": "x", "model": "y"}}
+        )
 
 
 def test_collect_usage_for_run_normalizes_fields() -> None:
+    sample = collect_usage_for_run({"usage": _usage()})
+    assert sample == UsageSample(
+        100,
+        50,
+        20,
+        0.2,
+        5000,
+        "codex",
+        "codex-1",
+        "snap-1",
+        "absolute",
+    )
+
+
+def test_collect_usage_for_run_keeps_unmeasured_fields_unknown() -> None:
     sample = collect_usage_for_run(
         {
-            "usage": {
-                "input_tokens": 100,
-                "output_tokens": 50,
-                "cache_tokens": 20,
-                "cost_usd": 0.2,
-                "duration_ms": 5000,
-                "provider": "codex",
-                "model": "codex-1",
-            }
+            "usage": _usage(
+                cache_tokens=None,
+                cost_usd=None,
+                duration_ms=None,
+            )
         }
     )
-    assert sample == UsageSample(100, 50, 20, 0.2, 5000, "codex", "codex-1")
+    assert sample is not None
+    assert sample.cache_tokens is None
+    assert sample.cost_usd is None
+    assert sample.duration_ms is None
 
 
 def test_build_usage_summary_aggregates_usage_within_windows() -> None:
@@ -73,27 +129,26 @@ def test_build_usage_summary_aggregates_usage_within_windows() -> None:
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 100,
-                    "output_tokens": 50,
-                    "cache_tokens": 20,
-                    "cost_usd": 0.1,
-                    "duration_ms": 1000,
-                    "provider": "codex",
-                    "model": "codex",
-                },
+                usage=_usage(
+                    input_tokens=100,
+                    output_tokens=50,
+                    cache_tokens=20,
+                    cost_usd=0.1,
+                    duration_ms=1000,
+                    source_snapshot_id="a",
+                ),
             ),
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 200,
-                    "output_tokens": 60,
-                    "cost_usd": 0.2,
-                    "duration_ms": 2000,
-                    "provider": "codex",
-                    "model": "codex",
-                },
+                usage=_usage(
+                    input_tokens=200,
+                    output_tokens=60,
+                    cache_tokens=None,
+                    cost_usd=0.2,
+                    duration_ms=2000,
+                    source_snapshot_id="b",
+                ),
             ),
         ]
     }
@@ -120,8 +175,27 @@ def test_build_usage_summary_degrades_when_runs_report_no_usage() -> None:
         assert "input_tokens_7d" not in bucket
         assert "cost_usd_7d" not in bucket
         assert "duration_ms_7d" not in bucket
-    # existing run accounting still works alongside the new fields
     assert summary["totals"]["runs_24h"] == 1
+
+
+def test_build_usage_summary_omits_unknown_optional_metrics() -> None:
+    now = datetime.now(timezone.utc)
+    history = {
+        "runs": [
+            _run(
+                "g1",
+                generated_at=now,
+                usage=_usage(cache_tokens=None, cost_usd=None, duration_ms=None),
+            )
+        ]
+    }
+    summary = build_usage_summary(history, parse_timestamp=_identity_parse)
+    totals = summary["totals"]
+    assert totals["input_tokens_24h"] == 100
+    assert totals["output_tokens_24h"] == 50
+    assert "cache_tokens_24h" not in totals
+    assert "cost_usd_24h" not in totals
+    assert "duration_ms_24h" not in totals
 
 
 def test_build_usage_summary_only_emits_windows_with_usage_samples() -> None:
@@ -131,12 +205,13 @@ def test_build_usage_summary_only_emits_windows_with_usage_samples() -> None:
             _run(
                 "g1",
                 generated_at=now - timedelta(days=2),
-                usage={
-                    "input_tokens": 25,
-                    "output_tokens": 5,
-                    "provider": "codex",
-                    "model": "codex",
-                },
+                usage=_usage(
+                    input_tokens=25,
+                    output_tokens=5,
+                    cache_tokens=None,
+                    cost_usd=None,
+                    duration_ms=None,
+                ),
             )
         ]
     }
@@ -155,22 +230,12 @@ def test_build_usage_summary_keeps_old_runs_out_of_usage_windows() -> None:
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 100,
-                    "output_tokens": 1,
-                    "provider": "codex",
-                    "model": "codex",
-                },
+                usage=_usage(input_tokens=100, output_tokens=1, source_snapshot_id="new"),
             ),
             _run(
                 "g1",
                 generated_at=old,
-                usage={
-                    "input_tokens": 999,
-                    "output_tokens": 1,
-                    "provider": "codex",
-                    "model": "codex",
-                },
+                usage=_usage(input_tokens=999, output_tokens=1, source_snapshot_id="old"),
             ),
         ]
     }
@@ -186,22 +251,24 @@ def test_build_usage_summary_is_provider_neutral() -> None:
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 10,
-                    "output_tokens": 1,
-                    "provider": "codex",
-                    "model": "codex",
-                },
+                usage=_usage(
+                    input_tokens=10,
+                    output_tokens=1,
+                    provider="codex",
+                    model="codex",
+                    source_snapshot_id="c1",
+                ),
             ),
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 40,
-                    "output_tokens": 1,
-                    "provider": "claude",
-                    "model": "claude-x",
-                },
+                usage=_usage(
+                    input_tokens=40,
+                    output_tokens=1,
+                    provider="claude",
+                    model="claude-x",
+                    source_snapshot_id="c2",
+                ),
             ),
         ]
     }
@@ -216,24 +283,26 @@ def test_build_usage_summary_rounds_cost_to_avoid_float_drift() -> None:
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 1,
-                    "output_tokens": 1,
-                    "cost_usd": 0.1,
-                    "provider": "x",
-                    "model": "y",
-                },
+                usage=_usage(
+                    input_tokens=1,
+                    output_tokens=1,
+                    cost_usd=0.1,
+                    source_snapshot_id="r1",
+                    provider="x",
+                    model="y",
+                ),
             ),
             _run(
                 "g1",
                 generated_at=now,
-                usage={
-                    "input_tokens": 1,
-                    "output_tokens": 1,
-                    "cost_usd": 0.2,
-                    "provider": "x",
-                    "model": "y",
-                },
+                usage=_usage(
+                    input_tokens=1,
+                    output_tokens=1,
+                    cost_usd=0.2,
+                    source_snapshot_id="r2",
+                    provider="x",
+                    model="y",
+                ),
             ),
         ]
     }
@@ -242,37 +311,147 @@ def test_build_usage_summary_rounds_cost_to_avoid_float_drift() -> None:
 
 
 def test_collect_usage_for_run_rejects_bool_tokens() -> None:
-    # bool is not a valid token count and must not be accepted as 1.
-    sample = collect_usage_for_run(
-        {"usage": {"input_tokens": True, "output_tokens": 10}}
-    )
-    assert sample is not None
-    assert sample.input_tokens == 0
-    assert sample.output_tokens == 10
+    with pytest.raises(UsageRowError, match="input_tokens"):
+        collect_usage_for_run(
+            {"usage": _usage(input_tokens=True)}  # type: ignore[arg-type]
+        )
 
 
 def test_collect_usage_for_run_rejects_negative_tokens() -> None:
-    sample = collect_usage_for_run(
-        {"usage": {"input_tokens": -100, "output_tokens": 10}}
-    )
-    assert sample is not None
-    assert sample.input_tokens == 0
-    assert sample.output_tokens == 10
+    with pytest.raises(UsageRowError, match="non-negative"):
+        collect_usage_for_run({"usage": _usage(input_tokens=-100)})
 
 
 def test_collect_usage_for_run_rejects_non_numeric_tokens() -> None:
-    # a numeric string is not coerced; only real numbers count.
-    sample = collect_usage_for_run(
-        {"usage": {"input_tokens": "100", "output_tokens": 10}}
-    )
-    assert sample is not None
-    assert sample.input_tokens == 0
-    assert sample.output_tokens == 10
+    with pytest.raises(UsageRowError, match="input_tokens"):
+        collect_usage_for_run(
+            {
+                "usage": {
+                    **_usage(),
+                    "input_tokens": "100",
+                }
+            }
+        )
 
 
 def test_collect_usage_for_run_rejects_negative_cost() -> None:
-    sample = collect_usage_for_run(
-        {"usage": {"input_tokens": 1, "output_tokens": 1, "cost_usd": -0.5}}
+    with pytest.raises(UsageRowError, match="cost_usd"):
+        collect_usage_for_run({"usage": _usage(cost_usd=-0.5)})
+
+
+def test_build_compact_usage_row_from_cumulative_delta() -> None:
+    previous = {
+        "source_snapshot_id": "snap-1",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "cache_tokens": 10,
+        "cost_usd": 0.1,
+        "duration_ms": 1000,
+    }
+    row = build_compact_usage_row(
+        input_tokens=150,
+        output_tokens=55,
+        cache_tokens=12,
+        cost_usd=0.15,
+        duration_ms=1600,
+        provider="codex",
+        model="codex-1",
+        source_snapshot_id="snap-2",
+        previous_snapshot=previous,
     )
+    assert row["schema_version"] == RUN_USAGE_SCHEMA_VERSION
+    assert row["measurement_kind"] == "delta"
+    assert row["input_tokens"] == 50
+    assert row["output_tokens"] == 15
+    assert row["cache_tokens"] == 2
+    assert row["cost_usd"] == pytest.approx(0.05)
+    assert row["duration_ms"] == 600
+    assert row["source_snapshot_id"] == "snap-2"
+
+
+def test_build_compact_usage_row_idempotent_replay_same_snapshot() -> None:
+    previous = {
+        "source_snapshot_id": "snap-9",
+        "input_tokens": 100,
+        "output_tokens": 40,
+        "cache_tokens": 10,
+        "cost_usd": 0.1,
+        "duration_ms": 1000,
+    }
+    row = build_compact_usage_row(
+        input_tokens=100,
+        output_tokens=40,
+        cache_tokens=10,
+        cost_usd=0.1,
+        duration_ms=1000,
+        provider="codex",
+        model="codex-1",
+        source_snapshot_id="snap-9",
+        previous_snapshot=previous,
+    )
+    assert row["measurement_kind"] == "delta"
+    assert row["input_tokens"] == 0
+    assert row["output_tokens"] == 0
+    assert row["cache_tokens"] == 0
+    assert row["cost_usd"] == 0.0
+    assert row["duration_ms"] == 0
+
+
+def test_build_compact_usage_row_fails_closed_on_cumulative_reset() -> None:
+    previous = {
+        "source_snapshot_id": "snap-1",
+        "input_tokens": 100,
+        "output_tokens": 40,
+    }
+    with pytest.raises(UsageRowError, match="reset or out-of-order"):
+        build_compact_usage_row(
+            input_tokens=80,
+            output_tokens=40,
+            provider="codex",
+            model="codex-1",
+            source_snapshot_id="snap-2",
+            previous_snapshot=previous,
+        )
+
+
+def test_ingest_usage_into_run_record_attaches_typed_row() -> None:
+    record: dict[str, Any] = {
+        "generated_at": "2026-08-26T00:00:00+00:00",
+        "goal_id": "g1",
+        "run_id": "run-1",
+    }
+    index_record: dict[str, Any] = dict(record)
+    row = ingest_usage_into_run_record(
+        record,
+        {
+            "input_tokens": 12,
+            "output_tokens": 3,
+            "provider": "fixture",
+            "model": "fixture-1",
+            "source_snapshot_id": "host-snap-1",
+        },
+        index_record=index_record,
+    )
+    assert row is not None
+    assert record["usage"]["schema_version"] == RUN_USAGE_SCHEMA_VERSION
+    assert index_record["usage"]["input_tokens"] == 12
+    sample = collect_usage_for_run(record)
     assert sample is not None
-    assert sample.cost_usd == 0.0
+    assert sample.input_tokens == 12
+    assert sample.source_snapshot_id == "host-snap-1"
+
+
+def test_ingest_usage_into_run_record_fails_closed_on_negative() -> None:
+    record: dict[str, Any] = {"generated_at": "2026-08-26T00:00:00+00:00"}
+    with pytest.raises(UsageRowError, match="non-negative"):
+        ingest_usage_into_run_record(
+            record,
+            {
+                "input_tokens": -1,
+                "output_tokens": 1,
+                "provider": "fixture",
+                "model": "fixture-1",
+                "source_snapshot_id": "bad",
+            },
+        )
+    assert "usage" not in record

--- a/tests/control_plane/test_usage_summary.py
+++ b/tests/control_plane/test_usage_summary.py
@@ -14,6 +14,7 @@ from loopx.control_plane.quota.usage_collector import (
     ingest_usage_into_run_record,
 )
 from loopx.control_plane.quota.usage_summary import (
+    _accumulate_usage,
     blank_usage_goal,
     build_usage_summary,
 )
@@ -325,6 +326,48 @@ def test_build_usage_summary_rounds_cost_to_avoid_float_drift() -> None:
     }
     summary = build_usage_summary(history, parse_timestamp=_identity_parse)
     assert summary["totals"]["cost_usd_24h"] == 0.3
+
+
+def test_build_usage_summary_fails_closed_when_total_cost_overflows() -> None:
+    now = datetime.now(timezone.utc)
+    history = {
+        "runs": [
+            _run(
+                goal_id,
+                generated_at=now,
+                usage=_usage(
+                    input_tokens=1,
+                    output_tokens=1,
+                    cost_usd=1e308,
+                    source_snapshot_id=f"overflow-{goal_id}",
+                ),
+            )
+            for goal_id in ("g1", "g2")
+        ]
+    }
+
+    with pytest.raises(UsageRowError, match="cost_usd_7d must be finite"):
+        build_usage_summary(history, parse_timestamp=_identity_parse)
+
+
+def test_accumulate_usage_fails_closed_when_goal_cost_overflows() -> None:
+    bucket = blank_usage_goal("g1")
+    sample = UsageSample(
+        input_tokens=1,
+        output_tokens=1,
+        cache_tokens=None,
+        cost_usd=1e308,
+        duration_ms=None,
+        provider="codex",
+        model="codex-1",
+        source_snapshot_id="overflow-goal",
+        measurement_kind="delta",
+    )
+    observed_metrics: set[str] = set()
+    _accumulate_usage(bucket, sample, "24h", observed_metrics)
+
+    with pytest.raises(UsageRowError, match="cost_usd_24h must be finite"):
+        _accumulate_usage(bucket, sample, "24h", observed_metrics)
 
 
 def test_collect_usage_for_run_rejects_bool_tokens() -> None:


### PR DESCRIPTION
## Summary
- Implements **GH-C95** / #3163 follow-up: provider-neutral `run_usage_v0` producer (`build_compact_usage_row` / `ingest_usage_into_run_record`) writes compact usage onto run-history records; `write_reserved_run_artifacts` is the first call site.
- `usage_summary` remains the only aggregator (no second ledger). Cumulative host snapshots become non-negative deltas bound to `source_snapshot_id` for idempotent replay; missing optional metrics stay unknown; malformed/negative/reset/out-of-order observations fail closed via `UsageRowError`.
- Updates `docs/status-data-contract.md` for the typed row + fail-closed contract; preserves usage on compact run projections.

## Test plan
- [x] `python3 -m pytest tests/control_plane/test_usage_summary.py -q`
- [x] `loopx check --scan-path docs/status-data-contract.md --scan-path docs/development/contributor-tasks.md`

Closes #3648
Related: #3163


Made with [Cursor](https://cursor.com)