### PR TITLE
fix(smoke): align checks with demo relocation

### DIFF
--- a/examples/capability-extension-registry-smoke.py
+++ b/examples/capability-extension-registry-smoke.py
@@ -76,7 +76,6 @@ next_real_step = "Keep explicit enablement bounded."
         "content-ops",
         "value-connectors",
         "explore",
-        "auto-research",
         "deep-research",
         "public-safe-outbound",
         "connector-registry",

--- a/examples/cli-multi-agent-command-modularization-smoke.py
+++ b/examples/cli-multi-agent-command-modularization-smoke.py
@@ -8,8 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "loopx" / "cli.py"
-MODULE = ROOT / "loopx" / "cli_commands" / "multi_agent.py"
-INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+MODULE = ROOT / "demo" / "multi_agent_cli.py"
 
 
 def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
@@ -39,16 +38,17 @@ def require_success(result: subprocess.CompletedProcess[str]) -> str:
 def main() -> None:
     cli_source = CLI.read_text(encoding="utf-8")
     module_source = MODULE.read_text(encoding="utf-8")
-    init_source = INIT.read_text(encoding="utf-8")
 
     require("multi_agent.py" not in cli_source, "cli.py should not embed multi-agent module details")
     require(
-        "register_multi_agent_commands(sub, add_subcommand_format)" in cli_source,
-        "cli.py did not register multi-agent commands",
+        '("multi-agent", "demo.multi_agent_cli", "register_multi_agent_commands")'
+        in cli_source,
+        "cli.py did not register the source-checkout multi-agent demo",
     )
-    require("handle_multi_agent_command(" in cli_source, "cli.py did not dispatch multi-agent commands")
-    require("register_multi_agent_commands" in init_source, "__init__ omitted multi-agent registration")
-    require("handle_multi_agent_command" in init_source, "__init__ omitted multi-agent handler")
+    require(
+        "from demo.multi_agent_cli import handle_multi_agent_command" in cli_source,
+        "cli.py did not dispatch the source-checkout multi-agent demo",
+    )
 
     for marker in (
         "register_multi_agent_commands",


### PR DESCRIPTION
## Summary

- remove the stale `auto-research` built-in capability expectation after that showcase moved to `demo/`
- update the multi-agent modularization smoke to verify the source-checkout demo registration and dispatch boundary
- keep both existing durable smoke files instead of adding duplicate fixtures or compatibility wrappers

## Validation

- Python 3.11 focused smokes: 2/2 passed
- Full Public Smokes runner selections for the changed files: 2/2 passed with no failures, timeouts, git skips, or tracked side effects
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed; 10/10 selected checks plus 4 direct checks, no failures, warnings, skips, or manual holds
- public/private boundary scan: clean for both changed files
- change-quality receipt: `cqr_970cf522690585a9d8df` (exact committed scope verified)

## Scope and risk

This is a two-file assertion repair for the current demo relocation. It does not change runtime behavior, permissions, packaging, or public evidence policy. No private state, credentials, local paths, raw logs, or generated artifacts are included.

The bounded future-facing pass considered replacing these source-boundary assertions with a new helper; the existing checks are already small and own distinct durable contracts, so no adjacent refactor is warranted.
