### PR TITLE
fix(release): sign and notarize macOS desktop artifacts

### DIFF
--- a/.github/workflows/desktop-release-artifacts.yml
+++ b/.github/workflows/desktop-release-artifacts.yml
@@ -7,6 +7,7 @@ on:
       - "apps/desktop/loopx-control-plane/**"
       - "apps/presentation/dashboard/**"
       - "examples/desktop-icon-alpha-smoke.py"
+      - "examples/desktop-release-workflow-smoke.py"
   release:
     types: [published]
   workflow_dispatch:
@@ -92,9 +93,97 @@ jobs:
       - name: Validate desktop icon background
         run: python examples/desktop-icon-alpha-smoke.py
 
-      - name: Build desktop bundles
+      - name: Validate desktop release workflow
+        if: github.event_name == 'pull_request'
+        run: python examples/desktop-release-workflow-smoke.py
+
+      - name: Build unsigned desktop preview bundles
+        if: github.event_name == 'pull_request'
         working-directory: apps/desktop/loopx-control-plane
         run: npm run build -- --bundles ${{ matrix.bundles }} --no-sign
+
+      - name: Build signed macOS release bundles
+        if: github.event_name != 'pull_request' && runner.os == 'macOS'
+        working-directory: apps/desktop/loopx-control-plane
+        env:
+          RELEASE_TAG: ${{ steps.identity.outputs.release-tag }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          for name in \
+            APPLE_CERTIFICATE \
+            APPLE_CERTIFICATE_PASSWORD \
+            KEYCHAIN_PASSWORD \
+            APPLE_ID \
+            APPLE_PASSWORD \
+            APPLE_TEAM_ID
+          do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error title=Missing Apple signing secret::${name} is required for a macOS desktop release"
+              exit 1
+            fi
+          done
+          release_version="${RELEASE_TAG#v}"
+          if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid desktop release version::${RELEASE_TAG} is not a supported release tag"
+            exit 1
+          fi
+          npm run build -- --bundles ${{ matrix.bundles }} \
+            --config "{\"version\":\"${release_version}\"}"
+
+      - name: Notarize macOS disk image
+        if: github.event_name != 'pull_request' && runner.os == 'macOS'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          dmg_path="$(find apps/desktop/loopx-control-plane/src-tauri/target/release/bundle/dmg -maxdepth 1 -name '*.dmg' -print -quit)"
+          test -n "${dmg_path}"
+          xcrun notarytool submit "${dmg_path}" \
+            --apple-id "${APPLE_ID}" \
+            --password "${APPLE_PASSWORD}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --wait
+          xcrun stapler staple "${dmg_path}"
+
+      - name: Build Windows release bundles
+        if: github.event_name != 'pull_request' && runner.os == 'Windows'
+        working-directory: apps/desktop/loopx-control-plane
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ steps.identity.outputs.release-tag }}
+        run: |
+          set -euo pipefail
+          release_version="${RELEASE_TAG#v}"
+          if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid desktop release version::${RELEASE_TAG} is not a supported release tag"
+            exit 1
+          fi
+          npm run build -- --bundles ${{ matrix.bundles }} --no-sign \
+            --config "{\"version\":\"${release_version}\"}"
+
+      - name: Verify signed and notarized macOS bundles
+        if: github.event_name != 'pull_request' && runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_path="apps/desktop/loopx-control-plane/src-tauri/target/release/bundle/macos/LoopX.app"
+          dmg_path="$(find apps/desktop/loopx-control-plane/src-tauri/target/release/bundle/dmg -maxdepth 1 -name '*.dmg' -print -quit)"
+          test -n "${dmg_path}"
+          codesign --verify --deep --strict --verbose=2 "${app_path}"
+          spctl --assess --type execute --verbose=4 "${app_path}"
+          xcrun stapler validate "${app_path}"
+          codesign --verify --deep --strict --verbose=2 "${dmg_path}"
+          spctl --assess --type open --context context:primary-signature --verbose=4 "${dmg_path}"
+          xcrun stapler validate "${dmg_path}"
+          hdiutil verify "${dmg_path}"
 
       - name: Collect macOS desktop bundles
         if: runner.os == 'macOS'
@@ -104,8 +193,8 @@ jobs:
           mkdir -p dist/desktop
           cp apps/desktop/loopx-control-plane/src-tauri/target/release/bundle/dmg/*.dmg dist/desktop/
           ditto -c -k --keepParent \
-            "apps/desktop/loopx-control-plane/src-tauri/target/release/bundle/macos/Loopx.app" \
-            "dist/desktop/Loopx.app.zip"
+            "apps/desktop/loopx-control-plane/src-tauri/target/release/bundle/macos/LoopX.app" \
+            "dist/desktop/LoopX.app.zip"
 
       - name: Collect Windows desktop bundles
         if: runner.os == 'Windows'
@@ -143,6 +232,17 @@ jobs:
           pattern: loopx-*
           path: dist/desktop
           merge-multiple: true
+
+      - name: Generate desktop checksums
+        run: |
+          set -euo pipefail
+          cd dist/desktop
+          find . -maxdepth 1 -type f ! -name DESKTOP-SHA256SUMS -printf '%f\n' \
+            | LC_ALL=C sort \
+            | while IFS= read -r artifact; do sha256sum "${artifact}"; done \
+            > DESKTOP-SHA256SUMS
+          test -s DESKTOP-SHA256SUMS
+          sha256sum --check DESKTOP-SHA256SUMS
 
       - name: Resolve release identity
         id: identity

--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -15,6 +15,14 @@ desktop release workflow succeeds:
 The desktop shell still depends on a local `loopx` command at runtime. Install
 or update the LoopX CLI first, then open the desktop app.
 
+Official macOS release artifacts must be signed with an Apple Developer ID
+certificate and notarized before upload. Maintainers configure
+`APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`,
+`APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID` as GitHub Actions secrets.
+Pull requests still build unsigned preview artifacts, but the release workflow
+fails closed when those secrets are unavailable rather than publishing a DMG
+that macOS Gatekeeper rejects.
+
 ## Runtime Model
 
 The shell:
@@ -91,6 +99,11 @@ npm run build
 `src-tauri/target/release/bundle/`. The release workflow builds macOS `.dmg`
 and `.app.zip` artifacts on macOS, Windows `.msi` and `.exe` artifacts on
 Windows, and uploads them to the GitHub Release that triggered the workflow.
+It notarizes both the app and its disk image, then validates macOS code
+signing, Gatekeeper assessment, and both stapled tickets before upload. A
+separate `DESKTOP-SHA256SUMS` manifest covers all desktop artifacts attached
+by the workflow, and release builds use the Git tag as the desktop bundle
+version.
 
 ## Disable Or Remove
 

--- a/examples/desktop-release-workflow-smoke.py
+++ b/examples/desktop-release-workflow-smoke.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate the desktop release workflow's macOS distribution contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "desktop-release-artifacts.yml"
+
+
+def assert_contains(text: str, needle: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"missing desktop release contract: {needle}")
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    for required in [
+        'APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}',
+        'APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}',
+        'KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}',
+        'APPLE_ID: ${{ secrets.APPLE_ID }}',
+        'APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}',
+        'APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}',
+        "github.event_name == 'pull_request'",
+        "github.event_name != 'pull_request'",
+        "- name: Validate desktop release workflow\n        if: github.event_name == 'pull_request'",
+        'npm run build -- --bundles ${{ matrix.bundles }} --no-sign',
+        'npm run build -- --bundles ${{ matrix.bundles }}',
+        'RELEASE_TAG: ${{ steps.identity.outputs.release-tag }}',
+        'release_version="${RELEASE_TAG#v}"',
+        r'--config "{\"version\":\"${release_version}\"}"',
+        'codesign --verify --deep --strict --verbose=2',
+        'spctl --assess --type execute --verbose=4',
+        'xcrun notarytool submit',
+        'spctl --assess --type open --context context:primary-signature --verbose=4',
+        'xcrun stapler validate',
+        'hdiutil verify',
+        'bundle/macos/LoopX.app',
+        'dist/desktop/LoopX.app.zip',
+        'Generate desktop checksums',
+        'sha256sum',
+        'DESKTOP-SHA256SUMS',
+    ]:
+        assert_contains(text, required)
+
+    signed_step = text.split("- name: Build signed macOS release bundles", 1)[1].split(
+        "- name:", 1
+    )[0]
+    if "--no-sign" in signed_step:
+        raise AssertionError("signed macOS release build must not use --no-sign")
+
+    print("desktop-release-workflow-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Stop publishing unsigned macOS desktop releases that Gatekeeper rejects.
- Keep pull-request desktop builds unsigned for portable preview validation, while requiring Developer ID signing and notarization for release and manual upload runs.
- Validate the signed app and DMG before upload, align desktop bundle versions with the release tag, and attach a dedicated desktop checksum manifest.

## Issue Or Task

- Closes #
- Contributor task ID:

### Problem

The `v0.5.2` asset `LoopX_0.1.0_aarch64.dmg` downloads and mounts successfully, but its embedded `LoopX.app` was produced by a workflow that always passed `--no-sign`. The app therefore has no Developer ID identity or notarization ticket, and strict `codesign` / Gatekeeper verification rejects it. The fixed `0.1.0` desktop version also did not match the GitHub Release version.

### Fix

- Split pull-request preview builds from release builds.
- Require `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `KEYCHAIN_PASSWORD`, `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID` for macOS release builds.
- Let Tauri sign and notarize `LoopX.app`, explicitly notarize and staple the final DMG, then verify both with `codesign`, `spctl`, `stapler`, and `hdiutil`.
- Fail the release before upload when signing credentials or validation are unavailable.
- Inject the Git tag as the desktop bundle version and normalize `LoopX.app` artifact casing.
- Generate and verify `DESKTOP-SHA256SUMS` for all desktop release assets.
- Add a workflow contract smoke so published macOS builds cannot silently return to `--no-sign`.

### Rollout Requirement

The upstream repository currently has no Apple signing secrets configured. Before the next macOS desktop release or a manual rebuild of `v0.5.2`, maintainers must add the six secrets listed above. Until then, the macOS release job intentionally fails closed instead of uploading another Gatekeeper-rejected DMG.

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .`
- [x] `python3 examples/desktop-release-workflow-smoke.py`
- [x] `python3 examples/desktop-icon-alpha-smoke.py`
- [x] `cargo fmt --check`
- [x] `cargo test` (10 passed)
- [x] `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/desktop-release-artifacts.yml`
- [x] Local unsigned preview build: `npm run build -- --bundles dmg,app --no-sign --config '{"version":"0.5.2"}'`
- [x] `hdiutil verify` on `LoopX_0.5.2_aarch64.dmg`
- [ ] Real Developer ID / notarization run; requires upstream Apple credentials described above.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [x] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: Desktop release artifacts

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
