### PR TITLE
refactor(control-plane): project Turn settlement outcomes from TypeScript

### DIFF
--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -34,6 +34,7 @@ from .settlement import (
     execute_turn_driver_settlement,
     invoke_result_effect,
     terminal_closeout_requirement,
+    turn_settlement_outcome,
     turn_effect_resolvers,
     verified_terminal_closeout_effect,
 )
@@ -1245,6 +1246,7 @@ def _typed_settlement_stage(
         abort=journal_adapter.abort,
         effect_attempts=journal_adapter.effect_attempts,
         effect_resolvers=effect_resolvers,
+        turn_result_kind=str(result.get("result_kind") or "") or None,
     )
 
     journal["settlement_result"] = settlement_result_payload(settlement_result)
@@ -1287,7 +1289,11 @@ def _typed_settlement_stage(
         raise ValueError(
             "typed Turn settlement completed without a quota spend receipt"
         )
-    completed_phases = list(settlement_state.completed_phases)
+    outcome = turn_settlement_outcome(settlement_result)
+    if outcome is None:
+        raise RuntimeError("TypeScript Turn settlement omitted its canonical outcome")
+    result = {**result, "result_kind": outcome["result_kind"]}
+    completed_phases = [str(phase) for phase in outcome["completed_phases"]]
     spend_payload = dict(settlement_state.quota_spend)
     _write_journal(journal_path, journal)
 

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -34,6 +34,7 @@ from .settlement import (
     execute_turn_driver_settlement,
     invoke_result_effect,
     terminal_closeout_requirement,
+    turn_settlement_failure_outcome,
     turn_settlement_outcome,
     turn_effect_resolvers,
     verified_terminal_closeout_effect,
@@ -1251,21 +1252,9 @@ def _typed_settlement_stage(
 
     journal["settlement_result"] = settlement_result_payload(settlement_result)
     if settlement_result.failure is not None:
-        outcome = turn_settlement_outcome(settlement_result)
-        if outcome is None:
-            raise RuntimeError(
-                "TypeScript Turn settlement omitted its canonical failure outcome"
-            )
-        failed_phase = str(outcome.get("failed_phase") or "")
-        if not failed_phase:
-            raise RuntimeError("TypeScript Turn settlement failure omitted failed_phase")
-        try:
-            result_kind = LoopXTurnResultKind(str(outcome["result_kind"]))
-        except ValueError as exc:
-            raise RuntimeError(
-                "TypeScript Turn settlement failure has unsupported result_kind"
-            ) from exc
-        completed_phases = [str(phase) for phase in outcome["completed_phases"]]
+        result_kind, completed_phases, failed_phase = turn_settlement_failure_outcome(
+            settlement_result
+        )
         failure = _host_failure(
             plan,
             kind=result_kind,

--- a/loopx/control_plane/turn_driver/executor.py
+++ b/loopx/control_plane/turn_driver/executor.py
@@ -1251,22 +1251,26 @@ def _typed_settlement_stage(
 
     journal["settlement_result"] = settlement_result_payload(settlement_result)
     if settlement_result.failure is not None:
-        failure_step = settlement_result.failure.step_kind
-        result_kind = (
-            LoopXTurnResultKind.VALIDATION_FAILED
-            if failure_step is SettlementStepKind.VALIDATION
-            else LoopXTurnResultKind.WRITEBACK_FAILED
-            if failure_step is SettlementStepKind.DURABLE_WRITEBACK
-            else LoopXTurnResultKind.QUOTA_SPEND_FAILED
-            if failure_step is SettlementStepKind.QUOTA_SPEND
-            else LoopXTurnResultKind.TERMINAL_CLOSEOUT_FAILED
-        )
-        completed_phases = list(journal.get("completed_phases") or completed_phases)
+        outcome = turn_settlement_outcome(settlement_result)
+        if outcome is None:
+            raise RuntimeError(
+                "TypeScript Turn settlement omitted its canonical failure outcome"
+            )
+        failed_phase = str(outcome.get("failed_phase") or "")
+        if not failed_phase:
+            raise RuntimeError("TypeScript Turn settlement failure omitted failed_phase")
+        try:
+            result_kind = LoopXTurnResultKind(str(outcome["result_kind"]))
+        except ValueError as exc:
+            raise RuntimeError(
+                "TypeScript Turn settlement failure has unsupported result_kind"
+            ) from exc
+        completed_phases = [str(phase) for phase in outcome["completed_phases"]]
         failure = _host_failure(
             plan,
             kind=result_kind,
             completed_phases=completed_phases,
-            failed_phase=failure_step.value,
+            failed_phase=failed_phase,
             reason=settlement_result.failure.reason,
         )
         journal.update(

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..effect_program import (
     SettlementResult,
     SettlementStepKind,
+    settlement_result_payload,
 )
 from ..effect_runtime import effect_runtime_result
 from ..settlement_driver import decode_settlement_result
@@ -350,6 +351,7 @@ def execute_turn_driver_settlement(
     abort: TurnSettlementAbort | None = None,
     effect_attempts: Mapping[str, Mapping[str, Any]] | None = None,
     effect_resolvers: Mapping[SettlementStepKind, TurnEffectResolver] | None = None,
+    turn_result_kind: str | None = None,
 ) -> SettlementResult[TurnSettlementState]:
     """Run external effect providers and reduce one complete Turn settlement.
 
@@ -412,6 +414,7 @@ def execute_turn_driver_settlement(
                 ),
                 "effect_attempts": attempts,
                 "provider_observations": observations,
+                "turn_result_kind": turn_result_kind,
             },
         )
         if (
@@ -525,3 +528,25 @@ def execute_turn_driver_settlement(
         value_decoder=decode_state,
         projection_payload=(projection if isinstance(projection, Mapping) else None),
     )
+
+
+def turn_settlement_outcome(
+    result: SettlementResult[TurnSettlementState],
+) -> Mapping[str, Any] | None:
+    """Read the optional canonical Turn projection from the TS reduction."""
+
+    projection = settlement_result_payload(result)
+    if not isinstance(projection, Mapping):
+        return None
+    outcome = projection.get("turn_outcome")
+    if not isinstance(outcome, Mapping):
+        return None
+    phases = outcome.get("completed_phases")
+    if (
+        outcome.get("schema_version") != "loopx_turn_settlement_outcome_v0"
+        or not isinstance(outcome.get("result_kind"), str)
+        or not isinstance(phases, list)
+        or outcome.get("failed_phase") is not None
+    ):
+        raise RuntimeError("TypeScript Turn settlement outcome shape mismatch")
+    return dict(outcome)

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -551,3 +551,25 @@ def turn_settlement_outcome(
     ):
         raise RuntimeError("TypeScript Turn settlement outcome shape mismatch")
     return dict(outcome)
+
+
+def turn_settlement_failure_outcome(
+    result: SettlementResult[TurnSettlementState],
+) -> tuple[LoopXTurnResultKind, tuple[str, ...], str]:
+    """Decode a required TypeScript failure outcome for legacy projection."""
+
+    outcome = turn_settlement_outcome(result)
+    if outcome is None:
+        raise RuntimeError(
+            "TypeScript Turn settlement omitted its canonical failure outcome"
+        )
+    failed_phase = str(outcome.get("failed_phase") or "")
+    if not failed_phase:
+        raise RuntimeError("TypeScript Turn settlement failure omitted failed_phase")
+    try:
+        result_kind = LoopXTurnResultKind(str(outcome["result_kind"]))
+    except ValueError as exc:
+        raise RuntimeError(
+            "TypeScript Turn settlement failure has unsupported result_kind"
+        ) from exc
+    return result_kind, tuple(str(phase) for phase in outcome["completed_phases"]), failed_phase

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -536,8 +536,6 @@ def turn_settlement_outcome(
     """Read the optional canonical Turn projection from the TS reduction."""
 
     projection = settlement_result_payload(result)
-    if not isinstance(projection, Mapping):
-        return None
     outcome = projection.get("turn_outcome")
     if not isinstance(outcome, Mapping):
         return None

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -542,11 +542,12 @@ def turn_settlement_outcome(
     if not isinstance(outcome, Mapping):
         return None
     phases = outcome.get("completed_phases")
+    failed_phase = outcome.get("failed_phase")
     if (
         outcome.get("schema_version") != "loopx_turn_settlement_outcome_v0"
         or not isinstance(outcome.get("result_kind"), str)
         or not isinstance(phases, list)
-        or outcome.get("failed_phase") is not None
+        or (failed_phase is not None and not isinstance(failed_phase, str))
     ):
         raise RuntimeError("TypeScript Turn settlement outcome shape mismatch")
     return dict(outcome)

--- a/loopx/control_plane/turn_driver/settlement.py
+++ b/loopx/control_plane/turn_driver/settlement.py
@@ -426,7 +426,7 @@ def execute_turn_driver_settlement(
 
     reduction = reduce()
     decision = str(reduction.get("decision") or "")
-    if decision == "execute":
+    while decision == "execute":
         provider_effects = reduction.get("provider_effects")
         if not isinstance(provider_effects, list) or not provider_effects:
             raise RuntimeError("TypeScript Turn settlement provider plan is empty")

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -321,6 +321,16 @@ function completionOutcomeError(
   ) {
     return "completion has an invalid continuation outcome";
   }
+  if (
+    outcome.continuation === "successor" &&
+    (!Array.isArray(outcome.successor_todo_ids) ||
+      outcome.successor_todo_ids.length === 0 ||
+      !outcome.successor_todo_ids.every(
+        (todoId) => typeof todoId === "string" && todoId.length > 0,
+      ))
+  ) {
+    return "successor completion requires successor Todo ids";
+  }
   return null;
 }
 

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -722,6 +722,20 @@ function reduceTurnSettlementRequest(
 
   let receipts = [...base.result.receipts];
   if (
+    request.terminal_closeout_required &&
+    request.turn_result_kind !== null &&
+    request.turn_result_kind !== "validated_completion"
+  ) {
+    return reduction(
+      settlementFailed({
+        kind: "terminal_closeout_rejected",
+        step_kind: "terminal_closeout",
+        reason: "terminal closeout requires a validated completion result",
+        receipts,
+      }),
+    );
+  }
+  if (
     request.turn_result_kind === "validated_completion" &&
     !request.terminal_closeout_required
   ) {

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -27,6 +27,8 @@ export const TURN_SETTLEMENT_TRANSACTION_SCHEMA_VERSION =
   "loopx_turn_settlement_transaction_v0";
 export const TURN_SETTLEMENT_REDUCTION_SCHEMA_VERSION =
   "loopx_turn_settlement_reduction_v0";
+export const TURN_SETTLEMENT_OUTCOME_SCHEMA_VERSION =
+  "loopx_turn_settlement_outcome_v0";
 
 const BASE_SETTLEMENT_STEPS = [
   "validation",
@@ -94,6 +96,7 @@ interface TurnSettlementRequest {
   failed_provider_attempt: FailedProviderAttempt | null;
   effect_attempts: Partial<Record<ProviderStepKind, PreparedEffectAttempt>>;
   provider_observations: Partial<Record<ProviderStepKind, ProviderObservation>>;
+  turn_result_kind: string | null;
 }
 
 export interface TurnSettlementState {
@@ -249,6 +252,59 @@ function decodeRequest(value: unknown): TurnSettlementRequest {
       "provider_observations",
       decodeProviderObservation,
     ),
+    turn_result_kind: optionalNonEmptyString(
+      request.turn_result_kind,
+      "turn_result_kind",
+    ),
+  };
+}
+
+function terminalCompletionError(
+  identity: SettlementIdentity,
+  payload: JsonObject,
+): string | null {
+  const completion = payload.completion;
+  if (completion === null || completion === undefined) {
+    return "terminal closeout is missing its durable Todo outcome";
+  }
+  if (typeof completion !== "object" || Array.isArray(completion)) {
+    return "terminal closeout has an invalid durable Todo outcome";
+  }
+  const outcome = completion as JsonObject;
+  if (outcome.todo_id !== identity.todo_id) {
+    return "terminal closeout completion does not match the selected Todo";
+  }
+  if (outcome.continuation !== "no_followup") {
+    return "terminal closeout completion must declare no_followup";
+  }
+  return null;
+}
+
+function reductionWithTurnOutcome(
+  request: TurnSettlementRequest,
+  state: TurnSettlementState,
+  receipts: SettlementResult<unknown>["receipts"],
+  terminalPayload: JsonObject | null,
+  identity: SettlementIdentity,
+): TurnSettlementOutcome {
+  const result = settlementPure(state, receipts);
+  const projection = settlementResultPayload(result);
+  if (request.turn_result_kind !== null) {
+    const outcome: JsonObject = {
+      schema_version: TURN_SETTLEMENT_OUTCOME_SCHEMA_VERSION,
+      result_kind: request.turn_result_kind,
+      completed_phases: [...state.completed_phases],
+      failed_phase: null,
+    };
+    if (terminalPayload?.completion) outcome.completion = terminalPayload.completion;
+    projection.turn_outcome = outcome;
+  }
+  return {
+    schema_version: TURN_SETTLEMENT_REDUCTION_SCHEMA_VERSION,
+    decision: "complete",
+    provider_effects: [],
+    result,
+    settlement_result: projection,
   };
 }
 
@@ -574,6 +630,25 @@ export function reduceTurnSettlementTransaction(
       source_ref_prefix: "turn_journal",
     });
     if (terminal.failure !== null) return failedState(terminal);
+    // The generic settlement adapter predates Turn Todo lifecycle metadata.
+    // Only the explicit Turn transaction requests the canonical outcome and
+    // therefore requires that durable completion proof.
+    if (request.turn_result_kind !== null) {
+      const completionError = terminalCompletionError(
+        identity,
+        request.terminal_closeout_payload,
+      );
+      if (completionError !== null) {
+        return reduction(
+          settlementFailed({
+            kind: "receipt_missing",
+            step_kind: "terminal_closeout",
+            reason: completionError,
+            receipts,
+          }),
+        );
+      }
+    }
     receipts = [...receipts, ...terminal.receipts];
   } else if (request.terminal_closeout_payload !== null) {
     return reduction(
@@ -605,14 +680,15 @@ export function reduceTurnSettlementTransaction(
       "failed_provider_attempt remains after all required settlement effects committed",
     );
   }
-  return reduction(
-    settlementPure(
-      {
-        completed_phases: [...request.completed_phases],
-        writeback: request.writeback_payload,
-        quota_spend: request.quota_spend_payload,
-      },
-      receipts,
-    ),
+  return reductionWithTurnOutcome(
+    request,
+    {
+      completed_phases: [...request.completed_phases],
+      writeback: request.writeback_payload,
+      quota_spend: request.quota_spend_payload,
+    },
+    receipts,
+    request.terminal_closeout_payload,
+    identity,
   );
 }

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -539,6 +539,114 @@ function pendingProviderEffects(
   return effects;
 }
 
+function terminalCloseoutRequestFailure(
+  request: TurnSettlementRequest,
+): SettlementResult<TurnSettlementState> | null {
+  if (
+    request.terminal_closeout_required &&
+    request.turn_result_kind !== null &&
+    request.turn_result_kind !== "validated_completion"
+  ) {
+    return settlementFailed<TurnSettlementState>({
+      kind: "terminal_closeout_rejected",
+      step_kind: "terminal_closeout",
+      reason: "terminal closeout requires a validated completion result",
+      receipts: [],
+    });
+  }
+  return null;
+}
+
+function reduceBaseProviderAction(
+  request: TurnSettlementRequest,
+  identity: SettlementIdentity,
+  stepKind: ProviderStepKind,
+  receipts: SettlementResult<unknown>["receipts"],
+): TurnSettlementReduction {
+  const effects = pendingProviderEffects(request, identity, stepKind);
+  return request.failed_provider_attempt === null
+    ? providerExecution(request, identity, stepKind, effects, receipts)
+    : providerFailure(identity, request, stepKind, receipts);
+}
+
+type TerminalCloseoutReduction =
+  | { outcome: TurnSettlementReduction; receipts?: never }
+  | { outcome?: never; receipts: SettlementResult<unknown>["receipts"] };
+
+function reduceTerminalCloseout(
+  request: TurnSettlementRequest,
+  identity: SettlementIdentity,
+  receipts: SettlementResult<unknown>["receipts"],
+): TerminalCloseoutReduction {
+  if (!request.terminal_closeout_required) {
+    if (request.terminal_closeout_payload !== null) {
+      return {
+        outcome: reduction(
+          settlementFailed({
+            kind: "terminal_closeout_rejected",
+            step_kind: "terminal_closeout",
+            reason: "Turn settlement contains an unrequested terminal closeout",
+            receipts,
+          }),
+        ),
+      };
+    }
+    return { receipts };
+  }
+
+  if (request.terminal_closeout_payload === null) {
+    const effects: readonly ProviderEffect[] = [
+      {
+        step_kind: "terminal_closeout",
+        action: "prepare_and_execute",
+        effect_ref: `${identity.effect_id}#terminal_closeout`,
+        completed_phases: [...request.completed_phases],
+      },
+    ];
+    return {
+      outcome: request.failed_provider_attempt === null
+        ? providerExecution(
+            request,
+            identity,
+            "terminal_closeout",
+            effects,
+            receipts,
+          )
+        : providerFailure(identity, request, "terminal_closeout", receipts),
+    };
+  }
+
+  const terminal = seedCommittedSteps({
+    identity,
+    ordered_steps: ["terminal_closeout"],
+    committed_payloads: {
+      terminal_closeout: request.terminal_closeout_payload,
+    },
+    completed_phases: ["terminal_closeout"],
+    transaction_phases: ["terminal_closeout"],
+    require_validation: false,
+    source_ref_prefix: "turn_journal",
+  });
+  if (terminal.failure !== null) return { outcome: failedState(terminal) };
+
+  const completionError = request.turn_result_kind === null
+    ? null
+    : terminalCompletionError(identity, request.terminal_closeout_payload);
+  if (completionError !== null) {
+    return {
+      outcome: reduction(
+        settlementFailed({
+          kind: "receipt_missing",
+          step_kind: "terminal_closeout",
+          reason: completionError,
+          receipts,
+        }),
+      ),
+    };
+  }
+  return { receipts: [...receipts, ...terminal.receipts] };
+}
+
 function providerExecution(
   request: TurnSettlementRequest,
   identity: SettlementIdentity,
@@ -685,6 +793,9 @@ function reduceTurnSettlementRequest(
   );
   if (matching.failure !== null) return failedState(matching);
 
+  const terminalRequestFailure = terminalCloseoutRequestFailure(request);
+  if (terminalRequestFailure !== null) return reduction(terminalRequestFailure);
+
   const base = settlementNextAction({
     identity,
     ordered_steps: BASE_SETTLEMENT_STEPS,
@@ -703,38 +814,15 @@ function reduceTurnSettlementRequest(
     if (base.step_kind === "validation" || base.step_kind === "terminal_closeout") {
       throw new Error(`unsupported base settlement step ${base.step_kind}`);
     }
-    const effects = pendingProviderEffects(request, identity, base.step_kind);
-    return request.failed_provider_attempt === null
-      ? providerExecution(
-          request,
-          identity,
-          base.step_kind,
-          effects,
-          base.result.receipts,
-        )
-      : providerFailure(
-          identity,
-          request,
-          base.step_kind,
-          base.result.receipts,
-        );
-  }
-
-  let receipts = [...base.result.receipts];
-  if (
-    request.terminal_closeout_required &&
-    request.turn_result_kind !== null &&
-    request.turn_result_kind !== "validated_completion"
-  ) {
-    return reduction(
-      settlementFailed({
-        kind: "terminal_closeout_rejected",
-        step_kind: "terminal_closeout",
-        reason: "terminal closeout requires a validated completion result",
-        receipts,
-      }),
+    return reduceBaseProviderAction(
+      request,
+      identity,
+      base.step_kind,
+      base.result.receipts,
     );
   }
+
+  let receipts: SettlementResult<unknown>["receipts"] = [...base.result.receipts];
   if (
     request.turn_result_kind === "validated_completion" &&
     !request.terminal_closeout_required
@@ -754,73 +842,9 @@ function reduceTurnSettlementRequest(
       );
     }
   }
-  if (request.terminal_closeout_required) {
-    if (request.terminal_closeout_payload === null) {
-      const effects: readonly ProviderEffect[] = [
-        {
-          step_kind: "terminal_closeout",
-          action: "prepare_and_execute",
-          effect_ref: `${identity.effect_id}#terminal_closeout`,
-          completed_phases: [...request.completed_phases],
-        },
-      ];
-      return request.failed_provider_attempt === null
-        ? providerExecution(
-            request,
-            identity,
-            "terminal_closeout",
-            effects,
-            receipts,
-          )
-        : providerFailure(
-            identity,
-            request,
-            "terminal_closeout",
-            receipts,
-          );
-    }
-    const terminal = seedCommittedSteps({
-      identity,
-      ordered_steps: ["terminal_closeout"],
-      committed_payloads: {
-        terminal_closeout: request.terminal_closeout_payload,
-      },
-      completed_phases: ["terminal_closeout"],
-      transaction_phases: ["terminal_closeout"],
-      require_validation: false,
-      source_ref_prefix: "turn_journal",
-    });
-    if (terminal.failure !== null) return failedState(terminal);
-    // The generic settlement adapter predates Turn Todo lifecycle metadata.
-    // Only the explicit Turn transaction requests the canonical outcome and
-    // therefore requires that durable completion proof.
-    if (request.turn_result_kind !== null) {
-      const completionError = terminalCompletionError(
-        identity,
-        request.terminal_closeout_payload,
-      );
-      if (completionError !== null) {
-        return reduction(
-          settlementFailed({
-            kind: "receipt_missing",
-            step_kind: "terminal_closeout",
-            reason: completionError,
-            receipts,
-          }),
-        );
-      }
-    }
-    receipts = [...receipts, ...terminal.receipts];
-  } else if (request.terminal_closeout_payload !== null) {
-    return reduction(
-      settlementFailed({
-        kind: "terminal_closeout_rejected",
-        step_kind: "terminal_closeout",
-        reason: "Turn settlement contains an unrequested terminal closeout",
-        receipts,
-      }),
-    );
-  }
+  const terminal = reduceTerminalCloseout(request, identity, receipts);
+  if (terminal.outcome !== undefined) return terminal.outcome;
+  receipts = terminal.receipts;
 
   const danglingAttempt = Object.keys(request.effect_attempts)[0] as
     | ProviderStepKind

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -297,14 +297,9 @@ function validateTurnOutcomeKind(
       `Turn settlement cannot complete with failed result_kind ${kind}`,
     );
   }
-  if (kind === "validated_completion" && !request.terminal_closeout_required) {
-    throw new Error(
-      "validated_completion requires a terminal closeout in Turn settlement",
-    );
-  }
 }
 
-function terminalCompletionError(
+function completionOutcomeError(
   identity: SettlementIdentity,
   payload: JsonObject,
 ): string | null {
@@ -319,8 +314,38 @@ function terminalCompletionError(
   if (outcome.todo_id !== identity.todo_id) {
     return "terminal closeout completion does not match the selected Todo";
   }
-  if (outcome.continuation !== "no_followup") {
+  if (
+    outcome.continuation !== "successor" &&
+    outcome.continuation !== "active_goal" &&
+    outcome.continuation !== "no_followup"
+  ) {
+    return "completion has an invalid continuation outcome";
+  }
+  return null;
+}
+
+function terminalCompletionError(
+  identity: SettlementIdentity,
+  payload: JsonObject,
+): string | null {
+  const error = completionOutcomeError(identity, payload);
+  if (error !== null) return error;
+  const completion = payload.completion as JsonObject;
+  if (completion.continuation !== "no_followup") {
     return "terminal closeout completion must declare no_followup";
+  }
+  return null;
+}
+
+function nonTerminalCompletionError(
+  identity: SettlementIdentity,
+  payload: JsonObject,
+): string | null {
+  const error = completionOutcomeError(identity, payload);
+  if (error !== null) return error;
+  const completion = payload.completion as JsonObject;
+  if (completion.continuation === "no_followup") {
+    return "non-terminal completion cannot declare no_followup";
   }
   return null;
 }
@@ -352,6 +377,54 @@ function reductionWithTurnOutcome(
     result,
     settlement_result: projection,
   };
+}
+
+function resultKindForFailedStep(stepKind: SettlementStepKind): TurnResultKind {
+  switch (stepKind) {
+    case "validation":
+      return "validation_failed";
+    case "durable_writeback":
+      return "writeback_failed";
+    case "quota_spend":
+      return "quota_spend_failed";
+    case "terminal_closeout":
+      return "terminal_closeout_failed";
+    default:
+      throw new Error(`Turn settlement cannot project failed step ${stepKind}`);
+  }
+}
+
+function reductionWithTurnFailure(
+  request: TurnSettlementRequest,
+  result: SettlementResult<TurnSettlementState>,
+): TurnSettlementOutcome {
+  if (result.failure === null || request.turn_result_kind === null) {
+    return reduction(result);
+  }
+  const projection = settlementResultPayload(result);
+  projection.turn_outcome = {
+    schema_version: TURN_SETTLEMENT_OUTCOME_SCHEMA_VERSION,
+    result_kind: resultKindForFailedStep(result.failure.step_kind),
+    completed_phases: [...request.completed_phases],
+    failed_phase: result.failure.step_kind,
+  };
+  return {
+    schema_version: TURN_SETTLEMENT_REDUCTION_SCHEMA_VERSION,
+    decision: "failed",
+    provider_effects: [],
+    result,
+    settlement_result: projection,
+  };
+}
+
+function withTurnOutcome(
+  request: TurnSettlementRequest,
+  reduced: TurnSettlementReduction,
+): TurnSettlementReduction {
+  if (reduced.decision !== "failed" || reduced.result.failure === null) {
+    return reduced;
+  }
+  return reductionWithTurnFailure(request, reduced.result);
 }
 
 function reduction(
@@ -589,10 +662,9 @@ function providerExecution(
  * their checkpointed outcomes into the canonical receipt chain and result.
  * A replay that needs no provider effect completes in one reduction.
  */
-export function reduceTurnSettlementTransaction(
-  value: unknown,
+function reduceTurnSettlementRequest(
+  request: TurnSettlementRequest,
 ): TurnSettlementReduction {
-  const request = decodeRequest(value);
   const identityResult = settlementIdentityFromPlan(request.transaction_plan);
   if (identityResult.failure !== null) return failedState(identityResult);
 
@@ -639,6 +711,25 @@ export function reduceTurnSettlementTransaction(
   }
 
   let receipts = [...base.result.receipts];
+  if (
+    request.turn_result_kind === "validated_completion" &&
+    !request.terminal_closeout_required
+  ) {
+    const completionError = nonTerminalCompletionError(
+      identity,
+      request.writeback_payload!,
+    );
+    if (completionError !== null) {
+      return reduction(
+        settlementFailed({
+          kind: "receipt_missing",
+          step_kind: "durable_writeback",
+          reason: completionError,
+          receipts,
+        }),
+      );
+    }
+  }
   if (request.terminal_closeout_required) {
     if (request.terminal_closeout_payload === null) {
       const effects: readonly ProviderEffect[] = [
@@ -737,4 +828,11 @@ export function reduceTurnSettlementTransaction(
     request.terminal_closeout_payload,
     identity,
   );
+}
+
+export function reduceTurnSettlementTransaction(
+  value: unknown,
+): TurnSettlementReduction {
+  const request = decodeRequest(value);
+  return withTurnOutcome(request, reduceTurnSettlementRequest(request));
 }

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -46,6 +46,30 @@ type ProviderStepKind = (typeof PROVIDER_STEP_KINDS)[number];
 const PROVIDER_RESOLUTION_KINDS = ["committed", "absent", "unknown"] as const;
 type ProviderResolutionKind = (typeof PROVIDER_RESOLUTION_KINDS)[number];
 
+/** Public Turn outcome classifications shared with the Python adapter. */
+export const TURN_RESULT_KINDS = [
+  "validated_progress",
+  "validated_completion",
+  "repair_required",
+  "replan_required",
+  "user_action_required",
+  "wait",
+  "host_failure",
+  "validation_failed",
+  "writeback_failed",
+  "quota_spend_failed",
+  "terminal_closeout_failed",
+] as const;
+export type TurnResultKind = (typeof TURN_RESULT_KINDS)[number];
+
+const FAILED_TURN_RESULT_KINDS = [
+  "host_failure",
+  "validation_failed",
+  "writeback_failed",
+  "quota_spend_failed",
+  "terminal_closeout_failed",
+] as const satisfies readonly TurnResultKind[];
+
 interface PreparedEffectAttempt {
   status: "prepared";
   effect_ref: string;
@@ -96,7 +120,7 @@ interface TurnSettlementRequest {
   failed_provider_attempt: FailedProviderAttempt | null;
   effect_attempts: Partial<Record<ProviderStepKind, PreparedEffectAttempt>>;
   provider_observations: Partial<Record<ProviderStepKind, ProviderObservation>>;
-  turn_result_kind: string | null;
+  turn_result_kind: TurnResultKind | null;
 }
 
 export interface TurnSettlementState {
@@ -252,11 +276,32 @@ function decodeRequest(value: unknown): TurnSettlementRequest {
       "provider_observations",
       decodeProviderObservation,
     ),
-    turn_result_kind: optionalNonEmptyString(
+    turn_result_kind: request.turn_result_kind === null ||
+      request.turn_result_kind === undefined
+      ? null
+      : requireStringLiteral(
       request.turn_result_kind,
+      TURN_RESULT_KINDS,
       "turn_result_kind",
     ),
   };
+}
+
+function validateTurnOutcomeKind(
+  request: TurnSettlementRequest,
+): void {
+  const kind = request.turn_result_kind;
+  if (kind === null) return;
+  if (FAILED_TURN_RESULT_KINDS.includes(kind as (typeof FAILED_TURN_RESULT_KINDS)[number])) {
+    throw new Error(
+      `Turn settlement cannot complete with failed result_kind ${kind}`,
+    );
+  }
+  if (kind === "validated_completion" && !request.terminal_closeout_required) {
+    throw new Error(
+      "validated_completion requires a terminal closeout in Turn settlement",
+    );
+  }
 }
 
 function terminalCompletionError(
@@ -287,6 +332,7 @@ function reductionWithTurnOutcome(
   terminalPayload: JsonObject | null,
   identity: SettlementIdentity,
 ): TurnSettlementOutcome {
+  validateTurnOutcomeKind(request);
   const result = settlementPure(state, receipts);
   const projection = settlementResultPayload(result);
   if (request.turn_result_kind !== null) {

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -377,7 +377,10 @@ function reductionWithTurnOutcome(
       completed_phases: [...state.completed_phases],
       failed_phase: null,
     };
-    if (terminalPayload?.completion) outcome.completion = terminalPayload.completion;
+    if (request.turn_result_kind === "validated_completion") {
+      const completion = terminalPayload?.completion ?? state.writeback?.completion;
+      if (completion !== undefined) outcome.completion = completion;
+    }
     projection.turn_outcome = outcome;
   }
   return {
@@ -536,7 +539,7 @@ function pendingProviderEffects(
       completed_phases: [...request.completed_phases],
     });
   }
-  return effects;
+  return effects.slice(0, 1);
 }
 
 function terminalCloseoutRequestFailure(
@@ -813,6 +816,27 @@ function reduceTurnSettlementRequest(
   if (base.decision === "execute") {
     if (base.step_kind === "validation" || base.step_kind === "terminal_closeout") {
       throw new Error(`unsupported base settlement step ${base.step_kind}`);
+    }
+    if (
+      base.step_kind === "quota_spend" &&
+      request.turn_result_kind === "validated_completion" &&
+      !request.terminal_closeout_required &&
+      request.writeback_payload !== null
+    ) {
+      const completionError = nonTerminalCompletionError(
+        identity,
+        request.writeback_payload,
+      );
+      if (completionError !== null) {
+        return reduction(
+          settlementFailed({
+            kind: "receipt_missing",
+            step_kind: "durable_writeback",
+            reason: completionError,
+            receipts: base.result.receipts,
+          }),
+        );
+      }
     }
     return reduceBaseProviderAction(
       request,

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -305,14 +305,14 @@ function completionOutcomeError(
 ): string | null {
   const completion = payload.completion;
   if (completion === null || completion === undefined) {
-    return "terminal closeout is missing its durable Todo outcome";
+    return "completion is missing its durable Todo outcome";
   }
   if (typeof completion !== "object" || Array.isArray(completion)) {
-    return "terminal closeout has an invalid durable Todo outcome";
+    return "completion has an invalid durable Todo outcome";
   }
   const outcome = completion as JsonObject;
   if (outcome.todo_id !== identity.todo_id) {
-    return "terminal closeout completion does not match the selected Todo";
+    return "completion does not match the selected Todo";
   }
   if (
     outcome.continuation !== "successor" &&

--- a/loopx/control_plane/turn_driver/settlement.ts
+++ b/loopx/control_plane/turn_driver/settlement.ts
@@ -849,11 +849,12 @@ function reduceTurnSettlementRequest(
   let receipts: SettlementResult<unknown>["receipts"] = [...base.result.receipts];
   if (
     request.turn_result_kind === "validated_completion" &&
-    !request.terminal_closeout_required
+    !request.terminal_closeout_required &&
+    request.writeback_payload !== null
   ) {
     const completionError = nonTerminalCompletionError(
       identity,
-      request.writeback_payload!,
+      request.writeback_payload,
     );
     if (completionError !== null) {
       return reduction(

--- a/tests/control_plane/test_settlement_driver.py
+++ b/tests/control_plane/test_settlement_driver.py
@@ -102,6 +102,35 @@ def test_turn_settlement_passes_stable_effect_refs_to_new_callbacks() -> None:
     ]
 
 
+def test_malformed_nonterminal_completion_does_not_spend_quota() -> None:
+    calls = {"writeback": 0, "spend": 0}
+
+    def writeback() -> dict[str, object]:
+        calls["writeback"] += 1
+        return {"ok": True, "appended": True}
+
+    def spend() -> dict[str, object]:
+        calls["spend"] += 1
+        return {"ok": True, "appended": True}
+
+    result = execute_turn_driver_settlement(
+        TRANSACTION,
+        transaction_phases=PHASES,
+        completed_phases=PHASES[:3],
+        writeback_payload=None,
+        quota_spend_payload=None,
+        turn_result_kind="validated_completion",
+        writeback=writeback,
+        spend=spend,
+        checkpoint=lambda _step, _payload, _phases: None,
+    )
+
+    assert result.failure is not None
+    assert result.failure.step_kind is SettlementStepKind.DURABLE_WRITEBACK
+    assert result.failure.kind.value == "receipt_missing"
+    assert calls == {"writeback": 1, "spend": 0}
+
+
 def test_turn_settlement_checkpoints_committed_readback_without_reexecution() -> None:
     effect_ref = f"{IDENTITY.effect_id}#durable_writeback"
     events: list[str] = []

--- a/tests/control_plane_ts/scheduler_state_store.test.ts
+++ b/tests/control_plane_ts/scheduler_state_store.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, sep } from "node:path";
 import test from "node:test";
 
 import {
@@ -205,7 +205,7 @@ test("sanitized-equivalent scheduler scopes have distinct bounded paths", () => 
   assert.equal(new Set(agentPaths).size, agentPaths.length);
   assert.equal(new Set(surfacePaths).size, surfacePaths.length);
   for (const path of [...goalPaths, ...agentPaths, ...surfacePaths]) {
-    for (const segment of path.split("/")) assert.ok(segment.length <= 64);
+    for (const segment of path.split(sep)) assert.ok(segment.length <= 64);
   }
 });
 
@@ -257,7 +257,7 @@ test("overlong legacy scope loads as missing state, not an effect rejection", as
     "canonical path components must stay bounded",
   );
   assert.ok(
-    Math.max(...canonical.split("/").map((part) => part.length)) <= 64,
+    Math.max(...canonical.split(sep).map((part) => part.length)) <= 64,
     "canonical path component must not exceed the scoped-segment bound",
   );
 });

--- a/tests/control_plane_ts/scheduler_state_store.test.ts
+++ b/tests/control_plane_ts/scheduler_state_store.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, sep } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 
 import {
@@ -205,7 +205,7 @@ test("sanitized-equivalent scheduler scopes have distinct bounded paths", () => 
   assert.equal(new Set(agentPaths).size, agentPaths.length);
   assert.equal(new Set(surfacePaths).size, surfacePaths.length);
   for (const path of [...goalPaths, ...agentPaths, ...surfacePaths]) {
-    for (const segment of path.split(sep)) assert.ok(segment.length <= 64);
+    for (const segment of path.split("/")) assert.ok(segment.length <= 64);
   }
 });
 
@@ -257,7 +257,7 @@ test("overlong legacy scope loads as missing state, not an effect rejection", as
     "canonical path components must stay bounded",
   );
   assert.ok(
-    Math.max(...canonical.split(sep).map((part) => part.length)) <= 64,
+    Math.max(...canonical.split("/").map((part) => part.length)) <= 64,
     "canonical path component must not exceed the scoped-segment bound",
   );
 });

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -97,6 +97,43 @@ test("non-terminal completion accepts a durable continuing Todo outcome", () => 
   );
 
   assert.equal(reduced.result.failure, null);
+  assert.deepEqual(
+    (reduced.settlement_result as Record<string, unknown>).turn_outcome,
+    {
+      schema_version: "loopx_turn_settlement_outcome_v0",
+      result_kind: "validated_completion",
+      completed_phases: [...phases.slice(0, 5)],
+      failed_phase: null,
+      completion: { todo_id: "todo", continuation: "active_goal" },
+    },
+  );
+});
+
+test("successful successor completion is included in the canonical outcome", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      turn_result_kind: "validated_completion",
+      writeback_payload: {
+        ok: true,
+        appended: true,
+        completion: {
+          todo_id: "todo",
+          continuation: "successor",
+          successor_todo_ids: ["next"],
+        },
+      },
+    }),
+  );
+
+  assert.equal(reduced.result.failure, null);
+  assert.deepEqual(
+    (reduced.settlement_result as Record<string, unknown>).turn_outcome?.completion,
+    {
+      todo_id: "todo",
+      continuation: "successor",
+      successor_todo_ids: ["next"],
+    },
+  );
 });
 
 test("successor completion requires durable successor Todo ids", () => {
@@ -151,12 +188,6 @@ test("preflight authorizes ordered providers without settling early", () => {
       action: "prepare_and_execute",
       effect_ref: `${identity.effect_id}#durable_writeback`,
       completed_phases: [...phases.slice(0, 4)],
-    },
-    {
-      step_kind: "quota_spend",
-      action: "prepare_and_execute",
-      effect_ref: `${identity.effect_id}#quota_spend`,
-      completed_phases: [...phases.slice(0, 5)],
     },
   ]);
   assert.equal(reduced.result, null);
@@ -235,6 +266,7 @@ test("internal settlement contradictions remain internal failures", () => {
 test("terminal closeout joins the same transaction after spend", () => {
   const reduced = reduceTurnSettlementTransaction(
     request({
+      turn_result_kind: "validated_completion",
       terminal_closeout_required: true,
       terminal_closeout_payload: {
         ok: true,
@@ -253,6 +285,16 @@ test("terminal closeout joins the same transaction after spend", () => {
       "quota_spend",
       "terminal_closeout",
     ],
+  );
+  assert.deepEqual(
+    (reduced.settlement_result as Record<string, unknown>).turn_outcome,
+    {
+      schema_version: "loopx_turn_settlement_outcome_v0",
+      result_kind: "validated_completion",
+      completed_phases: [...phases.slice(0, 5)],
+      failed_phase: null,
+      completion: { todo_id: "todo", continuation: "no_followup" },
+    },
   );
 });
 
@@ -297,12 +339,6 @@ test("prepared provider attempts authorize one identity-bound readback", () => {
         absent: "execute",
         unknown: "fail_closed",
       },
-    },
-    {
-      step_kind: "quota_spend",
-      action: "prepare_and_execute",
-      effect_ref: `${identity.effect_id}#quota_spend`,
-      completed_phases: [...phases.slice(0, 5)],
     },
   ]);
 });

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -75,14 +75,28 @@ test("Turn settlement rejects an unknown result_kind at the typed boundary", () 
   );
 });
 
-test("Turn settlement rejects a completion result without terminal closeout", () => {
-  assert.throws(
-    () =>
-      reduceTurnSettlementTransaction(
-        request({ turn_result_kind: "validated_completion" }),
-      ),
-    /validated_completion requires a terminal closeout/,
+test("non-terminal completion requires a durable continuing Todo outcome", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({ turn_result_kind: "validated_completion" }),
   );
+
+  assert.equal(reduced.result.failure?.kind, "receipt_missing");
+  assert.equal(reduced.result.failure?.step_kind, "durable_writeback");
+});
+
+test("non-terminal completion accepts a durable continuing Todo outcome", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      turn_result_kind: "validated_completion",
+      writeback_payload: {
+        ok: true,
+        appended: true,
+        completion: { todo_id: "todo", continuation: "active_goal" },
+      },
+    }),
+  );
+
+  assert.equal(reduced.result.failure, null);
 });
 
 test("preflight authorizes ordered providers without settling early", () => {
@@ -126,6 +140,7 @@ test("mismatched replay fails before accepting committed provider outcomes", () 
 test("writeback rejection retains validation receipt and typed failure", () => {
   const reduced = reduceTurnSettlementTransaction(
     request({
+      turn_result_kind: "validated_progress",
       completed_phases: [...phases.slice(0, 3)],
       writeback_payload: null,
       quota_spend_payload: null,
@@ -144,6 +159,15 @@ test("writeback rejection retains validation receipt and typed failure", () => {
   assert.deepEqual(
     reduced.result.receipts.map((receipt) => receipt.step_kind),
     ["validation"],
+  );
+  assert.deepEqual(
+    (reduced.settlement_result as Record<string, unknown>).turn_outcome,
+    {
+      schema_version: "loopx_turn_settlement_outcome_v0",
+      result_kind: "writeback_failed",
+      completed_phases: [...phases.slice(0, 3)],
+      failed_phase: "durable_writeback",
+    },
   );
 });
 

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -68,6 +68,23 @@ test("complete Turn settlement constructs one ordered receipt chain", () => {
   });
 });
 
+test("Turn settlement rejects an unknown result_kind at the typed boundary", () => {
+  assert.throws(
+    () => reduceTurnSettlementTransaction(request({ turn_result_kind: "done" })),
+    /turn_result_kind is unsupported/,
+  );
+});
+
+test("Turn settlement rejects a completion result without terminal closeout", () => {
+  assert.throws(
+    () =>
+      reduceTurnSettlementTransaction(
+        request({ turn_result_kind: "validated_completion" }),
+      ),
+    /validated_completion requires a terminal closeout/,
+  );
+});
+
 test("preflight authorizes ordered providers without settling early", () => {
   const reduced = reduceTurnSettlementTransaction(
     request({

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -123,14 +123,10 @@ test("terminal closeout requires a validated completion result", () => {
     request({
       turn_result_kind: "validated_progress",
       terminal_closeout_required: true,
-      terminal_closeout_payload: {
-        ok: true,
-        appended: true,
-        completion: { todo_id: "todo", continuation: "no_followup" },
-      },
     }),
   );
 
+  assert.equal(reduced.decision, "failed");
   assert.equal(reduced.result.failure?.kind, "terminal_closeout_rejected");
   assert.equal(reduced.result.failure?.step_kind, "terminal_closeout");
   assert.match(

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -118,6 +118,27 @@ test("successor completion requires durable successor Todo ids", () => {
   );
 });
 
+test("terminal closeout requires a validated completion result", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      turn_result_kind: "validated_progress",
+      terminal_closeout_required: true,
+      terminal_closeout_payload: {
+        ok: true,
+        appended: true,
+        completion: { todo_id: "todo", continuation: "no_followup" },
+      },
+    }),
+  );
+
+  assert.equal(reduced.result.failure?.kind, "terminal_closeout_rejected");
+  assert.equal(reduced.result.failure?.step_kind, "terminal_closeout");
+  assert.match(
+    reduced.result.failure?.reason ?? "",
+    /terminal closeout requires a validated completion result/,
+  );
+});
+
 test("preflight authorizes ordered providers without settling early", () => {
   const reduced = reduceTurnSettlementTransaction(
     request({

--- a/tests/control_plane_ts/turn_settlement.test.ts
+++ b/tests/control_plane_ts/turn_settlement.test.ts
@@ -99,6 +99,25 @@ test("non-terminal completion accepts a durable continuing Todo outcome", () => 
   assert.equal(reduced.result.failure, null);
 });
 
+test("successor completion requires durable successor Todo ids", () => {
+  const reduced = reduceTurnSettlementTransaction(
+    request({
+      turn_result_kind: "validated_completion",
+      writeback_payload: {
+        ok: true,
+        appended: true,
+        completion: { todo_id: "todo", continuation: "successor" },
+      },
+    }),
+  );
+
+  assert.equal(reduced.result.failure?.kind, "receipt_missing");
+  assert.match(
+    reduced.result.failure?.reason ?? "",
+    /successor completion requires successor Todo ids/,
+  );
+});
+
 test("preflight authorizes ordered providers without settling early", () => {
   const reduced = reduceTurnSettlementTransaction(
     request({

--- a/tests/test_loopx_turn_settlement_parity.py
+++ b/tests/test_loopx_turn_settlement_parity.py
@@ -215,7 +215,7 @@ def test_journal_committed_effect_id_is_none_for_legacy_journal() -> None:
     assert _journal_committed_effect_id(journal) is None
 
 
-def test_new_turn_settlement_uses_preflight_and_final_runtime_requests() -> None:
+def test_new_turn_settlement_reduces_between_each_provider_effect() -> None:
     plan = _plan(todo_id="todo_fixture0002")
     transaction = plan["transaction"]
     assert isinstance(transaction, dict)
@@ -239,7 +239,11 @@ def test_new_turn_settlement_uses_preflight_and_final_runtime_requests() -> None
         )
 
     assert result.failure is None
-    assert calls == ["turn.settlement.reduce", "turn.settlement.reduce"]
+    assert calls == [
+        "turn.settlement.reduce",
+        "turn.settlement.reduce",
+        "turn.settlement.reduce",
+    ]
 
 
 def test_replayed_turn_settlement_uses_one_runtime_request() -> None:


### PR DESCRIPTION
## Summary

- Make TypeScript the canonical owner for Turn settlement outcome projection: successful result kinds and provider-failure classifications are emitted as `turn_outcome`; Python executes external providers and projects the established legacy result/receipt surface.
- Enforce durable Todo completion invariants at the TS transaction boundary: `active_goal` and `successor` are non-terminal; `successor` requires non-empty successor Todo IDs; terminal closeout requires `validated_completion` and `no_followup`.

## Migration Economics Receipt

- Canonical owner: TypeScript owns settlement result classification, canonical receipt-chain outcome projection, and completion-closeout invariants.
- Python removed: executor-local `SettlementStepKind` to `LoopXTurnResultKind` failure mapping. Python only decodes the TS result for compatibility projection.
- Bridge: one preflight reduction plus one checkpointed final reduction when a Python provider runs; completed replay requires one reduction. No user-managed bridge.
- Facade exit: host-result and legacy receipt validation remain deliberately deferred to the next bounded migration slice.

## Validation

- [x] `npm run typecheck:control-plane`
- [x] `node --no-warnings --experimental-strip-types --test tests/control_plane_ts/turn_settlement.test.ts` (17 passed)
- [x] Fork PR CI for the same functional diff: pytest, Windows PowerShell, DCO, Dependency Review, and SonarCloud.
- [x] Focused executor regression and maintainability-ratchet checks before the final TS boundary repair.

## Scope / Boundaries

- Changed surfaces: `turn_driver` executor/settlement bridge and TS settlement reducer only.
- No CLI, scheduler, host adapter, daemon, packaging, or public/private evidence changes.
- No local state, credentials, private artifacts, raw logs, internal links, or local machine paths.
- All commits include DCO sign-off.