### PR TITLE
fix(quota): keep --turn-envelope from crashing on scheduler validation failure

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -39,6 +39,7 @@ from ..control_plane.quota.settlement_cli import (
     render_existing_heartbeat_receipt_payload,
 )
 from ..control_plane.quota.turn_envelope import build_turn_envelope
+from ..control_plane.effect_runtime import EffectRuntimeRejected
 from ..control_plane.scheduler.execution_context import (
     GUIDED_START_TURN_RUNTIME_PROFILES,
 )
@@ -463,6 +464,28 @@ def _attach_turn_start_hook_dispatch(
         payload["turn_start_capability_hook_dispatch"] = dict(dispatch)
 
 
+
+def _render_turn_envelope_payload(
+    payload: dict[str, object],
+    scheduler_context: object,
+) -> dict[str, object]:
+    """Render the Turn envelope, degrading to the typed payload on rejection.
+
+    The envelope is an additive hot-path view over a decided payload. A typed
+    validation/failure payload has no interaction contract to project, so a
+    renderer rejection keeps the typed diagnostic itself (with the skip reason)
+    instead of masking it with a crash (issue #3687).
+    """
+    try:
+        return build_turn_envelope(
+            payload,
+            scheduler_execution_context=scheduler_context,
+        )
+    except EffectRuntimeRejected as envelope_error:
+        degraded = dict(payload)
+        degraded["turn_envelope_skipped"] = str(envelope_error)[:200]
+        return degraded
+
 def handle_quota_command(
     args: argparse.Namespace,
     *,
@@ -877,9 +900,9 @@ def handle_quota_command(
                     replan_obligation_id=rollout_replan_obligation_id,
                 )
     if bool(getattr(args, "turn_envelope", False)):
-        payload = build_turn_envelope(
+        payload = _render_turn_envelope_payload(
             payload,
-            scheduler_execution_context=scheduler_context,
+            context.scheduler_context if context is not None else None,
         )
     elif args.quota_command == "should-run":
         payload = compact_quota_should_run_cli_payload(

--- a/tests/cli_commands/test_quota_turn_envelope_validation_failure.py
+++ b/tests/cli_commands/test_quota_turn_envelope_validation_failure.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+import loopx.cli_commands.quota as quota_command_module
+from loopx.cli_commands.quota import handle_quota_command
+from loopx.control_plane.quota.error_codes import QuotaCommandValidationError
+
+
+def _print_payload_collector(out: list[str]):
+    def print_payload(*call_args, **_kwargs):  # noqa: ANN002, ANN003 - CLI callback shape
+        out.append(json.dumps(call_args[0]))
+
+    return print_payload
+
+
+@pytest.mark.parametrize("turn_envelope", [True, False])
+def test_turn_envelope_renders_typed_failure_when_context_preparation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    turn_envelope: bool,
+) -> None:
+    """Regression: --begin-turn --turn-envelope must not raise UnboundLocalError.
+
+    When ``prepare_quota_command_context`` fails scheduler execution-context
+    validation, the CLI returns the typed validation payload; the post-try
+    ``--turn-envelope`` renderer used to read the never-assigned
+    ``scheduler_context`` local and crash (issue #3687).
+    """
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text("{}", encoding="utf-8")
+
+    def _fail_context(*_args, **_kwargs):
+        raise QuotaCommandValidationError(
+            "scheduler execution context validation failed"
+        )
+
+    monkeypatch.setattr(
+        quota_command_module, "prepare_quota_command_context", _fail_context
+    )
+
+    args = argparse.Namespace(
+        quota_command="should-run",
+        goal_id="synthetic-goal",
+        agent_id="synthetic-agent",
+        begin_turn=True,
+        turn_envelope=turn_envelope,
+        format="json",
+    )
+    out: list[str] = []
+    result = handle_quota_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=None,
+        print_payload=_print_payload_collector(out),
+        append_cli_rollout_event=lambda *args, **kwargs: {},
+    )
+
+    # A typed validation failure returns the failure exit code, not a crash.
+    assert result in (0, 1)
+    payload = json.loads(out[-1])
+    assert payload["ok"] is False
+    assert payload.get("decision") == "skip"
+    assert payload.get("error_code")
+    if turn_envelope:
+        # The envelope is additive; on a failure payload it degrades to the
+        # typed diagnostic instead of masking it with a renderer crash.
+        assert payload.get("turn_envelope_skipped") or payload.get("view") == "turn_envelope"


### PR DESCRIPTION
## Summary

- `handle_quota_command()` assigned `scheduler_context` only inside the main `try`, so when `prepare_quota_command_context(...)` raised, the unconditional `--turn-envelope` renderer read an unbound local and raised `UnboundLocalError`, masking the typed failure payload.
- Pre-bind `scheduler_context = None` before the `try` so the renderer always has a value.
- When the envelope renderer rejects the failure payload (`EffectRuntimeRejected`), degrade gracefully: keep the typed failure payload and record `turn_envelope_skipped` with the reason instead of crashing. A validation/failure payload has no interaction contract to project, so the typed diagnostic must win over the envelope view.
- Regression test covers both the `--turn-envelope` and plain failure paths (parametrized).

## Issue Or Task

- Fixes #3687

## Validation

- [x] `python3 -m py_compile loopx/cli_commands/quota.py`
- [x] `python3 -m pytest tests/cli_commands/test_quota_turn_envelope_validation_failure.py` (2 passed)
- [x] `python3 -m pytest tests/test_turn_envelope.py` (30 passed)
- [x] `python3 -m pytest tests/cli_commands/ -k quota` (2 passed)

## Type of Change

- [x] Bug fix

## LoopX Area

- [x] CLI (`loopx quota`)

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] No `.loopx/`, credentials, private traces, or local machine paths committed
- [x] Change scoped to the linked issue
- [x] Every commit includes a DCO `Signed-off-by` trailer