### PR TITLE
fix(goal): preserve turn through capability re-entry

### DIFF
--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -750,6 +750,7 @@ def interaction_next_cli_actions(
             payload,
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
+            turn_instance_id=turn_instance_id,
         )
     capability_reentry_actions = (
         [str(candidate["command"]) for candidate in capability_reentry["candidates"]]
@@ -1243,6 +1244,7 @@ def _build_interaction_cli_channel(
             payload,
             available_capabilities=available_capabilities,
             scheduler_execution_context=scheduler_execution_context,
+            turn_instance_id=turn_instance_id,
         )
     settlement_plan, replan_settlement_contract = (
         _turn_scoped_cli_settlement_context(
@@ -1448,6 +1450,7 @@ def build_interaction_contract(
         payload,
         available_capabilities=available_capabilities,
         scheduler_execution_context=scheduler_execution_context,
+        turn_instance_id=turn_instance_id,
     )
 
     user_channel = _build_interaction_user_channel(

--- a/loopx/control_plane/work_items/runtime_capability_reentry.py
+++ b/loopx/control_plane/work_items/runtime_capability_reentry.py
@@ -64,6 +64,7 @@ def build_runtime_capability_reentry_packet(
     scheduler_execution_context: (
         Mapping[str, Any] | SchedulerExecutionContextResolution | None
     ),
+    turn_instance_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Project verified runtime-capability re-entry without persisting a grant."""
 
@@ -119,6 +120,8 @@ def build_runtime_capability_reentry_packet(
     ]
     if agent_id:
         base_args.extend(["--agent-id", agent_id])
+    if turn_instance_id:
+        base_args.extend(["--turn-instance-id", turn_instance_id])
     for capability in observed:
         base_args.extend(["--available-capability", capability])
 

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -217,23 +217,38 @@ def _configure_repository_write_todo(project: Path) -> Path:
     return state_path
 
 
-def _configure_selectable_alternative(project: Path) -> None:
+def _configure_selectable_alternative(
+    project: Path,
+    *,
+    required_capability: str | None = None,
+) -> None:
     state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
     state_text = state_path.read_text(encoding="utf-8")
+    capability_metadata = (
+        f" required_capabilities={required_capability}"
+        if required_capability
+        else ""
+    )
     state_path.write_text(
         state_text.rstrip()
         + "\n- [ ] [P1] Advance the independent alternative delivery.\n"
         + "  <!-- loopx:todo "
         + f"todo_id={ALTERNATIVE_TODO_ID} status=open "
-        + "task_class=advancement_task action_kind=implement -->\n"
+        + "task_class=advancement_task action_kind=implement"
+        + capability_metadata
+        + " -->\n"
         + "- [ ] [P1] Advance the second independent alternative.\n"
         + "  <!-- loopx:todo "
         + f"todo_id={SECOND_ALTERNATIVE_TODO_ID} status=open "
-        + "task_class=advancement_task action_kind=implement -->\n"
+        + "task_class=advancement_task action_kind=implement"
+        + capability_metadata
+        + " -->\n"
         + "- [ ] [P1] Advance the fourth eligible action.\n"
         + "  <!-- loopx:todo "
         + f"todo_id={OUTSIDE_BOUNDED_PORTFOLIO_TODO_ID} status=open "
-        + "task_class=advancement_task action_kind=implement -->\n",
+        + "task_class=advancement_task action_kind=implement"
+        + capability_metadata
+        + " -->\n",
         encoding="utf-8",
     )
 
@@ -1388,6 +1403,67 @@ def test_visible_goal_continuation_begins_turn_and_executes_returned_selection(
     assert any(
         "--source visible-goal" in action for action in cli_channel["next_cli_actions"]
     )
+    assert _heartbeat_receipt_count(runtime, turn_instance_id) == 2
+
+
+def test_visible_goal_capability_reentry_preserves_turn_through_selection(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(
+        tmp_path,
+        required_capability="network",
+    )
+    _configure_runtime_capability_reentry_fixture(project)
+    _configure_selectable_alternative(project, required_capability="network")
+    prompt = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        runtime_profile="codex_app_ssh_goal",
+        thin=True,
+    )
+    guard_command = prompt["quota_guard_command"].replace(
+        "$HOME/.codex/loopx/registry.global.json",
+        str(registry_path),
+    )
+
+    first_rc, first = _run_generated_cli(
+        guard_command,
+        registry_path=registry_path,
+    )
+
+    assert first_rc == 0, first
+    turn_instance_id = first["heartbeat_receipt"]["turn_instance_id"]
+    reentry_command = first["runtime_capability_reentry"]["candidates"][0][
+        "command"
+    ]
+    assert f"--turn-instance-id {turn_instance_id}" in reentry_command
+
+    reentry_rc, reentry = _run_generated_cli(
+        reentry_command,
+        registry_path=registry_path,
+    )
+
+    assert reentry_rc == 0, reentry
+    cli_channel = reentry["interaction_contract"]["cli_channel"]
+    assert cli_channel["selection_required"] is True
+    selection = cli_channel["selection_command"]
+    assert f"--turn-instance-id {turn_instance_id}" in selection[
+        "command_args_template"
+    ]
+    selection_command = f"{selection['route_prefix']} " + selection[
+        "command_args_template"
+    ].replace("{todo_id}", REENTRY_TODO_ID)
+
+    selected_rc, selected = _run_generated_cli(
+        selection_command,
+        registry_path=registry_path,
+    )
+
+    assert selected_rc == 0, selected
+    assert selected["selected_todo"]["todo_id"] == REENTRY_TODO_ID
+    receipt_identity = selected["heartbeat_receipt"]["settlement_identity"]
+    assert receipt_identity["turn_instance_id"] == turn_instance_id
+    assert receipt_identity["todo_id"] == REENTRY_TODO_ID
     assert _heartbeat_receipt_count(runtime, turn_instance_id) == 2
 
 

--- a/tests/control_plane/test_runtime_capability_reentry.py
+++ b/tests/control_plane/test_runtime_capability_reentry.py
@@ -144,6 +144,28 @@ def test_runtime_capability_gap_returns_verified_reentry_packet() -> None:
     )
 
 
+def test_runtime_capability_reentry_preserves_visible_goal_turn() -> None:
+    turn_instance_id = "guided-start:fixture-turn"
+    contract = build_interaction_contract(
+        _blocked_payload(missing=["network"]),
+        available_capabilities=["shell"],
+        scheduler_execution_context=MANAGED_AGENT_CONTEXT,
+        turn_instance_id=turn_instance_id,
+    )
+
+    candidate = contract["cli_channel"]["runtime_capability_reentry"][
+        "candidates"
+    ][0]
+    assert candidate["command"] == (
+        "loopx --format json quota should-run --goal-id "
+        f"{GOAL_ID} --agent-id {AGENT_ID} "
+        f"--turn-instance-id {turn_instance_id} "
+        "--available-capability shell --available-capability network "
+        "--runtime-profile ark_managed_agent_goal"
+    )
+    assert contract["cli_channel"]["next_cli_actions"] == [candidate["command"]]
+
+
 def test_runtime_capability_reentry_does_not_switch_from_selected_todo() -> None:
     payload = {
         **_blocked_payload(missing=["network"]),


### PR DESCRIPTION
## Summary

- preserve the CLI-owned visible Goal Turn in generated runtime-capability re-entry commands
- carry the same Turn through any explicit Todo selection and subsequent settlement
- add unit and CLI regressions for the full begin-turn → capability re-entry → Todo selection path

Fixes #3680.

## Validation

- `python -m pytest -q tests/control_plane/test_runtime_capability_reentry.py tests/control_plane/test_quota_action_portfolio.py tests/control_plane/test_selected_todo_tool_behavior.py` (30 passed)
- `python -m pytest -q tests/control_plane/test_quota_settlement_cli.py` (35 passed)
- `loopx canary premerge --from-git-diff` (17 selected checks passed, no manual holds)
- changed-file compile and `git diff --check` passed

A direct local mypy invocation was not counted because the host has mypy 2.3.0 and hit its internal error; the repository pins mypy below 2.