### PR TITLE
test(cli): isolate command module contract state

### DIFF
--- a/regression/cli-command-module-contract.py
+++ b/regression/cli-command-module-contract.py
@@ -9,6 +9,7 @@ while command registration/handling moves behind a small module contract.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -17,7 +18,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_cli(*args: str) -> dict[str, object]:
+def run_cli(*args: str, env: dict[str, str] | None = None) -> dict[str, object]:
     result = subprocess.run(
         [
             sys.executable,
@@ -30,6 +31,7 @@ def run_cli(*args: str) -> dict[str, object]:
         cwd=REPO_ROOT,
         check=True,
         capture_output=True,
+        env=env,
         text=True,
     )
     payload = json.loads(result.stdout)
@@ -65,80 +67,106 @@ def main() -> int:
     assert callable(handle_review_packet_command)
     assert callable(handle_status_command)
 
-    doctor = run_cli("doctor")
-    assert doctor.get("ok") is True, doctor
-    assert "checks" in doctor, doctor
-
-    prompt = run_cli(
-        "new-project-prompt",
-        "--project",
-        "/tmp/loopx-command-module-fixture",
-        "--goal-doc",
-        "GOAL.md",
-        "--goal-id",
-        "command-module-fixture",
-    )
-    assert prompt.get("ok") is True, prompt
-    assert prompt.get("goal_id") == "command-module-fixture", prompt
-    assert "prompt" in prompt, prompt
-
     with tempfile.TemporaryDirectory(prefix="loopx-cli-command-module-") as raw_tmp:
         root = Path(raw_tmp)
-        demo = run_cli(
-            "--runtime-root",
-            str(root / "runtime"),
+        home = root / "home"
+        home.mkdir()
+        runtime_root = root / "runtime"
+        environment = os.environ.copy()
+        # This contract exercises command wiring, not the caller's installed state.
+        environment.update(
+            HOME=str(home),
+            LOOPX_RUNTIME_ROOT=str(runtime_root),
+            USERPROFILE=str(home),
+        )
+
+        def isolated_cli(*args: str) -> dict[str, object]:
+            return run_cli(
+                "--runtime-root",
+                str(runtime_root),
+                *args,
+                env=environment,
+            )
+
+        doctor = isolated_cli("doctor")
+        assert doctor.get("ok") is True, doctor
+        assert "checks" in doctor, doctor
+
+        prompt = isolated_cli(
+            "new-project-prompt",
+            "--project",
+            str(root / "prompt-project"),
+            "--goal-doc",
+            "GOAL.md",
+            "--goal-id",
+            "command-module-fixture",
+        )
+        assert prompt.get("ok") is True, prompt
+        assert prompt.get("goal_id") == "command-module-fixture", prompt
+        assert "prompt" in prompt, prompt
+
+        demo = isolated_cli(
             "demo",
             "--project",
             str(root / "project"),
             "--goal-id",
             "command-module-demo",
         )
-    assert demo.get("ok") is True, demo
-    assert demo.get("goal_id") == "command-module-demo", demo
-    assert "quota" in demo, demo
+        assert demo.get("ok") is True, demo
+        assert demo.get("goal_id") == "command-module-demo", demo
+        assert "quota" in demo, demo
 
-    check = run_cli("check", "--scan-root", "README.md", "--limit", "1")
-    assert check.get("ok") is True, check
-    assert "summary" in check, check
+        check = isolated_cli("check", "--scan-root", "README.md", "--limit", "1")
+        assert check.get("ok") is True, check
+        assert "summary" in check, check
 
-    status = run_cli("status", "--limit", "1")
-    assert status.get("ok") is True, status
-    assert "attention_queue" in status, status
+        status = isolated_cli("status", "--limit", "1")
+        assert status.get("ok") is True, status
+        assert "attention_queue" in status, status
 
-    review = run_cli("review-packet", "--goal-id", "loopx-meta", "--limit", "1")
-    assert review.get("ok") is True, review
-    assert review.get("goal_id") == "loopx-meta", review
+        review = isolated_cli(
+            "review-packet",
+            "--goal-id",
+            "command-module-demo",
+            "--limit",
+            "1",
+        )
+        assert review.get("ok") is True, review
+        assert review.get("goal_id") == "command-module-demo", review
 
-    ml_preview = run_cli(
-        "ml-experiment",
-        "preview",
-        "--experiment-id",
-        "command-module-exp",
-        "--primary-metric",
-        "offline_auc",
-        "--baseline-value",
-        "0.42",
-        "--candidate-value",
-        "0.43",
-        "--train-window",
-        "train_2026w24",
-        "--eval-window",
-        "eval_2026w25",
-        "--hypothesis-id",
-        "h_command_module",
-        "--mechanism-family",
-        "routing",
-        "--route",
-        "route_a",
-        "--positive-evidence",
-        "compact_eval_delta",
-        "--next-candidate",
-        "holdout_eval",
-    )
-    assert ml_preview.get("ok") is True, ml_preview
-    assert ml_preview.get("mode") == "default_off_advisory_preview", ml_preview
-    assert ml_preview.get("result", {}).get("experiment_id") == "command-module-exp", ml_preview
-    assert ml_preview.get("pack", {}).get("pack") == "ml_experiment", ml_preview
+        ml_preview = isolated_cli(
+            "ml-experiment",
+            "preview",
+            "--experiment-id",
+            "command-module-exp",
+            "--primary-metric",
+            "offline_auc",
+            "--baseline-value",
+            "0.42",
+            "--candidate-value",
+            "0.43",
+            "--train-window",
+            "train_2026w24",
+            "--eval-window",
+            "eval_2026w25",
+            "--hypothesis-id",
+            "h_command_module",
+            "--mechanism-family",
+            "routing",
+            "--route",
+            "route_a",
+            "--positive-evidence",
+            "compact_eval_delta",
+            "--next-candidate",
+            "holdout_eval",
+        )
+        assert ml_preview.get("ok") is True, ml_preview
+        assert ml_preview.get("mode") == "default_off_advisory_preview", ml_preview
+        assert (
+            ml_preview.get("result", {}).get("experiment_id")
+            == "command-module-exp"
+        ), ml_preview
+        assert ml_preview.get("pack", {}).get("pack") == "ml_experiment", ml_preview
 
     print("cli-command-module-contract-regression ok")
     return 0

--- a/regression/cli-command-module-contract.py
+++ b/regression/cli-command-module-contract.py
@@ -71,17 +71,24 @@ def main() -> int:
         root = Path(raw_tmp)
         home = root / "home"
         home.mkdir()
+        project = root / "project"
+        registry = project / ".loopx" / "registry.json"
         runtime_root = root / "runtime"
+        caller_registry = root / "caller-registry"
+        caller_registry.mkdir()
         environment = os.environ.copy()
         # This contract exercises command wiring, not the caller's installed state.
         environment.update(
             HOME=str(home),
+            LOOPX_REGISTRY=str(caller_registry),
             LOOPX_RUNTIME_ROOT=str(runtime_root),
             USERPROFILE=str(home),
         )
 
         def isolated_cli(*args: str) -> dict[str, object]:
             return run_cli(
+                "--registry",
+                str(registry),
                 "--runtime-root",
                 str(runtime_root),
                 *args,
@@ -108,7 +115,7 @@ def main() -> int:
         demo = isolated_cli(
             "demo",
             "--project",
-            str(root / "project"),
+            str(project),
             "--goal-id",
             "command-module-demo",
         )


### PR DESCRIPTION
## Summary

- run the command-module regression under a temporary `HOME`, `USERPROFILE`, and LoopX runtime root
- pass one explicit `--runtime-root` through every exercised CLI command
- keep review-packet validation bound to the demo goal created inside the isolated scenario

## Why

The regression previously read the caller global LoopX runtime and state. An unwritable or unrelated `HOME` could fail before the smoke reached the command-registration contract it is meant to validate.

## Validation

- `HOME=/dev/null LOOPX_RUNTIME_ROOT=/dev/null python3 regression/cli-command-module-contract.py`
- `python3 regression/cli-command-module-contract.py`
- `python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py`
- `python3 -m py_compile regression/cli-command-module-contract.py`
- `loopx check --scan-path regression/cli-command-module-contract.py`
- `loopx canary premerge --from-git-diff`
- `git diff --check origin/main...HEAD`

All checks passed. The two contract runs require the local TypeScript Effect runtime loopback; an initial sandbox-only `EPERM` was re-run successfully with loopback permission. Premerge reported zero failures, warnings, or manual holds.

## Scope and boundary

This changes one durable regression smoke and no product runtime behavior. Credential, private-state, local-path, raw-log, and external-link scans were clean. An all-state semantic PR search found no existing change that isolates this contract from caller HOME or LoopX state.

The focused coverage is sufficient because the changed surface is only the regression harness, while the harness still executes the same command modules end to end under isolated state.