### PR TITLE
feat(inbox): require turn-start Agent reading

### DIFF
--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -1,0 +1,73 @@
+# RFC: Provider-Neutral Turn-Start Inbox Hook v0
+
+| Field | Value |
+|---|---|
+| Status | Implemented behind explicit provider configuration |
+| Date | 2026-08-26 |
+| Decision boundary | How fresh external inbox evidence reaches an Agent before it selects ordinary Goal work |
+| Core owner | Hook admission, ordering, bounded public receipt, and Agent-read obligation |
+| Provider owner | External read, provider schema validation, private cursor, and local inbox persistence |
+| Agent owner | Semantic triage and durable Goal/Todo/effect writeback |
+
+## Decision
+
+LoopX adds a provider-neutral `turn_start` capability-hook phase. An enabled
+provider hook runs before status and quota projection. It may perform bounded
+external reads and mutate only declared owner-private inbox/cursor state. The
+public result contains counts, booleans, status, and an error code; it cannot
+contain message content, provider payloads, credentials, destinations, profile
+names, or private cursor values.
+
+The hook is complete only when fresh evidence is routed to Agent reading. A
+result with new observations must set `agent_read_required=true`. The same turn
+then recomputes inbox urgency, selects the inbox work lane ahead of ordinary
+work, and exposes the existing goal-bound private `drain_command`. The Agent
+reads the messages and chooses one typed semantic disposition:
+
+- `steer_current_turn`: update the selected work without changing the durable
+  Goal frontier;
+- `replan_goal`: update Todo/vision/priority state before continuing;
+- `record_context`: commit a durable domain effect or evidence record;
+- `continue_current_work`: record that the message was considered but does not
+  change the current plan; or
+- `no_follow_up`: settle irrelevant or duplicate material explicitly.
+
+Provider code never chooses these outcomes. Core never interprets private
+message text. The Agent owns semantic judgment and must bind any material result
+to a durable effect receipt before inbox ACK.
+
+## Ordering
+
+```text
+provider-neutral turn_start dispatch
+  -> provider read + owner-private commit/readback
+  -> fresh status + quota projection
+  -> inbox lane preempts ordinary work when agent_read_required
+  -> private drain into the active Agent turn
+  -> semantic disposition + durable settlement
+  -> ACK and resume the prior lane when appropriate
+```
+
+Running the hook after quota selection is incorrect because fresh steering can
+arrive after ordinary work has already been chosen. Returning raw content in
+the public hook result is also incorrect because shared registries and Turn
+journals are public-safe control-plane surfaces.
+
+## Failure and replay
+
+- `empty` means a valid provider success envelope was read and no new inbox
+  event was accepted.
+- `provider_contract_error` means the success envelope did not match its
+  declared schema; it must never degrade to `empty`.
+- provider permission and availability failures remain typed and isolated.
+- duplicate hook identities run once; duplicate messages collapse by provider
+  message identity.
+- provider-local cursors are single-flight and advance only after inbox and
+  cursor readback.
+- `partial` multi-route success still requires Agent reading for accepted
+  observations while retaining a compact failure code for the incomplete
+  routes.
+
+The hook grants no repository, production, outbound-message, or arbitrary
+external-write authority. Its only allowed local writes are the registered
+owner-private inbox and cursor scopes.

--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -51,7 +51,10 @@ provider-neutral turn_start dispatch
 Running the hook after quota selection is incorrect because fresh steering can
 arrive after ordinary work has already been chosen. Returning raw content in
 the public hook result is also incorrect because shared registries and Turn
-journals are public-safe control-plane surfaces.
+journals are public-safe control-plane surfaces. CLI request validation runs
+before hook dispatch, so an invalid quota request performs no provider read or
+owner-private write; a valid request still dispatches the hook before status
+collection and quota selection.
 
 ## Failure and replay
 

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -7,6 +7,11 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..capabilities.issue_fix.provider_hooks import IssueFixReviewerProviderHooks
+from ..control_plane.capability_hooks import (
+    TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+    TurnStartHookRegistration,
+    dispatch_turn_start_hooks,
+)
 from ..control_plane.runtime.goal_project_route import resolve_goal_project_route
 from ..extensions.lark import (
     LARK_COLLECTOR_PERMISSION,
@@ -45,6 +50,7 @@ from ..extensions.lark.routed_inbox import (
     resolve_routed_lark_inbox_config,
     settle_routed_lark_event_inbox_material_review,
 )
+from ..extensions.lark.turn_start_sync import sync_lark_turn_start_inbox
 from ..extensions.runtime import (
     default_extension_state_file,
     resolve_extension_activation,
@@ -319,6 +325,108 @@ def build_lark_operator_inbox_urgency_projector(
         )
 
     return project
+
+
+def build_lark_turn_start_inbox_hook(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    runtime_root_arg: str | Path | None,
+) -> TurnStartHookRegistration:
+    """Compose the opt-in provider sync behind the shared turn-start phase."""
+
+    def produce() -> dict[str, object]:
+        _resolve_lark_activation(
+            "history-catch-up",
+            runtime_root_arg=(
+                str(runtime_root_arg) if runtime_root_arg is not None else None
+            ),
+        )
+        result = sync_lark_turn_start_inbox(
+            project=project,
+            config_path=config_path,
+        )
+        status = str(result.get("status") or "failed")
+        error_code = result.get("error_code")
+        if error_code in {
+            "provider_contract_error",
+            "inbox_readback_failed",
+            "cursor_readback_failed",
+        }:
+            status = "failed"
+        if status not in {
+            "not_applicable",
+            "observed",
+            "empty",
+            "partial",
+            "unavailable",
+            "failed",
+        }:
+            status = "failed"
+            error_code = "provider_result_unmapped"
+        return {
+            "schema_version": TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+            "hook_id": "lark.turn_start_inbox_sync",
+            "capability_id": "lark-event-inbox",
+            "phase": "turn_start",
+            "status": status,
+            "observation_count": int(result.get("observation_count") or 0),
+            "agent_read_required": bool(
+                int(result.get("observation_count") or 0)
+                and status in {"observed", "partial"}
+            ),
+            "external_reads_performed": (
+                result.get("external_reads_performed") is True
+            ),
+            "local_private_state_mutated": (
+                result.get("local_private_state_mutated") is True
+            ),
+            "private_content_returned": False,
+            "provider_payload_returned": False,
+            "error_code": error_code,
+        }
+
+    return TurnStartHookRegistration(
+        hook_id="lark.turn_start_inbox_sync",
+        capability_id="lark-event-inbox",
+        requested_read_scope=(
+            "provider_group_history",
+            "owner_private_inbox_binding",
+        ),
+        requested_write_scope=(
+            "owner_private_inbox",
+            "owner_private_cursor",
+        ),
+        producer=produce,
+    )
+
+
+def dispatch_goal_lark_turn_start_hooks(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | Path | None,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, object]:
+    """Resolve one Goal-owned inbox and run its pre-decision sync hook."""
+
+    goal, project, _ = resolve_goal_project_route(
+        registry_path=registry_path,
+        goal_id=goal_id,
+    )
+    config_path = _goal_inbox_config(goal, agent_id=agent_id)
+    registrations = (
+        (
+            build_lark_turn_start_inbox_hook(
+                project=project,
+                config_path=config_path,
+                runtime_root_arg=runtime_root_arg,
+            ),
+        )
+        if config_path
+        else ()
+    )
+    return dispatch_turn_start_hooks(registrations)
 
 
 def build_lark_issue_fix_reviewer_provider_hooks(

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -65,8 +65,15 @@ from ..quota import (
 )
 from ..status import collect_status
 from ..upgrade import resolve_codex_app_automation_rrule
-from .quota_context import QuotaCommandContext, prepare_quota_command_context
-from .lark_inbox import build_lark_operator_inbox_urgency_projector
+from .lark_inbox import (
+    build_lark_operator_inbox_urgency_projector,
+    dispatch_goal_lark_turn_start_hooks,
+)
+from .quota_context import (
+    QuotaCommandContext,
+    prepare_quota_command_context,
+    validate_quota_command_context_request,
+)
 from .quota_host_poll import attach_host_poll_receipt
 from .quota_monitor_poll import record_quota_monitor_poll_for_cli
 from .quota_registration import (
@@ -401,9 +408,7 @@ def _require_requested_quota_action_selection(
         selected_todo_id != requested_todo_id
         or payload.get("ok") is not True
         or payload.get("should_run") is not True
-        or not (
-            pending_selection_qualified or exact_current_obligation_qualified
-        )
+        or not (pending_selection_qualified or exact_current_obligation_qualified)
     ):
         raise HeartbeatReceiptIdentityConflictError(
             "explicit action selection must name one currently projected "
@@ -427,6 +432,37 @@ def _commit_requested_action_selection(
         selected_todo["selection_binding"] = "heartbeat_receipt"
 
 
+def _dispatch_quota_turn_start_hooks(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> tuple[dict[str, object] | None, bool]:
+    validate_quota_command_context_request(args)
+    if args.quota_command != "should-run":
+        return None, False
+    dispatch = dispatch_goal_lark_turn_start_hooks(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+    )
+    local_private_state_mutated = any(
+        isinstance(result, Mapping)
+        and result.get("local_private_state_mutated") is True
+        for result in (dispatch.get("results") or [])
+    )
+    return dispatch, local_private_state_mutated
+
+
+def _attach_turn_start_hook_dispatch(
+    payload: dict[str, object],
+    dispatch: Mapping[str, object] | None,
+) -> None:
+    if dispatch and (dispatch.get("registered_count") or dispatch.get("failures")):
+        payload["turn_start_capability_hook_dispatch"] = dict(dispatch)
+
+
 def handle_quota_command(
     args: argparse.Namespace,
     *,
@@ -444,6 +480,11 @@ def handle_quota_command(
     detail_sections: frozenset[str] = frozenset()
     context: QuotaCommandContext | None = None
     try:
+        turn_start_hook_dispatch, turn_start_mutated = _dispatch_quota_turn_start_hooks(
+            args,
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+        )
         context = prepare_quota_command_context(
             args,
             registry_path=registry_path,
@@ -452,6 +493,7 @@ def handle_quota_command(
             operator_inbox_urgency_projector_factory=(
                 build_lark_operator_inbox_urgency_projector
             ),
+            force_projection_refresh=turn_start_mutated,
         )
         heartbeat_turn_id = context.heartbeat_turn_id
         detail_sections = context.detail_sections
@@ -505,6 +547,7 @@ def handle_quota_command(
                 turn_instance_id=heartbeat_turn_id,
                 interaction_projection_hooks=interaction_projection_hooks,
             )
+            _attach_turn_start_hook_dispatch(payload, turn_start_hook_dispatch)
             _require_requested_quota_action_selection(
                 payload,
                 requested_todo_id=_requested_quota_action_todo_id(args),

--- a/loopx/cli_commands/quota_context.py
+++ b/loopx/cli_commands/quota_context.py
@@ -88,16 +88,15 @@ def _scheduler_execution_context_from_args(
     return None
 
 
-def prepare_quota_command_context(
+def validate_quota_command_context_request(
     args: argparse.Namespace,
-    *,
-    registry_path: Path,
-    runtime_root_arg: str | None,
-    status_collector: Callable[..., dict[str, object]] | None = None,
-    operator_inbox_urgency_projector_factory: Callable[
-        ..., Callable[..., dict[str, object]]
-    ],
-) -> QuotaCommandContext:
+) -> tuple[
+    str | None,
+    Mapping[str, object] | SchedulerExecutionContextResolution | None,
+    bool,
+]:
+    """Validate the request before any provider read or local projection write."""
+
     command = args.quota_command
     if bool(getattr(args, "turn_envelope", False)) and command != "should-run":
         raise QuotaCommandValidationError(
@@ -178,11 +177,34 @@ def prepare_quota_command_context(
                 "--begin-turn requires runtime-profile codex_app_heartbeat "
                 "or codex_app_ssh_goal"
             )
-        heartbeat_turn_id = mint_turn_instance_id(prefix="guided-start")
-    if heartbeat_turn_id and command == "should-run" and bool(args.dry_run):
+    if (
+        (heartbeat_turn_id or begin_turn)
+        and command == "should-run"
+        and bool(args.dry_run)
+    ):
         raise QuotaCommandValidationError(
             "turn-scoped `quota should-run` cannot use --dry-run"
         )
+    return heartbeat_turn_id, scheduler_context, begin_turn
+
+
+def prepare_quota_command_context(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    status_collector: Callable[..., dict[str, object]] | None = None,
+    operator_inbox_urgency_projector_factory: Callable[
+        ..., Callable[..., dict[str, object]]
+    ],
+    force_projection_refresh: bool = False,
+) -> QuotaCommandContext:
+    command = args.quota_command
+    heartbeat_turn_id, scheduler_context, begin_turn = (
+        validate_quota_command_context_request(args)
+    )
+    if begin_turn:
+        heartbeat_turn_id = mint_turn_instance_id(prefix="guided-start")
 
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
     if not scan_roots:
@@ -204,7 +226,10 @@ def prepare_quota_command_context(
     )
     status_payload = None
     cache_metadata = None
-    if bool(getattr(args, "use_projection_cache", False)):
+    if (
+        bool(getattr(args, "use_projection_cache", False))
+        and not force_projection_refresh
+    ):
         status_payload, cache_metadata = load_status_projection_cache(
             registry_path=registry_path,
             runtime_root=runtime_root,

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -52,7 +52,10 @@ from ..quota import spend_quota_slot
 from ..state_refresh import refresh_state_run
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
 from ..todos import complete_goal_todo, resolve_todo_state_path, update_goal_todo
-from .lark_inbox import build_lark_operator_inbox_urgency_projector
+from .lark_inbox import (
+    build_lark_operator_inbox_urgency_projector,
+    dispatch_goal_lark_turn_start_hooks,
+)
 from .turn_registration import register_turn_commands as register_turn_commands
 from .turn_rendering import (
     render_loopx_turn_execution_markdown as _render_loopx_turn_execution_markdown,
@@ -148,6 +151,12 @@ def handle_turn_command(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
         )
+        turn_start_hook_dispatch = dispatch_goal_lark_turn_start_hooks(
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+        )
         operator_inbox_urgency_projector = build_lark_operator_inbox_urgency_projector(
             runtime_root_arg=runtime_root,
         )
@@ -240,6 +249,10 @@ def handle_turn_command(
             session_binding=session_binding,
             turn_instance_id=args.turn_instance_id,
         )
+        if turn_start_hook_dispatch.get("registered_count") or (
+            turn_start_hook_dispatch.get("failures")
+        ):
+            payload["turn_start_capability_hook_dispatch"] = turn_start_hook_dispatch
         if args.turn_command == "plan":
             if not args.include_transaction_detail:
                 payload.pop("session", None)

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -1243,6 +1243,11 @@ def configure_goal(
 
     after = _settings_summary(goal)
     changed_fields = _changed_fields(before, after)
+    if goal != before_goal and not changed_fields:
+        # Some local-private control-plane bindings intentionally project only
+        # counts and booleans. Rebinding one enabled provider to another can
+        # therefore preserve the public summary while still requiring a write.
+        changed_fields = ["control_plane"]
     dry_run = not execute
     model_changed = bool(
         before.get("legacy_hierarchy_present")

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -16,8 +16,14 @@ INTERACTION_PROJECTION_HOOK_RESULT_SCHEMA_VERSION = (
 INTERACTION_PROJECTION_HOOK_DISPATCH_SCHEMA_VERSION = (
     "loopx_interaction_projection_hook_dispatch_v0"
 )
+TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION = (
+    "loopx_turn_start_capability_hook_registration_v0"
+)
+TURN_START_HOOK_RESULT_SCHEMA_VERSION = "loopx_turn_start_capability_hook_result_v0"
+TURN_START_HOOK_DISPATCH_SCHEMA_VERSION = "loopx_turn_start_capability_hook_dispatch_v0"
 
 InteractionProjectionProducer = Callable[[], Mapping[str, Any]]
+TurnStartProducer = Callable[[], Mapping[str, Any]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +51,33 @@ class InteractionProjectionHookRegistration:
             "failure_policy": "isolate",
             "requested_read_scope": list(self.requested_read_scope),
             "requested_write_scope": [],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TurnStartHookRegistration:
+    """One bounded provider observation before a LoopX turn is selected."""
+
+    hook_id: str
+    capability_id: str
+    requested_read_scope: tuple[str, ...]
+    requested_write_scope: tuple[str, ...]
+    producer: TurnStartProducer
+    max_result_bytes: int = 16 * 1024
+
+    def contract(self) -> dict[str, Any]:
+        return {
+            "schema_version": TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION,
+            "hook_id": self.hook_id,
+            "capability_id": self.capability_id,
+            "phase": "turn_start",
+            "budget": {
+                "max_invocations_per_dispatch": 1,
+                "max_result_bytes": self.max_result_bytes,
+            },
+            "failure_policy": "isolate",
+            "requested_read_scope": list(self.requested_read_scope),
+            "requested_write_scope": list(self.requested_write_scope),
         }
 
 
@@ -118,8 +151,64 @@ def dispatch_interaction_projection_hooks(
     }
 
 
+def dispatch_turn_start_hooks(
+    registrations: Sequence[TurnStartHookRegistration] | None,
+) -> dict[str, Any]:
+    """Run bounded pre-turn observations without exposing provider payloads."""
+
+    results: list[dict[str, Any]] = []
+    failures: list[dict[str, str]] = []
+    seen_hook_ids: set[str] = set()
+    ordered = sorted(registrations or (), key=lambda item: item.hook_id)
+    for registration in ordered:
+        if registration.hook_id in seen_hook_ids:
+            failures.append(_hook_failure(registration, error_code="duplicate_hook_id"))
+            continue
+        seen_hook_ids.add(registration.hook_id)
+        try:
+            effect_runtime_result(
+                "capability_hook.turn_start.validate_registration",
+                {"registration": registration.contract()},
+            )
+        except (EffectRuntimeRejected, RuntimeError, TypeError, ValueError):
+            failures.append(
+                _hook_failure(registration, error_code="registration_rejected")
+            )
+            continue
+        try:
+            result = dict(registration.producer())
+        except Exception:  # noqa: BLE001 - capability failures are isolated.
+            failures.append(_hook_failure(registration, error_code="producer_failed"))
+            continue
+        try:
+            normalized = effect_runtime_result(
+                "capability_hook.turn_start.validate",
+                {
+                    "registration": registration.contract(),
+                    "result": result,
+                },
+            )
+        except (EffectRuntimeRejected, RuntimeError, TypeError, ValueError):
+            failures.append(_hook_failure(registration, error_code="contract_rejected"))
+            continue
+        if not isinstance(normalized, Mapping):
+            failures.append(
+                _hook_failure(registration, error_code="runtime_result_invalid")
+            )
+            continue
+        results.append(dict(normalized))
+    return {
+        "schema_version": TURN_START_HOOK_DISPATCH_SCHEMA_VERSION,
+        "phase": "turn_start",
+        "registered_count": len(registrations or ()),
+        "invoked_count": len(results),
+        "results": results,
+        "failures": failures,
+    }
+
+
 def _hook_failure(
-    registration: InteractionProjectionHookRegistration,
+    registration: InteractionProjectionHookRegistration | TurnStartHookRegistration,
     *,
     error_code: str,
 ) -> dict[str, str]:

--- a/loopx/control_plane/capability_hooks.ts
+++ b/loopx/control_plane/capability_hooks.ts
@@ -11,6 +11,10 @@ export const CAPABILITY_HOOK_REGISTRATION_SCHEMA_VERSION =
   "loopx_capability_hook_registration_v0";
 export const INTERACTION_PROJECTION_HOOK_RESULT_SCHEMA_VERSION =
   "loopx_interaction_projection_hook_result_v0";
+export const TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION =
+  "loopx_turn_start_capability_hook_registration_v0";
+export const TURN_START_HOOK_RESULT_SCHEMA_VERSION =
+  "loopx_turn_start_capability_hook_result_v0";
 
 const REGISTRATION_FIELDS = new Set([
   "schema_version",
@@ -35,6 +39,42 @@ const RESULT_FIELDS = new Set([
   "status",
   "projection_slot",
   "payload",
+]);
+const TURN_START_REGISTRATION_FIELDS = new Set([
+  "schema_version",
+  "hook_id",
+  "capability_id",
+  "phase",
+  "budget",
+  "failure_policy",
+  "requested_read_scope",
+  "requested_write_scope",
+]);
+const TURN_START_RESULT_FIELDS = new Set([
+  "schema_version",
+  "hook_id",
+  "capability_id",
+  "phase",
+  "status",
+  "observation_count",
+  "agent_read_required",
+  "external_reads_performed",
+  "local_private_state_mutated",
+  "private_content_returned",
+  "provider_payload_returned",
+  "error_code",
+]);
+const TURN_START_WRITE_SCOPES = new Set([
+  "owner_private_inbox",
+  "owner_private_cursor",
+]);
+const TURN_START_STATUSES = new Set([
+  "not_applicable",
+  "observed",
+  "empty",
+  "partial",
+  "unavailable",
+  "failed",
 ]);
 const TOKEN_RE = /^[a-z][a-z0-9_.:-]{2,95}$/;
 
@@ -205,4 +245,159 @@ export function validateInteractionProjectionHookInvocation(input: {
     projection_slot: projection ? slot : null,
     projection,
   };
+}
+
+export function validateTurnStartHookRegistration(
+  value: unknown,
+): JsonObject & {
+  hook_id: string;
+  capability_id: string;
+  max_result_bytes: number;
+  requested_write_scope: string[];
+} {
+  const registration = requiredObject(value, "turn-start hook registration");
+  requireExactFields(
+    registration,
+    TURN_START_REGISTRATION_FIELDS,
+    "turn-start hook registration",
+  );
+  if (
+    registration.schema_version !== TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION ||
+    registration.phase !== "turn_start" ||
+    registration.failure_policy !== "isolate"
+  ) {
+    throw new Error("turn-start hook registration contract is invalid");
+  }
+  const hookId = requiredString(registration.hook_id, "turn-start hook hook_id");
+  const capabilityId = requiredString(
+    registration.capability_id,
+    "turn-start hook capability_id",
+  );
+  if (!TOKEN_RE.test(hookId) || !TOKEN_RE.test(capabilityId)) {
+    throw new Error("turn-start hook identity is invalid");
+  }
+  boundedTokens(
+    registration.requested_read_scope,
+    "turn-start hook requested_read_scope",
+    16,
+  );
+  const writeScope = boundedTokens(
+    registration.requested_write_scope,
+    "turn-start hook requested_write_scope",
+    8,
+  );
+  if (writeScope.some((scope) => !TURN_START_WRITE_SCOPES.has(scope))) {
+    throw new Error("turn-start hook requested_write_scope is not owner-private");
+  }
+  const budget = requiredObject(registration.budget, "turn-start hook budget");
+  requireExactFields(budget, BUDGET_FIELDS, "turn-start hook budget");
+  const maxInvocations = requireInteger(
+    budget.max_invocations_per_dispatch,
+    "turn-start hook max_invocations_per_dispatch",
+  );
+  const maxResultBytes = requireInteger(
+    budget.max_result_bytes,
+    "turn-start hook max_result_bytes",
+  );
+  if (maxInvocations !== 1 || maxResultBytes < 1024 || maxResultBytes > 65_536) {
+    throw new Error("turn-start hook budget is outside the admitted envelope");
+  }
+  return {
+    ...registration,
+    hook_id: hookId,
+    capability_id: capabilityId,
+    max_result_bytes: maxResultBytes,
+    requested_write_scope: writeScope,
+  };
+}
+
+export function validateTurnStartHookInvocation(input: {
+  registration: unknown;
+  result: unknown;
+}): JsonObject {
+  const registration = validateTurnStartHookRegistration(input.registration);
+  const result = requiredObject(input.result, "turn-start hook result");
+  requireExactFields(result, TURN_START_RESULT_FIELDS, "turn-start hook result");
+  if (
+    result.schema_version !== TURN_START_HOOK_RESULT_SCHEMA_VERSION ||
+    result.hook_id !== registration.hook_id ||
+    result.capability_id !== registration.capability_id ||
+    result.phase !== "turn_start"
+  ) {
+    throw new Error("turn-start hook result identity is invalid");
+  }
+  if (
+    new TextEncoder().encode(JSON.stringify(result)).byteLength >
+      registration.max_result_bytes
+  ) {
+    throw new Error("turn-start hook result exceeds its budget");
+  }
+  const status = requiredString(result.status, "turn-start hook status");
+  if (!TURN_START_STATUSES.has(status)) {
+    throw new Error("turn-start hook result status is invalid");
+  }
+  const observationCount = requireInteger(
+    result.observation_count,
+    "turn-start hook observation_count",
+  );
+  if (observationCount < 0 || observationCount > 10_000) {
+    throw new Error("turn-start hook observation_count is invalid");
+  }
+  for (const field of [
+    "agent_read_required",
+    "external_reads_performed",
+    "local_private_state_mutated",
+    "private_content_returned",
+    "provider_payload_returned",
+  ]) {
+    if (typeof result[field] !== "boolean") {
+      throw new Error(`turn-start hook ${field} must be boolean`);
+    }
+  }
+  if (result.private_content_returned || result.provider_payload_returned) {
+    throw new Error("turn-start hook cannot return private provider content");
+  }
+  if (
+    result.local_private_state_mutated &&
+    registration.requested_write_scope.length === 0
+  ) {
+    throw new Error("turn-start hook mutated undeclared local-private state");
+  }
+  const errorCode = result.error_code;
+  if (errorCode !== null && (typeof errorCode !== "string" || !TOKEN_RE.test(errorCode))) {
+    throw new Error("turn-start hook error_code is invalid");
+  }
+  if (status === "observed" && (
+    observationCount === 0 ||
+    errorCode !== null ||
+    result.agent_read_required !== true
+  )) {
+    throw new Error("observed turn-start hook result is inconsistent");
+  }
+  if (status === "empty" && (
+    observationCount !== 0 ||
+    errorCode !== null ||
+    result.agent_read_required
+  )) {
+    throw new Error("empty turn-start hook result is inconsistent");
+  }
+  if (status === "not_applicable" && (
+    observationCount !== 0 ||
+    result.agent_read_required ||
+    result.external_reads_performed ||
+    result.local_private_state_mutated ||
+    errorCode !== null
+  )) {
+    throw new Error("not-applicable turn-start hook result must be empty");
+  }
+  if (["partial", "unavailable", "failed"].includes(status) && errorCode === null) {
+    throw new Error("failed turn-start hook result requires error_code");
+  }
+  if (status === "partial" && observationCount > 0 && !result.agent_read_required) {
+    throw new Error("partial turn-start observations require Agent reading");
+  }
+  if (["unavailable", "failed"].includes(status) && result.agent_read_required) {
+    throw new Error("unavailable turn-start hook cannot require unread evidence");
+  }
+  return { ...result };
 }

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -92,6 +92,8 @@ import {
 import {
   validateInteractionProjectionHookInvocation,
   validateInteractionProjectionHookRegistration,
+  validateTurnStartHookInvocation,
+  validateTurnStartHookRegistration,
 } from "./capability_hooks.ts";
 
 type EffectRuntimeHandler = (params: JsonObject) => unknown | Promise<unknown>;
@@ -370,6 +372,17 @@ export function createEffectRuntimeHandlers(
     [
       "capability_hook.interaction_projection.validate",
       (params) => validateInteractionProjectionHookInvocation({
+        registration: params.registration,
+        result: params.result,
+      }),
+    ],
+    [
+      "capability_hook.turn_start.validate_registration",
+      (params) => validateTurnStartHookRegistration(params.registration),
+    ],
+    [
+      "capability_hook.turn_start.validate",
+      (params) => validateTurnStartHookInvocation({
         registration: params.registration,
         result: params.result,
       }),

--- a/loopx/control_plane/heartbeat/task_body.py
+++ b/loopx/control_plane/heartbeat/task_body.py
@@ -101,7 +101,7 @@ Before spending delivery compute, make the CLI reachable; set
 
 If that preflight still fails: no work/spend; quiet `DONT_NOTIFY`.
 
-`lark_event_inbox`: `reply_due`: drain -> effect/reply/readback/ACK.
+`agent_read_required`: drain/read/triage before work; settle/ACK.
 
 {USER_TODO_FINAL_MESSAGE_RULE}
 {HEARTBEAT_VISION_WRITEBACK_RULE_SHORT}
@@ -313,7 +313,7 @@ If `should_run=false`: follow user channel. `monitor_quiet_skip`: receipt/stall
 done; quiet unless replan; write failure: retry same id. External/wait monitor:
 one read-only poll; new evidence -> writeback/spend. Safe bypass if allowed.
 {SCHEDULER_HINT_THIN_RULE}
-`lark_event_inbox`: reply_due: drain_command -> effect/reply/readback/ACK.
+`agent_read_required`: drain/read/triage before work; settle/ACK.
 
 If `should_run=true`: fetch compact; use `status --limit 3` and
 `review-packet --handoff-only`. Obey
@@ -377,7 +377,7 @@ Preflight fail: quiet; no work/spend.
 {SCHEDULER_HINT_COMPACT_RULE}
 {HEARTBEAT_VISION_WRITEBACK_RULE_SHORT}
 
-`lark_event_inbox`: reply_due: drain_command -> effect/reply/readback/ACK.
+`agent_read_required`: drain/read/triage before work; settle/ACK.
 
 Output policy: authority=`interaction_contract.user_channel.notify`;
 external=`NOTIFY`; quiet=`DONT_NOTIFY`; quiet_missing_action=`internal_repair`.
@@ -692,7 +692,7 @@ def render_thin_heartbeat_task_body(
 {SCHEDULER_HINT_THIN_RULE}
 {HEARTBEAT_VISION_WRITEBACK_RULE_SHORT}
 Done->todo/rationale; guard receipt; 2 stalls->replan.
-`lark_event_inbox`: reply_due; drain_command/reply-readback/ACK.
+`agent_read_required`: drain/read/triage before work; settle/ACK.
 
 P0 blocked: safe P1/P2; monitor quiet/no-spend.
 

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -321,11 +321,19 @@ def lark_inbox_reply_due_work_lane_contract(
         ),
         "oldest_pending_age_seconds": urgency.get("oldest_pending_age_seconds"),
         "drain_command": inbox.get("drain_command"),
+        "semantic_triage_required": True,
+        "allowed_dispositions": [
+            "steer_current_turn",
+            "replan_goal",
+            "record_context",
+            "continue_current_work",
+        ],
         "monitor_policy": "durable_effect_then_one_verified_reply_then_ack",
         "action": (
-            "drain the configured Lark inbox before ordinary work; translate the "
-            "direct question, mention, or verified bot reply into a durable effect, "
-            "send exactly one "
+            "drain and read the configured Lark inbox before ordinary work; classify "
+            "the direct question, mention, or verified bot reply as steering, Goal "
+            "replan, context capture, or continue-current-work; commit any required "
+            "durable effect, then send exactly one "
             "source-thread reply with idempotency and readback, then ACK"
         ),
     }
@@ -379,11 +387,21 @@ def operator_inbox_material_review_due_work_lane_contract(
         ),
         "drain_limit": drain_limit,
         "drain_command": drain_command or None,
+        "semantic_triage_required": True,
+        "allowed_dispositions": [
+            "steer_current_turn",
+            "replan_goal",
+            "record_context",
+            "continue_current_work",
+            "no_follow_up",
+        ],
         "monitor_policy": "bounded_effect_or_no_follow_up_receipt_then_ack",
         "action": (
-            f"drain at most {drain_limit} captured operator-inbox materials; "
-            "for each unaddressed message or attachment, write one durable effect "
-            "or explicit no-follow-up receipt, settle it idempotently, and ACK; "
+            f"drain and read at most {drain_limit} captured operator-inbox materials "
+            "before ordinary work; classify each as steering, Goal replan, context "
+            "capture, continue-current-work, or no-follow-up; write the matching "
+            "durable effect or explicit no-follow-up receipt, settle it idempotently, "
+            "and ACK; "
             "do not send a reply unless a separate reply_due item requires one"
         ),
     }

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -31,6 +31,82 @@ parent sender is the app id of the configured profile. A reply to a person,
 another app, or an unverifiable parent remains captured but does not wake the
 agent. The agent does not need to keep a websocket open.
 
+### Optional turn-start Agent reading hook
+
+Realtime collection is the preferred ingress, but a long-running Agent may also
+need a bounded provider-history tail at the beginning of every LoopX turn. The
+collector config can opt into `turn_start_sync`. This is not a background-only
+sync: it is a pre-decision capability hook with the following ordering:
+
+```text
+turn-start hook
+  -> read one bounded provider page per route
+  -> commit and read back owner-private inbox events and cursor
+  -> recompute quota inbox urgency in the same CLI invocation
+  -> agent_read_required=true when new events were accepted
+  -> selected inbox lane drains private message content before ordinary work
+  -> Agent chooses steering / Goal replan / context capture /
+     continue-current-work / no-follow-up
+  -> durable effect or no-follow-up receipt -> ACK
+```
+
+Core owns the provider-neutral hook registration, output budget, allowed
+owner-private write scopes, failure isolation, and `agent_read_required`
+contract. The Lark extension owns history pagination, provider-envelope
+validation, private cursors, and inbox readback. The CLI composition root runs
+the hook before status/quota projection. Raw content remains only in the local
+inbox and appears to the Agent only through the existing goal-bound
+`drain_command`; it never enters the public Goal registry, hook receipt, or
+quota packet.
+
+The distinction between `empty`, `provider_contract_error`, permission failure,
+and provider unavailability is mandatory. A success envelope whose message list
+does not match the declared provider schema fails closed and cannot be treated
+as an empty inbox. Hook failure is isolated from ordinary Goal state, but it is
+visible in `turn_start_capability_hook_dispatch` and does not claim that Agent
+reading occurred.
+
+The feature is default-off. Enable it only with `configured_chat_all` and
+`material_review.enabled=true` on every route, so every newly accepted message
+enters an Agent semantic-triage lane rather than being synchronized and ignored:
+
+```json
+{
+  "schema_version": "lark_event_collector_config_v1",
+  "enabled": true,
+  "service_name": "loopx-project-context",
+  "identity": "bot",
+  "profile": "project-context-bot",
+  "supervisor": "systemd",
+  "consume_timeout": "30m",
+  "turn_start_sync": {
+    "enabled": true,
+    "initial_lookback_seconds": 900,
+    "overlap_seconds": 5,
+    "page_size": 50
+  },
+  "routes": [
+    {
+      "route_key": "requirements-a",
+      "chat_id": "oc_<local-private-chat-id>",
+      "event_inbox_config": ".loopx/config/lark/requirements-a.json"
+    }
+  ]
+}
+```
+
+Each completed poll opens a new forward window from the previous end with a
+small overlap. Inbox `message_id` deduplication makes the overlap replay-safe.
+When a page reports `has_more`, later turns resume the same private page token
+before opening a new window. The initial lookback is bounded to seven days,
+the overlap to five minutes, and each route reads at most one 50-message page
+per turn. Cursor and single-flight lock identity combine the public-safe route
+key with a digest of the configured profile, chat, inbox config, inbox path,
+and capture scope. Two Agent-scoped collectors may therefore reuse a semantic
+route key without sharing progress or permanently rejecting each other's
+source binding, while duplicate registrations for the same source still share
+one single-flight boundary.
+
 Use `addressed_only` only when direct bot mentions are the entire feedback
 contract. A review or collaboration inbox that accepts non-mention replies to
 bot messages should use `configured_chat_all`: the host collector filters by

--- a/loopx/extensions/lark/event_collector.py
+++ b/loopx/extensions/lark/event_collector.py
@@ -34,6 +34,8 @@ TIMEOUT_RE = re.compile(r"^[1-9][0-9]*(?:s|m|h)$")
 SUPPORTED_SUPERVISORS = {"launchd", "systemd"}
 SUPPORTED_EVENT_KEY = "im.message.receive_v1"
 MAX_ROUTE_COUNT = 50
+TURN_START_SYNC_MAX_LOOKBACK_SECONDS = 7 * 24 * 60 * 60
+TURN_START_SYNC_MAX_OVERLAP_SECONDS = 5 * 60
 
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 
@@ -101,6 +103,39 @@ def load_lark_event_collector_config(
     supervisor = str(payload.get("supervisor") or "").strip()
     timeout = str(payload.get("consume_timeout") or "30m").strip()
     lark_cli_bin = str(payload.get("lark_cli_bin") or "lark-cli").strip()
+    raw_turn_start_sync = payload.get("turn_start_sync")
+    if raw_turn_start_sync is not None and not isinstance(raw_turn_start_sync, Mapping):
+        raise TypeError("collector turn_start_sync must be an object")
+    raw_turn_start_sync = (
+        raw_turn_start_sync if isinstance(raw_turn_start_sync, Mapping) else {}
+    )
+    turn_start_sync_enabled = raw_turn_start_sync.get("enabled") is True
+    turn_start_sync_lookback = raw_turn_start_sync.get(
+        "initial_lookback_seconds", 15 * 60
+    )
+    turn_start_sync_overlap = raw_turn_start_sync.get("overlap_seconds", 5)
+    turn_start_sync_page_size = raw_turn_start_sync.get("page_size", 50)
+    for label, value, lower, upper in (
+        (
+            "initial_lookback_seconds",
+            turn_start_sync_lookback,
+            60,
+            TURN_START_SYNC_MAX_LOOKBACK_SECONDS,
+        ),
+        (
+            "overlap_seconds",
+            turn_start_sync_overlap,
+            0,
+            TURN_START_SYNC_MAX_OVERLAP_SECONDS,
+        ),
+        ("page_size", turn_start_sync_page_size, 1, 50),
+    ):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, int)
+            or not lower <= value <= upper
+        ):
+            raise ValueError(f"collector turn_start_sync {label} is invalid")
     if not SERVICE_RE.fullmatch(service_name):
         raise ValueError("service_name must be a lowercase loopx- service token")
     if event_key != SUPPORTED_EVENT_KEY:
@@ -231,6 +266,13 @@ def load_lark_event_collector_config(
         raise ValueError(
             "lark collector profile must match every inbox reply sender_profile"
         )
+    if turn_start_sync_enabled and any(
+        route["inbox"]["material_review"].get("enabled") is not True for route in routes
+    ):
+        raise ValueError(
+            "collector turn_start_sync requires material_review on every route so "
+            "new messages enter an Agent triage lane"
+        )
     return {
         "schema_version": schema_version,
         "enabled": enabled,
@@ -244,6 +286,12 @@ def load_lark_event_collector_config(
         "supervisor": supervisor,
         "consume_timeout": timeout,
         "lark_cli_bin": lark_cli_bin,
+        "turn_start_sync": {
+            "enabled": turn_start_sync_enabled,
+            "initial_lookback_seconds": turn_start_sync_lookback,
+            "overlap_seconds": turn_start_sync_overlap,
+            "page_size": turn_start_sync_page_size,
+        },
         "routes": routes,
     }
 

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -1,0 +1,394 @@
+"""Bounded incremental Lark history sync for the LoopX turn-start hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections.abc import Callable, Mapping
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from ...file_lock import (
+    LockAcquireTimeoutError,
+    LockAcquisitionPolicy,
+    exclusive_file_lock,
+)
+from .event_collector import _executable_prefix, load_lark_event_collector_config
+from .group_history import (
+    _canonical_events,
+    _page_digest,
+    _provider_argv,
+    _provider_failure,
+    _provider_page,
+    _route_context,
+    _verify_inbox_events,
+)
+from .routed_inbox import ingest_routed_lark_event_inbox
+
+CURSOR_SCHEMA_VERSION = "lark_turn_start_sync_cursor_v0"
+SYNC_SCHEMA_VERSION = "lark_turn_start_inbox_sync_v0"
+Runner = Callable[..., subprocess.CompletedProcess[str]]
+SOURCE_FINGERPRINT_PATTERN = re.compile(r"^sha256:([0-9a-f]{24})$")
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _cursor_path(project: Path, *, route_key: str, source_fingerprint: str) -> Path:
+    match = SOURCE_FINGERPRINT_PATTERN.fullmatch(source_fingerprint)
+    if match is None:
+        raise ValueError("Lark turn-start sync source fingerprint is invalid")
+    return (
+        project
+        / ".loopx"
+        / "inbox"
+        / ".turn-start"
+        / route_key
+        / f"{match.group(1)}.json"
+    )
+
+
+def _load_cursor(
+    path: Path, *, route_key: str, source_fingerprint: str
+) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("Lark turn-start sync cursor is unreadable") from exc
+    if not isinstance(payload, Mapping) or payload.get("schema_version") != (
+        CURSOR_SCHEMA_VERSION
+    ):
+        raise ValueError("Lark turn-start sync cursor schema is invalid")
+    if payload.get("route_key") != route_key:
+        raise ValueError("Lark turn-start sync cursor route binding changed")
+    if payload.get("source_fingerprint") != source_fingerprint:
+        raise ValueError("Lark turn-start sync cursor source binding changed")
+    for field in ("window_start", "window_end"):
+        value = payload.get(field)
+        if not isinstance(value, str):
+            raise TypeError("Lark turn-start sync cursor window is invalid")
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError as exc:
+            raise ValueError("Lark turn-start sync cursor window is invalid") from exc
+        if parsed.tzinfo is None:
+            raise ValueError("Lark turn-start sync cursor window is invalid")
+    next_page_token = payload.get("next_page_token")
+    if next_page_token is not None and (
+        not isinstance(next_page_token, str) or not next_page_token.strip()
+    ):
+        raise ValueError("Lark turn-start sync cursor page token is invalid")
+    page_count = payload.get("page_count")
+    message_count = payload.get("message_count")
+    if (
+        isinstance(page_count, bool)
+        or not isinstance(page_count, int)
+        or page_count < 1
+        or isinstance(message_count, bool)
+        or not isinstance(message_count, int)
+        or message_count < 0
+    ):
+        raise ValueError("Lark turn-start sync cursor counters are invalid")
+    return dict(payload)
+
+
+def _write_cursor(path: Path, state: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, 0o700)
+    temporary = path.with_suffix(".json.tmp")
+    temporary.write_text(
+        json.dumps(state, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    os.chmod(temporary, 0o600)
+    temporary.replace(path)
+    os.chmod(path, 0o600)
+
+
+def _window_state(
+    existing: Mapping[str, Any] | None,
+    *,
+    route_key: str,
+    source_fingerprint: str,
+    now: datetime,
+    initial_lookback_seconds: int,
+    overlap_seconds: int,
+) -> tuple[dict[str, Any], str]:
+    if existing and existing.get("next_page_token"):
+        return dict(existing), "page_resumed"
+    end = now.astimezone(UTC)
+    if existing:
+        prior_end = datetime.fromisoformat(str(existing["window_end"])).astimezone(UTC)
+        if end <= prior_end:
+            end = prior_end + timedelta(microseconds=1)
+        start = prior_end - timedelta(seconds=overlap_seconds)
+        transition = "tail_advanced"
+    else:
+        start = end - timedelta(seconds=initial_lookback_seconds)
+        transition = "initialized"
+    return (
+        {
+            "schema_version": CURSOR_SCHEMA_VERSION,
+            "route_key": route_key,
+            "source_fingerprint": source_fingerprint,
+            "window_start": _timestamp(start),
+            "window_end": _timestamp(end),
+            "next_page_token": None,
+            "page_count": 0,
+            "message_count": 0,
+            "last_page_digest": "",
+        },
+        transition,
+    )
+
+
+def _route_receipt(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    route_key: str,
+    now: datetime,
+    initial_lookback_seconds: int,
+    overlap_seconds: int,
+    page_size: int,
+    lark_cli_executable: str,
+    runner: Runner,
+) -> dict[str, Any]:
+    config, route, _, source_fingerprint = _route_context(
+        project=project,
+        config_path=config_path,
+        route_key=route_key,
+    )
+    cursor_path = _cursor_path(
+        Path(config["project"]),
+        route_key=route_key,
+        source_fingerprint=source_fingerprint,
+    )
+    try:
+        lock = exclusive_file_lock(
+            cursor_path,
+            policy=LockAcquisitionPolicy.SINGLE_FLIGHT,
+            operation="lark_turn_start_sync",
+        )
+        with lock:
+            existing = _load_cursor(
+                cursor_path,
+                route_key=route_key,
+                source_fingerprint=source_fingerprint,
+            )
+            state, _transition = _window_state(
+                existing,
+                route_key=route_key,
+                source_fingerprint=source_fingerprint,
+                now=now,
+                initial_lookback_seconds=initial_lookback_seconds,
+                overlap_seconds=overlap_seconds,
+            )
+            argv = _provider_argv(
+                command_prefix=_executable_prefix(lark_cli_executable),
+                profile=str(config["profile"]),
+                chat_id=str(route["chat_id"]),
+                state=state,
+                page_size=page_size,
+            )
+            try:
+                provider = runner(
+                    argv,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=30,
+                )
+            except (OSError, subprocess.SubprocessError):
+                return {
+                    "ok": False,
+                    "status": "provider_unavailable",
+                    "error_code": "provider_unavailable",
+                    "external_read_performed": False,
+                    "local_private_state_mutated": False,
+                }
+            if provider.returncode != 0:
+                failed = _provider_failure(provider, route_key=route_key)
+                return {
+                    "ok": False,
+                    "status": str(failed["status"]),
+                    "error_code": str(failed["status"]),
+                    "external_read_performed": bool(failed["external_read_performed"]),
+                    "local_private_state_mutated": False,
+                }
+            try:
+                payload = json.loads(provider.stdout)
+                messages, has_more, next_page_token = _provider_page(payload)
+                events, skipped_count, invalid_count = _canonical_events(
+                    messages,
+                    chat_id=str(route["chat_id"]),
+                )
+            except (json.JSONDecodeError, TypeError, ValueError):
+                return {
+                    "ok": False,
+                    "status": "provider_contract_error",
+                    "error_code": "provider_contract_error",
+                    "external_read_performed": True,
+                    "local_private_state_mutated": False,
+                }
+            if invalid_count:
+                return {
+                    "ok": False,
+                    "status": "provider_contract_error",
+                    "error_code": "provider_contract_error",
+                    "external_read_performed": True,
+                    "local_private_state_mutated": False,
+                }
+            newly_missing = [
+                event
+                for event in events
+                if not (
+                    route["inbox"]["inbox_path"] / f"{event['message_id']}.json"
+                ).is_file()
+            ]
+            ingest = ingest_routed_lark_event_inbox(
+                project=config["project"],
+                config_path=config["config_path"],
+                events=events,
+                execute=True,
+            )
+            try:
+                verified_count = _verify_inbox_events(route, newly_missing)
+            except ValueError:
+                return {
+                    "ok": False,
+                    "status": "inbox_readback_failed",
+                    "error_code": "inbox_readback_failed",
+                    "external_read_performed": True,
+                    "local_private_state_mutated": bool(ingest["write_performed"]),
+                }
+            updated = {
+                **state,
+                "next_page_token": next_page_token,
+                "page_count": int(state["page_count"]) + 1,
+                "message_count": int(state["message_count"]) + len(events),
+                "last_page_digest": _page_digest(events, next_page_token),
+            }
+            try:
+                _write_cursor(cursor_path, updated)
+                readback = _load_cursor(
+                    cursor_path,
+                    route_key=route_key,
+                    source_fingerprint=source_fingerprint,
+                )
+                if readback != updated:
+                    raise ValueError("Lark turn-start sync cursor readback mismatch")
+            except (OSError, TypeError, ValueError):
+                return {
+                    "ok": False,
+                    "status": "cursor_readback_failed",
+                    "error_code": "cursor_readback_failed",
+                    "accepted_count": int(ingest["accepted_count"]),
+                    "external_read_performed": True,
+                    "local_private_state_mutated": bool(ingest["write_performed"]),
+                }
+            return {
+                "ok": True,
+                "status": "page_pending" if has_more else "synced",
+                "error_code": None,
+                "accepted_count": int(ingest["accepted_count"]),
+                "duplicate_count": int(ingest["duplicate_count"]),
+                "skipped_count": skipped_count,
+                "verified_count": verified_count,
+                "external_read_performed": True,
+                "local_private_state_mutated": True,
+            }
+    except LockAcquireTimeoutError:
+        return {
+            "ok": False,
+            "status": "sync_already_running",
+            "error_code": "sync_already_running",
+            "external_read_performed": False,
+            "local_private_state_mutated": False,
+        }
+
+
+def sync_lark_turn_start_inbox(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    lark_cli_executable: str = "lark-cli",
+    runner: Runner = subprocess.run,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Sync one bounded page per configured route and return a content-free receipt."""
+
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=config_path,
+    )
+    policy = config["turn_start_sync"]
+    if policy["enabled"] is not True:
+        return {
+            "ok": True,
+            "schema_version": SYNC_SCHEMA_VERSION,
+            "status": "not_applicable",
+            "observation_count": 0,
+            "agent_read_required": False,
+            "external_reads_performed": False,
+            "local_private_state_mutated": False,
+            "error_code": None,
+            "private_content_returned": False,
+            "provider_payload_returned": False,
+        }
+    observed_at = (now or datetime.now(UTC)).astimezone(UTC)
+    receipts = [
+        _route_receipt(
+            project=project,
+            config_path=config_path,
+            route_key=str(route["route_key"]),
+            now=observed_at,
+            initial_lookback_seconds=int(policy["initial_lookback_seconds"]),
+            overlap_seconds=int(policy["overlap_seconds"]),
+            page_size=int(policy["page_size"]),
+            lark_cli_executable=lark_cli_executable,
+            runner=runner,
+        )
+        for route in config["routes"]
+    ]
+    failures = [receipt for receipt in receipts if receipt["ok"] is not True]
+    observation_count = sum(
+        int(receipt.get("accepted_count") or 0) for receipt in receipts
+    )
+    if failures and observation_count:
+        status = "partial"
+        error_code = "route_sync_partial"
+    elif failures and len(failures) == len(receipts):
+        status = "unavailable"
+        error_code = str(failures[0]["error_code"])
+    elif failures:
+        status = "partial"
+        error_code = "route_sync_partial"
+    elif observation_count:
+        status = "observed"
+        error_code = None
+    else:
+        status = "empty"
+        error_code = None
+    return {
+        "ok": not failures,
+        "schema_version": SYNC_SCHEMA_VERSION,
+        "status": status,
+        "observation_count": observation_count,
+        "agent_read_required": bool(observation_count),
+        "external_reads_performed": any(
+            receipt.get("external_read_performed") is True for receipt in receipts
+        ),
+        "local_private_state_mutated": any(
+            receipt.get("local_private_state_mutated") is True for receipt in receipts
+        ),
+        "error_code": error_code,
+        "private_content_returned": False,
+        "provider_payload_returned": False,
+    }

--- a/tests/control_plane/test_turn_start_capability_hooks.py
+++ b/tests/control_plane/test_turn_start_capability_hooks.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from loopx.control_plane.capability_hooks import (
+    TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+    TurnStartHookRegistration,
+    dispatch_turn_start_hooks,
+)
+
+
+def _result(**overrides: object) -> dict[str, object]:
+    return {
+        "schema_version": TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+        "hook_id": "operator_inbox.turn_start_sync",
+        "capability_id": "operator-inbox",
+        "phase": "turn_start",
+        "status": "observed",
+        "observation_count": 1,
+        "agent_read_required": True,
+        "external_reads_performed": True,
+        "local_private_state_mutated": True,
+        "private_content_returned": False,
+        "provider_payload_returned": False,
+        "error_code": None,
+        **overrides,
+    }
+
+
+def _hook(producer: object) -> TurnStartHookRegistration:
+    return TurnStartHookRegistration(
+        hook_id="operator_inbox.turn_start_sync",
+        capability_id="operator-inbox",
+        requested_read_scope=("provider_history",),
+        requested_write_scope=("owner_private_inbox", "owner_private_cursor"),
+        producer=producer,  # type: ignore[arg-type]
+    )
+
+
+def test_turn_start_hook_returns_only_validated_agent_read_obligation() -> None:
+    dispatch = dispatch_turn_start_hooks([_hook(lambda: _result())])
+
+    assert dispatch["failures"] == []
+    assert dispatch["invoked_count"] == 1
+    assert dispatch["results"][0]["agent_read_required"] is True
+    assert dispatch["results"][0]["observation_count"] == 1
+    assert "content" not in dispatch["results"][0]
+
+
+def test_provider_shape_mismatch_is_not_misclassified_as_empty() -> None:
+    malformed = _result()
+    malformed.pop("agent_read_required")
+
+    dispatch = dispatch_turn_start_hooks([_hook(lambda: malformed)])
+
+    assert dispatch["results"] == []
+    assert dispatch["failures"] == [
+        {
+            "hook_id": "operator_inbox.turn_start_sync",
+            "capability_id": "operator-inbox",
+            "error_code": "contract_rejected",
+        }
+    ]
+
+
+def test_turn_start_hooks_are_single_flight_by_identity() -> None:
+    hook = _hook(lambda: _result())
+
+    dispatch = dispatch_turn_start_hooks([hook, hook])
+
+    assert dispatch["invoked_count"] == 1
+    assert dispatch["failures"][0]["error_code"] == "duplicate_hook_id"

--- a/tests/control_plane_ts/capability_hooks.test.ts
+++ b/tests/control_plane_ts/capability_hooks.test.ts
@@ -4,7 +4,10 @@ import test from "node:test";
 import {
   CAPABILITY_HOOK_REGISTRATION_SCHEMA_VERSION,
   INTERACTION_PROJECTION_HOOK_RESULT_SCHEMA_VERSION,
+  TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION,
+  TURN_START_HOOK_RESULT_SCHEMA_VERSION,
   validateInteractionProjectionHookInvocation,
+  validateTurnStartHookInvocation,
 } from "../../loopx/control_plane/capability_hooks.ts";
 
 function registration(overrides: Record<string, unknown> = {}) {
@@ -138,5 +141,100 @@ test("registration denies effects and candidates cannot escape declared slots", 
       result: candidate(status(true), { projection_slot: "other_slot" }),
     }),
     /not registered/,
+  );
+});
+
+function turnStartRegistration(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION,
+    hook_id: "operator_inbox.turn_start_sync",
+    capability_id: "operator-inbox",
+    phase: "turn_start",
+    budget: {
+      max_invocations_per_dispatch: 1,
+      max_result_bytes: 16 * 1024,
+    },
+    failure_policy: "isolate",
+    requested_read_scope: ["provider_history"],
+    requested_write_scope: ["owner_private_inbox", "owner_private_cursor"],
+    ...overrides,
+  };
+}
+
+function turnStartResult(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+    hook_id: "operator_inbox.turn_start_sync",
+    capability_id: "operator-inbox",
+    phase: "turn_start",
+    status: "observed",
+    observation_count: 2,
+    agent_read_required: true,
+    external_reads_performed: true,
+    local_private_state_mutated: true,
+    private_content_returned: false,
+    provider_payload_returned: false,
+    error_code: null,
+    ...overrides,
+  };
+}
+
+test("turn-start observations require Agent reading without returning private content", () => {
+  const observed = validateTurnStartHookInvocation({
+    registration: turnStartRegistration(),
+    result: turnStartResult(),
+  });
+  assert.equal(observed.status, "observed");
+  assert.equal(observed.agent_read_required, true);
+  assert.equal(observed.observation_count, 2);
+
+  assert.throws(
+    () => validateTurnStartHookInvocation({
+      registration: turnStartRegistration(),
+      result: turnStartResult({ agent_read_required: false }),
+    }),
+    /Agent reading|inconsistent/,
+  );
+  assert.throws(
+    () => validateTurnStartHookInvocation({
+      registration: turnStartRegistration(),
+      result: turnStartResult({ private_content_returned: true }),
+    }),
+    /private provider content/,
+  );
+});
+
+test("turn-start empty, provider failure, and owner-private write scopes stay distinct", () => {
+  const empty = validateTurnStartHookInvocation({
+    registration: turnStartRegistration(),
+    result: turnStartResult({
+      status: "empty",
+      observation_count: 0,
+      agent_read_required: false,
+      local_private_state_mutated: true,
+    }),
+  });
+  assert.equal(empty.status, "empty");
+
+  const failed = validateTurnStartHookInvocation({
+    registration: turnStartRegistration(),
+    result: turnStartResult({
+      status: "failed",
+      observation_count: 0,
+      agent_read_required: false,
+      local_private_state_mutated: false,
+      error_code: "provider_contract_error",
+    }),
+  });
+  assert.equal(failed.error_code, "provider_contract_error");
+
+  assert.throws(
+    () => validateTurnStartHookInvocation({
+      registration: turnStartRegistration({
+        requested_write_scope: ["repository_write"],
+      }),
+      result: turnStartResult(),
+    }),
+    /not owner-private/,
   );
 });

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.work_items.work_lane import (
+    operator_inbox_material_review_due_work_lane_contract,
+)
+from loopx.extensions.lark import turn_start_sync as turn_start_sync_module
+from loopx.extensions.lark.event_collector import load_lark_event_collector_config
+from loopx.extensions.lark.routed_inbox import project_routed_lark_event_inbox_urgency
+from loopx.extensions.lark.turn_start_sync import sync_lark_turn_start_inbox
+
+FIRST_NOW = datetime(2026, 8, 26, 10, 0, tzinfo=UTC)
+SECOND_NOW = datetime(2026, 8, 26, 10, 5, tzinfo=UTC)
+
+
+def _project(tmp_path: Path, *, material_review: bool = True) -> tuple[Path, Path]:
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+    )
+    (project / ".gitignore").write_text(".loopx/\n", encoding="utf-8")
+    config_dir = project / ".loopx" / "config"
+    config_dir.mkdir(parents=True)
+    inbox = config_dir / "inbox.json"
+    inbox.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/requirements",
+                "capture_scope": "configured_chat_all",
+                "material_review": {"enabled": material_review, "drain_limit": 20},
+                "reply": {"enabled": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    collector = config_dir / "collector.json"
+    collector.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_collector_config_v1",
+                "enabled": True,
+                "service_name": "loopx-turn-start-fixture",
+                "supervisor": "systemd",
+                "consume_timeout": "30m",
+                "profile": "fixture-bot",
+                "turn_start_sync": {
+                    "enabled": True,
+                    "initial_lookback_seconds": 900,
+                    "overlap_seconds": 5,
+                    "page_size": 50,
+                },
+                "routes": [
+                    {
+                        "route_key": "requirements",
+                        "chat_id": "oc_fixture",
+                        "event_inbox_config": ".loopx/config/inbox.json",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return project, collector
+
+
+def _agent_collector(
+    project: Path,
+    *,
+    agent_key: str,
+    profile: str,
+    chat_id: str,
+) -> Path:
+    config_dir = project / ".loopx" / "config" / agent_key
+    config_dir.mkdir(parents=True)
+    inbox = config_dir / "inbox.json"
+    inbox.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": f".loopx/inbox/{agent_key}/requirements",
+                "capture_scope": "configured_chat_all",
+                "material_review": {"enabled": True, "drain_limit": 20},
+                "reply": {"enabled": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    collector = config_dir / "collector.json"
+    collector.write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_collector_config_v1",
+                "enabled": True,
+                "service_name": f"loopx-turn-start-{agent_key}",
+                "supervisor": "systemd",
+                "consume_timeout": "30m",
+                "profile": profile,
+                "turn_start_sync": {
+                    "enabled": True,
+                    "initial_lookback_seconds": 900,
+                    "overlap_seconds": 5,
+                    "page_size": 50,
+                },
+                "routes": [
+                    {
+                        "route_key": "requirements",
+                        "chat_id": chat_id,
+                        "event_inbox_config": (f".loopx/config/{agent_key}/inbox.json"),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return collector
+
+
+class PageRunner:
+    def __init__(self, pages: Sequence[dict[str, object]]) -> None:
+        self.pages = list(pages)
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, argv: Sequence[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(argv))
+        page = self.pages.pop(0)
+        return subprocess.CompletedProcess(
+            args=list(argv),
+            returncode=0,
+            stdout=json.dumps({"ok": True, "identity": "bot", "data": page}),
+            stderr="",
+        )
+
+
+def _page(*messages: dict[str, object]) -> dict[str, object]:
+    return {
+        "messages": list(messages),
+        "has_more": False,
+        "page_token": "",
+    }
+
+
+def test_turn_start_sync_captures_then_requires_same_turn_agent_read(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    runner = PageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_new_context",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "Please adjust the current plan.",
+                    "deleted": False,
+                }
+            )
+        ]
+    )
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "observed"
+    assert result["observation_count"] == 1
+    assert result["agent_read_required"] is True
+    assert result["private_content_returned"] is False
+    assert result["provider_payload_returned"] is False
+    captured = json.loads(
+        (project / ".loopx/inbox/requirements/om_new_context.json").read_text()
+    )
+    assert captured["content"] == "Please adjust the current plan."
+    urgency = project_routed_lark_event_inbox_urgency(
+        project=project,
+        config_path=config,
+    )
+    lane = operator_inbox_material_review_due_work_lane_contract(
+        {
+            "capabilities": {
+                "lark_event_inbox": {
+                    "urgency": urgency,
+                    "drain_command": "loopx lark-inbox drain --goal-id fixture",
+                }
+            }
+        },
+        current_contract={"lane": "advancement_task"},
+    )
+    assert lane is not None
+    assert lane["priority_preemption"] is True
+    assert lane["semantic_triage_required"] is True
+    assert "replan_goal" in lane["allowed_dispositions"]
+    assert "before ordinary work" in str(lane["action"])
+
+
+def test_completed_sync_opens_a_new_overlapping_tail_window(tmp_path: Path) -> None:
+    project, config = _project(tmp_path)
+    first = PageRunner([_page()])
+    first_result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=first,
+        now=FIRST_NOW,
+    )
+    assert first_result["status"] == "empty"
+
+    second = PageRunner([_page()])
+    second_result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=second,
+        now=SECOND_NOW,
+    )
+
+    assert second_result["status"] == "empty"
+    argv = second.calls[0]
+    assert argv[argv.index("--start") + 1] == "2026-08-26T09:59:55Z"
+    assert argv[argv.index("--end") + 1] == "2026-08-26T10:05:00Z"
+
+
+def test_same_route_key_isolates_cursor_and_lock_for_two_agent_sources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=project,
+        check=True,
+        capture_output=True,
+    )
+    (project / ".gitignore").write_text(".loopx/\n", encoding="utf-8")
+    first_config = _agent_collector(
+        project,
+        agent_key="agent-alpha",
+        profile="fixture-alpha-bot",
+        chat_id="oc_fixture_alpha",
+    )
+    second_config = _agent_collector(
+        project,
+        agent_key="agent-beta",
+        profile="fixture-beta-bot",
+        chat_id="oc_fixture_beta",
+    )
+    lock_targets: list[Path] = []
+    real_lock = turn_start_sync_module.exclusive_file_lock
+
+    def capture_lock_target(path: Path, **kwargs: object) -> object:
+        lock_targets.append(path)
+        return real_lock(path, **kwargs)
+
+    monkeypatch.setattr(
+        turn_start_sync_module,
+        "exclusive_file_lock",
+        capture_lock_target,
+    )
+
+    for config in (first_config, second_config):
+        result = sync_lark_turn_start_inbox(
+            project=project,
+            config_path=config,
+            runner=PageRunner([_page()]),
+            now=FIRST_NOW,
+        )
+        assert result["status"] == "empty"
+
+    assert len(lock_targets) == 2
+    assert len(set(lock_targets)) == 2
+    cursor_paths = sorted(
+        (project / ".loopx/inbox/.turn-start/requirements").glob("*.json")
+    )
+    assert len(cursor_paths) == 2
+    assert set(cursor_paths) == set(lock_targets)
+
+    for config in (first_config, second_config):
+        runner = PageRunner([_page()])
+        result = sync_lark_turn_start_inbox(
+            project=project,
+            config_path=config,
+            runner=runner,
+            now=SECOND_NOW,
+        )
+        assert result["status"] == "empty"
+        argv = runner.calls[0]
+        assert argv[argv.index("--start") + 1] == "2026-08-26T09:59:55Z"
+
+
+def test_overlapping_duplicate_does_not_require_mutable_content_readback(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    first = PageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_overlap",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "Original provider rendering.",
+                    "deleted": False,
+                }
+            )
+        ]
+    )
+    assert (
+        sync_lark_turn_start_inbox(
+            project=project,
+            config_path=config,
+            runner=first,
+            now=FIRST_NOW,
+        )["status"]
+        == "observed"
+    )
+    second = PageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_overlap",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "Edited provider rendering.",
+                    "deleted": False,
+                }
+            )
+        ]
+    )
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=second,
+        now=SECOND_NOW,
+    )
+
+    assert result["status"] == "empty"
+    assert result["observation_count"] == 0
+    assert result["agent_read_required"] is False
+    captured = json.loads(
+        (project / ".loopx/inbox/requirements/om_overlap.json").read_text()
+    )
+    assert captured["content"] == "Original provider rendering."
+
+
+def test_provider_schema_error_is_distinct_from_a_real_empty_inbox(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    runner = PageRunner([{"items": [], "has_more": False, "page_token": ""}])
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "unavailable"
+    assert result["error_code"] == "provider_contract_error"
+    assert result["agent_read_required"] is False
+    assert not list((project / ".loopx/inbox/.turn-start").rglob("*.json"))
+
+
+def test_inbox_write_still_requires_agent_read_when_cursor_commit_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, config = _project(tmp_path)
+    runner = PageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_cursor_failure",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "Steer the current turn.",
+                    "deleted": False,
+                }
+            )
+        ]
+    )
+
+    def fail_cursor_write(*_args: object, **_kwargs: object) -> None:
+        raise OSError("fixture cursor write failure")
+
+    monkeypatch.setattr(turn_start_sync_module, "_write_cursor", fail_cursor_write)
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "partial"
+    assert result["observation_count"] == 1
+    assert result["agent_read_required"] is True
+    assert result["local_private_state_mutated"] is True
+    assert result["error_code"] == "route_sync_partial"
+    assert (project / ".loopx/inbox/requirements/om_cursor_failure.json").is_file()
+
+
+def test_turn_start_sync_requires_an_agent_material_triage_lane(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, material_review=False)
+
+    with pytest.raises(ValueError, match="Agent triage lane"):
+        load_lark_event_collector_config(project=project, config_path=config)

--- a/tests/extensions/test_lark_urgency_composition.py
+++ b/tests/extensions/test_lark_urgency_composition.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from loopx.cli_commands import lark_inbox
 from loopx.configure_goal import configure_goal
+from loopx.control_plane.operator_inbox_binding import local_private_config_digest
 from loopx.control_plane.quota.goal_boundary import goal_boundary
 from loopx.extensions.lark.routed_inbox import (
     project_routed_lark_event_inbox_urgency,
@@ -262,3 +263,86 @@ def test_agent_scoped_binding_accepts_one_multi_chat_collector_authority(
     serialized = json.dumps(capability)
     assert "oc_public_fixture_alpha" not in serialized
     assert "oc_public_fixture_beta" not in serialized
+
+
+def test_agent_scoped_binding_rebind_writes_when_public_counts_are_unchanged(
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir()
+    inbox_relative = ".loopx/config/lark/inbox.json"
+    collector_relative = ".loopx/config/lark/collector.json"
+    config_dir = tmp_path / ".loopx" / "config" / "lark"
+    config_dir.mkdir(parents=True)
+    (tmp_path / inbox_relative).write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_config_v0",
+                "enabled": True,
+                "inbox_dir": ".loopx/inbox/requirements",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / collector_relative).write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_collector_config_v1",
+                "enabled": True,
+                "service_name": "loopx-rebind-fixture",
+                "profile": "fixture-bot",
+                "supervisor": "systemd",
+                "routes": [
+                    {
+                        "route_key": "requirements",
+                        "chat_id": "oc_public_fixture",
+                        "event_inbox_config": inbox_relative,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    initial_digest = local_private_config_digest(
+        project=tmp_path,
+        config_path=inbox_relative,
+    )
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "goal-rebind",
+                        "repo": str(tmp_path),
+                        "coordination": {"registered_agents": ["agent-context"]},
+                        "control_plane": {
+                            "lark_event_inboxes": {
+                                "agent-context": {
+                                    "enabled": True,
+                                    "config_path": inbox_relative,
+                                    "config_digest": initial_digest,
+                                }
+                            }
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rebound = configure_goal(
+        registry_path=registry_path,
+        goal_id="goal-rebind",
+        lark_event_inbox_config=collector_relative,
+        lark_event_inbox_agent_id="agent-context",
+        execute=True,
+    )
+
+    assert rebound["written"] is True
+    assert rebound["changed_fields"] == ["control_plane"]
+    binding = json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0][
+        "control_plane"
+    ]["lark_event_inboxes"]["agent-context"]
+    assert binding["config_path"] == collector_relative
+    assert binding["config_digest"] != initial_digest

--- a/tests/extensions/test_operator_inbox_material_review.py
+++ b/tests/extensions/test_operator_inbox_material_review.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import json
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FutureTimeout
 from pathlib import Path
 from threading import Event
 
@@ -118,6 +119,15 @@ def test_material_review_projection_is_separate_from_reply_due(tmp_path: Path) -
     assert work_lane_contract_is_operator_inbox_material_review_due(material)
     assert material["drain_limit"] == 3
     assert str(material["drain_command"]).endswith("--limit 3")
+    assert material["semantic_triage_required"] is True
+    assert material["allowed_dispositions"] == [
+        "steer_current_turn",
+        "replan_goal",
+        "record_context",
+        "continue_current_work",
+        "no_follow_up",
+    ]
+    assert "before ordinary work" in str(material["action"])
 
     reply = lark_inbox_reply_due_work_lane_contract(
         _boundary(urgency),
@@ -125,6 +135,14 @@ def test_material_review_projection_is_separate_from_reply_due(tmp_path: Path) -
     )
     assert work_lane_contract_is_lark_inbox_reply_due(reply)
     assert reply["next_lane"] == "operator_inbox_material_review"
+    assert reply["semantic_triage_required"] is True
+    assert reply["allowed_dispositions"] == [
+        "steer_current_turn",
+        "replan_goal",
+        "record_context",
+        "continue_current_work",
+    ]
+    assert "before ordinary work" in str(reply["action"])
 
 
 def test_material_review_no_follow_up_settlement_is_idempotent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a provider-neutral `turn_start` capability-hook phase that runs before status/quota projection and returns only bounded, content-free receipts
- add an opt-in Lark history-tail provider with owner-private cursors, overlap-safe deduplication, provider-contract fail-closed handling, and an explicit `agent_read_required` obligation
- route observed messages into semantic triage before ordinary Goal work, with typed steering/replan/context/continue/no-follow-up dispositions
- isolate turn-start cursor and single-flight lock identity by route plus a public-safe source/config digest, so Agent-scoped collectors may reuse semantic route keys safely
- validate quota requests before any provider read, and keep the Quota command composition below the maintainability ratchet

## Review-finding resolution

- P1: fixed on exact head `4c85d92f470501b7ff6d2d2895447d42cc4eeb8b`; the regression covers two Agent-scoped collectors with different profiles/chats/inboxes and the same `requirements` route key, proves distinct cursor and lock targets, and proves independent tail advancement on the next turn
- P2: the single PR commit now contains `Signed-off-by: huangruiteng <huangrt01@163.com>`
- the branch was rebased onto the latest `origin/main` before the exact-head validation below

## Validation

- 195 focused Python tests passed across Lark routing/history, quota validation/decision, hook dispatch, inbox urgency, and material-review surfaces
- all 190 TypeScript control-plane tests passed; control-plane typecheck passed
- repository-constrained mypy and CI Ruff surfaces passed
- `loopx canary premerge --from-git-diff` standard tier passed: 18/18 selected checks, zero failures, zero warnings, zero manual holds, and `self_merge_allowed=true`
- public-boundary scan passed over all 19 changed files; diff/compile checks passed
- required GitHub `pytest` and `windows-powershell` checks must pass on this exact head before merge

## Boundary

Raw provider content, profile names, destinations, credentials, and private cursors remain outside hook receipts, Goal state, and public fixtures. The Agent reads private message content only through the existing goal-bound inbox drain command.
