### PR TITLE
refactor(task-lease): cut settlement over to TypeScript

### DIFF
--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -237,7 +237,8 @@ domains would now increase total complexity.
 
 Select by deletion leverage and runtime traffic, not by ease of translation.
 The shipped Turn settlement, quota delivery-routing, Todo-completion,
-scheduler-heartbeat, and quota-spend commit cutovers establish the pattern.
+scheduler-heartbeat, quota-spend commit, and task-lease acquire cutovers
+establish the pattern.
 Subsequent candidates must name a remaining transaction and its deletion
 leverage; remaining quota settlement readback is eligible only when it can
 retire or materially shrink the facade rather than add another leaf handler.
@@ -285,6 +286,13 @@ shipped Stage 2B cutovers are in place:
   Python retains `should-run`/settlement fact projection plus one coarse
   transport call and the legacy kernel index lock; it no longer constructs or
   writes the spend event.
+- Task-lease acquire: TypeScript owns identity normalization, settlement-plan
+  projection, provider failure classification, ordered receipt construction,
+  and the canonical result. Python invokes the existing atomic provider between
+  one preflight and one final reduction; the provider retains the per-goal lock,
+  owner eligibility, conflict, compare-and-swap, idempotency, and lease-file
+  durability checks. Invalid identities stop before the provider, while a
+  crash/retry after the provider re-enters its same-key idempotent path.
 
 The quota-spend cutover removes the Python spend-event builder and three-file
 writer. Its bounded facade exits when the quota CLI and remaining run-index
@@ -296,9 +304,12 @@ leaves. The remaining Python Todo facade owns transport, external command
 execution, source compare-and-swap, legacy response projection, and the actual
 Markdown/event write. It exits when those writers and the CLI move into the
 native TS transaction. The remaining fine-grained Turn facade exits after
-quota, host-adapter, and task-lease callers move to their own coarse
-transactions. Vision checkpointing remains a separate refresh/writeback
-transaction because it does not share the delivery-selection lifecycle phase.
+quota and host-adapter callers move to their own coarse transactions. The
+task-lease Python facade now contains only transport, the atomic provider, and
+legacy CLI projection; it exits when lease persistence and the task-lease CLI
+run in the native TS transaction. Vision checkpointing remains a separate
+refresh/writeback transaction because it does not share the delivery-selection
+lifecycle phase.
 
 ### Stage 3 — CLI and App convergence
 

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -205,10 +205,10 @@ leaf pattern 会增加总复杂度。
 ### Stage 2B — 完整 transaction cutover（进行中）
 
 按删除杠杆与 runtime traffic 选切口，而不是按翻译难度选。已经交付的 Turn
-settlement、quota delivery routing、Todo completion、scheduler heartbeat 与 quota
-spend commit cutover 建立了这一模式。后续候选必须明确剩余 transaction 及其删除
-杠杆；剩余 quota settlement readback 只有在能退出或显著收窄 facade，而不是再增加
-leaf handler 时才适合迁移。
+settlement、quota delivery routing、Todo completion、scheduler heartbeat、quota
+spend commit 与 task-lease acquire cutover 建立了这一模式。后续候选必须明确剩余
+transaction 及其删除杠杆；剩余 quota settlement readback 只有在能退出或显著收窄
+facade，而不是再增加 leaf handler 时才适合迁移。
 
 每完成一笔 transaction，就用 native TS semantic/invariant test 加一个持久的
 end-to-end adapter contract，替换 migration-only characterization worker 与 Python
@@ -246,6 +246,12 @@ window 仍需 differential proof 时才保留 characterization corpus；引入�
   截断 JSONL 尾行，其他损坏仍然 fail closed。
   Python 只保留 `should-run`/settlement fact projection、一次 coarse transport call 与
   legacy kernel index lock；它不再构造或写入 spend event。
+- Task-lease acquire：TypeScript 拥有 identity normalization、settlement plan
+  projection、provider failure classification、ordered receipt construction 与
+  canonical result。Python 在一次 preflight 与一次 final reduction 之间调用现有
+  atomic provider；provider 继续拥有 per-goal lock、owner eligibility、conflict、
+  compare-and-swap、idempotency 与 lease-file durability check。无效 identity 会在
+  provider 前停止；provider 后发生 crash/retry 时则重入同 key 的幂等路径。
 
 Quota-spend cutover 删除了 Python spend-event builder 与三文件 writer。它的 bounded
 facade 会在 quota CLI 和剩余 run-index writer 进程内执行 transaction 后退出；在此
@@ -254,9 +260,11 @@ lock。Todo cutover 删除了 Python state-evaluation dataclass、local identity
 replay helper，以及这些 implementation leaf 的 public runtime handler。剩余 Python
 Todo facade 只拥有 transport、external command execution、source compare-and-swap、
 legacy response projection 与实际 Markdown/event write；当 writer 与 CLI 进入 native
-TS transaction 后即可退出。剩余细粒度 Turn facade 则在 quota、host-adapter 与
-task-lease caller 进入各自 coarse transaction 后退出。Vision checkpointing 属于
-不同的 refresh/writeback 生命周期阶段，因此继续作为独立 transaction。
+TS transaction 后即可退出。剩余细粒度 Turn facade 则在 quota 与 host-adapter
+caller 进入各自 coarse transaction 后退出。Task-lease Python facade 现在只包含
+transport、atomic provider 与 legacy CLI projection；当 lease persistence 与
+task-lease CLI 在 native TS transaction 中运行时即可退出。Vision checkpointing
+属于不同的 refresh/writeback 生命周期阶段，因此继续作为独立 transaction。
 
 ### Stage 3 — CLI 与 App 汇合
 

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -80,6 +80,7 @@ import {
   projectReplanSettlementContract,
   projectTodoLifecycleSettlementReentry,
 } from "./work_items/replan_settlement.ts";
+import { reduceTaskLeaseAcquire } from "./work_items/task_lease_settlement.ts";
 import {
   projectQuotaActionPortfolio,
   qualifyActionSelection,
@@ -451,6 +452,7 @@ export function createEffectRuntimeHandlers(
       ),
     ],
     ["turn.settlement.reduce", reduceTurnSettlementTransaction],
+    ["task_lease.acquire.reduce", reduceTaskLeaseAcquire],
     ["work_item.replan_settlement.project", projectReplanSettlementContract],
     [
       "work_item.replan_settlement.reentry",

--- a/loopx/control_plane/work_items/task_lease_settlement.py
+++ b/loopx/control_plane/work_items/task_lease_settlement.py
@@ -1,382 +1,149 @@
-"""Task-lease adapter for the shared typed settlement algebra.
+"""Python provider bridge for the TypeScript-owned task-lease transaction.
 
-Wraps the existing task_lease acquire path with typed identity, receipt,
-and failure semantics so it participates in the same conformance, fault/replay,
-and incident-replay coverage as the quota and Turn adapters.
-
-Pure decision logic (owner eligibility, conflict detection, lease persistence)
-remains in the owning ``task_lease`` module.  This adapter only models the
-orchestration as a typed settlement chain.
+TypeScript owns request normalization, settlement identity and plan projection,
+provider failure classification, ordered receipts, and the canonical result.
+Python retains the atomic task-lease provider and the legacy CLI projection
+until task-lease persistence and the CLI move to the native TS runtime.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from loopx.control_plane.effect_program import (
-    SettlementFailureKind,
-    SettlementIdentity,
-    SettlementPlan,
-    SettlementReceipt,
-    SettlementResult,
-    SettlementStep,
-    SettlementStepKind,
-)
+from loopx.control_plane.effect_program import SettlementResult
+from loopx.control_plane.effect_runtime import effect_runtime_result
+from loopx.control_plane.settlement_driver import decode_settlement_result
 from loopx.control_plane.work_items.task_lease import (
     TaskLeaseError,
     acquire_task_lease,
-    active_conflicts,
-    lease_is_active,
-    normalize_goal_id,
-    normalize_idempotency_key,
-    normalize_lease_todo_id,
-    normalize_owner,
-    normalize_ttl_seconds,
-    read_lease,
-    require_task_lease_owner_allowed,
     task_lease_path,
 )
 
-__all__ = [
-    "build_task_lease_settlement_plan",
-    "commit_task_lease_acquire",
-    "execute_task_lease_settlement",
-    "resolve_task_lease_validation",
-]
+__all__ = ["execute_task_lease_settlement"]
 
 
-def _now_utc() -> datetime:
-    return datetime.now(tz=timezone.utc)
+TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION = (
+    "loopx_task_lease_acquire_transaction_v0"
+)
+TASK_LEASE_ACQUIRE_REDUCTION_SCHEMA_VERSION = "loopx_task_lease_acquire_reduction_v0"
 
 
-def _typed_failure(
-    *,
-    kind: SettlementFailureKind,
-    step_kind: SettlementStepKind,
-    reason: str,
-    code: str | None = None,
-    task_lease_payload: dict[str, Any] | None = None,
-) -> SettlementResult[Any]:
-    details: dict[str, Any] = {}
-    if code:
-        details["task_lease_error_code"] = code
-    if task_lease_payload:
-        details["task_lease_payload"] = dict(task_lease_payload)
-    return SettlementResult.failed(
-        kind=kind,
-        step_kind=step_kind,
-        reason=reason,
-        details=details or None,
+def _require_mapping(value: object, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RuntimeError(f"TypeScript task-lease {label} shape mismatch")
+    return value
+
+
+def _reduce_task_lease_acquire(params: Mapping[str, Any]) -> dict[str, Any]:
+    result = effect_runtime_result("task_lease.acquire.reduce", params)
+    reduction = _require_mapping(result, "reduction")
+    if reduction.get(
+        "schema_version"
+    ) != TASK_LEASE_ACQUIRE_REDUCTION_SCHEMA_VERSION or reduction.get(
+        "decision"
+    ) not in {"execute", "complete", "failed"}:
+        raise RuntimeError("TypeScript task-lease reduction shape mismatch")
+    return dict(reduction)
+
+
+def _decode_task_lease_result(
+    reduction: Mapping[str, Any],
+) -> SettlementResult[dict[str, Any]]:
+    result = reduction.get("result")
+    projection = reduction.get("settlement_result")
+    if not isinstance(result, Mapping) or not isinstance(projection, Mapping):
+        raise RuntimeError("TypeScript task-lease result shape mismatch")
+
+    def decode_lease(value: Any) -> dict[str, Any]:
+        if not isinstance(value, Mapping):
+            raise RuntimeError("TypeScript task-lease value shape mismatch")
+        return dict(value)
+
+    return decode_settlement_result(
+        result,
+        value_decoder=decode_lease,
+        projection_payload=projection,
     )
 
 
-
-def _settlement_identity(
-    *,
-    goal_id: str,
-    owner: str,
-    todo_id: str,
-    idempotency_key: str,
-) -> SettlementIdentity:
-    return SettlementIdentity(
-        goal_id=normalize_goal_id(goal_id),
-        agent_id=normalize_owner(owner),
-        todo_id=normalize_lease_todo_id(todo_id),
-        turn_instance_id=normalize_idempotency_key(idempotency_key),
-    )
-
-
-def build_task_lease_settlement_plan(
-    *,
-    goal_id: str,
-    owner: str,
-    todo_id: str,
-    idempotency_key: str,
-    write_scopes: list[str] | None = None,
-    ttl_seconds: int | None = None,
-) -> SettlementPlan:
-    """Build a typed settlement plan for a task-lease acquire.
-
-    The plan uses two ordered steps: validation (identity + eligibility +
-    no-conflicts check) and acquire (committed file write). The scheduler
-    is deliberately left outside the settlement boundary.
-    """
-    identity = _settlement_identity(
-        goal_id=goal_id,
-        owner=owner,
-        todo_id=todo_id,
-        idempotency_key=idempotency_key,
-    )
-    normalized_scopes = sorted(set(write_scopes or []))
-    normalized_ttl = normalize_ttl_seconds(ttl_seconds)
-    effect_ref = "$.identity.effect_id"
-    return SettlementPlan(
-        identity=identity,
-        steps=(
-            SettlementStep(
-                kind=SettlementStepKind.VALIDATION,
-                owner="agent",
-                precondition=(
-                    "owner is registered and eligible for this todo; "
-                    "no active lease with different owner/key exists; "
-                    "no write-scope conflict with another active lease"
-                ),
-                idempotency_key_ref=effect_ref,
-                expected_receipt="task_lease_validation_receipt",
-            ),
-            SettlementStep(
-                kind=SettlementStepKind.DURABLE_WRITEBACK,
-                owner="agent",
-                precondition=(
-                    "validation succeeded; lease file can be committed"
-                ),
-                idempotency_key_ref=effect_ref,
-                expected_receipt="task_lease_acquire_receipt",
-                command_template=(
-                    f"loopx task-lease acquire --goal-id {identity.goal_id}"
-                    f" --todo-id {identity.todo_id}"
-                    f" --owner {identity.agent_id}"
-                    f" --ttl {normalized_ttl}"
-                    + (
-                        "".join(f" --write-scope {s}" for s in normalized_scopes)
-                        if normalized_scopes
-                        else ""
-                    )
-                ),
-            ),
-        ),
-    )
-
-
-def resolve_task_lease_validation(
+def _provider_result(
+    provider_effect: Mapping[str, Any],
     *,
     registry_path: Path,
     runtime_root: Path,
-    goal_id: str,
-    owner: str,
-    todo_id: str,
-    idempotency_key: str,
-    write_scopes: list[str] | None = None,
-) -> SettlementResult[SettlementIdentity]:
-    """Validate task-lease acquire preconditions.
-
-    Returns a typed result: either a pure identity with a validation receipt,
-    or a typed failure that short-circuits the acquire step.
-    """
-    try:
-        normalized_goal_id = normalize_goal_id(goal_id)
-    except ValueError as exc:
-        return _typed_failure(
-            kind=SettlementFailureKind.INVALID_IDENTITY,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason=str(exc),
-            code="invalid_goal_id",
-        )
-    try:
-        normalized_owner = normalize_owner(owner)
-    except ValueError as exc:
-        return _typed_failure(
-            kind=SettlementFailureKind.INVALID_IDENTITY,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason=str(exc),
-            code="invalid_owner",
-        )
-    try:
-        normalized_todo_id = normalize_lease_todo_id(todo_id)
-    except ValueError as exc:
-        return _typed_failure(
-            kind=SettlementFailureKind.INVALID_IDENTITY,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason=str(exc),
-            code="invalid_todo_id",
-        )
-    try:
-        normalized_key = normalize_idempotency_key(idempotency_key)
-    except ValueError as exc:
-        return _typed_failure(
-            kind=SettlementFailureKind.INVALID_IDENTITY,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason=str(exc),
-            code="invalid_idempotency_key",
-        )
-
-    identity = SettlementIdentity(
-        goal_id=normalized_goal_id,
-        agent_id=normalized_owner,
-        todo_id=normalized_todo_id,
-        turn_instance_id=normalized_key,
+    acquire: bool,
+) -> dict[str, Any]:
+    if (
+        provider_effect.get("step_kind") != "durable_writeback"
+        or provider_effect.get("action") != "acquire"
+        or not isinstance(provider_effect.get("effect_id"), str)
+    ):
+        raise RuntimeError("TypeScript task-lease provider effect shape mismatch")
+    effect_id = str(provider_effect["effect_id"])
+    parameters = _require_mapping(
+        provider_effect.get("parameters"),
+        "provider parameters",
     )
-
-    # --- owner eligibility (pure decision, owned by task_lease module) ---
-    try:
-        require_task_lease_owner_allowed(
-            registry_path=registry_path,
-            goal_id=normalized_goal_id,
-            todo_id=normalized_todo_id,
-            owner=normalized_owner,
-        )
-    except ValueError as exc:
-        return _typed_failure(
-            kind=SettlementFailureKind.PERMISSION_DENIED,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason=str(exc),
-            code=getattr(exc, "code", None),
-        )
-
-    # --- existing active lease check ---
+    write_scopes = parameters.get("write_scopes")
+    if not isinstance(write_scopes, list) or any(
+        not isinstance(scope, str) for scope in write_scopes
+    ):
+        raise RuntimeError("TypeScript task-lease write scopes shape mismatch")
+    ttl_seconds = parameters.get("ttl_seconds")
+    expected_version = parameters.get("expected_version")
+    if ttl_seconds is not None and (
+        isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, int)
+    ):
+        raise RuntimeError("TypeScript task-lease ttl shape mismatch")
+    if expected_version is not None and (
+        isinstance(expected_version, bool) or not isinstance(expected_version, int)
+    ):
+        raise RuntimeError("TypeScript task-lease expected version shape mismatch")
     lease_path = task_lease_path(
         runtime_root=runtime_root,
-        goal_id=normalized_goal_id,
-        todo_id=normalized_todo_id,
+        goal_id=str(parameters.get("goal_id") or ""),
+        todo_id=str(parameters.get("todo_id") or ""),
     )
-    existing = read_lease(lease_path)
-    if existing is not None and lease_is_active(existing):
-        existing_owner = str(existing.get("owner") or "")
-        existing_key = str(existing.get("idempotency_key") or "")
-        if existing_owner == normalized_owner and existing_key == normalized_key:
-            # Same owner + key — would be idempotent; surface as already-settled
-            return SettlementResult.pure(
-                identity,
-                receipts=(
-                    SettlementReceipt(
-                        step_kind=SettlementStepKind.VALIDATION,
-                        status="idempotent",
-                        effect_id=identity.effect_id,
-                        source_ref=str(lease_path),
-                    ),
-                ),
-            )
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.WRITEBACK_REJECTED,
-            step_kind=SettlementStepKind.VALIDATION,
-            reason="todo already has an active lease with a different owner or key",
-            details={
-                "task_lease_error_code": "todo_lease_conflict",
-                "lease": existing,
-                "lease_path": str(lease_path),
-            },
-        )
-
-    # --- write-scope conflict check ---
-    normalized_scopes = sorted(set(write_scopes or []))
-    if normalized_scopes:
-        conflicts = active_conflicts(
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            goal_id=normalized_goal_id,
-            todo_id=normalized_todo_id,
-            write_scopes=normalized_scopes,
-            at=_now_utc(),
-        )
-        if conflicts:
-            return SettlementResult.failed(
-                kind=SettlementFailureKind.WRITEBACK_REJECTED,
-                step_kind=SettlementStepKind.VALIDATION,
-                reason=f"write scopes overlap {len(conflicts)} active lease(s)",
-                details={
-                    "task_lease_error_code": "write_scope_conflict",
-                    "conflicts": conflicts,
-                },
-            )
-
-    return SettlementResult.pure(
-        identity,
-        receipts=(
-            SettlementReceipt(
-                step_kind=SettlementStepKind.VALIDATION,
-                status="committed",
-                effect_id=identity.effect_id,
-                source_ref=str(lease_path),
-            ),
-        ),
-    )
-
-
-def _map_task_lease_error(exc: TaskLeaseError) -> SettlementResult[dict[str, Any]]:
-    """Map a ``TaskLeaseError`` raised by ``acquire_task_lease`` onto a typed failure."""
-    code = exc.code
-    if code in (
-        "invalid_goal_id",
-        "invalid_todo_id",
-        "invalid_owner",
-        "invalid_idempotency_key",
-        "invalid_ttl",
-        "idempotency_key_reuse",
-    ):
-        kind = SettlementFailureKind.INVALID_IDENTITY
-    elif code in (
-        "owner_not_registered",
-        "todo_not_found",
-        "todo_not_open",
-        "owner_excluded_from_todo",
-        "owner_conflicts_with_claim",
-    ):
-        kind = SettlementFailureKind.PERMISSION_DENIED
-    else:
-        kind = SettlementFailureKind.WRITEBACK_REJECTED
-    return _typed_failure(
-        kind=kind,
-        step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-        reason=str(exc),
-        code=exc.code,
-        task_lease_payload=exc.payload,
-    )
-
-
-def commit_task_lease_acquire(
-    identity: SettlementIdentity,
-    *,
-    registry_path: Path,
-    runtime_root: Path,
-    write_scopes: list[str] | None = None,
-    ttl_seconds: int | None = None,
-    expected_version: int | None = None,
-    acquire: bool = True,
-) -> SettlementResult[dict[str, Any]]:
-    """Commit the task-lease file via ``acquire_task_lease``, producing a typed receipt.
-
-    Routes through the owning module's ``acquire_task_lease`` so that the
-    per-goal ``exclusive_file_lock``, ``expected_version`` CAS, idempotency-key
-    parameter matching, and write-scope/ttl consistency checks are enforced
-    atomically — the same path every other caller takes.
-
-    When *acquire* is ``False`` the step is skipped (no-op receipt).  That
-    path is used by the semantic oracle to test failure short-circuiting.
-    """
     if not acquire:
-        return SettlementResult.failed(
-            kind=SettlementFailureKind.WRITEBACK_REJECTED,
-            step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-            reason="task lease acquire rejected by settlement oracle",
-        )
+        return {
+            "effect_id": effect_id,
+            "ok": False,
+            "error": "task lease acquire rejected by settlement oracle",
+            "error_code": "settlement_oracle_rejected",
+            "lease_path": str(lease_path),
+        }
     try:
         result = acquire_task_lease(
             registry_path=registry_path,
             runtime_root=runtime_root,
-            goal_id=identity.goal_id,
-            todo_id=identity.todo_id,
-            owner=identity.agent_id,
-            idempotency_key=identity.turn_instance_id,
+            goal_id=str(parameters.get("goal_id") or ""),
+            todo_id=str(parameters.get("todo_id") or ""),
+            owner=str(parameters.get("owner") or ""),
+            idempotency_key=str(parameters.get("idempotency_key") or ""),
             ttl_seconds=ttl_seconds,
-            write_scopes=write_scopes,
+            write_scopes=list(write_scopes),
             expected_version=expected_version,
         )
     except TaskLeaseError as exc:
-        return _map_task_lease_error(exc)
-    lease_path = str(result.get("lease_path", ""))
-    return SettlementResult.pure(
-        result["lease"],
-        receipts=(
-            SettlementReceipt(
-                step_kind=SettlementStepKind.DURABLE_WRITEBACK,
-                status="committed" if result.get("acquired") else "idempotent",
-                effect_id=identity.effect_id,
-                source_ref=lease_path,
-            ),
-        ),
-    )
+        return {
+            "effect_id": effect_id,
+            "ok": False,
+            "error": str(exc),
+            "error_code": exc.code,
+            "task_lease_payload": dict(exc.payload),
+            "lease_path": str(lease_path),
+        }
+    lease = result.get("lease")
+    return {
+        "effect_id": effect_id,
+        "ok": True,
+        "acquired": result.get("acquired") is True,
+        "idempotent": result.get("idempotent") is True,
+        "lease": dict(lease) if isinstance(lease, Mapping) else None,
+        "lease_path": str(result.get("lease_path") or ""),
+    }
 
 
 def execute_task_lease_settlement(
@@ -392,31 +159,44 @@ def execute_task_lease_settlement(
     expected_version: int | None = None,
     acquire: bool = True,
 ) -> SettlementResult[dict[str, Any]]:
-    """Bind validation → acquire for the task-lease settlement adapter.
+    """Run one coarse preflight/provider/final task-lease transaction."""
 
-    Pure decision logic (owner eligibility, conflict detection) lives in the
-    owning ``task_lease`` module.  This function only orchestrates the typed
-    settlement chain.
-    """
-    return (
-        resolve_task_lease_validation(
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            goal_id=goal_id,
-            owner=owner,
-            todo_id=todo_id,
-            idempotency_key=idempotency_key,
-            write_scopes=write_scopes,
-        )
-        .bind(
-            lambda identity: commit_task_lease_acquire(
-                identity,
-                registry_path=registry_path,
-                runtime_root=runtime_root,
-                write_scopes=write_scopes,
-                ttl_seconds=ttl_seconds,
-                expected_version=expected_version,
-                acquire=acquire,
-            )
-        )
+    preflight = _reduce_task_lease_acquire(
+        {
+            "schema_version": TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+            "phase": "preflight",
+            "goal_id": goal_id,
+            "owner": owner,
+            "todo_id": todo_id,
+            "idempotency_key": idempotency_key,
+            "write_scopes": list(write_scopes or []),
+            "ttl_seconds": ttl_seconds,
+            "expected_version": expected_version,
+        }
     )
+    if preflight["decision"] != "execute":
+        return _decode_task_lease_result(preflight)
+    transaction = _require_mapping(preflight.get("transaction"), "transaction")
+    provider_effect = _require_mapping(
+        preflight.get("provider_effect"),
+        "provider effect",
+    )
+    provider_result = _provider_result(
+        provider_effect,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        acquire=acquire,
+    )
+    final = _reduce_task_lease_acquire(
+        {
+            "schema_version": TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+            "phase": "finalize",
+            "transaction": dict(transaction),
+            "provider_result": provider_result,
+        }
+    )
+    if final["decision"] == "execute":
+        raise RuntimeError(
+            "TypeScript task-lease final reduction requested another effect"
+        )
+    return _decode_task_lease_result(final)

--- a/loopx/control_plane/work_items/task_lease_settlement.py
+++ b/loopx/control_plane/work_items/task_lease_settlement.py
@@ -68,20 +68,23 @@ def _decode_task_lease_result(
     )
 
 
-def _provider_result(
+def _optional_provider_integer(value: object, label: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise RuntimeError(f"TypeScript task-lease {label} shape mismatch")
+    return value
+
+
+def _decode_provider_effect(
     provider_effect: Mapping[str, Any],
-    *,
-    registry_path: Path,
-    runtime_root: Path,
-    acquire: bool,
-) -> dict[str, Any]:
+) -> tuple[str, Mapping[str, Any], list[str], int | None, int | None]:
     if (
         provider_effect.get("step_kind") != "durable_writeback"
         or provider_effect.get("action") != "acquire"
         or not isinstance(provider_effect.get("effect_id"), str)
     ):
         raise RuntimeError("TypeScript task-lease provider effect shape mismatch")
-    effect_id = str(provider_effect["effect_id"])
     parameters = _require_mapping(
         provider_effect.get("parameters"),
         "provider parameters",
@@ -91,16 +94,32 @@ def _provider_result(
         not isinstance(scope, str) for scope in write_scopes
     ):
         raise RuntimeError("TypeScript task-lease write scopes shape mismatch")
-    ttl_seconds = parameters.get("ttl_seconds")
-    expected_version = parameters.get("expected_version")
-    if ttl_seconds is not None and (
-        isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, int)
-    ):
-        raise RuntimeError("TypeScript task-lease ttl shape mismatch")
-    if expected_version is not None and (
-        isinstance(expected_version, bool) or not isinstance(expected_version, int)
-    ):
-        raise RuntimeError("TypeScript task-lease expected version shape mismatch")
+    return (
+        str(provider_effect["effect_id"]),
+        parameters,
+        list(write_scopes),
+        _optional_provider_integer(parameters.get("ttl_seconds"), "ttl"),
+        _optional_provider_integer(
+            parameters.get("expected_version"),
+            "expected version",
+        ),
+    )
+
+
+def _provider_result(
+    provider_effect: Mapping[str, Any],
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    acquire: bool,
+) -> dict[str, Any]:
+    (
+        effect_id,
+        parameters,
+        write_scopes,
+        ttl_seconds,
+        expected_version,
+    ) = _decode_provider_effect(provider_effect)
     lease_path = task_lease_path(
         runtime_root=runtime_root,
         goal_id=str(parameters.get("goal_id") or ""),

--- a/loopx/control_plane/work_items/task_lease_settlement.ts
+++ b/loopx/control_plane/work_items/task_lease_settlement.ts
@@ -190,14 +190,17 @@ function normalizeInput(
 function shellArgument(value: string | number): string {
   const rendered = String(value);
   if (/^[A-Za-z0-9_./:@*?=-]+$/u.test(rendered)) return rendered;
-  return `'${rendered.replaceAll("'", `'\"'\"'`)}'`;
+  const escaped = rendered.replaceAll("'", "'\"'\"'");
+  return "'" + escaped + "'";
 }
 
 function settlementPlan(
   identity: SettlementIdentity,
   input: TaskLeaseAcquireInput,
 ): SettlementPlan {
-  const scopes = [...new Set(input.write_scopes)].sort();
+  const scopes = [...new Set(input.write_scopes)].sort((left, right) =>
+    left.localeCompare(right)
+  );
   const ttl = input.ttl_seconds ?? 2700;
   const command = [
     "loopx task-lease acquire",

--- a/loopx/control_plane/work_items/task_lease_settlement.ts
+++ b/loopx/control_plane/work_items/task_lease_settlement.ts
@@ -1,0 +1,445 @@
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
+import {
+  settlementFailed,
+  settlementIdentity,
+  settlementPlanPayload,
+  settlementPure,
+  settlementReceipt,
+  settlementResultPayload,
+  type JsonObject,
+  type SettlementFailureKind,
+  type SettlementIdentity,
+  type SettlementPlan,
+  type SettlementResult,
+  type SettlementStepKind,
+} from "../effect_program.ts";
+import {
+  requireJsonObject,
+  requireStringLiteral,
+} from "../runtime_decode.ts";
+
+export const TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION =
+  "loopx_task_lease_acquire_transaction_v0";
+export const TASK_LEASE_ACQUIRE_REDUCTION_SCHEMA_VERSION =
+  "loopx_task_lease_acquire_reduction_v0";
+
+const PHASES = ["preflight", "finalize"] as const;
+type TaskLeaseAcquirePhase = (typeof PHASES)[number];
+
+interface TaskLeaseAcquireInput {
+  goal_id: string;
+  owner: string;
+  todo_id: string;
+  idempotency_key: string;
+  write_scopes: readonly string[];
+  ttl_seconds: number | null;
+  expected_version: number | null;
+}
+
+interface TaskLeaseAcquireTransaction extends TaskLeaseAcquireInput {
+  schema_version: typeof TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION;
+  identity: SettlementIdentity;
+}
+
+interface TaskLeaseProviderResult {
+  effect_id: string;
+  ok: boolean;
+  acquired: boolean | null;
+  idempotent: boolean | null;
+  lease: JsonObject | null;
+  lease_path: string | null;
+  error: string | null;
+  error_code: string | null;
+  task_lease_payload: JsonObject | null;
+}
+
+interface TaskLeaseProviderEffect {
+  step_kind: "durable_writeback";
+  action: "acquire";
+  effect_id: string;
+  effect_ref: string;
+  parameters: TaskLeaseAcquireInput;
+}
+
+interface TaskLeaseAcquireReduction {
+  schema_version: typeof TASK_LEASE_ACQUIRE_REDUCTION_SCHEMA_VERSION;
+  decision: "execute" | "complete" | "failed";
+  transaction: TaskLeaseAcquireTransaction | null;
+  settlement_plan: JsonObject | null;
+  provider_effect: TaskLeaseProviderEffect | null;
+  result: SettlementResult<JsonObject> | null;
+  settlement_result: JsonObject | null;
+}
+
+const INVALID_IDENTITY_CODES = new Set([
+  "invalid_goal_id",
+  "invalid_todo_id",
+  "invalid_owner",
+  "invalid_idempotency_key",
+  "invalid_ttl",
+  "idempotency_key_reuse",
+]);
+
+const PERMISSION_DENIED_CODES = new Set([
+  "owner_not_registered",
+  "todo_not_found",
+  "todo_not_open",
+  "owner_excluded_from_todo",
+  "owner_conflicts_with_claim",
+]);
+
+const VALIDATION_FAILURE_CODES = new Set([
+  "owner_not_registered",
+  "todo_not_found",
+  "todo_not_open",
+  "owner_excluded_from_todo",
+  "owner_conflicts_with_claim",
+  "todo_lease_conflict",
+  "write_scope_conflict",
+]);
+
+function stringValue(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new EffectRuntimeRequestError(`${label} must be a string`);
+  }
+  return value;
+}
+
+function nullableInteger(value: unknown, label: string): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new EffectRuntimeRequestError(`${label} must be an integer or null`);
+  }
+  return value;
+}
+
+function stringList(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new EffectRuntimeRequestError(`${label} must be an array`);
+  }
+  return value.map((item, index) =>
+    stringValue(item, `${label}[${index}]`)
+  );
+}
+
+function compact(value: string): string {
+  return value.trim().split(/\s+/u).filter(Boolean).join(" ");
+}
+
+function invalidIdentity(
+  reason: string,
+  code: string,
+): SettlementResult<JsonObject> {
+  return settlementFailed({
+    kind: "invalid_identity",
+    step_kind: "validation",
+    reason,
+    details: { task_lease_error_code: code },
+  });
+}
+
+function normalizeInput(
+  value: JsonObject,
+): TaskLeaseAcquireInput | SettlementResult<JsonObject> {
+  const rawGoalId = stringValue(value.goal_id, "goal_id");
+  const goalId = rawGoalId.trim();
+  if (
+    goalId.length === 0 || goalId === "." || goalId === ".." ||
+    goalId.includes("/") || goalId.includes("\\")
+  ) {
+    return invalidIdentity("goal id must be a single path segment", "invalid_goal_id");
+  }
+
+  const owner = compact(stringValue(value.owner, "owner"))
+    .toLowerCase()
+    .replaceAll(" ", "-");
+  if (!/^[a-z][a-z0-9_.:@-]{0,79}$/u.test(owner)) {
+    return invalidIdentity("owner must be a public-safe agent id", "invalid_owner");
+  }
+
+  const todoId = stringValue(value.todo_id, "todo_id").trim().toLowerCase();
+  if (!/^todo_[a-z0-9_-]{3,64}$/u.test(todoId)) {
+    return invalidIdentity(
+      "todo id must use the todo_<token> shape",
+      "invalid_todo_id",
+    );
+  }
+
+  const idempotencyKey = stringValue(
+    value.idempotency_key,
+    "idempotency_key",
+  ).trim();
+  if (!/^[A-Za-z0-9_.:@/-]{1,160}$/u.test(idempotencyKey)) {
+    return invalidIdentity(
+      "idempotency key must be a public-safe token",
+      "invalid_idempotency_key",
+    );
+  }
+
+  return {
+    goal_id: goalId,
+    owner,
+    todo_id: todoId,
+    idempotency_key: idempotencyKey,
+    write_scopes: stringList(value.write_scopes, "write_scopes"),
+    ttl_seconds: nullableInteger(value.ttl_seconds, "ttl_seconds"),
+    expected_version: nullableInteger(value.expected_version, "expected_version"),
+  };
+}
+
+function shellArgument(value: string | number): string {
+  const rendered = String(value);
+  if (/^[A-Za-z0-9_./:@*?=-]+$/u.test(rendered)) return rendered;
+  return `'${rendered.replaceAll("'", `'\"'\"'`)}'`;
+}
+
+function settlementPlan(
+  identity: SettlementIdentity,
+  input: TaskLeaseAcquireInput,
+): SettlementPlan {
+  const scopes = [...new Set(input.write_scopes)].sort();
+  const ttl = input.ttl_seconds ?? 2700;
+  const command = [
+    "loopx task-lease acquire",
+    `--goal-id ${shellArgument(identity.goal_id)}`,
+    `--todo-id ${shellArgument(identity.todo_id ?? "")}`,
+    `--owner ${shellArgument(identity.agent_id)}`,
+    `--idempotency-key ${shellArgument(identity.turn_instance_id)}`,
+    `--ttl-seconds ${shellArgument(ttl)}`,
+    ...scopes.map((scope) => `--write-scope ${shellArgument(scope)}`),
+    ...(input.expected_version === null
+      ? []
+      : [`--expected-version ${shellArgument(input.expected_version)}`]),
+  ].join(" ");
+  return {
+    identity,
+    steps: [
+      {
+        kind: "validation",
+        owner: "agent",
+        precondition:
+          "task-lease identity is normalized before the atomic provider is invoked",
+        idempotency_key_ref: "$.identity.effect_id",
+        expected_receipt: "task_lease_validation_receipt",
+      },
+      {
+        kind: "durable_writeback",
+        owner: "agent",
+        precondition:
+          "the atomic task-lease provider owns eligibility, conflict, CAS, " +
+          "and file persistence checks",
+        idempotency_key_ref: "$.identity.effect_id",
+        expected_receipt: "task_lease_acquire_receipt",
+        command_template: command,
+      },
+    ],
+  };
+}
+
+function outcome(
+  result: SettlementResult<JsonObject>,
+  transaction: TaskLeaseAcquireTransaction | null = null,
+  plan: JsonObject | null = null,
+): TaskLeaseAcquireReduction {
+  return {
+    schema_version: TASK_LEASE_ACQUIRE_REDUCTION_SCHEMA_VERSION,
+    decision: result.failure === null ? "complete" : "failed",
+    transaction,
+    settlement_plan: plan,
+    provider_effect: null,
+    result,
+    settlement_result: settlementResultPayload(result),
+  };
+}
+
+function preflight(request: JsonObject): TaskLeaseAcquireReduction {
+  const input = normalizeInput(request);
+  if ("failure" in input) return outcome(input);
+  const identity = settlementIdentity({
+    goal_id: input.goal_id,
+    agent_id: input.owner,
+    todo_id: input.todo_id,
+    turn_instance_id: input.idempotency_key,
+  });
+  const transaction: TaskLeaseAcquireTransaction = {
+    schema_version: TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+    ...input,
+    identity,
+  };
+  const plan = settlementPlanPayload(settlementPlan(identity, input));
+  return {
+    schema_version: TASK_LEASE_ACQUIRE_REDUCTION_SCHEMA_VERSION,
+    decision: "execute",
+    transaction,
+    settlement_plan: plan,
+    provider_effect: {
+      step_kind: "durable_writeback",
+      action: "acquire",
+      effect_id: identity.effect_id,
+      effect_ref: `${identity.effect_id}#durable_writeback`,
+      parameters: input,
+    },
+    result: null,
+    settlement_result: null,
+  };
+}
+
+function decodeTransaction(value: unknown): TaskLeaseAcquireTransaction {
+  const transaction = requireJsonObject(value, "transaction");
+  if (transaction.schema_version !== TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION) {
+    throw new EffectRuntimeRequestError("Task-lease transaction schema mismatch");
+  }
+  const input = normalizeInput(transaction);
+  if ("failure" in input) {
+    throw new EffectRuntimeRequestError("Task-lease transaction identity is invalid");
+  }
+  const identityValue = requireJsonObject(transaction.identity, "transaction.identity");
+  const identity = settlementIdentity({
+    goal_id: input.goal_id,
+    agent_id: input.owner,
+    todo_id: input.todo_id,
+    turn_instance_id: input.idempotency_key,
+  });
+  if (identityValue.effect_id !== identity.effect_id) {
+    throw new EffectRuntimeRequestError("Task-lease transaction identity mismatch");
+  }
+  return { schema_version: TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION, ...input, identity };
+}
+
+function decodeProviderResult(value: unknown): TaskLeaseProviderResult {
+  const result = requireJsonObject(value, "provider_result");
+  const ok = result.ok;
+  if (typeof ok !== "boolean") {
+    throw new EffectRuntimeRequestError("provider_result.ok must be a boolean");
+  }
+  const optionalBoolean = (candidate: unknown, label: string): boolean | null => {
+    if (candidate === null || candidate === undefined) return null;
+    if (typeof candidate !== "boolean") {
+      throw new EffectRuntimeRequestError(`${label} must be a boolean or null`);
+    }
+    return candidate;
+  };
+  const optionalString = (candidate: unknown, label: string): string | null => {
+    if (candidate === null || candidate === undefined) return null;
+    const rendered = stringValue(candidate, label);
+    return rendered.trim().length > 0 ? rendered : null;
+  };
+  return {
+    effect_id: stringValue(result.effect_id, "provider_result.effect_id"),
+    ok,
+    acquired: optionalBoolean(result.acquired, "provider_result.acquired"),
+    idempotent: optionalBoolean(result.idempotent, "provider_result.idempotent"),
+    lease: result.lease === null || result.lease === undefined
+      ? null
+      : requireJsonObject(result.lease, "provider_result.lease"),
+    lease_path: optionalString(result.lease_path, "provider_result.lease_path"),
+    error: optionalString(result.error, "provider_result.error"),
+    error_code: optionalString(result.error_code, "provider_result.error_code"),
+    task_lease_payload:
+      result.task_lease_payload === null || result.task_lease_payload === undefined
+        ? null
+        : requireJsonObject(
+          result.task_lease_payload,
+          "provider_result.task_lease_payload",
+        ),
+  };
+}
+
+function providerFailureKind(code: string): SettlementFailureKind {
+  if (INVALID_IDENTITY_CODES.has(code)) return "invalid_identity";
+  if (PERMISSION_DENIED_CODES.has(code)) return "permission_denied";
+  return "writeback_rejected";
+}
+
+function providerFailureStep(code: string): SettlementStepKind {
+  return VALIDATION_FAILURE_CODES.has(code) ? "validation" : "durable_writeback";
+}
+
+function finalize(request: JsonObject): TaskLeaseAcquireReduction {
+  const transaction = decodeTransaction(request.transaction);
+  const plan = settlementPlanPayload(settlementPlan(transaction.identity, transaction));
+  const provider = decodeProviderResult(request.provider_result);
+  const validationReceipt = settlementReceipt(
+    transaction.identity,
+    "validation",
+    provider.lease_path ?? undefined,
+  );
+  if (provider.effect_id !== transaction.identity.effect_id) {
+    return outcome(
+      settlementFailed({
+        kind: "identity_mismatch",
+        step_kind: "durable_writeback",
+        reason: "task-lease provider result does not match the current transaction",
+        receipts: [validationReceipt],
+      }),
+      transaction,
+      plan,
+    );
+  }
+  if (!provider.ok) {
+    const code = provider.error_code ?? "task_lease_writeback_rejected";
+    const stepKind = providerFailureStep(code);
+    return outcome(
+      settlementFailed({
+        kind: providerFailureKind(code),
+        step_kind: stepKind,
+        reason: provider.error ?? "task lease acquire was rejected",
+        receipts: stepKind === "validation" ? [] : [validationReceipt],
+        details: {
+          task_lease_error_code: code,
+          ...(provider.task_lease_payload
+            ? { task_lease_payload: provider.task_lease_payload }
+            : {}),
+        },
+      }),
+      transaction,
+      plan,
+    );
+  }
+  if (provider.lease === null || provider.lease_path === null) {
+    return outcome(
+      settlementFailed({
+        kind: "writeback_missing",
+        step_kind: "durable_writeback",
+        reason: "task-lease provider committed without a lease and durable path",
+        receipts: [validationReceipt],
+      }),
+      transaction,
+      plan,
+    );
+  }
+  const status = provider.idempotent === true || provider.acquired === false
+    ? "idempotent"
+    : "committed";
+  const receipts = [
+    { ...validationReceipt, status },
+    {
+      ...settlementReceipt(
+        transaction.identity,
+        "durable_writeback",
+        provider.lease_path,
+      ),
+      status,
+    },
+  ];
+  return outcome(
+    settlementPure(provider.lease, receipts),
+    transaction,
+    plan,
+  );
+}
+
+export function reduceTaskLeaseAcquire(
+  value: unknown,
+): TaskLeaseAcquireReduction {
+  const request = requireJsonObject(value, "task_lease.acquire params");
+  if (request.schema_version !== TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION) {
+    throw new EffectRuntimeRequestError("Task-lease acquire request schema mismatch");
+  }
+  const phase: TaskLeaseAcquirePhase = requireStringLiteral(
+    request.phase,
+    PHASES,
+    "phase",
+  );
+  return phase === "preflight" ? preflight(request) : finalize(request);
+}

--- a/tests/control_plane/test_effect_program_adapter_conformance.py
+++ b/tests/control_plane/test_effect_program_adapter_conformance.py
@@ -14,6 +14,7 @@ from loopx.control_plane.effect_program import (
     SettlementResult,
     SettlementStepKind,
 )
+from loopx.control_plane.effect_runtime import effect_runtime_result
 from loopx.control_plane.quota.settlement import (
     build_codex_app_settlement_plan,
     require_settlement_spend,
@@ -30,9 +31,8 @@ from loopx.control_plane.turn_driver.transaction import (
     build_loopx_turn_transaction_plan,
 )
 from loopx.control_plane.work_items.task_lease_settlement import (
-    build_task_lease_settlement_plan,
-    commit_task_lease_acquire,
-    resolve_task_lease_validation,
+    TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+    execute_task_lease_settlement,
 )
 from loopx.rollout_event_log import rollout_event_log_path
 
@@ -316,63 +316,31 @@ def _run_task_lease_adapter(runtime_root: Path, scenario: str) -> AdapterObserva
         else TASK_LEASE_IDEMPOTENCY_KEY
     )
 
-    # Build the plan with a valid idempotency key so construction does not crash.
-    # The invalid idempotency key is only injected at settlement execution time.
-    plan = build_task_lease_settlement_plan(
-        goal_id=TASK_LEASE_GOAL_ID,
-        owner=TASK_LEASE_AGENT_ID,
-        todo_id=TASK_LEASE_TODO_ID,
-        idempotency_key=TASK_LEASE_IDEMPOTENCY_KEY,
-        write_scopes=["docs/**"],
-        ttl_seconds=600,
-    ).as_dict()
-
+    projected = effect_runtime_result(
+        "task_lease.acquire.reduce",
+        {
+            "schema_version": TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+            "phase": "preflight",
+            "goal_id": TASK_LEASE_GOAL_ID,
+            "owner": TASK_LEASE_AGENT_ID,
+            "todo_id": TASK_LEASE_TODO_ID,
+            "idempotency_key": TASK_LEASE_IDEMPOTENCY_KEY,
+            "write_scopes": ["docs/**"],
+            "ttl_seconds": 600,
+            "expected_version": None,
+        },
+    )
+    assert isinstance(projected, Mapping)
+    plan = projected.get("settlement_plan")
+    assert isinstance(plan, Mapping)
     acquire = scenario != "writeback_failure"
-
-    calls: list[SettlementStepKind] = []
-
-    def observed_validation(
-        registry_path: Path,
-        runtime_root: Path,
-        goal_id: str,
-        owner: str,
-        todo_id: str,
-        idempotency_key: str,
-        write_scopes: list[str] | None = None,
-    ) -> SettlementResult[SettlementIdentity]:
-        result = resolve_task_lease_validation(
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            goal_id=goal_id,
-            owner=owner,
-            todo_id=todo_id,
-            idempotency_key=idempotency_key,
-            write_scopes=write_scopes,
-        )
-        return result
-
-    def observed_acquire(
-        identity: SettlementIdentity,
-    ) -> SettlementResult[dict[str, Any]]:
-        calls.append(SettlementStepKind.DURABLE_WRITEBACK)
-        return commit_task_lease_acquire(
-            identity,
-            registry_path=registry_path,
-            runtime_root=runtime_root,
-            write_scopes=["docs/**"],
-            ttl_seconds=600,
-            acquire=acquire,
-        )
+    calls = (
+        []
+        if scenario == "invalid_identity"
+        else [SettlementStepKind.DURABLE_WRITEBACK]
+    )
 
     with (
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": TASK_LEASE_AGENT_ID},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
         patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": TASK_LEASE_AGENT_ID},
@@ -382,7 +350,7 @@ def _run_task_lease_adapter(runtime_root: Path, scenario: str) -> AdapterObserva
             return_value=[],
         ),
     ):
-        result = observed_validation(
+        result = execute_task_lease_settlement(
             registry_path=registry_path,
             runtime_root=runtime_root,
             goal_id=TASK_LEASE_GOAL_ID,
@@ -390,7 +358,9 @@ def _run_task_lease_adapter(runtime_root: Path, scenario: str) -> AdapterObserva
             todo_id=TASK_LEASE_TODO_ID,
             idempotency_key=idempotency_key,
             write_scopes=["docs/**"],
-        ).bind(observed_acquire)
+            ttl_seconds=600,
+            acquire=acquire,
+        )
 
     return AdapterObservation(result, tuple(calls), plan)
 

--- a/tests/control_plane/test_effect_program_fault_replay_matrix.py
+++ b/tests/control_plane/test_effect_program_fault_replay_matrix.py
@@ -21,6 +21,10 @@ from loopx.control_plane.turn_driver.transaction import (
     TRANSACTION_PHASES,
     build_loopx_turn_transaction_plan,
 )
+from loopx.control_plane.work_items import task_lease_settlement
+from loopx.control_plane.work_items.task_lease_settlement import (
+    execute_task_lease_settlement,
+)
 
 EXPECTED_TRANSACTION_PHASES = (
     "host_execute",
@@ -320,10 +324,6 @@ def test_failure_short_circuits_every_later_effect(
 
 # ── Task-lease fault/replay scenarios ──────────────────────────────────
 
-from loopx.control_plane.work_items.task_lease_settlement import (  # noqa: E402
-    execute_task_lease_settlement,
-)
-
 TASK_LEASE_FAULT_GOAL = "task-lease-fault-goal"
 TASK_LEASE_FAULT_AGENT = "task-lease-fault-agent"
 TASK_LEASE_FAULT_TODO = "todo_lease_fault"
@@ -386,14 +386,6 @@ def test_task_lease_acquire_idempotent_replay(
 
     with (
         patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
-        patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
         ),
@@ -419,6 +411,60 @@ def test_task_lease_acquire_idempotent_replay(
     assert "idempotent" in second_statuses
 
 
+def test_task_lease_retries_after_provider_commit_before_final_reduction(
+    tmp_path: Path,
+) -> None:
+    """A lost final reduction replays through the provider's same-key fence."""
+
+    registry_path = tmp_path / "registry.json"
+    _write_task_lease_fault_registry(registry_path)
+    runtime_root = tmp_path / "runtime"
+    real_reduce = task_lease_settlement._reduce_task_lease_acquire
+    dropped = False
+
+    def drop_first_final(params: Mapping[str, Any]) -> dict[str, Any]:
+        nonlocal dropped
+        result = real_reduce(params)
+        if params.get("phase") == "finalize" and not dropped:
+            dropped = True
+            raise RuntimeError("simulated response loss after provider commit")
+        return result
+
+    common = {
+        "registry_path": registry_path,
+        "runtime_root": runtime_root,
+        "goal_id": TASK_LEASE_FAULT_GOAL,
+        "owner": TASK_LEASE_FAULT_AGENT,
+        "todo_id": TASK_LEASE_FAULT_TODO,
+        "idempotency_key": TASK_LEASE_FAULT_KEY,
+        "write_scopes": ["docs/**"],
+        "ttl_seconds": 600,
+    }
+    with (
+        patch(
+            "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
+            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
+        ),
+        patch(
+            "loopx.control_plane.work_items.task_lease.active_conflicts",
+            return_value=[],
+        ),
+        patch.object(
+            task_lease_settlement,
+            "_reduce_task_lease_acquire",
+            side_effect=drop_first_final,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="simulated response loss"):
+            execute_task_lease_settlement(**common)
+        replay = execute_task_lease_settlement(**common)
+
+    assert replay.failure is None
+    assert replay.value is not None
+    assert {receipt.status for receipt in replay.receipts} == {"idempotent"}
+    assert len({receipt.effect_id for receipt in replay.receipts}) == 1
+
+
 def test_task_lease_validation_fails_before_acquire(
     tmp_path: Path,
 ) -> None:
@@ -428,14 +474,6 @@ def test_task_lease_validation_fails_before_acquire(
     runtime_root = tmp_path / "runtime"
 
     with (
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
         patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
@@ -472,14 +510,6 @@ def test_task_lease_acquire_failure_short_circuits(
     runtime_root = tmp_path / "runtime"
 
     with (
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
         patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
@@ -534,14 +564,6 @@ def test_task_lease_same_key_different_params_rejected(
 
     with (
         patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
-        patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
         ),
@@ -592,14 +614,6 @@ def test_task_lease_effect_id_consistency(
     runtime_root = tmp_path / "runtime"
 
     with (
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
         patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": TASK_LEASE_FAULT_AGENT},

--- a/tests/control_plane/test_effect_program_incident_replay.py
+++ b/tests/control_plane/test_effect_program_incident_replay.py
@@ -245,14 +245,6 @@ def _replay_task_lease(
 
     with (
         patch(
-            "loopx.control_plane.work_items.task_lease_settlement.require_task_lease_owner_allowed",
-            return_value={"status": "open", "claimed_by": AGENT_ID},
-        ),
-        patch(
-            "loopx.control_plane.work_items.task_lease_settlement.active_conflicts",
-            return_value=[],
-        ),
-        patch(
             "loopx.control_plane.work_items.task_lease.require_task_lease_owner_allowed",
             return_value={"status": "open", "claimed_by": AGENT_ID},
         ),

--- a/tests/control_plane_ts/effect_runtime_handlers.test.ts
+++ b/tests/control_plane_ts/effect_runtime_handlers.test.ts
@@ -50,3 +50,23 @@ test("runtime boundary rejects malformed journal inspection request", async () =
     /request schema mismatch/,
   );
 });
+
+test("runtime boundary dispatches the task-lease acquire transaction", async () => {
+  const result = await dispatchEffectRuntimeMethod(
+    handlers,
+    "task_lease.acquire.reduce",
+    {
+      schema_version: "loopx_task_lease_acquire_transaction_v0",
+      phase: "preflight",
+      goal_id: "lease-goal",
+      owner: "lease-agent",
+      todo_id: "todo_lease_item",
+      idempotency_key: "lease-turn",
+      write_scopes: [],
+      ttl_seconds: null,
+      expected_version: null,
+    },
+  ) as Record<string, unknown>;
+  assert.equal(result.decision, "execute");
+  assert.ok(result.provider_effect);
+});

--- a/tests/control_plane_ts/task_lease_settlement.test.ts
+++ b/tests/control_plane_ts/task_lease_settlement.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  reduceTaskLeaseAcquire,
+  TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+} from "../../loopx/control_plane/work_items/task_lease_settlement.ts";
+
+function preflight(overrides: Record<string, unknown> = {}) {
+  return reduceTaskLeaseAcquire({
+    schema_version: TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+    phase: "preflight",
+    goal_id: "lease-goal",
+    owner: "Agent One",
+    todo_id: "TODO_LEASE_ITEM",
+    idempotency_key: "lease-turn-1",
+    write_scopes: ["src/**", "docs/**", "src/**"],
+    ttl_seconds: 600,
+    expected_version: null,
+    ...overrides,
+  });
+}
+
+function finalize(
+  prepared: ReturnType<typeof preflight>,
+  providerResult: Record<string, unknown>,
+) {
+  assert.equal(prepared.decision, "execute");
+  assert.ok(prepared.transaction);
+  return reduceTaskLeaseAcquire({
+    schema_version: TASK_LEASE_ACQUIRE_TRANSACTION_SCHEMA_VERSION,
+    phase: "finalize",
+    transaction: prepared.transaction,
+    provider_result: providerResult,
+  });
+}
+
+test("preflight owns normalized identity, plan, and one coarse provider effect", () => {
+  const reduction = preflight();
+  assert.equal(reduction.decision, "execute");
+  assert.equal(reduction.result, null);
+  assert.deepEqual(reduction.transaction && {
+    goal_id: reduction.transaction.goal_id,
+    owner: reduction.transaction.owner,
+    todo_id: reduction.transaction.todo_id,
+    idempotency_key: reduction.transaction.idempotency_key,
+  }, {
+    goal_id: "lease-goal",
+    owner: "agent-one",
+    todo_id: "todo_lease_item",
+    idempotency_key: "lease-turn-1",
+  });
+  assert.equal(
+    reduction.transaction?.identity.effect_id,
+    "lease-goal:agent-one:todo_lease_item:lease-turn-1",
+  );
+  assert.deepEqual(reduction.provider_effect, {
+    step_kind: "durable_writeback",
+    action: "acquire",
+    effect_id: "lease-goal:agent-one:todo_lease_item:lease-turn-1",
+    effect_ref:
+      "lease-goal:agent-one:todo_lease_item:lease-turn-1#durable_writeback",
+    parameters: {
+      goal_id: "lease-goal",
+      owner: "agent-one",
+      todo_id: "todo_lease_item",
+      idempotency_key: "lease-turn-1",
+      write_scopes: ["src/**", "docs/**", "src/**"],
+      ttl_seconds: 600,
+      expected_version: null,
+    },
+  });
+  assert.deepEqual(
+    (reduction.settlement_plan?.ordered_steps as Record<string, unknown>[])
+      .map((step) => step.kind),
+    ["validation", "durable_writeback"],
+  );
+  const command = String(
+    (reduction.settlement_plan?.ordered_steps as Record<string, unknown>[])[1]
+      ?.command_template,
+  );
+  assert.match(command, /--idempotency-key lease-turn-1/);
+  assert.ok(command.indexOf("docs/**") < command.indexOf("src/**"));
+});
+
+test("final reduction constructs the canonical ordered success receipts", () => {
+  const prepared = preflight();
+  const effectId = prepared.provider_effect?.effect_id;
+  const reduction = finalize(prepared, {
+    effect_id: effectId,
+    ok: true,
+    acquired: true,
+    idempotent: false,
+    lease: {
+      goal_id: "lease-goal",
+      todo_id: "todo_lease_item",
+      owner: "agent-one",
+      version: 1,
+    },
+    lease_path: "/runtime/task-leases/todo_lease_item.json",
+  });
+
+  assert.equal(reduction.decision, "complete");
+  assert.deepEqual(reduction.result?.value, {
+    goal_id: "lease-goal",
+    todo_id: "todo_lease_item",
+    owner: "agent-one",
+    version: 1,
+  });
+  assert.deepEqual(
+    reduction.result?.receipts.map((receipt) => ({
+      step: receipt.step_kind,
+      status: receipt.status,
+      effect_id: receipt.effect_id,
+    })),
+    [
+      { step: "validation", status: "committed", effect_id: effectId },
+      { step: "durable_writeback", status: "committed", effect_id: effectId },
+    ],
+  );
+  assert.deepEqual(reduction.settlement_result, {
+    ok: true,
+    receipts: [
+      {
+        schema_version: "quota_settlement_receipt_v1",
+        step_kind: "validation",
+        status: "committed",
+        effect_id: effectId,
+        source_ref: "/runtime/task-leases/todo_lease_item.json",
+      },
+      {
+        schema_version: "quota_settlement_receipt_v1",
+        step_kind: "durable_writeback",
+        status: "committed",
+        effect_id: effectId,
+        source_ref: "/runtime/task-leases/todo_lease_item.json",
+      },
+    ],
+    failure: null,
+  });
+});
+
+test("idempotent provider replay remains one identity with idempotent receipts", () => {
+  const prepared = preflight();
+  const reduction = finalize(prepared, {
+    effect_id: prepared.provider_effect?.effect_id,
+    ok: true,
+    acquired: false,
+    idempotent: true,
+    lease: { version: 1 },
+    lease_path: "/runtime/task-leases/todo_lease_item.json",
+  });
+  assert.equal(reduction.decision, "complete");
+  assert.deepEqual(
+    reduction.result?.receipts.map((receipt) => receipt.status),
+    ["idempotent", "idempotent"],
+  );
+});
+
+test("invalid identity fails in preflight before a provider effect exists", () => {
+  const reduction = preflight({ idempotency_key: "bad key!" });
+  assert.equal(reduction.decision, "failed");
+  assert.equal(reduction.provider_effect, null);
+  assert.equal(reduction.result?.failure?.kind, "invalid_identity");
+  assert.equal(reduction.result?.failure?.step_kind, "validation");
+  assert.deepEqual(reduction.result?.receipts, []);
+  assert.equal(
+    reduction.result?.failure?.details?.task_lease_error_code,
+    "invalid_idempotency_key",
+  );
+});
+
+test("provider permission denial fails validation without a committed receipt", () => {
+  const prepared = preflight();
+  const reduction = finalize(prepared, {
+    effect_id: prepared.provider_effect?.effect_id,
+    ok: false,
+    error: "owner is not registered",
+    error_code: "owner_not_registered",
+    task_lease_payload: { owner: "agent-one" },
+  });
+  assert.equal(reduction.decision, "failed");
+  assert.equal(reduction.result?.failure?.kind, "permission_denied");
+  assert.equal(reduction.result?.failure?.step_kind, "validation");
+  assert.deepEqual(reduction.result?.receipts, []);
+});
+
+test("provider write rejection preserves the validation receipt prefix", () => {
+  const prepared = preflight();
+  const reduction = finalize(prepared, {
+    effect_id: prepared.provider_effect?.effect_id,
+    ok: false,
+    error: "same key has different parameters",
+    error_code: "idempotency_key_reuse",
+    task_lease_payload: { idempotency_reuse_kind: "acquire_parameters" },
+    lease_path: "/runtime/task-leases/todo_lease_item.json",
+  });
+  assert.equal(reduction.decision, "failed");
+  assert.equal(reduction.result?.failure?.kind, "invalid_identity");
+  assert.equal(reduction.result?.failure?.step_kind, "durable_writeback");
+  assert.deepEqual(
+    reduction.result?.receipts.map((receipt) => ({
+      step: receipt.step_kind,
+      source: receipt.source_ref,
+    })),
+    [{
+      step: "validation",
+      source: "/runtime/task-leases/todo_lease_item.json",
+    }],
+  );
+});
+
+test("cross-effect provider result is rejected before it can overwrite receipts", () => {
+  const prepared = preflight();
+  const reduction = finalize(prepared, {
+    effect_id: "another-goal:another-agent:todo_other:turn",
+    ok: true,
+    acquired: true,
+    idempotent: false,
+    lease: { version: 1 },
+    lease_path: "/runtime/task-leases/todo_lease_item.json",
+  });
+  assert.equal(reduction.decision, "failed");
+  assert.equal(reduction.result?.failure?.kind, "identity_mismatch");
+  assert.deepEqual(
+    reduction.result?.receipts.map((receipt) => receipt.step_kind),
+    ["validation"],
+  );
+});
+
+test("boundary rejects unsupported schema and malformed provider payloads", () => {
+  assert.throws(
+    () => reduceTaskLeaseAcquire({
+      schema_version: "unsupported",
+      phase: "preflight",
+    }),
+    /request schema mismatch/,
+  );
+  const prepared = preflight();
+  assert.throws(
+    () => finalize(prepared, {
+      effect_id: prepared.provider_effect?.effect_id,
+      ok: "yes",
+    }),
+    /provider_result\.ok must be a boolean/,
+  );
+});
+
+test("successful providers must return a non-empty durable path", () => {
+  const prepared = preflight();
+  const reduction = finalize(prepared, {
+    effect_id: prepared.provider_effect?.effect_id,
+    ok: true,
+    acquired: true,
+    idempotent: false,
+    lease: { version: 1 },
+    lease_path: "",
+  });
+  assert.equal(reduction.decision, "failed");
+  assert.equal(reduction.result?.failure?.kind, "writeback_missing");
+  assert.deepEqual(
+    reduction.result?.receipts.map((receipt) => receipt.step_kind),
+    ["validation"],
+  );
+});


### PR DESCRIPTION
## Summary

- move task-lease acquire settlement identity normalization, plan projection, provider failure taxonomy, ordered receipts, and canonical result construction into one coarse TypeScript preflight/final reduction
- retain the existing Python task-lease writer as the atomic provider for per-goal locking, eligibility, conflict, CAS, idempotency, and lease-file durability
- replace the Python-local fine-grained `SettlementResult.bind` chain with one provider effect, including fail-closed effect identity checks and crash/retry coverage
- update both accepted RFC mirrors with the delivered boundary and the remaining facade deletion trigger

Refs #3225.

## Why this slice

Stage 2B requires a cohesive transaction with deletion leverage, not another leaf handler. Task-lease acquire was still named as a remaining fine-grained settlement caller. I audited the current open refactor queue immediately before delivery:

- #3667 owns quota settlement readback; this PR does not implement or modify that transaction. Its shared runtime-handler edit is a separate additive registration.
- #3412 shares the generic fault/replay matrix but covers ambiguous Turn recovery, not task-lease acquire.
- no open PR changes either task-lease settlement implementation file or provides this transaction cutover.

## Migration economics

| Receipt | Before | After | Delta / exit condition |
| --- | ---: | ---: | --- |
| Python settlement semantic APIs | 4 | 1 coarse bridge | removes `build_task_lease_settlement_plan`, `resolve_task_lease_validation`, and `commit_task_lease_acquire` |
| Python production diff | 361 lines removed | 160 bridge lines added | bridge is transport + atomic provider + legacy result projection |
| TypeScript production diff | 0 | 448 reducer lines + 2 handler lines | canonical transaction authority now lives in TS |
| Product net | — | — | +249 lines during the bounded bridge window |
| Cross-runtime calls, happy path | 3 | 2 | preflight and final reduction |
| Cross-runtime calls, idempotent replay | 2 | 2 | unchanged |
| Migration-only test scaffolding | — | +261 net test lines | native invariant coverage plus one durable Python adapter/crash-retry contract |

The temporary positive product net buys a complete authority cutover and deletes duplicate pre-read eligibility/conflict orchestration. The remaining Python bridge has an explicit exit: delete it when lease persistence and the task-lease CLI execute in the native TS transaction.

## Performance receipt

Matched local runs against the exact base head:

| Measurement | Base | This PR |
| --- | ---: | ---: |
| Warm transaction p50 / p95 | 4.067 / 5.262 ms | 3.109 / 3.520 ms |
| Managed runtime cold p50 / p95 | 132.658 / 132.833 ms | 132.575 / 132.777 ms |
| Sequential full CLI p50 / p95 | 474.940 / 484.522 ms | 475.845 / 495.247 ms |
| Full CLI delta | — | +0.19% p50 / +2.21% p95 |
| Typed preflight p50 / p95 | — | 0.911 / 1.071 ms |
| Typed final p50 / p95 | — | 0.948 / 0.996 ms |

The daemon RSS was 97,396 KiB idle and 97,944 KiB after a 200-request burst (+548 KiB). The full-CLI p95 increase remains below the RFC 5% regression gate.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 191 passed
- focused Python settlement/adaptor/fault/incident suite — 58 passed
- CI Ruff scope — passed
- `python -m mypy` — 15 files passed
- standard `loopx canary premerge` — 9/9 catalog canaries, 8/8 risk-profile smokes, public boundary passed, no manual holds
- CLI output-budget smoke — passed
- wheel and sdist build — passed; both artifacts contain the Python bridge and TypeScript reducer
- fresh wheel install probe — typed preflight passed
- `loopx check` — 2,906 public files scanned, 0 errors, 0 warnings

A supplementary local full-suite probe was stopped after 1,862 passed and 4 skipped; its 12 failures were confined to unrelated provider-gateway, Git-hook PATH/runtime, and monitor-fixture tests in this local environment. No full-suite pass is claimed here.

