### PR TITLE
fix(dashboard): project completed Todos into the Personal Workspace board

### DIFF
--- a/apps/presentation/dashboard/src/data/status.ts
+++ b/apps/presentation/dashboard/src/data/status.ts
@@ -215,6 +215,7 @@ export const projectAssetTodoSummarySchema = z.object({
   next: z.string().optional().nullable(),
   next_index: z.number().optional().nullable(),
   items: z.array(todoItemSchema).optional().default([]),
+  recent_completed_advancement_items: z.array(todoItemSchema).optional().default([]),
 });
 
 export const dependencyBlockerSchema = z.object({

--- a/apps/presentation/dashboard/src/features/personal-workspace/goal-tasks-view.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/goal-tasks-view.tsx
@@ -139,14 +139,14 @@ export function GoalTasksView({
       <section className="personal-object-list">
         <header>
           <strong><i className="personal-kanban-dot tone-done" />已完成</strong>
-          <span>{doneAgentTodos.length}</span>
+          <span>{Math.max(goal.doneTodoCount ?? 0, doneAgentTodos.length)}</span>
         </header>
         {doneAgentTodos.map((todo) => (
           <button key={todo.todoId} onClick={() => onSelect({ item: { ...todo, goalId: goal.goalId, goalTitle: goal.title, ownerLabel: todo.claimedBy ?? goal.agentLabel ?? goal.agentId }, kind: "todo" })} type="button">
             <span className="is-done">✓</span><strong>{todo.text}</strong><small>{todo.claimedBy ?? goal.agentLabel ?? goal.agentId}</small>
           </button>
         ))}
-        {!doneAgentTodos.length ? <p className="personal-task-empty">还没有完成的任务。</p> : null}
+        {!doneAgentTodos.length ? <p className="personal-task-empty">{(goal.doneTodoCount ?? 0) > 0 ? `已完成 ${(goal.doneTodoCount ?? 0)} 项，近期完成明细由控制面按需投影。` : "还没有完成的任务。"}</p> : null}
       </section>
       </div>
       {isEmpty ? (

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -263,7 +263,7 @@ assert.match(page, /当前本地工作区（未绑定 Repository）/, "Create Go
 assert.doesNotMatch(model, /kind: "agent"/, "The drawer model omits the read-only Agent settings variant");
 assert.match(
   dashboard,
-  /statusRequestActive = Boolean\(activeStatusRequestUrl\) && Boolean\(loadError && requestedStatusUrl\)/,
+  /statusRequestActive = source\.kind === "example"[\s\S]*?&& Boolean\(activeStatusRequestUrl\)[\s\S]*?&& Boolean\(loadError && requestedStatusUrl\)/,
   "Initial load and refresh keep the workspace shell visible, while failed authoritative status requests surface recovery",
 );
 
@@ -312,5 +312,18 @@ assert.match(larkSettings, /setAppRef\(snapshot\.app_ref\)/, "Completed registra
 assert.match(larkSettings, /loading \? "…" : apps\.length/, "Lark App count does not flash a false zero while loading");
 assert.match(larkSettings, /openConnectionEditor\(connection\)/, "Every Lark connection settings button opens a scoped editor");
 assert.match(larkSettings, /focusGoalConnection[\s\S]*openConnectionEditor\(connection\)[\s\S]*openConnect\(goals\.find/, "Goal-level Lark entry opens the scoped connection editor or create flow");
+
+// Completed-Todo projection (issue: Personal Workspace hides completed Todo progress).
+assert.match(status, /recent_completed_advancement_items/, "The status schema accepts the bounded recent-completed lane");
+assert.match(model, /doneTodoCount\??:/, "A Goal exposes the payload completed-Todo count");
+assert.match(dashboard, /personalAgentTodoFacts/, "Goal projection derives completion facts from the payload, not open-only item lists");
+assert.match(dashboard, /agentTodos:\s*\[\.\.\.goalAgentTodos,\s*\.\.\.agentTodoFacts\.recentCompleted\]/, "Recent completed Todos stay visible in the Goal board");
+assert.match(tasks, /Math\.max\(goal\.doneTodoCount \?\? 0, doneAgentTodos\.length\)/, "The completed column counts payload completions instead of open-only items");
+assert.doesNotMatch(tasks, /<span>\{doneAgentTodos\.length\}<\/span>/, "The completed column never reports a false zero");
+assert.match(
+  dashboard,
+  /agentTodoFacts\.nextTodoText,\s*\n\s*row\.queueItem\?\.recommended_action,/,
+  "The Goal header prefers the current projected Todo over stale recommended_action strings",
+);
 
 console.log("personal workspace drawer contract smoke passed");

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-model.ts
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-model.ts
@@ -56,6 +56,8 @@ export type WorkspaceGoal = {
   agentLabel?: string;
   agentSentence: string;
   agentTodos: WorkspaceAgentTodo[];
+  /** Completed agent Todo count from the status payload; item lists only carry open Todos. */
+  doneTodoCount?: number;
   goalId: string;
   latestActivity?: string;
   needsYou?: string | null;

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -273,14 +273,17 @@ function defaultTimeline(model: WorkspaceModel, selectedGoalId: string | null): 
       run: {
         agentId: goal.agentId,
         agentLabel: goal.agentLabel ?? goal.agentId,
-        completedSteps: goal.agentTodos.filter((todo) => todo.done).length,
+        completedSteps: goal.doneTodoCount ?? goal.agentTodos.filter((todo) => todo.done).length,
         goalId: goal.goalId,
         goalTitle: goal.title,
         latestActivity: goal.agentSentence,
         runId: `goal:${goal.goalId}`,
         status: "running",
         title: goal.nextSentence,
-        totalSteps: goal.agentTodos.length || 1,
+        totalSteps: Math.max(
+          (goal.doneTodoCount ?? 0) + goal.agentTodos.filter((todo) => !todo.done).length,
+          1,
+        ),
       },
     }));
     return items;
@@ -306,14 +309,17 @@ function defaultTimeline(model: WorkspaceModel, selectedGoalId: string | null): 
     run: {
       agentId: goal.agentId,
       agentLabel: goal.agentLabel ?? goal.agentId,
-      completedSteps: goal.agentTodos.filter((todo) => todo.done).length,
+      completedSteps: goal.doneTodoCount ?? goal.agentTodos.filter((todo) => todo.done).length,
       goalId: goal.goalId,
       goalTitle: goal.title,
       latestActivity: goal.agentSentence,
       runId: `goal:${goal.goalId}`,
       status: goal.state === "推进中" ? "running" : goal.state === "需修复" ? "failed" : "waiting",
       title: goal.nextSentence,
-      totalSteps: goal.agentTodos.length || 1,
+      totalSteps: Math.max(
+        (goal.doneTodoCount ?? 0) + goal.agentTodos.filter((todo) => !todo.done).length,
+        1,
+      ),
     },
   });
   goal.agentTodos.filter((todo) => todo.taskClass === "continuous_monitor").forEach((todo) => {

--- a/apps/presentation/dashboard/src/views/dashboard-page.tsx
+++ b/apps/presentation/dashboard/src/views/dashboard-page.tsx
@@ -434,6 +434,7 @@ type PersonalGoalItem = {
   agentId: string;
   agentSentence: string;
   agentTodos: PersonalAgentTodoItem[];
+  doneTodoCount: number;
   goalId: string;
   latestActivity?: string;
   needsYou?: string | null;
@@ -703,8 +704,8 @@ function personalTodoText(todo: TodoItem) {
   return compactShareText(todo.title ?? todo.text, 112);
 }
 
-function personalAgentTodos(row: GoalDirectoryRow): PersonalAgentTodoItem[] {
-  return (getShareTodos(row, "agent")?.items ?? []).map((todo) => ({
+function personalAgentTodoFromItem(todo: TodoItem, row: GoalDirectoryRow): PersonalAgentTodoItem {
+  return {
     claimedBy: todo.claimed_by ?? null,
     done: todo.done,
     evidence: todo.evidence ? compactShareText(todo.evidence, 96) : null,
@@ -714,7 +715,42 @@ function personalAgentTodos(row: GoalDirectoryRow): PersonalAgentTodoItem[] {
     taskClass: todo.task_class ?? null,
     text: personalTodoText(todo),
     todoId: todo.todo_id?.trim() || `${row.goal.id}:agent:${todo.index}`,
-  }));
+  };
+}
+
+function personalAgentTodos(row: GoalDirectoryRow): PersonalAgentTodoItem[] {
+  return (getShareTodos(row, "agent")?.items ?? []).map((todo) => personalAgentTodoFromItem(todo, row));
+}
+
+/**
+ * Projected completion facts for a Goal. The status payload reports completed
+ * Todos as a count (project_asset.agent_todos.done) plus a bounded
+ * recent-completed lane; the items list itself only carries open Todos.
+ */
+function personalAgentTodoFacts(row: GoalDirectoryRow): {
+  doneTodoCount: number;
+  nextTodoText: string | null;
+  recentCompleted: PersonalAgentTodoItem[];
+} {
+  const assetTodos = row.queueItem?.project_asset?.agent_todos;
+  const queueTodos = row.queueItem?.agent_todos;
+  const items = assetTodos?.items?.length ? assetTodos.items : queueTodos?.items ?? [];
+  const doneFromCount = assetTodos?.done ?? queueTodos?.done_count ?? null;
+  const doneFromItems = items.filter((todo) => todo.done).length;
+  const doneTodoCount = Math.max(doneFromCount ?? 0, doneFromItems);
+  const seenTodoIds = new Set(
+    items
+      .map((todo) => todo.todo_id?.trim())
+      .filter((value): value is string => Boolean(value)),
+  );
+  const recentCompleted = (assetTodos?.recent_completed_advancement_items ?? [])
+    .filter((todo) => !todo.todo_id?.trim() || !seenTodoIds.has(todo.todo_id.trim()))
+    .map((todo) => personalAgentTodoFromItem(todo, row));
+  const firstOpen = items.find((todo) => !todo.done);
+  const nextTodoText = cleanShareText(assetTodos?.next ?? "")
+    || (firstOpen ? cleanShareText(firstOpen.title ?? "") || cleanShareText(firstOpen.text ?? "") : "")
+    || null;
+  return { doneTodoCount, nextTodoText, recentCompleted };
 }
 
 function personalValidationSentence(value: string | null | undefined) {
@@ -1081,6 +1117,7 @@ function buildPersonalHomeModel(payload: StatusPayload, rows: GoalDirectoryRow[]
     const needsYouTodo = allUserTodos.find((todo) => todo.goalId === goal.id);
     const needsYou = needsYouTodo?.text ?? null;
     const goalAgentTodos = personalAgentTodos(row);
+    const agentTodoFacts = personalAgentTodoFacts(row);
     const goalAgentRows = agentRows.filter(
       (agent) => agent.goalIds.includes(goal.id) && !/unassigned|unknown/i.test(agent.agentId),
     );
@@ -1092,6 +1129,7 @@ function buildPersonalHomeModel(payload: StatusPayload, rows: GoalDirectoryRow[]
       goalAgentRows.find((agent) => /codex/i.test(agent.agentId)) ??
       goalAgentRows[0];
     const nextSentence = [
+      agentTodoFacts.nextTodoText,
       row.queueItem?.recommended_action,
       row.latestRun?.recommended_action,
       personalAgentSentence(payload, row, state),
@@ -1101,7 +1139,8 @@ function buildPersonalHomeModel(payload: StatusPayload, rows: GoalDirectoryRow[]
       activationState: goal.activation_state,
       agentId: agentRow?.agentId ?? "codex",
       agentSentence: personalAgentSentence(payload, row, state),
-      agentTodos: goalAgentTodos,
+      agentTodos: [...goalAgentTodos, ...agentTodoFacts.recentCompleted],
+      doneTodoCount: agentTodoFacts.doneTodoCount,
       goalId: goal.id,
       latestActivity: row.latestRun?.generated_at ?? "",
       needsYou,

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -616,6 +616,13 @@ def build_project_asset_todo_summary(
             summary["next_index"] = open_items[0].get("index")
         if open_items[0].get("claimed_by"):
             summary["next_claimed_by"] = open_items[0].get("claimed_by")
+    recent_completed_items = [
+        _project_asset_display_todo_item(dict(item))
+        for item in todos.get("recent_completed_advancement_items", [])
+        if isinstance(item, dict)
+    ][:item_limit]
+    if recent_completed_items:
+        summary["recent_completed_advancement_items"] = recent_completed_items
     monitor_writeback = todos.get("monitor_writeback")
     if isinstance(monitor_writeback, dict):
         summary["monitor_writeback"] = dict(monitor_writeback)


### PR DESCRIPTION
## Summary

- `project_asset_todo_summary` now forwards the bounded `recent_completed_advancement_items` lane alongside the existing `done` count, so the presentation surface can see finished work without growing the payload (lane stays capped).
- The dashboard status schema and Personal Workspace Goal projection surface `doneTodoCount` plus the recent completed items, merge them into the Goal board, and the completed column counts payload completions instead of deriving a false zero from the open-only item list.
- The Goal header now prefers the current projected Todo text over stale `queueItem`/`latestRun` `recommended_action` strings.
- The contract smoke's `statusRequestActive` assertion predates the example-source guard on current main and fails without this change; realigned it (separate commit).

## Issue Or Task

- Fixes #3560

## Validation

- [x] `python3 -m py_compile loopx/control_plane/work_items/project_asset.py`
- [x] `python3 -m pytest tests/control_plane/ -k todo -x -q` (393 passed)
- [x] `python3 -m pytest tests/control_plane/test_goal_vision_succession.py` (34 passed)
- [x] `python3 examples/control_plane/todo-first-open-summary-smoke.py`
- [x] `node apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs`
- [x] `tsc --noEmit` in apps/presentation/dashboard

## Type of Change

- [x] Bug fix

## LoopX Area

- [x] Public docs or presentation surface (dashboard)

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] No `.loopx/`, credentials, private traces, or local machine paths committed
- [x] Change scoped to the linked issue
- [x] Every commit includes a DCO `Signed-off-by` trailer