### PR TITLE
feat(benchmark): add qualified four-arm factorial contrasts

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -559,6 +559,25 @@ LoopX with the hint. The interaction contrast compares the two LoopX effects. A
 historical arm that mixed startup guidance and domain guidance is diagnostic only;
 renaming it does not make it a member of this factorial study.
 
+After all four cells have board rows, pass the compact contract back to the board
+read model:
+
+```bash
+loopx benchmark experiment-board-show \
+  --goal-id <goal-id> \
+  --four-arm-contract-json <compact-four-arm-contract.json> \
+  --format json
+```
+
+The factorial projection selects exactly one score-countable run per declared cell,
+checks exact anchors, non-factor parity, and distinct LoopX/non-LoopX runtime
+cohorts, then reports the three conditional effects plus their
+difference-in-differences. It fails closed on missing or ambiguous cells. This is
+separate from the standard matched-pair projection: the hinted Goal cell remains a
+`control`, not a baseline, and the hinted LoopX cell is qualified only through the
+explicit factorial contract. The read model does not infer membership from arm
+names and does not elevate design qualification into runner or scorer authority.
+
 ## Experiment lifecycle
 
 A countable experiment uses the toolkit in this order:
@@ -700,6 +719,10 @@ loopx benchmark experiment-board-show \
   --goal-id <goal-id> \
   --format json
 ```
+
+For a preregistered four-arm study, add
+`--four-arm-contract-json <compact-four-arm-contract.json>` to project conditional
+effects and the interaction contrast alongside ordinary matched comparisons.
 
 Preview and then execute an idempotent row update when a run starts or reaches a
 terminal state:

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -45,6 +45,10 @@ from .experiment_board import (
     render_benchmark_experiment_board_markdown,
     upsert_benchmark_experiment_board_row,
 )
+from .factorial_contrast import (
+    BENCHMARK_FACTORIAL_CONTRAST_SCHEMA_VERSION,
+    build_benchmark_factorial_contrasts,
+)
 from .four_arm_contract import (
     BENCHMARK_FOUR_ARM_ATTESTATIONS,
     BENCHMARK_FOUR_ARM_CONTRACT_SCHEMA_VERSION,
@@ -105,14 +109,14 @@ from .native_codex_profile import (
     native_codex_profile_environment,
     render_native_codex_goal_prompt,
 )
-from .provider_gateway import (
-    RunnerOwnedProviderGateway,
-    serve_runner_owned_provider_gateway,
-)
 from .plan_fidelity import (
     BENCHMARK_PLAN_FIDELITY_SCHEMA_VERSION,
     BenchmarkPlanRole,
     build_benchmark_plan_fidelity_receipt,
+)
+from .provider_gateway import (
+    RunnerOwnedProviderGateway,
+    serve_runner_owned_provider_gateway,
 )
 from .public_trajectory import (
     NATIVE_GOAL_LIFECYCLE_SCHEMA_VERSION,
@@ -168,6 +172,7 @@ __all__ = [
     "BENCHMARK_EXPERIMENT_BOARD_LEDGER_FILENAME",
     "BENCHMARK_EXPERIMENT_BOARD_ROW_SCHEMA_VERSION",
     "BENCHMARK_EXPERIMENT_BOARD_SCHEMA_VERSION",
+    "BENCHMARK_FACTORIAL_CONTRAST_SCHEMA_VERSION",
     "BENCHMARK_FOUR_ARM_ATTESTATIONS",
     "BENCHMARK_FOUR_ARM_CONTRACT_SCHEMA_VERSION",
     "BENCHMARK_FOUR_ARM_QUALIFICATION_SCOPE",
@@ -230,6 +235,7 @@ __all__ = [
     "build_benchmark_concurrency_config",
     "build_benchmark_concurrency_status",
     "build_benchmark_experiment_board",
+    "build_benchmark_factorial_contrasts",
     "build_benchmark_four_arm_contract",
     "build_benchmark_four_arm_contract_from_spec",
     "build_benchmark_integrity_qualification",
@@ -278,8 +284,8 @@ __all__ = [
     "run_native_goal_process_until_terminal",
     "run_native_goal_turn",
     "run_native_goal_until_terminal",
-    "serve_runner_owned_provider_gateway",
     "select_exact_docker_container",
+    "serve_runner_owned_provider_gateway",
     "start_native_goal_turn",
     "upsert_benchmark_experiment_board_row",
     "validate_run_permission_policy",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -79,11 +79,12 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         {
             "command": (
                 "loopx benchmark experiment-board-show --goal-id <goal-id> "
-                "--format json"
+                "[--four-arm-contract-json <compact-contract.json>] --format json"
             ),
             "purpose": (
                 "Read baseline, treatment, explore, countability, effort, and "
-                "insight status before selecting or launching another arm."
+                "insight status before selecting or launching another arm; an "
+                "explicit four-arm contract also projects conditional effects."
             ),
             "write_boundary": "read-only project-local public-safe domain state",
         },
@@ -279,7 +280,7 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         "board_commands": {
             "read": (
                 "loopx benchmark experiment-board-show --goal-id <goal-id> "
-                "--format json"
+                "[--four-arm-contract-json <compact-contract.json>] --format json"
             ),
             "preview": (
                 "loopx benchmark experiment-board-upsert --goal-id <goal-id> "

--- a/loopx/capabilities/benchmark_toolkit/experiment_board.py
+++ b/loopx/capabilities/benchmark_toolkit/experiment_board.py
@@ -9,6 +9,10 @@ from pathlib import Path
 from typing import Any
 
 from ...domain_state import default_domain_state_file_path, upsert_domain_state_jsonl
+from .factorial_contrast import (
+    build_benchmark_factorial_contrasts,
+    build_benchmark_metric_delta,
+)
 
 BENCHMARK_EXPERIMENT_BOARD_ROW_SCHEMA_VERSION = "benchmark_experiment_board_row_v0"
 BENCHMARK_EXPERIMENT_BOARD_SCHEMA_VERSION = "benchmark_experiment_board_v0"
@@ -597,50 +601,6 @@ def preview_benchmark_experiment_board_reconcile(
     return [result_by_key[key] for key in ordered_keys], counts
 
 
-def _metric_delta(
-    baseline: Mapping[str, Any], candidate: Mapping[str, Any]
-) -> dict[str, Any]:
-    delta = float(candidate["value"]) - float(baseline["value"])
-    result: dict[str, Any] = {
-        "baseline_value": baseline["value"],
-        "candidate_value": candidate["value"],
-        "delta": delta,
-    }
-    baseline_total = baseline.get("total")
-    candidate_total = candidate.get("total")
-    if (
-        isinstance(baseline_total, (int, float))
-        and not isinstance(baseline_total, bool)
-        and baseline_total > 0
-        and isinstance(candidate_total, (int, float))
-        and not isinstance(candidate_total, bool)
-        and candidate_total > 0
-    ):
-        baseline_rate = float(baseline["value"]) / float(baseline_total)
-        candidate_rate = float(candidate["value"]) / float(candidate_total)
-        result.update(
-            {
-                "baseline_total": baseline_total,
-                "candidate_total": candidate_total,
-                "baseline_rate": baseline_rate,
-                "candidate_rate": candidate_rate,
-                "delta_rate": candidate_rate - baseline_rate,
-            }
-        )
-    higher_is_better = candidate.get("higher_is_better")
-    if (
-        isinstance(higher_is_better, bool)
-        and baseline.get("higher_is_better") == higher_is_better
-    ):
-        if delta == 0:
-            result["direction"] = "flat"
-        elif (delta > 0) == higher_is_better:
-            result["direction"] = "improved"
-        else:
-            result["direction"] = "regressed"
-    return result
-
-
 def _build_comparison(
     candidate: Mapping[str, Any], anchor: Mapping[str, Any] | None
 ) -> dict[str, Any]:
@@ -678,7 +638,7 @@ def _build_comparison(
         anchor_metrics = anchor.get("metrics", {})
         candidate_metrics = candidate.get("metrics", {})
         for name in sorted(set(anchor_metrics) & set(candidate_metrics)):
-            metric_deltas[name] = _metric_delta(
+            metric_deltas[name] = build_benchmark_metric_delta(
                 anchor_metrics[name], candidate_metrics[name]
             )
 
@@ -751,6 +711,7 @@ def build_benchmark_experiment_board(
     *,
     benchmark_id: str | None = None,
     study_id: str | None = None,
+    four_arm_contract: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     normalized = [normalize_benchmark_experiment_board_row(dict(row)) for row in rows]
     if benchmark_id is not None:
@@ -762,6 +723,12 @@ def build_benchmark_experiment_board(
         study_filter = _token(study_id, field="study_id")
         normalized = [row for row in normalized if row["study_id"] == study_filter]
     normalized.sort(key=_row_sort_key)
+
+    factorial_contrasts = (
+        build_benchmark_factorial_contrasts(normalized, four_arm_contract)
+        if four_arm_contract is not None
+        else []
+    )
 
     by_run_id = {row["run_id"]: row for row in normalized}
     comparisons = [
@@ -810,6 +777,12 @@ def build_benchmark_experiment_board(
             "matched_pair_countable_count": sum(
                 1 for item in comparisons if item["matched_pair_countable"]
             ),
+            "factorial_contrast_count": len(factorial_contrasts),
+            "factorial_contrast_countable_count": sum(
+                1
+                for item in factorial_contrasts
+                if item["factorial_contrast_countable"]
+            ),
             "arm_role_counts": role_counts,
             "comparison_arm_role_counts": comparison_arm_role_counts,
             "comparison_claim_scope_counts": comparison_claim_scope_counts,
@@ -819,6 +792,7 @@ def build_benchmark_experiment_board(
         },
         "runs": normalized,
         "comparisons": comparisons,
+        "factorial_contrasts": factorial_contrasts,
         "agent_guidance": {
             "required_sequence": [
                 "read_board_before_launch_or_case_selection",
@@ -832,7 +806,9 @@ def build_benchmark_experiment_board(
             ),
             "claim_boundary": (
                 "Only matched_pair_countable comparisons support paired claims; "
-                "diagnostic_only explore rows remain a separate evidence lane."
+                "only factorial_contrast_countable projections support conditional "
+                "effects or difference-in-differences; diagnostic_only explore rows "
+                "remain a separate evidence lane."
             ),
             "next_action": (
                 "upsert_first_run_row"
@@ -895,6 +871,7 @@ def render_benchmark_experiment_board_markdown(payload: Mapping[str, Any]) -> st
         f"- Cases: `{summary.get('case_count', 0)}`",
         f"- Score-countable runs: `{summary.get('score_countable_run_count', 0)}`",
         f"- Countable matched comparisons: `{summary.get('matched_pair_countable_count', 0)}`",
+        f"- Countable factorial contrasts: `{summary.get('factorial_contrast_countable_count', 0)}`",
         f"- Countable matched-study comparisons: `{matched_study_counts.get('matched_pair_countable', 0)}`",
         f"- Countable diagnostic-only comparisons: `{diagnostic_counts.get('matched_pair_countable', 0)}`",
         "",
@@ -990,6 +967,53 @@ def render_benchmark_experiment_board_markdown(payload: Mapping[str, Any]) -> st
         )
     if not payload.get("comparisons"):
         lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a |")
+
+    lines.extend(
+        [
+            "",
+            "## Factorial Contrasts",
+            "",
+            "| Case | Primary interaction | Countable | Reasons |",
+            "| --- | ---: | --- | --- |",
+        ]
+    )
+    for item in payload.get("factorial_contrasts", []) or []:
+        if not isinstance(item, Mapping):
+            continue
+        interaction = (
+            item.get("interaction_contrast")
+            if isinstance(item.get("interaction_contrast"), Mapping)
+            else {}
+        )
+        metrics = (
+            interaction.get("metric_contrasts")
+            if isinstance(interaction.get("metric_contrasts"), Mapping)
+            else {}
+        )
+        primary = metrics.get(item.get("primary_metric"))
+        interaction_value = (
+            primary.get("difference_in_differences")
+            if isinstance(primary, Mapping)
+            else "n/a"
+        )
+        reasons = (
+            ", ".join(str(value) for value in item.get("reason_codes", []) or [])
+            or "none"
+        )
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(item.get("case_id")),
+                    str(interaction_value),
+                    str(item.get("factorial_contrast_countable")),
+                    reasons,
+                ]
+            )
+            + " |"
+        )
+    if not payload.get("factorial_contrasts"):
+        lines.append("| n/a | n/a | n/a | n/a |")
 
     guidance = (
         payload.get("agent_guidance")

--- a/loopx/capabilities/benchmark_toolkit/factorial_contrast.py
+++ b/loopx/capabilities/benchmark_toolkit/factorial_contrast.py
@@ -1,0 +1,519 @@
+"""Factorial contrast read model for benchmark experiment-board rows."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .four_arm_contract import (
+    BENCHMARK_FOUR_ARM_CONTRACT_SCHEMA_VERSION,
+    BENCHMARK_FOUR_ARM_QUALIFICATION_SCOPE,
+)
+
+BENCHMARK_FACTORIAL_CONTRAST_SCHEMA_VERSION = "benchmark_factorial_contrast_v0"
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:@+-]{0,127}$")
+_FACTOR_CELLS = {(False, False), (True, False), (False, True), (True, True)}
+
+
+def _token(value: Any, *, field: str) -> str:
+    text = str(value or "").strip()
+    if not _TOKEN_RE.fullmatch(text):
+        raise ValueError(f"{field} must be a compact public-safe token")
+    return text
+
+
+def _optional_token(value: Any, *, field: str) -> str | None:
+    if value in (None, ""):
+        return None
+    return _token(value, field=field)
+
+
+def build_benchmark_metric_delta(
+    baseline: Mapping[str, Any], candidate: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Compare two normalized experiment-board metric values."""
+
+    delta = float(candidate["value"]) - float(baseline["value"])
+    result: dict[str, Any] = {
+        "baseline_value": baseline["value"],
+        "candidate_value": candidate["value"],
+        "delta": delta,
+    }
+    baseline_total = baseline.get("total")
+    candidate_total = candidate.get("total")
+    if (
+        isinstance(baseline_total, (int, float))
+        and not isinstance(baseline_total, bool)
+        and baseline_total > 0
+        and isinstance(candidate_total, (int, float))
+        and not isinstance(candidate_total, bool)
+        and candidate_total > 0
+    ):
+        baseline_rate = float(baseline["value"]) / float(baseline_total)
+        candidate_rate = float(candidate["value"]) / float(candidate_total)
+        result.update(
+            {
+                "baseline_total": baseline_total,
+                "candidate_total": candidate_total,
+                "baseline_rate": baseline_rate,
+                "candidate_rate": candidate_rate,
+                "delta_rate": candidate_rate - baseline_rate,
+            }
+        )
+    higher_is_better = candidate.get("higher_is_better")
+    if (
+        isinstance(higher_is_better, bool)
+        and baseline.get("higher_is_better") == higher_is_better
+    ):
+        if delta == 0:
+            result["direction"] = "flat"
+        elif (delta > 0) == higher_is_better:
+            result["direction"] = "improved"
+        else:
+            result["direction"] = "regressed"
+    return result
+
+
+def _normalize_four_arm_design(contract: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(contract, Mapping):
+        raise TypeError("four-arm contract must be an object")
+    if contract.get("schema_version") != BENCHMARK_FOUR_ARM_CONTRACT_SCHEMA_VERSION:
+        raise ValueError("four-arm contract schema mismatch")
+    if contract.get("qualified") is not True:
+        raise ValueError("four-arm contract must be design-qualified")
+    if contract.get("qualification_scope") != BENCHMARK_FOUR_ARM_QUALIFICATION_SCOPE:
+        raise ValueError("four-arm contract qualification scope mismatch")
+    attestations = contract.get("attestations")
+    if (
+        not isinstance(attestations, Mapping)
+        or attestations.get("domain_hint_independent_of_loopx") is not True
+    ):
+        raise ValueError("four-arm domain hint independence is not attested")
+    if contract.get("factors") != {
+        "loopx": [False, True],
+        "domain_hint": [False, True],
+    }:
+        raise ValueError("four-arm contract factors are unsupported")
+
+    raw_arms = contract.get("arms")
+    if not isinstance(raw_arms, list) or len(raw_arms) != 4:
+        raise ValueError("four-arm contract must declare exactly four arms")
+    cells: dict[tuple[bool, bool], dict[str, Any]] = {}
+    arms_by_id: dict[str, dict[str, Any]] = {}
+    for raw_arm in raw_arms:
+        if not isinstance(raw_arm, Mapping):
+            raise TypeError("four-arm contract arms must be objects")
+        arm_id = _token(raw_arm.get("arm_id"), field="four-arm arm_id")
+        loopx_enabled = raw_arm.get("loopx_enabled")
+        hint_enabled = raw_arm.get("domain_hint_enabled")
+        if not isinstance(loopx_enabled, bool) or not isinstance(hint_enabled, bool):
+            raise TypeError("four-arm factors must be boolean")
+        cell_key = (loopx_enabled, hint_enabled)
+        if cell_key in cells or arm_id in arms_by_id:
+            raise ValueError("four-arm contract cells and arm ids must be unique")
+        expected_role = (
+            "baseline"
+            if cell_key == (False, False)
+            else "control"
+            if cell_key == (False, True)
+            else "treatment"
+        )
+        arm_role = _token(raw_arm.get("arm_role"), field="four-arm arm_role")
+        if arm_role != expected_role:
+            raise ValueError("four-arm contract role does not match its factor cell")
+        task_goal_sha256 = str(raw_arm.get("task_goal_sha256") or "").strip()
+        if not re.fullmatch(r"[0-9a-f]{64}", task_goal_sha256):
+            raise ValueError("four-arm task-goal hash must be sha256")
+        arm = {
+            "arm_id": arm_id,
+            "arm_role": arm_role,
+            "loopx_enabled": loopx_enabled,
+            "domain_hint_enabled": hint_enabled,
+            "task_goal_sha256": task_goal_sha256,
+        }
+        anchor_id = _optional_token(
+            raw_arm.get("comparison_anchor_arm_id"),
+            field="four-arm comparison_anchor_arm_id",
+        )
+        if anchor_id is not None:
+            arm["comparison_anchor_arm_id"] = anchor_id
+        cells[cell_key] = arm
+        arms_by_id[arm_id] = arm
+
+    if set(cells) != _FACTOR_CELLS:
+        raise ValueError("four-arm contract is missing a factor cell")
+    expected_anchors = {
+        (True, False): cells[(False, False)]["arm_id"],
+        (False, True): cells[(False, False)]["arm_id"],
+        (True, True): cells[(False, True)]["arm_id"],
+    }
+    if "comparison_anchor_arm_id" in cells[(False, False)]:
+        raise ValueError("plain Goal cell cannot declare a comparison anchor")
+    for cell_key, expected_anchor in expected_anchors.items():
+        if cells[cell_key].get("comparison_anchor_arm_id") != expected_anchor:
+            raise ValueError("four-arm comparison anchor does not match factor design")
+    if (
+        cells[(False, False)]["task_goal_sha256"]
+        != cells[(True, False)]["task_goal_sha256"]
+    ):
+        raise ValueError("plain Goal and LoopX cells must have prompt parity")
+    if (
+        cells[(False, True)]["task_goal_sha256"]
+        != cells[(True, True)]["task_goal_sha256"]
+    ):
+        raise ValueError("hinted Goal and LoopX cells must have prompt parity")
+    if (
+        cells[(False, False)]["task_goal_sha256"]
+        == cells[(False, True)]["task_goal_sha256"]
+    ):
+        raise ValueError("plain and hinted task goals must be distinct")
+
+    expected_effects = {
+        "loopx_without_domain_hint": (
+            cells[(True, False)]["arm_id"],
+            cells[(False, False)]["arm_id"],
+        ),
+        "domain_hint_without_loopx": (
+            cells[(False, True)]["arm_id"],
+            cells[(False, False)]["arm_id"],
+        ),
+        "loopx_with_domain_hint": (
+            cells[(True, True)]["arm_id"],
+            cells[(False, True)]["arm_id"],
+        ),
+    }
+    raw_effects = contract.get("primary_comparisons")
+    if not isinstance(raw_effects, list) or len(raw_effects) != 3:
+        raise ValueError("four-arm contract must declare three primary comparisons")
+    effects: list[dict[str, str]] = []
+    observed_effects: dict[str, tuple[str, str]] = {}
+    for raw_effect in raw_effects:
+        if not isinstance(raw_effect, Mapping):
+            raise TypeError("four-arm primary comparisons must be objects")
+        effect = _token(raw_effect.get("effect"), field="four-arm effect")
+        pair = (
+            _token(
+                raw_effect.get("candidate_arm_id"),
+                field="four-arm candidate_arm_id",
+            ),
+            _token(raw_effect.get("anchor_arm_id"), field="four-arm anchor_arm_id"),
+        )
+        if effect in observed_effects or pair in observed_effects.values():
+            raise ValueError("four-arm primary comparisons must be unique")
+        if pair[0] not in arms_by_id or pair[1] not in arms_by_id:
+            raise ValueError("four-arm primary comparison names an unknown arm")
+        observed_effects[effect] = pair
+        effects.append(
+            {
+                "effect": effect,
+                "candidate_arm_id": pair[0],
+                "anchor_arm_id": pair[1],
+            }
+        )
+    if observed_effects != expected_effects:
+        raise ValueError("four-arm primary comparisons do not match factor design")
+
+    raw_interaction = contract.get("interaction_contrast")
+    if not isinstance(raw_interaction, Mapping):
+        raise TypeError("four-arm interaction contrast must be an object")
+
+    def interaction_pair(field: str) -> tuple[str, str]:
+        raw_pair = raw_interaction.get(field)
+        if not isinstance(raw_pair, Mapping):
+            raise TypeError(f"four-arm interaction {field} must be an object")
+        pair = (
+            _token(
+                raw_pair.get("candidate_arm_id"),
+                field=f"four-arm interaction {field} candidate_arm_id",
+            ),
+            _token(
+                raw_pair.get("anchor_arm_id"),
+                field=f"four-arm interaction {field} anchor_arm_id",
+            ),
+        )
+        if pair not in observed_effects.values():
+            raise ValueError("four-arm interaction names an unknown primary effect")
+        return pair
+
+    interaction = {
+        "candidate_effect_pair": interaction_pair("candidate_effect"),
+        "anchor_effect_pair": interaction_pair("anchor_effect"),
+    }
+    if interaction != {
+        "candidate_effect_pair": expected_effects["loopx_with_domain_hint"],
+        "anchor_effect_pair": expected_effects["loopx_without_domain_hint"],
+    }:
+        raise ValueError("four-arm interaction contrast does not match factor design")
+    return {
+        "arms_by_id": arms_by_id,
+        "effects": effects,
+        "interaction": interaction,
+    }
+
+
+def _interaction_metric(
+    *,
+    candidate_effect: Mapping[str, Any],
+    anchor_effect: Mapping[str, Any],
+    higher_is_better: bool | None,
+) -> dict[str, Any]:
+    candidate_delta = candidate_effect.get("delta")
+    anchor_delta = anchor_effect.get("delta")
+    result: dict[str, Any] = {
+        "candidate_effect_delta": candidate_delta,
+        "anchor_effect_delta": anchor_delta,
+    }
+    if isinstance(candidate_delta, (int, float)) and isinstance(
+        anchor_delta, (int, float)
+    ):
+        difference = candidate_delta - anchor_delta
+        result["difference_in_differences"] = difference
+        if difference == 0:
+            result["direction"] = "flat"
+        elif isinstance(higher_is_better, bool):
+            result["direction"] = (
+                "improved" if (difference > 0) == higher_is_better else "regressed"
+            )
+    candidate_rate = candidate_effect.get("delta_rate")
+    anchor_rate = anchor_effect.get("delta_rate")
+    if isinstance(candidate_rate, (int, float)) and isinstance(
+        anchor_rate, (int, float)
+    ):
+        result["candidate_effect_delta_rate"] = candidate_rate
+        result["anchor_effect_delta_rate"] = anchor_rate
+        result["difference_in_differences_rate"] = candidate_rate - anchor_rate
+    return result
+
+
+def build_benchmark_factorial_contrasts(
+    rows: Iterable[Mapping[str, Any]],
+    contract: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Project conditional effects from explicitly declared four-arm cells."""
+
+    design = _normalize_four_arm_design(contract)
+    arms_by_id = design["arms_by_id"]
+    grouped: dict[tuple[str, str, str], list[Mapping[str, Any]]] = {}
+    for row in rows:
+        if row.get("arm_id") not in arms_by_id:
+            continue
+        key = (
+            str(row.get("benchmark_id")),
+            str(row.get("study_id")),
+            str(row.get("case_id")),
+        )
+        grouped.setdefault(key, []).append(row)
+
+    contrasts: list[dict[str, Any]] = []
+    for (benchmark_id, study_id, case_id), case_rows in sorted(grouped.items()):
+        reasons: list[str] = []
+        selected: dict[str, Mapping[str, Any]] = {}
+        cell_status: list[dict[str, Any]] = []
+        cells_by_arm_id: dict[str, dict[str, Any]] = {}
+        for arm_id, arm_contract in arms_by_id.items():
+            candidates = [row for row in case_rows if row.get("arm_id") == arm_id]
+            countable = [
+                row
+                for row in candidates
+                if row.get("countability", {}).get("score_countable") is True
+            ]
+            cell_reasons: list[str] = []
+            if not countable:
+                cell_reasons.append("no_score_countable_run")
+                reasons.append("cell_has_no_score_countable_run")
+            elif len(countable) > 1:
+                cell_reasons.append("ambiguous_score_countable_runs")
+                reasons.append("cell_has_ambiguous_score_countable_runs")
+            else:
+                selected[arm_id] = countable[0]
+            cell = {
+                "arm_id": arm_id,
+                "arm_role": arm_contract["arm_role"],
+                "loopx_enabled": arm_contract["loopx_enabled"],
+                "domain_hint_enabled": arm_contract["domain_hint_enabled"],
+                "run_count": len(candidates),
+                "score_countable_run_count": len(countable),
+                "selected_run_id": countable[0].get("run_id")
+                if len(countable) == 1
+                else None,
+                "reason_codes": cell_reasons,
+            }
+            cell_status.append(cell)
+            cells_by_arm_id[arm_id] = cell
+
+        if len(selected) == len(arms_by_id):
+            _qualify_selected_cells(
+                selected=selected,
+                arms_by_id=arms_by_id,
+                cells_by_arm_id=cells_by_arm_id,
+                reasons=reasons,
+            )
+
+        effects, effect_by_pair = _conditional_effects(
+            selected=selected,
+            design=design,
+        )
+        interaction_metrics = _interaction_metrics(
+            selected=selected,
+            design=design,
+            effect_by_pair=effect_by_pair,
+        )
+        contrasts.append(
+            {
+                "schema_version": BENCHMARK_FACTORIAL_CONTRAST_SCHEMA_VERSION,
+                "benchmark_id": benchmark_id,
+                "study_id": study_id,
+                "case_id": case_id,
+                "primary_metric": (
+                    next(iter(selected.values())).get("primary_metric")
+                    if selected
+                    else None
+                ),
+                "factorial_contrast_countable": not reasons,
+                "qualification_scope": "declared_factor_design_and_board_results",
+                "reason_codes": sorted(set(reasons)),
+                "cells": cell_status,
+                "conditional_effects": effects,
+                "interaction_contrast": {
+                    "candidate_effect_pair": list(
+                        design["interaction"]["candidate_effect_pair"]
+                    ),
+                    "anchor_effect_pair": list(
+                        design["interaction"]["anchor_effect_pair"]
+                    ),
+                    "metric_contrasts": interaction_metrics,
+                },
+            }
+        )
+    return contrasts
+
+
+def _qualify_selected_cells(
+    *,
+    selected: Mapping[str, Mapping[str, Any]],
+    arms_by_id: Mapping[str, Mapping[str, Any]],
+    cells_by_arm_id: Mapping[str, dict[str, Any]],
+    reasons: list[str],
+) -> None:
+    def reject_cell(arm_id: str, reason: str) -> None:
+        cells_by_arm_id[arm_id]["reason_codes"].append(reason)
+        reasons.append(f"cell_{reason}")
+
+    selected_rows = list(selected.values())
+    for arm_id, row in selected.items():
+        arm_contract = arms_by_id[arm_id]
+        if row.get("arm_role") != arm_contract["arm_role"]:
+            reject_cell(arm_id, "role_mismatch")
+        expected_fidelity = (
+            "not_applicable" if arm_contract["arm_role"] == "baseline" else "qualified"
+        )
+        if row.get("treatment_fidelity") != expected_fidelity:
+            reject_cell(arm_id, "treatment_fidelity_not_qualified")
+        if row.get("claim_scope") != "matched_study":
+            reject_cell(arm_id, "claim_scope_not_matched_study")
+        anchor_arm_id = arm_contract.get("comparison_anchor_arm_id")
+        if anchor_arm_id is not None and row.get(
+            "comparison_anchor_run_id"
+        ) != selected[anchor_arm_id].get("run_id"):
+            reject_cell(arm_id, "comparison_anchor_run_mismatch")
+
+    for field in ("model_id", "comparison_protocol_id", "primary_metric"):
+        values = [row.get(field) for row in selected_rows]
+        if any(value != values[0] for value in values[1:]):
+            reasons.append(f"{field}_mismatch")
+    runner_revisions = [row.get("runner_revision") for row in selected_rows]
+    if any(value in (None, "") for value in runner_revisions):
+        reasons.append("runner_revision_missing")
+    elif any(value != runner_revisions[0] for value in runner_revisions[1:]):
+        reasons.append("runner_revision_mismatch")
+
+    loopx_runtimes = [
+        selected[arm["arm_id"]].get("orchestrator_runtime")
+        for arm in arms_by_id.values()
+        if arm["loopx_enabled"]
+    ]
+    if any(runtime is None for runtime in loopx_runtimes):
+        reasons.append("loopx_orchestrator_runtime_missing")
+    elif loopx_runtimes[0] != loopx_runtimes[1]:
+        reasons.append("loopx_orchestrator_runtime_mismatch")
+    goal_runtimes = [
+        selected[arm["arm_id"]].get("orchestrator_runtime")
+        for arm in arms_by_id.values()
+        if not arm["loopx_enabled"]
+    ]
+    if goal_runtimes[0] != goal_runtimes[1]:
+        reasons.append("goal_orchestrator_runtime_mismatch")
+    elif (
+        loopx_runtimes
+        and all(runtime is not None for runtime in loopx_runtimes)
+        and goal_runtimes[0] == loopx_runtimes[0]
+    ):
+        reasons.append("factor_runtime_cohorts_not_distinct")
+
+    primary_metric = selected_rows[0]["primary_metric"]
+    metric_signatures = [
+        {
+            key: value
+            for key, value in row["metrics"][primary_metric].items()
+            if key != "value"
+        }
+        for row in selected_rows
+    ]
+    if any(signature != metric_signatures[0] for signature in metric_signatures[1:]):
+        reasons.append("primary_metric_definition_mismatch")
+
+
+def _conditional_effects(
+    *,
+    selected: Mapping[str, Mapping[str, Any]],
+    design: Mapping[str, Any],
+) -> tuple[list[dict[str, Any]], dict[tuple[str, str], dict[str, Any]]]:
+    if len(selected) != len(design["arms_by_id"]):
+        return [], {}
+    effects: list[dict[str, Any]] = []
+    effect_by_pair: dict[tuple[str, str], dict[str, Any]] = {}
+    for effect in design["effects"]:
+        candidate_arm_id = effect["candidate_arm_id"]
+        anchor_arm_id = effect["anchor_arm_id"]
+        candidate = selected[candidate_arm_id]
+        anchor = selected[anchor_arm_id]
+        metric_deltas = {
+            name: build_benchmark_metric_delta(
+                anchor["metrics"][name], candidate["metrics"][name]
+            )
+            for name in sorted(set(anchor["metrics"]) & set(candidate["metrics"]))
+        }
+        result = {
+            **effect,
+            "candidate_run_id": candidate.get("run_id"),
+            "anchor_run_id": anchor.get("run_id"),
+            "metric_deltas": metric_deltas,
+        }
+        effects.append(result)
+        effect_by_pair[(candidate_arm_id, anchor_arm_id)] = result
+    return effects, effect_by_pair
+
+
+def _interaction_metrics(
+    *,
+    selected: Mapping[str, Mapping[str, Any]],
+    design: Mapping[str, Any],
+    effect_by_pair: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> dict[str, Any]:
+    if not effect_by_pair:
+        return {}
+    candidate_effect = effect_by_pair[design["interaction"]["candidate_effect_pair"]]
+    anchor_effect = effect_by_pair[design["interaction"]["anchor_effect_pair"]]
+    candidate_metrics = candidate_effect["metric_deltas"]
+    anchor_metrics = anchor_effect["metric_deltas"]
+    interaction_metrics: dict[str, Any] = {}
+    for name in sorted(set(candidate_metrics) & set(anchor_metrics)):
+        metric_source = selected[candidate_effect["candidate_arm_id"]]["metrics"][name]
+        interaction_metrics[name] = _interaction_metric(
+            candidate_effect=candidate_metrics[name],
+            anchor_effect=anchor_metrics[name],
+            higher_is_better=metric_source.get("higher_is_better"),
+        )
+    return interaction_metrics

--- a/loopx/cli_commands/benchmark_experiment_board.py
+++ b/loopx/cli_commands/benchmark_experiment_board.py
@@ -48,7 +48,7 @@ def _read_json_object(path_text: str) -> dict[str, Any]:
     )
     payload = json.loads(raw)
     if not isinstance(payload, dict):
-        raise TypeError("benchmark experiment board row must be an object")
+        raise TypeError("benchmark experiment board JSON input must be an object")
     return payload
 
 
@@ -73,6 +73,13 @@ def register_benchmark_experiment_board_commands(
     )
     add_subcommand_format(show_parser)
     _add_board_location_arguments(show_parser)
+    show_parser.add_argument(
+        "--four-arm-contract-json",
+        help=(
+            "Optional compact benchmark_four_arm_contract_v0 JSON. When present, "
+            "project qualified conditional effects and difference-in-differences."
+        ),
+    )
 
     upsert_parser = benchmark_subparsers.add_parser(
         "experiment-board-upsert",
@@ -118,11 +125,13 @@ def _board_payload(
     rows: list[dict[str, Any]],
     benchmark_id: str | None,
     study_id: str | None,
+    four_arm_contract: dict[str, Any] | None,
 ) -> dict[str, Any]:
     return build_benchmark_experiment_board(
         rows,
         benchmark_id=benchmark_id,
         study_id=study_id,
+        four_arm_contract=four_arm_contract,
     )
 
 
@@ -217,6 +226,11 @@ def handle_benchmark_experiment_board_command(
             rows=rows,
             benchmark_id=args.benchmark_id,
             study_id=args.study_id,
+            four_arm_contract=(
+                _read_json_object(args.four_arm_contract_json)
+                if getattr(args, "four_arm_contract_json", None)
+                else None
+            ),
         )
         payload["goal_id"] = args.goal_id
         payload["path_recorded"] = False

--- a/tests/capabilities/test_benchmark_experiment_board.py
+++ b/tests/capabilities/test_benchmark_experiment_board.py
@@ -9,6 +9,8 @@ import pytest
 from loopx.capabilities.benchmark_toolkit import (
     BENCHMARK_EXPERIMENT_BOARD_ROW_SCHEMA_VERSION,
     build_benchmark_experiment_board,
+    build_benchmark_four_arm_contract,
+    compact_benchmark_four_arm_contract,
     default_benchmark_experiment_board_path,
     normalize_benchmark_experiment_board_row,
     preview_benchmark_experiment_board_reconcile,
@@ -122,6 +124,71 @@ def _running_baseline(**overrides: object) -> dict[str, object]:
     )
     payload.update(overrides)
     return payload
+
+
+def _four_arm_contract() -> dict[str, object]:
+    return compact_benchmark_four_arm_contract(
+        build_benchmark_four_arm_contract(
+            base_goal_text="Complete the requested task.",
+            domain_hint="Independently validate every public requirement.",
+            hint_id="swe_hint",
+            domain_hint_independent_of_loopx=True,
+        )
+    )
+
+
+def _four_arm_rows() -> list[dict[str, object]]:
+    runner_revision = "0123456789abcdef"
+    loopx_runtime = {
+        "provider_id": "loopx",
+        "version": "0.6.0",
+        "revision": "abcdef0123456789",
+    }
+    goal_plain = _baseline(
+        run_id="goal-plain-12",
+        arm_id="goal_plain",
+        runner_revision=runner_revision,
+    )
+    goal_plain["metrics"] = {
+        **goal_plain["metrics"],
+        "feature_pass": {
+            "value": 10,
+            "total": 66,
+            "higher_is_better": True,
+        },
+    }
+    loopx_plain = _row(
+        run_id="loopx-plain-12",
+        arm_id="loopx_plain",
+        arm_role="treatment",
+        protocol_id="loopx-plain-v1",
+        observed_at="2026-08-18T00:10:00+00:00",
+        f2p=14,
+        comparison_anchor_run_id="goal-plain-12",
+        orchestrator_runtime=loopx_runtime,
+    )
+    goal_hint = _row(
+        run_id="goal-hint-12",
+        arm_id="goal_swe_hint",
+        arm_role="control",
+        protocol_id="goal-hint-v1",
+        observed_at="2026-08-18T00:20:00+00:00",
+        f2p=13,
+        comparison_anchor_run_id="goal-plain-12",
+    )
+    loopx_hint = _row(
+        run_id="loopx-hint-12",
+        arm_id="loopx_swe_hint",
+        arm_role="treatment",
+        protocol_id="loopx-hint-v1",
+        observed_at="2026-08-18T00:30:00+00:00",
+        f2p=20,
+        comparison_anchor_run_id="goal-hint-12",
+        orchestrator_runtime=loopx_runtime,
+    )
+    for row in (loopx_plain, goal_hint, loopx_hint):
+        row["runner_revision"] = runner_revision
+    return [goal_plain, loopx_plain, goal_hint, loopx_hint]
 
 
 def _connected_goal_registries(tmp_path: Path) -> tuple[Path, Path]:
@@ -287,6 +354,114 @@ def test_board_keeps_standard_and_explore_lanes_and_compares_explicit_anchor() -
     assert board["agent_guidance"]["required_sequence"][0] == (
         "read_board_before_launch_or_case_selection"
     )
+
+
+def test_board_projects_explicit_four_arm_conditional_effects_and_interaction() -> None:
+    board = build_benchmark_experiment_board(
+        _four_arm_rows(),
+        four_arm_contract=_four_arm_contract(),
+    )
+
+    assert board["summary"]["factorial_contrast_count"] == 1
+    assert board["summary"]["factorial_contrast_countable_count"] == 1
+    contrast = board["factorial_contrasts"][0]
+    assert contrast["factorial_contrast_countable"] is True
+    assert contrast["reason_codes"] == []
+    effects = {
+        item["effect"]: item["metric_deltas"]["feature_pass"]["delta"]
+        for item in contrast["conditional_effects"]
+    }
+    assert effects == {
+        "loopx_without_domain_hint": 4,
+        "domain_hint_without_loopx": 3,
+        "loopx_with_domain_hint": 7,
+    }
+    interaction = contrast["interaction_contrast"]["metric_contrasts"]["feature_pass"]
+    assert interaction["difference_in_differences"] == 3
+    assert interaction["direction"] == "improved"
+    assert interaction["difference_in_differences_rate"] == pytest.approx(3 / 66)
+
+    standard = {item["candidate_arm_id"]: item for item in board["comparisons"]}
+    assert standard["loopx_swe_hint"]["matched_pair_countable"] is False
+    assert standard["loopx_swe_hint"]["reason_codes"] == [
+        "standard_arm_anchor_is_not_baseline"
+    ]
+    assert "Countable factorial contrasts: `1`" in (
+        render_benchmark_experiment_board_markdown(board)
+    )
+
+
+def test_factorial_projection_fails_closed_on_ambiguous_or_misaligned_cells() -> None:
+    rows = _four_arm_rows()
+    duplicate = dict(rows[1])
+    duplicate["run_id"] = "loopx-plain-12-r2"
+    duplicate["observed_at"] = "2026-08-18T00:11:00+00:00"
+    rows.append(duplicate)
+    board = build_benchmark_experiment_board(
+        rows,
+        four_arm_contract=_four_arm_contract(),
+    )
+    contrast = board["factorial_contrasts"][0]
+    assert contrast["factorial_contrast_countable"] is False
+    assert contrast["reason_codes"] == ["cell_has_ambiguous_score_countable_runs"]
+    cells = {item["arm_id"]: item for item in contrast["cells"]}
+    assert cells["loopx_plain"]["reason_codes"] == ["ambiguous_score_countable_runs"]
+
+    rows = _four_arm_rows()
+    rows[3]["comparison_anchor_run_id"] = "goal-plain-12"
+    rows[3]["runner_revision"] = "different-revision"
+    board = build_benchmark_experiment_board(
+        rows,
+        four_arm_contract=_four_arm_contract(),
+    )
+    contrast = board["factorial_contrasts"][0]
+    assert contrast["factorial_contrast_countable"] is False
+    assert contrast["reason_codes"] == [
+        "cell_comparison_anchor_run_mismatch",
+        "runner_revision_mismatch",
+    ]
+    cells = {item["arm_id"]: item for item in contrast["cells"]}
+    assert cells["loopx_swe_hint"]["reason_codes"] == ["comparison_anchor_run_mismatch"]
+
+    rows = _four_arm_rows()
+    rows[3]["orchestrator_runtime"] = {
+        "provider_id": "loopx",
+        "version": "0.6.0",
+        "revision": "different-revision",
+    }
+    rows[3]["metrics"]["feature_pass"]["total"] = 67
+    board = build_benchmark_experiment_board(
+        rows,
+        four_arm_contract=_four_arm_contract(),
+    )
+    contrast = board["factorial_contrasts"][0]
+    assert contrast["factorial_contrast_countable"] is False
+    assert contrast["reason_codes"] == [
+        "loopx_orchestrator_runtime_mismatch",
+        "primary_metric_definition_mismatch",
+    ]
+
+    rows = _four_arm_rows()
+    shared_runtime = rows[1]["orchestrator_runtime"]
+    rows[0]["orchestrator_runtime"] = shared_runtime
+    rows[2]["orchestrator_runtime"] = shared_runtime
+    board = build_benchmark_experiment_board(
+        rows,
+        four_arm_contract=_four_arm_contract(),
+    )
+    contrast = board["factorial_contrasts"][0]
+    assert contrast["factorial_contrast_countable"] is False
+    assert contrast["reason_codes"] == ["factor_runtime_cohorts_not_distinct"]
+
+    contract = _four_arm_contract()
+    contract["primary_comparisons"][0]["effect"] = "mislabelled_effect"
+    with pytest.raises(
+        ValueError, match="primary comparisons do not match factor design"
+    ):
+        build_benchmark_experiment_board(
+            _four_arm_rows(),
+            four_arm_contract=contract,
+        )
 
 
 def test_locked_jsonl_upsert_updates_one_stable_run_row(tmp_path: Path) -> None:
@@ -486,6 +661,47 @@ def test_cli_previews_then_writes_and_reads_board(tmp_path: Path) -> None:
     assert shown_payload["summary"]["run_count"] == 1
     assert shown_payload["agent_guidance"]["next_action"] == (
         "close_running_rows_or_review_matched_comparisons"
+    )
+
+
+def test_cli_show_projects_factorial_contrast_from_explicit_contract(
+    tmp_path: Path,
+) -> None:
+    ledger = default_benchmark_experiment_board_path(
+        project=tmp_path, goal_id="fixture-goal"
+    )
+    for row in _four_arm_rows():
+        upsert_benchmark_experiment_board_row(ledger, row)
+    contract_path = tmp_path / "four-arm-contract.json"
+    contract_path.write_text(json.dumps(_four_arm_contract()), encoding="utf-8")
+
+    shown = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts/loopx"),
+            "benchmark",
+            "experiment-board-show",
+            "--goal-id",
+            "fixture-goal",
+            "--project",
+            str(tmp_path),
+            "--four-arm-contract-json",
+            str(contract_path),
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    payload = json.loads(shown.stdout)
+    assert payload["summary"]["factorial_contrast_countable_count"] == 1
+    assert (
+        payload["factorial_contrasts"][0]["interaction_contrast"]["metric_contrasts"][
+            "feature_pass"
+        ]["difference_in_differences"]
+        == 3
     )
 
 


### PR DESCRIPTION
## Summary

- add a provider-neutral, fail-closed 2x2 factorial contrast read model for qualified experiment-board rows
- expose conditional LoopX, hint, and interaction effects without treating a control cell as a standard matched baseline
- require explicit arm roles, prompt parity, model/protocol/runner alignment, treatment fidelity, metric parity, and one score-countable row per cell
- document the projection and expose it through the experiment-board CLI

## Validation

- python -m pytest -q tests/capabilities/test_benchmark_*.py (177 passed)
- focused Ruff checks on all changed Python paths (passed)
- git diff --check (passed)
- public/private boundary scan on added lines (passed)
- LoopX premerge canary selected 18 relevant checks with zero failures; it correctly retained manual review because this is benchmark-sensitive

## Review boundary

This PR changes only the public benchmark read model, CLI projection, catalog/docs, and focused tests. It does not launch jobs, change scoring, alter benchmark tasks, include raw run evidence, or weaken qualification gates. Independent review is intentionally retained.