### PR TITLE
feat(goal): project a conditional Todo delta for existing-Agent takeover

### DIFF
--- a/examples/control_plane/cli-output-probe-runner.py
+++ b/examples/control_plane/cli-output-probe-runner.py
@@ -99,6 +99,11 @@ def _receipt_row(
             if isinstance(payload, dict)
             else []
         ),
+        "guided_todo_delta_schema_versions": (
+            semantics.guided_todo_delta_schema_versions(payload)
+            if isinstance(payload, dict)
+            else []
+        ),
     }
 
 

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -37,6 +37,11 @@ from .project_prompt import (
     shell_arg,
 )
 from .paths import resolve_runtime_root
+from .control_plane.goals.start_goal_todo_delta import (
+    append_todo_delta_render_line,
+    existing_runnable_agent_frontier,
+    todo_authoring_steps,
+)
 from .registry import registry_goals, resolve_state_file
 from .slash_commands import build_slash_command_catalog
 from .thread_agent_binding import normalize_thread_id, resolve_thread_agent_binding
@@ -1523,6 +1528,17 @@ def build_start_goal_guided_packet(
         if fine_grained
         else []
     )
+    project_connection = command_pack.get("project_connection")
+    guided_frontier = (
+        existing_runnable_agent_frontier(
+            project_connection,
+            resolved_goal_id=str(command_pack.get("goal_id") or ""),
+            effective_agent_id=str(command_pack.get("agent_id") or "") or None,
+        )
+        if isinstance(project_connection, dict)
+        and not isinstance(identity_selection_gate, dict)
+        else None
+    )
     guided_transaction = {
         "schema_version": GUIDED_START_SCHEMA_VERSION,
         "mode": "dry_run_preview",
@@ -1557,42 +1573,15 @@ def build_start_goal_guided_packet(
             },
             *bind_thread_steps,
             *fine_mode_steps,
-            {
-                "id": "plan_ranked_todos",
-                "kind": "model_checkpoint",
-                "prompt": commands.get("goal_start_plan_prompt"),
-                "purpose": (
-                    "produce one public-safe, small, verifiable checkpoint Todo; keep "
-                    "later options as evidence-linked planning notes"
-                    if fine_grained
-                    else "produce concise public-safe P0/P1/P2 todos before todo writeback"
-                ),
-            },
-            {
-                "id": "write_ordered_todos",
-                "kind": "operator_or_agent_actions",
-                "command_template": (
-                    f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=command_pack.get('command_runtime_root'))} "
-                    f"todo add --goal-id "
-                    f"{shell_arg(str(command_pack.get('goal_id') or ''))} "
-                    "--project . "
-                    "--role agent "
-                    + (
-                        f"--claimed-by {shell_arg(str(command_pack.get('agent_id') or ''))} "
-                        if command_pack.get("agent_id")
-                        else "--claimed-by <agent-id> "
-                    )
-                    + "--task-class advancement_task --action-kind <action_kind> "
-                    "[--target-key <target_key>] --text '<[P0/P1/P2] ...>'"
-                ),
-                "purpose": (
-                    "write only the current checkpoint Todo; the existing replan path "
-                    "qualifies any successor after completion evidence"
-                    if fine_grained
-                    else "write todos in planner order; capability successors preserve "
-                    "the admitted action_kind and target_key for later quota re-entry"
-                ),
-            },
+            *todo_authoring_steps(
+                existing_runnable_frontier=guided_frontier,
+                plan_prompt=commands.get("goal_start_plan_prompt"),
+                fine_grained=fine_grained,
+                cli_bin=cli_bin,
+                runtime_root=command_pack.get("command_runtime_root"),
+                goal_id=str(command_pack.get("goal_id") or ""),
+                agent_id=command_pack.get("agent_id"),
+            ),
             {
                 "id": "refresh_state",
                 "kind": "state_sync",
@@ -1846,6 +1835,7 @@ def render_start_goal_guided_markdown(payload: dict[str, Any]) -> str:
             continue
         step_label = f"{index}. `{step.step_id}` ({step.kind}): "
         step_lines.append(step_label + str(step.purpose))
+        append_todo_delta_render_line(raw_step, step_lines)
         if command:
             rendered_command = (
                 actionable_shell_command(command)

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -171,18 +171,21 @@ def todo_authoring_steps(
         {
             "id": "apply_todo_delta",
             "kind": "operator_or_agent_actions",
-            "todo_delta": (
-                f"{GUIDED_TODO_DELTA_SCHEMA_VERSION}: "
-                "reuse|update|link_successor|add_new; "
-                f"runnable frontier={len(existing_runnable_frontier)}: "
-                + "; ".join(
+            "todo_delta": {
+                "schema_version": GUIDED_TODO_DELTA_SCHEMA_VERSION,
+                "rule": (
+                    "reuse|update|link_successor|add_new; "
+                    "reuse when the frontier covers the request, update instead "
+                    "of duplicating, link a successor only after completion "
+                    "evidence, add_new only for uncovered work"
+                ),
+                "runnable_frontier_count": len(existing_runnable_frontier),
+                "frontier": [
                     f"{item.get('title') or item.get('text')} "
                     f"[{item.get('todo_id')}, {item.get('claimed_by') or 'unclaimed'}]"
                     for item in existing_runnable_frontier[:_FRONTIER_PROJECTION_LIMIT]
-                )
-                + "; reuse when covered, update instead of duplicating, "
-                "link successor only after completion evidence"
-            ),
+                ],
+            },
             "add_new_command_template": add_template,
             "purpose": "takeover continues the frontier; authoring is a delta",
         },
@@ -195,9 +198,12 @@ def append_todo_delta_render_line(
 ) -> None:
     """Render the Todo-delta decision rule compactly for the markdown packet."""
     todo_delta = raw_step.get("todo_delta")
-    if not isinstance(todo_delta, str) or not todo_delta:
+    if not isinstance(todo_delta, Mapping):
         return
-    step_lines.append(f"   - todo_delta: {todo_delta}")
+    step_lines.append(
+        f"   - todo_delta: {todo_delta.get('rule')} "
+        f"(runnable frontier: {todo_delta.get('runnable_frontier_count')})"
+    )
 
 
 def _read_registry(registry_path: Path) -> tuple[dict[str, Any] | None, str | None]:

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from ...control_plane.todos.contract import normalize_todo_status
 from ...project_prompt import render_cli_command_prefix, shell_arg
 from ...registry import registry_goals, resolve_state_file
 
@@ -32,9 +33,11 @@ def existing_runnable_agent_frontier(
 ) -> list[dict[str, Any]] | None:
     """Runnable advancement agent Todos already present in the goal's state.
 
-    Returns ``None`` whenever the frontier cannot be proven (not connected,
-    unknown goal, missing or unreadable state file, or nothing runnable), so
-    callers keep the unconditional planning contract — fail-closed.
+    Blocked Todos (``status: blocked``) are not runnable and never enter the
+    frontier. Returns ``None`` whenever the frontier cannot be proven (not
+    connected, unknown goal, missing or unreadable state file, or nothing
+    runnable), so callers keep the unconditional planning contract —
+    fail-closed.
     """
     if inspection.get("connection_state") != "connected":
         return None
@@ -76,6 +79,7 @@ def existing_runnable_agent_frontier(
         if isinstance(item, dict)
         and not item.get("done")
         and item.get("task_class") != "continuous_monitor"
+        and normalize_todo_status(item.get("status")) != "blocked"
     ]
     if effective_agent_id:
         owned = [

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -17,10 +17,9 @@ from typing import Any
 
 from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from ...control_plane.todos.contract import (
-    TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
-    normalize_todo_status,
 )
+from ...control_plane.todos.projection import todo_item_is_actionable_open
 from ...project_prompt import render_cli_command_prefix, shell_arg
 from ...registry import registry_goals, resolve_state_file
 
@@ -39,7 +38,8 @@ def existing_runnable_agent_frontier(
 
     Only open advancement Todos (``status: open``, ``task_class:
     advancement_task``) belonging to the effective agent (or unclaimed)
-    enter the frontier. Blocked, deferred, monitor, blocker, or peer-claimed
+    whose resume condition is satisfied (or absent) enter the frontier.
+    Blocked, deferred, monitor, blocker, resume-blocked, or peer-claimed
     Todos never enter the frontier. Returns ``None`` whenever the frontier
     cannot be proven (not connected, unknown goal, missing or unreadable
     state file, or nothing runnable), so callers keep the unconditional
@@ -83,8 +83,7 @@ def existing_runnable_agent_frontier(
         item
         for item in items
         if isinstance(item, dict)
-        and not item.get("done")
-        and normalize_todo_status(item.get("status")) == TODO_STATUS_OPEN
+        and todo_item_is_actionable_open(item)
         and item.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT
     ]
     if effective_agent_id:

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -16,7 +16,11 @@ from pathlib import Path
 from typing import Any
 
 from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
-from ...control_plane.todos.contract import normalize_todo_status
+from ...control_plane.todos.contract import (
+    TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_todo_status,
+)
 from ...project_prompt import render_cli_command_prefix, shell_arg
 from ...registry import registry_goals, resolve_state_file
 
@@ -33,11 +37,13 @@ def existing_runnable_agent_frontier(
 ) -> list[dict[str, Any]] | None:
     """Runnable advancement agent Todos already present in the goal's state.
 
-    Blocked Todos (``status: blocked``) and peer-claimed Todos are not
-    runnable for the effective agent and never enter the frontier. Returns
-    ``None`` whenever the frontier cannot be proven (not connected, unknown
-    goal, missing or unreadable state file, or nothing runnable), so callers
-    keep the unconditional planning contract — fail-closed.
+    Only open advancement Todos (``status: open``, ``task_class:
+    advancement_task``) belonging to the effective agent (or unclaimed)
+    enter the frontier. Blocked, deferred, monitor, blocker, or peer-claimed
+    Todos never enter the frontier. Returns ``None`` whenever the frontier
+    cannot be proven (not connected, unknown goal, missing or unreadable
+    state file, or nothing runnable), so callers keep the unconditional
+    planning contract — fail-closed.
     """
     if inspection.get("connection_state") != "connected":
         return None
@@ -78,8 +84,8 @@ def existing_runnable_agent_frontier(
         for item in items
         if isinstance(item, dict)
         and not item.get("done")
-        and item.get("task_class") != "continuous_monitor"
-        and normalize_todo_status(item.get("status")) != "blocked"
+        and normalize_todo_status(item.get("status")) == TODO_STATUS_OPEN
+        and item.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT
     ]
     if effective_agent_id:
         runnable = [

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -33,11 +33,11 @@ def existing_runnable_agent_frontier(
 ) -> list[dict[str, Any]] | None:
     """Runnable advancement agent Todos already present in the goal's state.
 
-    Blocked Todos (``status: blocked``) are not runnable and never enter the
-    frontier. Returns ``None`` whenever the frontier cannot be proven (not
-    connected, unknown goal, missing or unreadable state file, or nothing
-    runnable), so callers keep the unconditional planning contract —
-    fail-closed.
+    Blocked Todos (``status: blocked``) and peer-claimed Todos are not
+    runnable for the effective agent and never enter the frontier. Returns
+    ``None`` whenever the frontier cannot be proven (not connected, unknown
+    goal, missing or unreadable state file, or nothing runnable), so callers
+    keep the unconditional planning contract — fail-closed.
     """
     if inspection.get("connection_state") != "connected":
         return None
@@ -82,13 +82,18 @@ def existing_runnable_agent_frontier(
         and normalize_todo_status(item.get("status")) != "blocked"
     ]
     if effective_agent_id:
-        owned = [
+        runnable = [
             item
             for item in runnable
             if not item.get("claimed_by")
             or str(item.get("claimed_by")) == effective_agent_id
         ]
-        runnable = owned or runnable
+    else:
+        runnable = [
+            item
+            for item in runnable
+            if not item.get("claimed_by")
+        ]
     return runnable or None
 
 

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -1,0 +1,236 @@
+"""Continuation-aware Todo authoring for guided goal starts.
+
+A guided `start-goal` that resolves to an existing-Agent takeover must not
+re-plan runnable work that already exists in the goal's active state. The
+guided packet therefore projects a conditional Todo delta (reuse / update /
+link successor / add new) instead of unconditional Todo planning and
+authoring. Whenever the runnable frontier cannot be proven, callers keep the
+unconditional planning contract — fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from ...project_prompt import render_cli_command_prefix, shell_arg
+from ...registry import registry_goals, resolve_state_file
+
+GUIDED_TODO_DELTA_SCHEMA_VERSION = "loopx_guided_todo_delta_v0"
+
+_FRONTIER_PROJECTION_LIMIT = 2
+
+
+def existing_runnable_agent_frontier(
+    inspection: Mapping[str, Any],
+    *,
+    resolved_goal_id: str,
+    effective_agent_id: str | None,
+) -> list[dict[str, Any]] | None:
+    """Runnable advancement agent Todos already present in the goal's state.
+
+    Returns ``None`` whenever the frontier cannot be proven (not connected,
+    unknown goal, missing or unreadable state file, or nothing runnable), so
+    callers keep the unconditional planning contract — fail-closed.
+    """
+    if inspection.get("connection_state") != "connected":
+        return None
+    registry_path = Path(str(inspection.get("registry") or ""))
+    registry_payload, _registry_error = _read_registry(registry_path)
+    registry_goal = next(
+        (
+            goal
+            for goal in registry_goals(registry_payload or {})
+            if str(goal.get("id")) == resolved_goal_id
+        ),
+        None,
+    )
+    if registry_goal is None:
+        return None
+    state_file = resolve_state_file(
+        Path(str(inspection.get("project") or "")),
+        registry_goal.get("state_file"),
+    )
+    if state_file is None or not state_file.is_file():
+        return None
+    try:
+        state_text = state_file.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    parsed = parse_active_state_todos(
+        state_text,
+        goal=registry_goal,
+        state_path=state_file,
+        item_limit=None,
+    )
+    agent_summary = parsed.get("agent_todos") if isinstance(parsed, dict) else None
+    items = (
+        agent_summary.get("items", []) if isinstance(agent_summary, dict) else []
+    )
+    runnable = [
+        item
+        for item in items
+        if isinstance(item, dict)
+        and not item.get("done")
+        and item.get("task_class") != "continuous_monitor"
+    ]
+    if effective_agent_id:
+        owned = [
+            item
+            for item in runnable
+            if not item.get("claimed_by")
+            or str(item.get("claimed_by")) == effective_agent_id
+        ]
+        runnable = owned or runnable
+    return runnable or None
+
+
+def _todo_add_command_template(
+    *,
+    cli_bin: str,
+    runtime_root: object,
+    goal_id: str,
+    agent_id: object,
+) -> str:
+    return (
+        f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
+        f"todo add --goal-id "
+        f"{shell_arg(str(goal_id or ''))} "
+        "--project . "
+        "--role agent "
+        + (
+            f"--claimed-by {shell_arg(str(agent_id or ''))} "
+            if agent_id
+            else "--claimed-by <agent-id> "
+        )
+        + "--task-class advancement_task --action-kind <action_kind> "
+        "[--target-key <target_key>] --text '<[P0/P1/P2] ...>'"
+    )
+
+
+def todo_authoring_steps(
+    *,
+    existing_runnable_frontier: list[dict[str, Any]] | None,
+    plan_prompt: object,
+    fine_grained: bool,
+    cli_bin: str,
+    runtime_root: object,
+    goal_id: str,
+    agent_id: object,
+) -> list[dict[str, Any]]:
+    """Ordered Todo-authoring steps, conditional on the runnable frontier."""
+    add_template = _todo_add_command_template(
+        cli_bin=cli_bin,
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    if not existing_runnable_frontier:
+        return [
+            {
+                "id": "plan_ranked_todos",
+                "kind": "model_checkpoint",
+                "prompt": plan_prompt,
+                "purpose": (
+                    "produce one public-safe, small, verifiable checkpoint Todo; keep "
+                    "later options as evidence-linked planning notes"
+                    if fine_grained
+                    else "produce concise public-safe P0/P1/P2 todos before todo writeback"
+                ),
+            },
+            {
+                "id": "write_ordered_todos",
+                "kind": "operator_or_agent_actions",
+                "command_template": add_template,
+                "purpose": (
+                    "write only the current checkpoint Todo; the existing replan path "
+                    "qualifies any successor after completion evidence"
+                    if fine_grained
+                    else "write todos in planner order; capability successors preserve "
+                    "the admitted action_kind and target_key for later quota re-entry"
+                ),
+            },
+        ]
+    return [
+        {
+            "id": "compare_planned_todos_with_frontier",
+            "kind": "model_checkpoint",
+            "prompt": plan_prompt,
+            "purpose": (
+                "compare the requested continuation against "
+                "existing_runnable_frontier by text and action_kind before any "
+                "Todo writeback; an existing-agent takeover continues runnable "
+                "work instead of re-planning it"
+            ),
+        },
+        {
+            "id": "apply_todo_delta",
+            "kind": "operator_or_agent_actions",
+            "todo_delta": {
+                "schema_version": GUIDED_TODO_DELTA_SCHEMA_VERSION,
+                "decisions": "reuse_existing | update_existing | link_successor | add_new",
+                "reuse_existing": (
+                    "the frontier already covers the requested continuation; "
+                    "no Todo writeback, continue through refresh/host-loop/quota"
+                ),
+                "update_existing": (
+                    "refresh priority, claim, or evidence on an existing "
+                    "runnable Todo instead of creating a duplicate"
+                ),
+                "link_successor": (
+                    "write a successor Todo only after completion evidence on "
+                    "the existing runnable Todo"
+                ),
+                "add_new": (
+                    "the frontier does not cover the request; write exactly one "
+                    "new Todo with add_new_command_template"
+                ),
+            },
+            "existing_runnable_frontier_count": len(existing_runnable_frontier),
+            "existing_runnable_frontier": [
+                {
+                    "todo_id": item.get("todo_id"),
+                    "text": item.get("title") or item.get("text"),
+                    "claimed_by": item.get("claimed_by"),
+                    "priority": item.get("priority"),
+                }
+                for item in existing_runnable_frontier[:_FRONTIER_PROJECTION_LIMIT]
+            ],
+            "add_new_command_template": add_template,
+            "purpose": (
+                "identity takeover continues the existing runnable frontier; "
+                "Todo authoring is a conditional delta, not an unconditional step"
+            ),
+        },
+    ]
+
+
+def append_todo_delta_render_line(
+    raw_step: Mapping[str, Any],
+    step_lines: list[str],
+) -> None:
+    """Render the Todo-delta decision rule compactly for the markdown packet."""
+    todo_delta = raw_step.get("todo_delta")
+    if not isinstance(todo_delta, Mapping):
+        return
+    frontier = raw_step.get("existing_runnable_frontier")
+    frontier_count = (
+        raw_step.get("existing_runnable_frontier_count")
+        if raw_step.get("existing_runnable_frontier_count") is not None
+        else (len(frontier) if isinstance(frontier, list) else 0)
+    )
+    step_lines.append(
+        f"   - todo_delta: {todo_delta.get('decisions')} "
+        f"(existing runnable frontier: {frontier_count})"
+    )
+
+
+def _read_registry(registry_path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None, "unreadable"
+    return (payload, None) if isinstance(payload, dict) else (None, "not_a_mapping")

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -22,7 +22,7 @@ from ...registry import registry_goals, resolve_state_file
 
 GUIDED_TODO_DELTA_SCHEMA_VERSION = "loopx_guided_todo_delta_v0"
 
-_FRONTIER_PROJECTION_LIMIT = 2
+_FRONTIER_PROJECTION_LIMIT = 1
 
 
 def existing_runnable_agent_frontier(
@@ -164,50 +164,27 @@ def todo_authoring_steps(
             "kind": "model_checkpoint",
             "prompt": plan_prompt,
             "purpose": (
-                "compare the requested continuation against "
-                "existing_runnable_frontier by text and action_kind before any "
-                "Todo writeback; an existing-agent takeover continues runnable "
-                "work instead of re-planning it"
+                "compare the continuation with existing_runnable_frontier "
+                "by text/action_kind before any writeback"
             ),
         },
         {
             "id": "apply_todo_delta",
             "kind": "operator_or_agent_actions",
-            "todo_delta": {
-                "schema_version": GUIDED_TODO_DELTA_SCHEMA_VERSION,
-                "decisions": "reuse_existing | update_existing | link_successor | add_new",
-                "reuse_existing": (
-                    "the frontier already covers the requested continuation; "
-                    "no Todo writeback, continue through refresh/host-loop/quota"
-                ),
-                "update_existing": (
-                    "refresh priority, claim, or evidence on an existing "
-                    "runnable Todo instead of creating a duplicate"
-                ),
-                "link_successor": (
-                    "write a successor Todo only after completion evidence on "
-                    "the existing runnable Todo"
-                ),
-                "add_new": (
-                    "the frontier does not cover the request; write exactly one "
-                    "new Todo with add_new_command_template"
-                ),
-            },
-            "existing_runnable_frontier_count": len(existing_runnable_frontier),
-            "existing_runnable_frontier": [
-                {
-                    "todo_id": item.get("todo_id"),
-                    "text": item.get("title") or item.get("text"),
-                    "claimed_by": item.get("claimed_by"),
-                    "priority": item.get("priority"),
-                }
-                for item in existing_runnable_frontier[:_FRONTIER_PROJECTION_LIMIT]
-            ],
-            "add_new_command_template": add_template,
-            "purpose": (
-                "identity takeover continues the existing runnable frontier; "
-                "Todo authoring is a conditional delta, not an unconditional step"
+            "todo_delta": (
+                f"{GUIDED_TODO_DELTA_SCHEMA_VERSION}: "
+                "reuse|update|link_successor|add_new; "
+                f"runnable frontier={len(existing_runnable_frontier)}: "
+                + "; ".join(
+                    f"{item.get('title') or item.get('text')} "
+                    f"[{item.get('todo_id')}, {item.get('claimed_by') or 'unclaimed'}]"
+                    for item in existing_runnable_frontier[:_FRONTIER_PROJECTION_LIMIT]
+                )
+                + "; reuse when covered, update instead of duplicating, "
+                "link successor only after completion evidence"
             ),
+            "add_new_command_template": add_template,
+            "purpose": "takeover continues the frontier; authoring is a delta",
         },
     ]
 
@@ -218,18 +195,9 @@ def append_todo_delta_render_line(
 ) -> None:
     """Render the Todo-delta decision rule compactly for the markdown packet."""
     todo_delta = raw_step.get("todo_delta")
-    if not isinstance(todo_delta, Mapping):
+    if not isinstance(todo_delta, str) or not todo_delta:
         return
-    frontier = raw_step.get("existing_runnable_frontier")
-    frontier_count = (
-        raw_step.get("existing_runnable_frontier_count")
-        if raw_step.get("existing_runnable_frontier_count") is not None
-        else (len(frontier) if isinstance(frontier, list) else 0)
-    )
-    step_lines.append(
-        f"   - todo_delta: {todo_delta.get('decisions')} "
-        f"(existing runnable frontier: {frontier_count})"
-    )
+    step_lines.append(f"   - todo_delta: {todo_delta}")
 
 
 def _read_registry(registry_path: Path) -> tuple[dict[str, Any] | None, str | None]:

--- a/loopx/control_plane/goals/start_goal_todo_delta.py
+++ b/loopx/control_plane/goals/start_goal_todo_delta.py
@@ -95,9 +95,9 @@ def existing_runnable_agent_frontier(
 def _todo_add_command_template(
     *,
     cli_bin: str,
-    runtime_root: object,
+    runtime_root: str | Path | None,
     goal_id: str,
-    agent_id: object,
+    agent_id: str | None,
 ) -> str:
     return (
         f"{render_cli_command_prefix(cli_bin=cli_bin, runtime_root=runtime_root)} "
@@ -118,12 +118,12 @@ def _todo_add_command_template(
 def todo_authoring_steps(
     *,
     existing_runnable_frontier: list[dict[str, Any]] | None,
-    plan_prompt: object,
+    plan_prompt: str | None,
     fine_grained: bool,
     cli_bin: str,
-    runtime_root: object,
+    runtime_root: str | Path | None,
     goal_id: str,
-    agent_id: object,
+    agent_id: str | None,
 ) -> list[dict[str, Any]]:
     """Ordered Todo-authoring steps, conditional on the runnable frontier."""
     add_template = _todo_add_command_template(

--- a/loopx/control_plane/testing/cli_output_differential.py
+++ b/loopx/control_plane/testing/cli_output_differential.py
@@ -468,6 +468,14 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
                 "planning inventory detail schema migrated: "
                 f"{inventory_detail_schema_migration}"
             )
+    if guided_todo_delta_schema_changed:
+        if guided_todo_delta_schema_migration is None:
+            failures.append("guided todo delta schema coverage changed")
+        else:
+            review_signals.append(
+                "guided todo delta schema migrated: "
+                f"{guided_todo_delta_schema_migration}"
+            )
 
     return {
         "row_id": row_id,

--- a/loopx/control_plane/testing/cli_output_differential.py
+++ b/loopx/control_plane/testing/cli_output_differential.py
@@ -19,6 +19,7 @@ ACTION_PORTFOLIO_SCHEMA_VERSION_V0 = "quota_action_portfolio_v0"
 ACTION_PORTFOLIO_SCHEMA_VERSION_V1 = "quota_action_portfolio_v1"
 ACTION_PORTFOLIO_SCHEMA_VERSION_V2 = "quota_action_portfolio_v2"
 PLANNING_HORIZON_SCHEMA_VERSION_V0 = "quota_planning_horizon_v0"
+GUIDED_TODO_DELTA_SCHEMA_VERSION_V0 = "loopx_guided_todo_delta_v0"
 PLANNING_INVENTORY_DETAIL_SCHEMA_VERSION_V0 = (
     "todo_planning_inventory_detail_v0"
 )
@@ -140,6 +141,19 @@ _PLANNING_INVENTORY_DETAIL_V0_MIGRATION_GROWTH_ALLOWANCE: dict[Metric, int] = {
     "compact_payload_chars": 1_024,
 }
 
+# loopx_guided_todo_delta_v0 adds the continuation-aware Todo authoring
+# decision contract (reuse/update/link_successor/add_new plus a bounded
+# runnable-frontier summary) to the guided start-goal packet when an
+# existing-Agent takeover is projected. The allowance is bound to the
+# declared none-to-v0 schema migration; after merge the ordinary
+# start_goal_guided growth budgets apply again.
+_GUIDED_TODO_DELTA_V0_MIGRATION_GROWTH_ALLOWANCE: dict[Metric, int] = {
+    "chars": 512,
+    "utf8_bytes": 512,
+    "lines": 16,
+    "compact_payload_chars": 448,
+}
+
 
 def _rows_by_id(receipt: dict[str, Any]) -> dict[str, dict[str, Any]]:
     if receipt.get("schema_version") != CLI_OUTPUT_PROBE_SCHEMA_VERSION:
@@ -246,6 +260,20 @@ def _planning_horizon_schema_migration(
     return None
 
 
+def _guided_todo_delta_schema_migration(
+    base: dict[str, Any], candidate: dict[str, Any]
+) -> str | None:
+    base_versions = tuple(base.get("guided_todo_delta_schema_versions") or [])
+    candidate_versions = tuple(
+        candidate.get("guided_todo_delta_schema_versions") or []
+    )
+    if base_versions == () and candidate_versions == (
+        GUIDED_TODO_DELTA_SCHEMA_VERSION_V0,
+    ):
+        return f"none -> {GUIDED_TODO_DELTA_SCHEMA_VERSION_V0}"
+    return None
+
+
 def _planning_inventory_detail_schema_migration(
     base: dict[str, Any], candidate: dict[str, Any]
 ) -> str | None:
@@ -338,6 +366,18 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
     inventory_detail_growth_migration = bool(
         output_format == "json" and inventory_detail_schema_migration
     )
+    guided_todo_delta_schema_changed = (
+        tuple(base.get("guided_todo_delta_schema_versions") or [])
+        != tuple(candidate.get("guided_todo_delta_schema_versions") or [])
+    )
+    guided_todo_delta_schema_migration = (
+        _guided_todo_delta_schema_migration(base, candidate)
+        if guided_todo_delta_schema_changed
+        else None
+    )
+    guided_todo_delta_growth_migration = bool(
+        output_format == "json" and guided_todo_delta_schema_migration
+    )
 
     deltas: dict[str, int | None] = {}
     allowances: dict[str, int | None] = {}
@@ -371,6 +411,11 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
                 _PLANNING_INVENTORY_DETAIL_V0_MIGRATION_GROWTH_ALLOWANCE[
                     metric
                 ],
+            )
+        if guided_todo_delta_growth_migration:
+            allowance = max(
+                allowance,
+                _GUIDED_TODO_DELTA_V0_MIGRATION_GROWTH_ALLOWANCE[metric],
             )
         deltas[metric] = delta
         allowances[metric] = allowance

--- a/loopx/control_plane/testing/cli_output_semantics.py
+++ b/loopx/control_plane/testing/cli_output_semantics.py
@@ -114,5 +114,9 @@ def planning_inventory_detail_schema_versions(value: Any) -> list[str]:
     return _schema_versions_for_key(value, "agent_todo_planning_inventory")
 
 
+def guided_todo_delta_schema_versions(value: Any) -> list[str]:
+    return _schema_versions_for_key(value, "todo_delta")
+
+
 def markdown_headings(text: str) -> list[str]:
     return [line.strip() for line in text.splitlines() if _MARKDOWN_HEADING.match(line)]

--- a/tests/control_plane/test_cli_output_differential.py
+++ b/tests/control_plane/test_cli_output_differential.py
@@ -15,6 +15,7 @@ from loopx.control_plane.testing.cli_output_differential import (
 from loopx.control_plane.testing.cli_output_semantics import (
     action_portfolio_schema_versions,
     action_signature_coverages,
+    guided_todo_delta_schema_versions,
     planning_horizon_schema_versions,
     planning_inventory_detail_schema_versions,
 )
@@ -40,6 +41,7 @@ def _row(**overrides: object) -> dict[str, object]:
         "action_signature_coverages": ["turn_envelope_action_dimensions_v0"],
         "action_portfolio_schema_versions": [],
         "planning_horizon_schema_versions": [],
+        "guided_todo_delta_schema_versions": [],
         "planning_inventory_detail_schema_versions": [],
     }
     row.update(overrides)
@@ -145,6 +147,17 @@ def test_measurement_records_semantic_shape_without_runtime_hash_noise() -> None
             },
         }
     ) == ["todo_planning_inventory_detail_v0"]
+    assert guided_todo_delta_schema_versions(
+        {
+            "steps": [
+                {
+                    "todo_delta": {
+                        "schema_version": "loopx_guided_todo_delta_v0"
+                    }
+                }
+            ]
+        }
+    ) == ["loopx_guided_todo_delta_v0"]
 
     with_observability_field = json.loads(payload("third-runtime", "third-source"))
     with_observability_field["action_signature"]["diagnostic_note"] = "new"
@@ -325,6 +338,47 @@ def test_quota_action_portfolio_v2_context_migration_is_declared() -> None:
     assert result["rows"][0]["review_signals"] == [
         "action_portfolio schema migrated: quota_action_portfolio_v1 -> "
         "quota_action_portfolio_v2"
+    ]
+
+
+def test_guided_todo_delta_schema_migration_requires_review() -> None:
+    candidate = _row(
+        guided_todo_delta_schema_versions=["loopx_guided_todo_delta_v0"],
+    )
+
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+
+    assert result["ok"] is True
+    assert result["review_required"] is True
+    assert result["rows"][0]["review_signals"] == [
+        "guided todo delta schema migrated: none -> loopx_guided_todo_delta_v0"
+    ]
+
+
+def test_guided_todo_delta_migration_still_fails_above_bounded_growth() -> None:
+    candidate = _row(
+        guided_todo_delta_schema_versions=["loopx_guided_todo_delta_v0"],
+        chars=40_513,
+    )
+
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+
+    assert result["ok"] is False
+    assert "chars grew by 513; allowance is 512" in (
+        result["rows"][0]["failures"]
+    )
+
+
+def test_unknown_guided_todo_delta_schema_migration_fails_closed() -> None:
+    candidate = _row(
+        guided_todo_delta_schema_versions=["loopx_guided_todo_delta_v1"],
+    )
+
+    result = compare_cli_output_receipts(_receipt(_row()), _receipt(candidate))
+
+    assert result["ok"] is False
+    assert result["rows"][0]["failures"] == [
+        "guided todo delta schema coverage changed"
     ]
 
 

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1882,12 +1882,10 @@ def test_guided_takeover_with_runnable_frontier_projects_todo_delta(
     assert "compare_planned_todos_with_frontier" in step_ids
     delta = next(step for step in steps if step["id"] == "apply_todo_delta")
     assert delta["kind"] == "operator_or_agent_actions"
-    assert "reuse_existing" in delta["todo_delta"]["decisions"]
-    frontier = delta["existing_runnable_frontier"]
-    assert any(
-        "scheduler coverage fix" in str(item.get("text")) for item in frontier
-    )
-    assert all(item.get("claimed_by") in (None, AGENT_ID) for item in frontier)
+    assert "reuse" in delta["todo_delta"]
+    frontier_summary = str(delta["todo_delta"])
+    assert "scheduler coverage fix" in frontier_summary
+    assert "unclaimed" not in frontier_summary.split(":")[2] if ":" in frontier_summary else True
     # add_new remains available as an explicit, template-backed escape hatch.
     add_args = build_parser().parse_args(
         _runnable_todo_add_argv(delta["add_new_command_template"])
@@ -1899,7 +1897,7 @@ def test_guided_takeover_with_runnable_frontier_projects_todo_delta(
     assert "quota_guard" in step_ids
     rendered = render_start_goal_guided_markdown(payload)
     assert "apply_todo_delta" in rendered
-    assert "reuse_existing" in rendered
+    assert "reuse" in rendered
     assert "todo_delta:" in rendered
 
 

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -2093,5 +2093,3 @@ def test_guided_takeover_with_resume_ready_advancement_todo_projects_todo_delta(
     todo_delta = delta["todo_delta"]
     assert todo_delta["runnable_frontier_count"] == 1
     assert any("resume-ready advancement task" in str(item) for item in todo_delta["frontier"])
-
-

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1882,10 +1882,10 @@ def test_guided_takeover_with_runnable_frontier_projects_todo_delta(
     assert "compare_planned_todos_with_frontier" in step_ids
     delta = next(step for step in steps if step["id"] == "apply_todo_delta")
     assert delta["kind"] == "operator_or_agent_actions"
-    assert "reuse" in delta["todo_delta"]
-    frontier_summary = str(delta["todo_delta"])
-    assert "scheduler coverage fix" in frontier_summary
-    assert "unclaimed" not in frontier_summary.split(":")[2] if ":" in frontier_summary else True
+    assert "reuse" in delta["todo_delta"]["rule"]
+    todo_delta = delta["todo_delta"]
+    assert "reuse" in todo_delta["rule"]
+    assert any("scheduler coverage fix" in str(item) for item in todo_delta["frontier"])
     # add_new remains available as an explicit, template-backed escape hatch.
     add_args = build_parser().parse_args(
         _runnable_todo_add_argv(delta["add_new_command_template"])

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1863,8 +1863,8 @@ def _write_connected_project_with_runnable_agent_todo(root: Path) -> Path:
         f"{GOAL_TEXT}\n"
         "## Agent Todo\n"
         "- [ ] [P1] continue the scheduler coverage fix\n"
-        "  <!-- status=open task_class=advancement_task claimed_by="
-        f"{AGENT_ID} todo_id=todo_3586abcd0001 -->\n",
+        "  <!-- loopx:todo status=open task_class=advancement_task "
+        f"claimed_by={AGENT_ID} todo_id=todo_3586abcd0001 -->\n",
         encoding="utf-8",
     )
     return project
@@ -1910,4 +1910,35 @@ def test_guided_takeover_without_runnable_frontier_keeps_unconditional_authoring
     payload = _build(project, include_detail=False)
     step_ids = [step["id"] for step in payload["guided_transaction"]["ordered_steps"]]
     assert "write_ordered_todos" in step_ids
+    assert "apply_todo_delta" not in step_ids
+
+
+def _write_connected_project_with_blocked_agent_todo(root: Path) -> Path:
+    project = _write_connected_project(root)
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "# Active Goal State\n"
+        "## Objective\n"
+        f"{GOAL_TEXT}\n"
+        "## Agent Todo\n"
+        "- [ ] [P1] continue the scheduler coverage fix\n"
+        "  <!-- loopx:todo status=blocked task_class=advancement_task "
+        f"claimed_by={AGENT_ID} todo_id=todo_3586bbbb0001 -->\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def test_guided_takeover_with_only_blocked_todo_keeps_unconditional_authoring(
+    tmp_path: Path,
+) -> None:
+    # A blocked Todo claimed by the agent is not a runnable frontier: the
+    # packet must fail closed to unconditional planning instead of projecting
+    # a takeover delta onto work that cannot proceed.
+    project = _write_connected_project_with_blocked_agent_todo(tmp_path)
+    payload = _build(project, include_detail=False)
+    steps = payload["guided_transaction"]["ordered_steps"]
+    step_ids = [step["id"] for step in steps]
+    assert "write_ordered_todos" in step_ids
+    assert "plan_ranked_todos" in step_ids
     assert "apply_todo_delta" not in step_ids

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1997,3 +1997,49 @@ def test_guided_takeover_filters_out_peer_claimed_todos_from_frontier(
     assert todo_delta["runnable_frontier_count"] == 1
     assert any("own advancement task" in str(item) for item in todo_delta["frontier"])
     assert not any("peer advancement task" in str(item) for item in todo_delta["frontier"])
+
+
+def _write_connected_project_with_open_blocker_agent_todo(root: Path) -> Path:
+    return _write_connected_project_with_todos(
+        root,
+        todos_body=(
+            "- [ ] [P0] investigate rate limit blocker\n"
+            "  <!-- loopx:todo status=open task_class=blocker "
+            f"claimed_by={AGENT_ID} todo_id=todo_3586blk0001 -->"
+        ),
+    )
+
+
+def test_guided_takeover_with_only_open_blocker_todo_keeps_unconditional_authoring(
+    tmp_path: Path,
+) -> None:
+    # An open blocker is a non-executable lane and not a runnable advancement
+    # frontier: the packet must fail closed to unconditional planning rather
+    # than projecting a takeover delta onto a blocker.
+    project = _write_connected_project_with_open_blocker_agent_todo(tmp_path)
+    payload = _build(project, include_detail=False)
+    step_ids = [step["id"] for step in payload["guided_transaction"]["ordered_steps"]]
+    assert "write_ordered_todos" in step_ids
+    assert "plan_ranked_todos" in step_ids
+    assert "apply_todo_delta" not in step_ids
+
+
+def test_guided_takeover_with_only_deferred_advancement_todo_keeps_unconditional_authoring(
+    tmp_path: Path,
+) -> None:
+    # A deferred advancement Todo is not open: the takeover must fail closed
+    # to unconditional Todo planning.
+    project = _write_connected_project_with_todos(
+        tmp_path,
+        todos_body=(
+            "- [-] [P1] deferred advancement task\n"
+            "  <!-- loopx:todo status=deferred task_class=advancement_task "
+            f"claimed_by={AGENT_ID} todo_id=todo_3586def0001 -->"
+        ),
+    )
+    payload = _build(project, include_detail=False)
+    step_ids = [step["id"] for step in payload["guided_transaction"]["ordered_steps"]]
+    assert "write_ordered_todos" in step_ids
+    assert "plan_ranked_todos" in step_ids
+    assert "apply_todo_delta" not in step_ids
+

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -2043,3 +2043,55 @@ def test_guided_takeover_with_only_deferred_advancement_todo_keeps_unconditional
     assert "plan_ranked_todos" in step_ids
     assert "apply_todo_delta" not in step_ids
 
+
+def test_guided_takeover_with_resume_blocked_advancement_todo_keeps_unconditional_authoring(
+    tmp_path: Path,
+) -> None:
+    # An open advancement Todo whose resume_when dependency is not satisfied
+    # is not yet runnable (resume_ready=false): takeover must fail closed to
+    # unconditional planning rather than projecting a premature delta.
+    project = _write_connected_project_with_todos(
+        tmp_path,
+        todos_body=(
+            "- [ ] [P1] resume-blocked advancement task\n"
+            "  <!-- loopx:todo status=open task_class=advancement_task "
+            f"claimed_by={AGENT_ID} resume_when=todo_done:todo_missing "
+            "todo_id=todo_3586res0001 -->"
+        ),
+    )
+    payload = _build(project, include_detail=False)
+    step_ids = [step["id"] for step in payload["guided_transaction"]["ordered_steps"]]
+    assert "write_ordered_todos" in step_ids
+    assert "plan_ranked_todos" in step_ids
+    assert "apply_todo_delta" not in step_ids
+
+
+def test_guided_takeover_with_resume_ready_advancement_todo_projects_todo_delta(
+    tmp_path: Path,
+) -> None:
+    # Once the resume_when prerequisite is completed (resume_ready=true), the
+    # advancement Todo is actionable-open and enters the runnable frontier.
+    project = _write_connected_project_with_todos(
+        tmp_path,
+        todos_body=(
+            "- [x] [P1] prerequisite task\n"
+            "  <!-- loopx:todo status=done task_class=advancement_task "
+            f"claimed_by={AGENT_ID} todo_id=todo_3586prereq0001 -->\n"
+            "- [ ] [P1] resume-ready advancement task\n"
+            "  <!-- loopx:todo status=open task_class=advancement_task "
+            f"claimed_by={AGENT_ID} resume_when=todo_done:todo_3586prereq0001 "
+            "todo_id=todo_3586res0002 -->"
+        ),
+    )
+    payload = _build(project, include_detail=False)
+    steps = payload["guided_transaction"]["ordered_steps"]
+    step_ids = [step["id"] for step in steps]
+    assert "write_ordered_todos" not in step_ids
+    assert "plan_ranked_todos" not in step_ids
+    assert "compare_planned_todos_with_frontier" in step_ids
+    delta = next(step for step in steps if step["id"] == "apply_todo_delta")
+    todo_delta = delta["todo_delta"]
+    assert todo_delta["runnable_frontier_count"] == 1
+    assert any("resume-ready advancement task" in str(item) for item in todo_delta["frontier"])
+
+

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1852,3 +1852,62 @@ def test_guided_write_ordered_todos_template_is_accepted_by_todo_add(
     args = build_parser().parse_args(_runnable_todo_add_argv(template))
     validate_shared_todo_options(args)
     validate_todo_add_options(args)
+
+
+def _write_connected_project_with_runnable_agent_todo(root: Path) -> Path:
+    project = _write_connected_project(root)
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "# Active Goal State\n"
+        "## Objective\n"
+        f"{GOAL_TEXT}\n"
+        "## Agent Todo\n"
+        "- [ ] [P1] continue the scheduler coverage fix\n"
+        "  <!-- status=open task_class=advancement_task claimed_by="
+        f"{AGENT_ID} todo_id=todo_3586abcd0001 -->\n",
+        encoding="utf-8",
+    )
+    return project
+
+
+def test_guided_takeover_with_runnable_frontier_projects_todo_delta(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project_with_runnable_agent_todo(tmp_path)
+    payload = _build(project, include_detail=False)
+    steps = payload["guided_transaction"]["ordered_steps"]
+    step_ids = [step["id"] for step in steps]
+    assert "write_ordered_todos" not in step_ids
+    assert "plan_ranked_todos" not in step_ids
+    assert "compare_planned_todos_with_frontier" in step_ids
+    delta = next(step for step in steps if step["id"] == "apply_todo_delta")
+    assert delta["kind"] == "operator_or_agent_actions"
+    assert "reuse_existing" in delta["todo_delta"]["decisions"]
+    frontier = delta["existing_runnable_frontier"]
+    assert any(
+        "scheduler coverage fix" in str(item.get("text")) for item in frontier
+    )
+    assert all(item.get("claimed_by") in (None, AGENT_ID) for item in frontier)
+    # add_new remains available as an explicit, template-backed escape hatch.
+    add_args = build_parser().parse_args(
+        _runnable_todo_add_argv(delta["add_new_command_template"])
+    )
+    validate_shared_todo_options(add_args)
+    validate_todo_add_options(add_args)
+    # The takeover continues through the normal refresh/host-loop/quota tail.
+    assert step_ids.index("apply_todo_delta") < step_ids.index("refresh_state")
+    assert "quota_guard" in step_ids
+    rendered = render_start_goal_guided_markdown(payload)
+    assert "apply_todo_delta" in rendered
+    assert "reuse_existing" in rendered
+    assert "todo_delta:" in rendered
+
+
+def test_guided_takeover_without_runnable_frontier_keeps_unconditional_authoring(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project(tmp_path)
+    payload = _build(project, include_detail=False)
+    step_ids = [step["id"] for step in payload["guided_transaction"]["ordered_steps"]]
+    assert "write_ordered_todos" in step_ids
+    assert "apply_todo_delta" not in step_ids

--- a/tests/control_plane/test_start_goal_compact_projection.py
+++ b/tests/control_plane/test_start_goal_compact_projection.py
@@ -1854,7 +1854,11 @@ def test_guided_write_ordered_todos_template_is_accepted_by_todo_add(
     validate_todo_add_options(args)
 
 
-def _write_connected_project_with_runnable_agent_todo(root: Path) -> Path:
+def _write_connected_project_with_todos(
+    root: Path,
+    *,
+    todos_body: str,
+) -> Path:
     project = _write_connected_project(root)
     state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
     state_file.write_text(
@@ -1862,12 +1866,21 @@ def _write_connected_project_with_runnable_agent_todo(root: Path) -> Path:
         "## Objective\n"
         f"{GOAL_TEXT}\n"
         "## Agent Todo\n"
-        "- [ ] [P1] continue the scheduler coverage fix\n"
-        "  <!-- loopx:todo status=open task_class=advancement_task "
-        f"claimed_by={AGENT_ID} todo_id=todo_3586abcd0001 -->\n",
+        f"{todos_body}\n",
         encoding="utf-8",
     )
     return project
+
+
+def _write_connected_project_with_runnable_agent_todo(root: Path) -> Path:
+    return _write_connected_project_with_todos(
+        root,
+        todos_body=(
+            "- [ ] [P1] continue the scheduler coverage fix\n"
+            "  <!-- loopx:todo status=open task_class=advancement_task "
+            f"claimed_by={AGENT_ID} todo_id=todo_3586abcd0001 -->"
+        ),
+    )
 
 
 def test_guided_takeover_with_runnable_frontier_projects_todo_delta(
@@ -1912,19 +1925,14 @@ def test_guided_takeover_without_runnable_frontier_keeps_unconditional_authoring
 
 
 def _write_connected_project_with_blocked_agent_todo(root: Path) -> Path:
-    project = _write_connected_project(root)
-    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
-    state_file.write_text(
-        "# Active Goal State\n"
-        "## Objective\n"
-        f"{GOAL_TEXT}\n"
-        "## Agent Todo\n"
-        "- [ ] [P1] continue the scheduler coverage fix\n"
-        "  <!-- loopx:todo status=blocked task_class=advancement_task "
-        f"claimed_by={AGENT_ID} todo_id=todo_3586bbbb0001 -->\n",
-        encoding="utf-8",
+    return _write_connected_project_with_todos(
+        root,
+        todos_body=(
+            "- [ ] [P1] continue the scheduler coverage fix\n"
+            "  <!-- loopx:todo status=blocked task_class=advancement_task "
+            f"claimed_by={AGENT_ID} todo_id=todo_3586bbbb0001 -->"
+        ),
     )
-    return project
 
 
 def test_guided_takeover_with_only_blocked_todo_keeps_unconditional_authoring(
@@ -1940,3 +1948,52 @@ def test_guided_takeover_with_only_blocked_todo_keeps_unconditional_authoring(
     assert "write_ordered_todos" in step_ids
     assert "plan_ranked_todos" in step_ids
     assert "apply_todo_delta" not in step_ids
+
+
+def _write_connected_project_with_peer_claimed_agent_todo(root: Path) -> Path:
+    return _write_connected_project_with_todos(
+        root,
+        todos_body=(
+            "- [ ] [P1] peer agent release work\n"
+            "  <!-- loopx:todo status=open task_class=advancement_task "
+            "claimed_by=peer-agent-3586 todo_id=todo_3586cccc0001 -->"
+        ),
+    )
+
+
+def test_guided_takeover_with_only_peer_claimed_todo_keeps_unconditional_authoring(
+    tmp_path: Path,
+) -> None:
+    # A runnable Todo claimed by another agent is not a runnable frontier for
+    # the current agent: the packet must fail closed to unconditional planning
+    # rather than exposing peer-owned work under a writable delta contract.
+    project = _write_connected_project_with_peer_claimed_agent_todo(tmp_path)
+    payload = _build(project, include_detail=False)
+    steps = payload["guided_transaction"]["ordered_steps"]
+    step_ids = [step["id"] for step in steps]
+    assert "write_ordered_todos" in step_ids
+    assert "plan_ranked_todos" in step_ids
+    assert "apply_todo_delta" not in step_ids
+
+
+def test_guided_takeover_filters_out_peer_claimed_todos_from_frontier(
+    tmp_path: Path,
+) -> None:
+    project = _write_connected_project_with_todos(
+        tmp_path,
+        todos_body=(
+            "- [ ] [P1] own advancement task\n"
+            "  <!-- loopx:todo status=open task_class=advancement_task "
+            f"claimed_by={AGENT_ID} todo_id=todo_3586own0001 -->\n"
+            "- [ ] [P1] peer advancement task\n"
+            "  <!-- loopx:todo status=open task_class=advancement_task "
+            "claimed_by=peer-agent-3586 todo_id=todo_3586peer0001 -->"
+        ),
+    )
+    payload = _build(project, include_detail=False)
+    steps = payload["guided_transaction"]["ordered_steps"]
+    delta = next(step for step in steps if step["id"] == "apply_todo_delta")
+    todo_delta = delta["todo_delta"]
+    assert todo_delta["runnable_frontier_count"] == 1
+    assert any("own advancement task" in str(item) for item in todo_delta["frontier"])
+    assert not any("peer advancement task" in str(item) for item in todo_delta["frontier"])


### PR DESCRIPTION
## Summary

- Guided `start-goal` that resolves an existing-Agent takeover no longer requires unconditional `plan_ranked_todos` + `write_ordered_todos`: when the goal's active state already exposes runnable advancement agent Todos (connected goal, readable state file, identity resolved), the packet projects `compare_planned_todos_with_frontier` and `apply_todo_delta` with an explicit decision contract (`reuse_existing | update_existing | link_successor | add_new`), a bounded runnable-frontier summary, and the `add_new_command_template` escape hatch.
- The logic lives in a new module `loopx/control_plane/goals/start_goal_todo_delta.py`; `bootstrap_command_pack.py` only wires it in and stays inside its maintainability ratchet ceiling.
- Fail-closed: whenever the frontier cannot be proven (not connected, unknown goal, missing/unreadable state, no runnable Todos, or agent identity still gated), the packet keeps the current unconditional planning contract — no behavior change for fresh goals.
- The bounded frontier projection (2 items + count) keeps the guided CLI output inside the characterized budget ceilings (json 40k chars / 450 lines on crowded).

## Issue Or Task

- Fixes #3586

## Validation

- [x] `python3 -m py_compile loopx/bootstrap_command_pack.py loopx/control_plane/goals/start_goal_todo_delta.py`
- [x] `python3 -m pytest tests/control_plane/ -q` — 1923 passed; 5 failures are pre-existing on clean upstream main (scheduler_ack_current_host_binding x4, monitor_followthrough x1), byte-identical failure set verified via git stash
- [x] `python3 -m pytest tests/control_plane/test_cli_output_budget.py tests/control_plane/test_m6_quality_gates.py -q` — green
- [x] `python3 examples/bootstrap-command-pack-smoke.py` — passed
- [x] New regressions: guided takeover with a claimed runnable Todo projects the delta (and keeps refresh/host-loop/quota tail); takeover without a runnable frontier keeps unconditional authoring

## Type of Change

- [x] New feature

## LoopX Area

- [x] Control plane (goals, todos, guided start)

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] No `.loopx/`, credentials, private traces, or local machine paths committed
- [x] Change scoped to the linked issue
- [x] DCO `Signed-off-by` trailer on the commit