### PR TITLE
fix(refresh-state): prefer the agent-lane selected Todo over shared Next Action prose

### DIFF
--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -101,6 +101,7 @@ import {
   projectTodoPlanningInventory,
   projectTodoPlanningInventoryDetail,
 } from "./work_items/planning_inventory.ts";
+import { resolveRefreshRecommendation } from "./work_items/refresh_recommendation.ts";
 import {
   validateInteractionProjectionHookInvocation,
   validateInteractionProjectionHookRegistration,
@@ -340,6 +341,7 @@ export function createEffectRuntimeHandlers(
     ["work_item.planning_horizon.project", projectQuotaPlanningHorizon],
     ["work_item.planning_inventory.project", projectTodoPlanningInventory],
     ["work_item.planning_inventory.detail", projectTodoPlanningInventoryDetail],
+    ["work_item.refresh_recommendation.resolve", resolveRefreshRecommendation],
     ["goal.vision_checkpoint.evaluate", buildVisionCheckpoint],
     ["agent.delivery_workspace.evaluate", evaluateDeliveryWorkspace],
     [

--- a/loopx/control_plane/work_items/refresh_recommendation.py
+++ b/loopx/control_plane/work_items/refresh_recommendation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ..agents.agent_lane_recommendation import build_agent_lane_next_action
+from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
+from ..todos.active_state_todo_parser import parse_active_state_todos
+from ..todos.contract import normalize_todo_id
+from ...feedback import validate_local_control_text
+from ...state_projection import active_state_next_action_entries
+
+REFRESH_RECOMMENDATION_REQUEST_SCHEMA_VERSION = "refresh_recommendation_request_v0"
+REFRESH_RECOMMENDATION_SCHEMA_VERSION = "refresh_recommendation_v0"
+DEFAULT_REFRESH_ACTION = (
+    "inspect refreshed active goal state and continue the next bounded progress segment"
+)
+RECOMMENDED_ACTION_SOURCE_EXPLICIT = "explicit_arg"
+RECOMMENDED_ACTION_SOURCE_SETTLEMENT_BOUND_TODO = "settlement_bound_todo"
+RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO = "agent_lane_selected_todo"
+RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION = "active_state_next_action"
+RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK = "agent_todo_fallback"
+RECOMMENDED_ACTION_SOURCE_DEFAULT = "default_refresh_action"
+
+
+def _first_valid_action(values: list[str]) -> str | None:
+    for value in values:
+        try:
+            validate_local_control_text("derived recommended_action", value)
+        except ValueError:
+            continue
+        return value
+    return None
+
+
+def _agent_todo_summary(
+    state_text: str,
+    *,
+    registry_goal: dict[str, Any] | None,
+    state_path: Path | None,
+    settlement_todo_id: str | None,
+    rollout_events: list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    preferred = {settlement_todo_id} if settlement_todo_id else None
+    parsed = parse_active_state_todos(
+        state_text,
+        goal=registry_goal,
+        state_path=state_path,
+        preferred_todo_ids=preferred,
+        rollout_events=rollout_events,
+        item_limit=None,
+    )
+    summary = parsed.get("agent_todos")
+    return summary if isinstance(summary, dict) else None
+
+
+def _exact_todo(
+    summary: Mapping[str, Any] | None,
+    todo_id: str | None,
+) -> dict[str, Any] | None:
+    normalized = normalize_todo_id(todo_id)
+    if not normalized or not isinstance(summary, Mapping):
+        return None
+    items = summary.get("items")
+    for item in items if isinstance(items, list) else []:
+        if not isinstance(item, Mapping):
+            continue
+        if normalize_todo_id(item.get("todo_id")) != normalized:
+            continue
+        exact = dict(item)
+        exact["selection_binding"] = "heartbeat_receipt"
+        return exact
+    return None
+
+
+def _first_executable_todo(
+    summary: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(summary, Mapping):
+        return None
+    items = summary.get("first_executable_items")
+    for item in items if isinstance(items, list) else []:
+        if isinstance(item, Mapping):
+            return dict(item)
+    return None
+
+
+def resolve_refresh_recommendation(
+    state_text: str,
+    *,
+    explicit_action: str | None = None,
+    agent_id: str | None = None,
+    settlement_identity: Mapping[str, Any] | None = None,
+    registry_goal: dict[str, Any] | None = None,
+    state_path: Path | None = None,
+    rollout_events: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Adapt canonical Todo facts into the TS-owned refresh read reducer."""
+
+    settlement_todo_id: str | None = None
+    next_action_entries: list[str] = []
+    shared_action: str | None = None
+    summary: dict[str, Any] | None = None
+    lane_candidate: dict[str, Any] | None = None
+    if not explicit_action:
+        settlement_todo_id = normalize_todo_id(
+            settlement_identity.get("todo_id")
+            if isinstance(settlement_identity, Mapping)
+            else None
+        )
+        next_action_entries = active_state_next_action_entries(
+            state_text,
+            limit=None,
+            text_limit=500,
+        )
+        shared_action = _first_valid_action(next_action_entries)
+        summary = _agent_todo_summary(
+            state_text,
+            registry_goal=registry_goal,
+            state_path=state_path,
+            settlement_todo_id=settlement_todo_id,
+            rollout_events=rollout_events,
+        )
+        lane_candidate = build_agent_lane_next_action(
+            agent_identity={"agent_id": agent_id} if agent_id else None,
+            agent_todo_summary=summary,
+            capability_gate=None,
+            active_next_action=next_action_entries,
+            receipt_bound_todo_id=settlement_todo_id,
+        )
+    try:
+        result = effect_runtime_result(
+            "work_item.refresh_recommendation.resolve",
+            {
+                "schema_version": REFRESH_RECOMMENDATION_REQUEST_SCHEMA_VERSION,
+                "explicit_action": explicit_action,
+                "agent_id": agent_id,
+                "settlement_identity": (
+                    dict(settlement_identity)
+                    if settlement_todo_id and isinstance(settlement_identity, Mapping)
+                    else None
+                ),
+                "settlement_candidate": _exact_todo(summary, settlement_todo_id),
+                "agent_lane_candidate": lane_candidate,
+                "active_state_next_action": shared_action,
+                "unscoped_agent_todo_fallback": _first_executable_todo(summary),
+                "default_action": DEFAULT_REFRESH_ACTION,
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        raise ValueError(str(exc)) from None
+    if not isinstance(result, Mapping) or (
+        result.get("schema_version") != REFRESH_RECOMMENDATION_SCHEMA_VERSION
+    ):
+        raise RuntimeError("TypeScript refresh recommendation shape mismatch")
+    resolved = dict(result)
+    validate_local_control_text(
+        "recommended_action",
+        str(resolved.get("recommended_action") or ""),
+    )
+    return resolved
+
+
+def derive_recommended_action_with_source(
+    state_text: str,
+    *,
+    agent_id: str | None = None,
+) -> tuple[str, str]:
+    resolved = resolve_refresh_recommendation(state_text, agent_id=agent_id)
+    return (
+        str(resolved["recommended_action"]),
+        str(resolved["recommended_action_source"]),
+    )
+
+
+def derive_recommended_action(state_text: str) -> str:
+    return derive_recommended_action_with_source(state_text)[0]

--- a/loopx/control_plane/work_items/refresh_recommendation.ts
+++ b/loopx/control_plane/work_items/refresh_recommendation.ts
@@ -1,0 +1,294 @@
+import {
+  settlementIdentity as buildSettlementIdentity,
+  type JsonObject,
+  type SettlementIdentity,
+} from "../effect_program.ts";
+import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
+import {
+  optionalNonEmptyString,
+  requireJsonObject,
+  requireNonEmptyString,
+} from "../runtime_decode.ts";
+
+export const REFRESH_RECOMMENDATION_REQUEST_SCHEMA_VERSION =
+  "refresh_recommendation_request_v0";
+export const REFRESH_RECOMMENDATION_SCHEMA_VERSION =
+  "refresh_recommendation_v0";
+
+const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
+
+type RecommendationSource =
+  | "explicit_arg"
+  | "settlement_bound_todo"
+  | "agent_lane_selected_todo"
+  | "active_state_next_action"
+  | "agent_todo_fallback"
+  | "default_refresh_action";
+
+type SettlementAlignment = "not_applicable" | "exact" | "unavailable";
+type SettlementGapReason =
+  | "identity_mismatch"
+  | "candidate_missing"
+  | "candidate_mismatch"
+  | "candidate_ineligible";
+
+interface RecommendationCandidate extends JsonObject {
+  todo_id: string;
+  text: string;
+  status: string;
+  task_class: string;
+  claimed_by?: string;
+  resume_when?: string;
+  resume_ready?: boolean;
+  selection_binding?: string;
+  claim_required_before_work?: boolean;
+}
+
+export interface RefreshRecommendation extends JsonObject {
+  schema_version: typeof REFRESH_RECOMMENDATION_SCHEMA_VERSION;
+  recommended_action: string;
+  recommended_action_source: RecommendationSource;
+  authority: "explicit" | "settlement" | "agent_lane" | "shared_goal" | "compatibility" | "default";
+  settlement_alignment: SettlementAlignment;
+  settlement_gap_reason?: SettlementGapReason;
+  todo_id?: string;
+  selection_binding?: string;
+  claim_required_before_work?: boolean;
+}
+
+function todoId(value: unknown, label: string): string {
+  const normalized = requireNonEmptyString(value, label).trim().toLowerCase();
+  if (!TODO_ID_PATTERN.test(normalized)) {
+    throw new EffectRuntimeRequestError(`${label} must be a valid Todo id`);
+  }
+  return normalized;
+}
+
+function optionalBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new EffectRuntimeRequestError(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function candidate(value: unknown, label: string): RecommendationCandidate | null {
+  if (value === null || value === undefined) return null;
+  const raw = requireJsonObject(value, label);
+  const decoded: RecommendationCandidate = {
+    todo_id: todoId(raw.todo_id, `${label}.todo_id`),
+    text: requireNonEmptyString(raw.text, `${label}.text`),
+    status: requireNonEmptyString(raw.status, `${label}.status`).trim().toLowerCase(),
+    task_class: requireNonEmptyString(raw.task_class, `${label}.task_class`)
+      .trim()
+      .toLowerCase(),
+  };
+  for (const field of [
+    "claimed_by",
+    "resume_when",
+    "selection_binding",
+  ] as const) {
+    const normalized = optionalNonEmptyString(raw[field], `${label}.${field}`);
+    if (normalized !== null) decoded[field] = normalized;
+  }
+  const resumeReady = optionalBoolean(raw.resume_ready, `${label}.resume_ready`);
+  if (resumeReady !== undefined) decoded.resume_ready = resumeReady;
+  const claimRequired = optionalBoolean(
+    raw.claim_required_before_work,
+    `${label}.claim_required_before_work`,
+  );
+  if (claimRequired !== undefined) {
+    decoded.claim_required_before_work = claimRequired;
+  }
+  return decoded;
+}
+
+function settlementIdentity(value: unknown): SettlementIdentity | null {
+  if (value === null || value === undefined) return null;
+  const raw = requireJsonObject(value, "refresh_recommendation.settlement_identity");
+  const effectId = requireNonEmptyString(
+    raw.effect_id,
+    "refresh_recommendation.settlement_identity.effect_id",
+  );
+  const identity = buildSettlementIdentity({
+    goal_id: requireNonEmptyString(
+      raw.goal_id,
+      "refresh_recommendation.settlement_identity.goal_id",
+    ),
+    agent_id: requireNonEmptyString(
+      raw.agent_id,
+      "refresh_recommendation.settlement_identity.agent_id",
+    ),
+    todo_id: todoId(
+      raw.todo_id,
+      "refresh_recommendation.settlement_identity.todo_id",
+    ),
+    turn_instance_id: requireNonEmptyString(
+      raw.turn_instance_id,
+      "refresh_recommendation.settlement_identity.turn_instance_id",
+    ),
+  });
+  if (identity.effect_id !== effectId) {
+    throw new EffectRuntimeRequestError(
+      "refresh_recommendation.settlement_identity.effect_id mismatch",
+    );
+  }
+  return identity;
+}
+
+function candidateIsRunnable(
+  value: RecommendationCandidate,
+  agentId: string | null,
+): boolean {
+  if (value.status !== "open" || value.task_class !== "advancement_task") {
+    return false;
+  }
+  if (value.resume_when && value.resume_ready !== true) return false;
+  if (agentId && value.claimed_by && value.claimed_by !== agentId) return false;
+  return true;
+}
+
+function recommendation(
+  action: string,
+  source: RecommendationSource,
+  authority: RefreshRecommendation["authority"],
+  settlementAlignment: SettlementAlignment,
+  selected: RecommendationCandidate | null = null,
+  settlementGapReason?: SettlementGapReason,
+): RefreshRecommendation {
+  const result: RefreshRecommendation = {
+    schema_version: REFRESH_RECOMMENDATION_SCHEMA_VERSION,
+    recommended_action: action,
+    recommended_action_source: source,
+    authority,
+    settlement_alignment: settlementAlignment,
+  };
+  if (settlementGapReason) {
+    result.settlement_gap_reason = settlementGapReason;
+  }
+  if (selected) {
+    result.todo_id = selected.todo_id;
+    if (selected.selection_binding) {
+      result.selection_binding = selected.selection_binding;
+    }
+    result.claim_required_before_work =
+      selected.claim_required_before_work === true || !selected.claimed_by;
+  }
+  return result;
+}
+
+/** Resolve one refresh recommendation without recreating quota eligibility. */
+export function resolveRefreshRecommendation(value: unknown): RefreshRecommendation {
+  const request = requireJsonObject(value, "refresh_recommendation request");
+  if (request.schema_version !== REFRESH_RECOMMENDATION_REQUEST_SCHEMA_VERSION) {
+    throw new EffectRuntimeRequestError("refresh recommendation request schema mismatch");
+  }
+
+  const agentId = optionalNonEmptyString(request.agent_id, "refresh_recommendation.agent_id");
+  const explicitAction = optionalNonEmptyString(
+    request.explicit_action,
+    "refresh_recommendation.explicit_action",
+  );
+  const sharedAction = optionalNonEmptyString(
+    request.active_state_next_action,
+    "refresh_recommendation.active_state_next_action",
+  );
+  const defaultAction = requireNonEmptyString(
+    request.default_action,
+    "refresh_recommendation.default_action",
+  );
+  if (explicitAction) {
+    return recommendation(
+      explicitAction,
+      "explicit_arg",
+      "explicit",
+      "not_applicable",
+    );
+  }
+  const settlement = settlementIdentity(request.settlement_identity);
+  const settlementCandidate = candidate(
+    request.settlement_candidate,
+    "refresh_recommendation.settlement_candidate",
+  );
+  const laneCandidate = candidate(
+    request.agent_lane_candidate,
+    "refresh_recommendation.agent_lane_candidate",
+  );
+  const compatibilityCandidate = candidate(
+    request.unscoped_agent_todo_fallback,
+    "refresh_recommendation.unscoped_agent_todo_fallback",
+  );
+
+  let settlementAlignment: SettlementAlignment = "not_applicable";
+  let settlementGapReason: SettlementGapReason | undefined;
+  let exactSettlementCandidate = false;
+  if (settlement) {
+    settlementAlignment = "unavailable";
+    if (!agentId || settlement.agent_id !== agentId) {
+      settlementGapReason = "identity_mismatch";
+    } else if (!settlementCandidate) {
+      settlementGapReason = "candidate_missing";
+    } else if (
+      settlementCandidate.todo_id !== settlement.todo_id ||
+      settlementCandidate.selection_binding !== "heartbeat_receipt"
+    ) {
+      settlementGapReason = "candidate_mismatch";
+    } else if (!candidateIsRunnable(settlementCandidate, agentId)) {
+      settlementGapReason = "candidate_ineligible";
+    } else {
+      settlementAlignment = "exact";
+      exactSettlementCandidate = true;
+    }
+  }
+  if (exactSettlementCandidate && settlementCandidate) {
+    return recommendation(
+      settlementCandidate.text,
+      "settlement_bound_todo",
+      "settlement",
+      settlementAlignment,
+      settlementCandidate,
+    );
+  }
+  if (agentId && laneCandidate && candidateIsRunnable(laneCandidate, agentId)) {
+    return recommendation(
+      laneCandidate.text,
+      "agent_lane_selected_todo",
+      "agent_lane",
+      settlementAlignment,
+      laneCandidate,
+      settlementGapReason,
+    );
+  }
+  if (sharedAction) {
+    return recommendation(
+      sharedAction,
+      "active_state_next_action",
+      "shared_goal",
+      settlementAlignment,
+      null,
+      settlementGapReason,
+    );
+  }
+  if (
+    !agentId &&
+    compatibilityCandidate &&
+    candidateIsRunnable(compatibilityCandidate, null)
+  ) {
+    return recommendation(
+      compatibilityCandidate.text,
+      "agent_todo_fallback",
+      "compatibility",
+      settlementAlignment,
+      compatibilityCandidate,
+      settlementGapReason,
+    );
+  }
+  return recommendation(
+    defaultAction,
+    "default_refresh_action",
+    "default",
+    settlementAlignment,
+    null,
+    settlementGapReason,
+  );
+}

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -89,6 +89,7 @@ from .control_plane.todos.completion_validation_accountability import (
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
 DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
 RECOMMENDED_ACTION_SOURCE_EXPLICIT = "explicit_arg"
+RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO = "agent_lane_selected_todo"
 RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION = "active_state_next_action"
 RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK = "agent_todo_fallback"
 RECOMMENDED_ACTION_SOURCE_DEFAULT = "default_refresh_action"
@@ -332,7 +333,9 @@ def todo_priority_rank(action: str) -> int:
     return int(match.group("rank"))
 
 
-def first_open_agent_todo_action(state_text: str) -> str | None:
+def first_open_agent_todo_action(
+    state_text: str, *, claimed_by: str | None = None
+) -> str | None:
     lines = extract_section_lines(state_text, "Agent Todo", limit=512)
     advancement_candidates: list[tuple[int, int, str]] = []
     fallback_candidates: list[tuple[int, int, str]] = []
@@ -348,6 +351,8 @@ def first_open_agent_todo_action(state_text: str) -> str | None:
         except ValueError:
             continue
         metadata = todo_metadata(lines, index)
+        if claimed_by and metadata.get("claimed_by") != claimed_by:
+            continue
         if metadata.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT:
             advancement_candidates.append((todo_priority_rank(action), index, action))
             continue
@@ -385,7 +390,19 @@ def section_list_items(lines: list[str]) -> list[str]:
     return items
 
 
-def derive_recommended_action_with_source(state_text: str) -> tuple[str, str]:
+def derive_recommended_action_with_source(
+    state_text: str, *, agent_id: str | None = None
+) -> tuple[str, str]:
+    # Agent-scoped refresh: the lane's own selected Todo is authoritative and
+    # must not be shadowed by the shared global Next Action written by a peer
+    # agent lane (issue #3685). The shared section stays a labeled fallback.
+    agent_lane_action = (
+        first_open_agent_todo_action(state_text, claimed_by=agent_id)
+        if agent_id
+        else None
+    )
+    if agent_lane_action:
+        return agent_lane_action, RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO
     lines = extract_section_lines(state_text, "Next Action", limit=RECOMMENDED_ACTION_SECTION_LINE_LIMIT)
     for index, line in enumerate(lines):
         action = first_action_item(lines, index)
@@ -1142,7 +1159,9 @@ def refresh_state_run(
         action = recommended_action
         recommended_action_source = RECOMMENDED_ACTION_SOURCE_EXPLICIT
     else:
-        action, recommended_action_source = derive_recommended_action_with_source(state_text)
+        action, recommended_action_source = derive_recommended_action_with_source(
+            state_text, agent_id=normalized_agent_id or None
+        )
     validate_local_control_text("recommended_action", action)
     requested_classification = classification
     replan_qualification = qualify_refresh_replan_writeback(

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -44,6 +44,18 @@ from .control_plane.work_items.progress_observation import (
 from .control_plane.work_items.semantic_replan_writeback import (
     qualify_refresh_replan_writeback,
 )
+from .control_plane.work_items.refresh_recommendation import (
+    DEFAULT_REFRESH_ACTION as DEFAULT_REFRESH_ACTION,
+    RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION as RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION,
+    RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO as RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO,
+    RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK as RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK,
+    RECOMMENDED_ACTION_SOURCE_DEFAULT as RECOMMENDED_ACTION_SOURCE_DEFAULT,
+    RECOMMENDED_ACTION_SOURCE_EXPLICIT as RECOMMENDED_ACTION_SOURCE_EXPLICIT,
+    RECOMMENDED_ACTION_SOURCE_SETTLEMENT_BOUND_TODO as RECOMMENDED_ACTION_SOURCE_SETTLEMENT_BOUND_TODO,
+    derive_recommended_action as derive_recommended_action,
+    derive_recommended_action_with_source as derive_recommended_action_with_source,
+    resolve_refresh_recommendation,
+)
 from .control_plane.runtime.shared_runtime_refresh_projection import (
     build_shared_runtime_projection,
     write_shared_runtime_projection,
@@ -75,28 +87,18 @@ from .state_projection import (
     state_projection_gap_warning,
 )
 from .control_plane.todos.contract import (
-    TODO_TASK_CLASS_ADVANCEMENT,
-    TODO_TASK_CLASS_BLOCKER,
-    TODO_TASK_CLASS_MONITOR,
-    TODO_TASK_CLASS_USER_GATE,
     normalize_todo_claimed_by,
     normalize_todo_replan_obligation_id,
 )
 from .control_plane.todos.completion_validation_accountability import (
     require_accountable_completion_validation,
 )
+from .rollout_event_log import load_rollout_events, rollout_event_log_path
 
 DEFAULT_REFRESH_CLASSIFICATION = "state_refreshed"
-DEFAULT_REFRESH_ACTION = "inspect refreshed active goal state and continue the next bounded progress segment"
-RECOMMENDED_ACTION_SOURCE_EXPLICIT = "explicit_arg"
-RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO = "agent_lane_selected_todo"
-RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION = "active_state_next_action"
-RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK = "agent_todo_fallback"
-RECOMMENDED_ACTION_SOURCE_DEFAULT = "default_refresh_action"
 GOAL_PROGRESS_SCOPE = "goal"
 AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
 PROGRESS_SCOPE_CHOICES = (GOAL_PROGRESS_SCOPE, AGENT_LANE_PROGRESS_SCOPE)
-RECOMMENDED_ACTION_SECTION_LINE_LIMIT = 16
 BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
@@ -304,72 +306,6 @@ def first_action_item(lines: list[str], start: int) -> str:
     return " ".join(part for part in parts if part).strip()
 
 
-def checkbox_mark(line: str) -> str | None:
-    text = BULLET_PREFIX_RE.sub("", line.strip()).strip()
-    match = CHECKBOX_PREFIX_RE.match(text)
-    if not match:
-        return None
-    return match.group("mark")
-
-
-def todo_metadata(lines: list[str], start: int) -> dict[str, str]:
-    metadata: dict[str, str] = {}
-    for line in lines[start + 1 :]:
-        if is_bullet_line(line):
-            break
-        text = line.strip()
-        if not text.startswith("<!-- loopx:todo"):
-            continue
-        for key, value in re.findall(r"([A-Za-z_][A-Za-z0-9_]*)=([^ >]+)", text):
-            metadata[key] = value
-        break
-    return metadata
-
-
-def todo_priority_rank(action: str) -> int:
-    match = re.match(r"^\[P(?P<rank>\d+)\]\s+", action.strip(), flags=re.IGNORECASE)
-    if not match:
-        return 99
-    return int(match.group("rank"))
-
-
-def first_open_agent_todo_action(
-    state_text: str, *, claimed_by: str | None = None
-) -> str | None:
-    lines = extract_section_lines(state_text, "Agent Todo", limit=512)
-    advancement_candidates: list[tuple[int, int, str]] = []
-    fallback_candidates: list[tuple[int, int, str]] = []
-    for index, line in enumerate(lines):
-        mark = checkbox_mark(line)
-        if mark is None or mark.lower() == "x":
-            continue
-        action = first_action_item(lines, index)
-        if not action:
-            continue
-        try:
-            validate_local_control_text("derived agent_todo recommended_action", action)
-        except ValueError:
-            continue
-        metadata = todo_metadata(lines, index)
-        if claimed_by and metadata.get("claimed_by") != claimed_by:
-            continue
-        if metadata.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT:
-            advancement_candidates.append((todo_priority_rank(action), index, action))
-            continue
-        if metadata.get("task_class") in {
-            TODO_TASK_CLASS_MONITOR,
-            TODO_TASK_CLASS_USER_GATE,
-            TODO_TASK_CLASS_BLOCKER,
-        }:
-            continue
-        fallback_candidates.append((todo_priority_rank(action), index, action))
-    if advancement_candidates:
-        return sorted(advancement_candidates)[0][2]
-    if fallback_candidates:
-        return sorted(fallback_candidates)[0][2]
-    return None
-
-
 def section_list_items(lines: list[str]) -> list[str]:
     items: list[str] = []
     index = 0
@@ -388,39 +324,6 @@ def section_list_items(lines: list[str]) -> list[str]:
             items.append(cleaned)
         index += 1
     return items
-
-
-def derive_recommended_action_with_source(
-    state_text: str, *, agent_id: str | None = None
-) -> tuple[str, str]:
-    # Agent-scoped refresh: the lane's own selected Todo is authoritative and
-    # must not be shadowed by the shared global Next Action written by a peer
-    # agent lane (issue #3685). The shared section stays a labeled fallback.
-    agent_lane_action = (
-        first_open_agent_todo_action(state_text, claimed_by=agent_id)
-        if agent_id
-        else None
-    )
-    if agent_lane_action:
-        return agent_lane_action, RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO
-    lines = extract_section_lines(state_text, "Next Action", limit=RECOMMENDED_ACTION_SECTION_LINE_LIMIT)
-    for index, line in enumerate(lines):
-        action = first_action_item(lines, index)
-        if not action:
-            continue
-        try:
-            validate_local_control_text("derived recommended_action", action)
-        except ValueError:
-            continue
-        return action, RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION
-    agent_todo_action = first_open_agent_todo_action(state_text)
-    if agent_todo_action:
-        return agent_todo_action, RECOMMENDED_ACTION_SOURCE_AGENT_TODO_FALLBACK
-    return DEFAULT_REFRESH_ACTION, RECOMMENDED_ACTION_SOURCE_DEFAULT
-
-
-def derive_recommended_action(state_text: str) -> str:
-    return derive_recommended_action_with_source(state_text)[0]
 
 
 def resolve_goal_state(
@@ -471,6 +374,7 @@ def build_state_refresh_record(
     classification: str,
     recommended_action: str,
     recommended_action_source: str,
+    recommended_action_resolution: dict[str, Any] | None = None,
     generated_at: str,
     registry_goal: dict[str, Any] | None,
     delivery_batch_scale: str | None = None,
@@ -526,6 +430,8 @@ def build_state_refresh_record(
             "authority_source_count": len(authority_sources),
         },
     }
+    if recommended_action_resolution:
+        record["recommended_action_resolution"] = recommended_action_resolution
     projection_gap = state_projection_gap_warning(state_text)
     if projection_gap:
         record["state_projection_gap"] = projection_gap
@@ -608,6 +514,7 @@ def _build_state_refresh_output_projections(
         "runtime_projection_route": record["runtime_projection_route"],
     })
     for field in (
+        "recommended_action_resolution",
         "delivery_batch_scale",
         "delivery_outcome",
         "delivery_workspace",
@@ -842,9 +749,25 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
             "",
             "## Recommended Action",
             f"- source: `{payload.get('recommended_action_source')}`",
-            str(payload.get("recommended_action") or ""),
         ]
     )
+    recommendation_resolution = (
+        payload.get("recommended_action_resolution")
+        if isinstance(payload.get("recommended_action_resolution"), dict)
+        else {}
+    )
+    if recommendation_resolution:
+        lines.append(
+            "- authority: "
+            f"`{recommendation_resolution.get('authority')}`; "
+            "settlement_alignment: "
+            f"`{recommendation_resolution.get('settlement_alignment')}`"
+        )
+        if recommendation_resolution.get("todo_id"):
+            lines.append(
+                f"- todo_id: `{recommendation_resolution.get('todo_id')}`"
+            )
+    lines.append(str(payload.get("recommended_action") or ""))
     for heading, key in (
         ("Next Action", "next_action"),
         ("Recent Feedback", "recent_feedback"),
@@ -1155,14 +1078,26 @@ def refresh_state_run(
             }
             state_text = updated_state_text if state_updated else locked_state_text
 
-    if recommended_action:
-        action = recommended_action
-        recommended_action_source = RECOMMENDED_ACTION_SOURCE_EXPLICIT
-    else:
-        action, recommended_action_source = derive_recommended_action_with_source(
-            state_text, agent_id=normalized_agent_id or None
-        )
-    validate_local_control_text("recommended_action", action)
+    recommendation_resolution = resolve_refresh_recommendation(
+        state_text,
+        explicit_action=recommended_action,
+        agent_id=normalized_agent_id or None,
+        settlement_identity=(
+            settlement_identity.as_dict() if settlement_identity is not None else None
+        ),
+        registry_goal=registry_goal,
+        state_path=resolved_state_file,
+        rollout_events=(
+            load_rollout_events(rollout_event_log_path(runtime_root, safe_goal_id))
+            if not recommended_action
+            and (normalized_agent_id or settlement_identity is not None)
+            else None
+        ),
+    )
+    action = str(recommendation_resolution["recommended_action"])
+    recommended_action_source = str(
+        recommendation_resolution["recommended_action_source"]
+    )
     requested_classification = classification
     replan_qualification = qualify_refresh_replan_writeback(
         autonomous_replan_recorded=autonomous_replan_recorded,
@@ -1265,6 +1200,7 @@ def refresh_state_run(
         classification=classification,
         recommended_action=action,
         recommended_action_source=recommended_action_source,
+        recommended_action_resolution=recommendation_resolution,
         generated_at=generated_at,
         registry_goal=registry_goal,
         delivery_batch_scale=normalized_delivery_batch_scale,

--- a/tests/control_plane_ts/refresh_recommendation.test.ts
+++ b/tests/control_plane_ts/refresh_recommendation.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  resolveRefreshRecommendation,
+} from "../../loopx/control_plane/work_items/refresh_recommendation.ts";
+
+const baseRequest = {
+  schema_version: "refresh_recommendation_request_v0",
+  explicit_action: null,
+  agent_id: "agent-a",
+  settlement_identity: {
+    effect_id: "goal-shared:agent-a:todo_selected:turn-1",
+    goal_id: "goal-shared",
+    agent_id: "agent-a",
+    todo_id: "todo_selected",
+    turn_instance_id: "turn-1",
+  },
+  settlement_candidate: {
+    todo_id: "todo_selected",
+    text: "Continue the receipt-bound slice.",
+    status: "open",
+    task_class: "advancement_task",
+    claimed_by: "agent-a",
+    selection_binding: "heartbeat_receipt",
+  },
+  agent_lane_candidate: {
+    todo_id: "todo_higher_priority",
+    text: "Start a newer higher-priority slice.",
+    status: "open",
+    task_class: "advancement_task",
+    claimed_by: "agent-a",
+  },
+  active_state_next_action: "Follow another agent's shared action.",
+  unscoped_agent_todo_fallback: null,
+  default_action: "Inspect refreshed state.",
+};
+
+test("exact settlement binding outranks lane re-selection and shared prose", () => {
+  const result = resolveRefreshRecommendation(baseRequest);
+
+  assert.equal(result.recommended_action, "Continue the receipt-bound slice.");
+  assert.equal(result.recommended_action_source, "settlement_bound_todo");
+  assert.equal(result.authority, "settlement");
+  assert.equal(result.settlement_alignment, "exact");
+  assert.equal(result.todo_id, "todo_selected");
+});
+
+test("ineligible settlement Todo falls through to a runnable lane candidate", () => {
+  const result = resolveRefreshRecommendation({
+    ...baseRequest,
+    settlement_candidate: {
+      ...baseRequest.settlement_candidate,
+      status: "blocked",
+    },
+  });
+
+  assert.equal(result.recommended_action, "Start a newer higher-priority slice.");
+  assert.equal(result.recommended_action_source, "agent_lane_selected_todo");
+  assert.equal(result.settlement_alignment, "unavailable");
+  assert.equal(result.settlement_gap_reason, "candidate_ineligible");
+});
+
+test("a peer-claimed lane candidate cannot shadow the shared fallback", () => {
+  const result = resolveRefreshRecommendation({
+    ...baseRequest,
+    settlement_identity: null,
+    settlement_candidate: null,
+    agent_lane_candidate: {
+      ...baseRequest.agent_lane_candidate,
+      claimed_by: "agent-b",
+    },
+  });
+
+  assert.equal(result.recommended_action, "Follow another agent's shared action.");
+  assert.equal(result.recommended_action_source, "active_state_next_action");
+});
+
+test("agent-scoped resolution never consumes the unscoped compatibility lane", () => {
+  const result = resolveRefreshRecommendation({
+    ...baseRequest,
+    settlement_identity: null,
+    settlement_candidate: null,
+    agent_lane_candidate: null,
+    active_state_next_action: null,
+    unscoped_agent_todo_fallback: {
+      todo_id: "todo_peer_only",
+      text: "Run the peer-only Todo.",
+      status: "open",
+      task_class: "advancement_task",
+      claimed_by: "agent-b",
+    },
+  });
+
+  assert.equal(result.recommended_action, "Inspect refreshed state.");
+  assert.equal(result.recommended_action_source, "default_refresh_action");
+});
+
+test("an unclaimed agent-lane candidate preserves its claim prerequisite", () => {
+  const result = resolveRefreshRecommendation({
+    ...baseRequest,
+    settlement_identity: null,
+    settlement_candidate: null,
+    agent_lane_candidate: {
+      ...baseRequest.agent_lane_candidate,
+      claimed_by: undefined,
+      claim_required_before_work: true,
+    },
+  });
+
+  assert.equal(result.recommended_action_source, "agent_lane_selected_todo");
+  assert.equal(result.claim_required_before_work, true);
+});
+
+test("missing settlement Todo is a typed gap before legal lane fallback", () => {
+  const result = resolveRefreshRecommendation({
+    ...baseRequest,
+    settlement_candidate: null,
+  });
+
+  assert.equal(result.recommended_action_source, "agent_lane_selected_todo");
+  assert.equal(result.settlement_alignment, "unavailable");
+  assert.equal(result.settlement_gap_reason, "candidate_missing");
+});
+
+test("settlement identity drift is rejected instead of trusted as read-model input", () => {
+  assert.throws(
+    () =>
+      resolveRefreshRecommendation({
+        ...baseRequest,
+        settlement_identity: {
+          ...baseRequest.settlement_identity,
+          effect_id: "goal-shared:agent-a:todo_other:turn-1",
+        },
+      }),
+    /effect_id mismatch/,
+  );
+});
+
+test("explicit recommendation remains authoritative", () => {
+  const result = resolveRefreshRecommendation({
+    ...baseRequest,
+    explicit_action: "Record the validated successor.",
+  });
+
+  assert.equal(result.recommended_action, "Record the validated successor.");
+  assert.equal(result.recommended_action_source, "explicit_arg");
+  assert.equal(result.authority, "explicit");
+  assert.equal(result.settlement_alignment, "not_applicable");
+});

--- a/tests/test_state_refresh_agent_lane_action.py
+++ b/tests/test_state_refresh_agent_lane_action.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
+from loopx.control_plane.quota.effect_program import SettlementIdentity
+from loopx.control_plane.work_items.refresh_recommendation import (
+    RECOMMENDED_ACTION_SOURCE_DEFAULT,
+    RECOMMENDED_ACTION_SOURCE_SETTLEMENT_BOUND_TODO,
+    resolve_refresh_recommendation,
+)
+from loopx.rollout_event_log import rollout_event_log_path
 from loopx.state_refresh import (
     RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION,
     RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO,
     derive_recommended_action_with_source,
+    refresh_state_run,
 )
 
 TWO_AGENT_STATE = """# Active Goal State
@@ -15,9 +26,9 @@ TWO_AGENT_STATE = """# Active Goal State
 ## Agent Todo
 
 - [ ] [P1] continue agent A scheduler coverage fix
-  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-a todo_id=todo_a1 -->
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-a todo_id=todo_agent_a -->
 - [ ] [P1] polish agent B release notes
-  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-b todo_id=todo_b1 -->
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-b todo_id=todo_agent_b -->
 
 ## Completed Work Archive
 """
@@ -51,3 +62,217 @@ def test_unscoped_derivation_keeps_shared_section_priority() -> None:
     action, source = derive_recommended_action_with_source(TWO_AGENT_STATE)
     assert action == "Publish agent B's release checklist"
     assert source == RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION
+
+
+def test_blocked_p0_never_shadows_runnable_p1() -> None:
+    state = """# Active Goal State
+
+## Next Action
+
+- Keep the shared fallback.
+
+## Agent Todo
+
+- [ ] [P0] blocked delivery
+  <!-- loopx:todo status=blocked task_class=advancement_task claimed_by=agent-a todo_id=todo_blocked_delivery -->
+- [ ] [P1] runnable delivery
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-a todo_id=todo_runnable_delivery -->
+"""
+
+    action, source = derive_recommended_action_with_source(state, agent_id="agent-a")
+
+    assert action == "[P1] runnable delivery"
+    assert source == RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO
+
+
+def test_agent_scope_without_own_candidate_never_falls_into_peer_lane() -> None:
+    state = """# Active Goal State
+
+## Agent Todo
+
+- [ ] [P0] peer-only delivery
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-b todo_id=todo_peer_delivery -->
+"""
+
+    action, source = derive_recommended_action_with_source(state, agent_id="agent-a")
+
+    assert "peer-only" not in action
+    assert source == RECOMMENDED_ACTION_SOURCE_DEFAULT
+
+
+def test_exact_settlement_todo_outranks_newer_lane_priority() -> None:
+    identity = SettlementIdentity(
+        goal_id="goal-shared",
+        agent_id="agent-a",
+        todo_id="todo_agent_a",
+        turn_instance_id="turn-agent-a",
+    )
+    state = TWO_AGENT_STATE.replace(
+        "## Completed Work Archive",
+        """- [ ] [P0] newer agent A work
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-a todo_id=todo_agent_a_new -->
+
+## Completed Work Archive""",
+    )
+
+    result = resolve_refresh_recommendation(
+        state,
+        agent_id="agent-a",
+        settlement_identity=identity.as_dict(),
+    )
+
+    assert (
+        result["recommended_action"] == "[P1] continue agent A scheduler coverage fix"
+    )
+    assert (
+        result["recommended_action_source"]
+        == RECOMMENDED_ACTION_SOURCE_SETTLEMENT_BOUND_TODO
+    )
+    assert result["settlement_alignment"] == "exact"
+    assert result["todo_id"] == "todo_agent_a"
+
+
+def test_missing_settlement_todo_reports_typed_gap_before_lane_fallback() -> None:
+    identity = SettlementIdentity(
+        goal_id="goal-shared",
+        agent_id="agent-a",
+        todo_id="todo_removed_selection",
+        turn_instance_id="turn-agent-a",
+    )
+
+    result = resolve_refresh_recommendation(
+        TWO_AGENT_STATE,
+        agent_id="agent-a",
+        settlement_identity=identity.as_dict(),
+    )
+
+    assert (
+        result["recommended_action"] == "[P1] continue agent A scheduler coverage fix"
+    )
+    assert result["settlement_alignment"] == "unavailable"
+    assert result["settlement_gap_reason"] == "candidate_missing"
+
+
+def test_unclaimed_lane_candidate_exposes_claim_prerequisite() -> None:
+    state = """# Active Goal State
+
+## Next Action
+
+- Shared compatibility fallback.
+
+## Agent Todo
+
+- [ ] [P1] claim and continue this slice
+  <!-- loopx:todo status=open task_class=advancement_task todo_id=todo_unclaimed_slice -->
+"""
+
+    result = resolve_refresh_recommendation(state, agent_id="agent-a")
+
+    assert result["recommended_action"] == "[P1] claim and continue this slice"
+    assert (
+        result["recommended_action_source"]
+        == RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO
+    )
+    assert result["claim_required_before_work"] is True
+
+
+def _write_turn_receipt(
+    runtime_root: Path,
+    *,
+    identity: SettlementIdentity,
+) -> None:
+    path = rollout_event_log_path(runtime_root, identity.goal_id)
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "event_id": "event-agent-a-turn",
+                "event_kind": "quota_should_run",
+                "goal_id": identity.goal_id,
+                "agent_id": identity.agent_id,
+                "run_id": identity.turn_instance_id,
+                "details": {
+                    "todo_id": identity.todo_id,
+                    "settlement_effect_id": identity.effect_id,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_refresh_state_run_reuses_exact_turn_selection(tmp_path: Path) -> None:
+    goal_id = "goal-shared-refresh"
+    project = tmp_path / "project"
+    state_path = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(TWO_AGENT_STATE, encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_path.relative_to(project)),
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": ["agent-a", "agent-b"],
+                        },
+                        "workspace_guard_policy": {
+                            "peer_independent_worktree_required": False,
+                        },
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    identity = SettlementIdentity(
+        goal_id=goal_id,
+        agent_id="agent-a",
+        todo_id="todo_agent_a",
+        turn_instance_id="turn-agent-a",
+    )
+    _write_turn_receipt(runtime_root, identity=identity)
+
+    result = refresh_state_run(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime_root),
+        goal_id=goal_id,
+        project=project,
+        state_file=None,
+        classification="validated_progress",
+        recommended_action=None,
+        delivery_batch_scale="single_surface",
+        delivery_outcome="outcome_progress",
+        delivery_workspace_path=project,
+        todo_id=identity.todo_id,
+        turn_instance_id=identity.turn_instance_id,
+        agent_id=identity.agent_id,
+        dry_run=True,
+        sync_global=False,
+    )
+
+    assert (
+        result["recommended_action"] == "[P1] continue agent A scheduler coverage fix"
+    )
+    assert (
+        result["recommended_action_source"]
+        == RECOMMENDED_ACTION_SOURCE_SETTLEMENT_BOUND_TODO
+    )
+    assert result["recommended_action_resolution"] == {
+        "schema_version": "refresh_recommendation_v0",
+        "recommended_action": "[P1] continue agent A scheduler coverage fix",
+        "recommended_action_source": "settlement_bound_todo",
+        "authority": "settlement",
+        "settlement_alignment": "exact",
+        "todo_id": "todo_agent_a",
+        "selection_binding": "heartbeat_receipt",
+        "claim_required_before_work": False,
+    }

--- a/tests/test_state_refresh_agent_lane_action.py
+++ b/tests/test_state_refresh_agent_lane_action.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from loopx.state_refresh import (
+    RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION,
+    RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO,
+    derive_recommended_action_with_source,
+)
+
+TWO_AGENT_STATE = """# Active Goal State
+
+## Next Action
+
+- Publish agent B's release checklist
+
+## Agent Todo
+
+- [ ] [P1] continue agent A scheduler coverage fix
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-a todo_id=todo_a1 -->
+- [ ] [P1] polish agent B release notes
+  <!-- loopx:todo status=open task_class=advancement_task claimed_by=agent-b todo_id=todo_b1 -->
+
+## Completed Work Archive
+"""
+
+
+def test_agent_scoped_derivation_prefers_own_lane_todo() -> None:
+    action, source = derive_recommended_action_with_source(
+        TWO_AGENT_STATE, agent_id="agent-a"
+    )
+    assert action == "[P1] continue agent A scheduler coverage fix"
+    assert source == RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO
+
+
+def test_peer_lane_never_shadows_own_selection() -> None:
+    action, source = derive_recommended_action_with_source(
+        TWO_AGENT_STATE, agent_id="agent-b"
+    )
+    assert action == "[P1] polish agent B release notes"
+    assert source == RECOMMENDED_ACTION_SOURCE_AGENT_LANE_SELECTED_TODO
+
+
+def test_agent_without_claimed_todo_falls_back_to_shared_section() -> None:
+    action, source = derive_recommended_action_with_source(
+        TWO_AGENT_STATE, agent_id="agent-c"
+    )
+    assert action == "Publish agent B's release checklist"
+    assert source == RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION
+
+
+def test_unscoped_derivation_keeps_shared_section_priority() -> None:
+    action, source = derive_recommended_action_with_source(TWO_AGENT_STATE)
+    assert action == "Publish agent B's release checklist"
+    assert source == RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION


### PR DESCRIPTION
## Summary

- Preserve the contributor insight from #3693: an agent-scoped refresh must prefer its own execution lane over shared Goal prose.
- Replace the duplicate Markdown Todo selector with the canonical Active Goal State Todo parser and existing agent-lane projection.
- Bind the recommendation to the exact heartbeat settlement Todo before considering a newly ranked lane candidate.
- Resolve authority and fallback semantics in a pure TypeScript read reducer, while Python remains the state/receipt adapter.
- Persist a typed recommendation resolution with authority, Todo identity, claim prerequisite, settlement alignment, and closed-set gap reason.

## Issue Or Task

- Fixes #3685

## Authority Model

```text
explicit --recommended-action
  -> exact settlement-bound Todo
  -> canonical current-agent lane candidate
  -> shared Goal Next Action
  -> unscoped compatibility Todo
  -> neutral default
```

Effect Program continues to own immutable settlement identity and receipt causality. The new refresh reducer is domain-local: it consumes that identity plus canonical Todo facts and produces a read projection. It does not become a generic Effect Program action selector and does not recreate quota eligibility.

When the exact settlement Todo is missing, mismatched, or no longer runnable, the reducer falls back only to a legal projection and reports a typed `settlement_gap_reason`; it never silently labels a replacement as the original Turn selection.

## Contributor Continuity

The rebased first commit remains authored by @now-ing and preserves the original lane-first diagnosis and regression intent. The maintainer refinement is a separate signed commit so the contributor contribution remains visible in history.

## Validation

- [x] `npm run test:control-plane` — 392 passed, 1 PostgreSQL integration skipped
- [x] `npm run typecheck:control-plane`
- [x] `pytest tests/test_state_refresh_agent_lane_action.py tests/test_state_refresh_projections.py -q` — 11 passed
- [x] `pytest tests/control_plane/test_m6_quality_gates.py tests/control_plane/test_cli_output_budget.py tests/test_state_refresh_agent_lane_action.py tests/test_state_refresh_projections.py -q` — 35 passed
- [x] `ruff check` on changed Python files
- [x] `loopx canary premerge --from-git-diff` — 12/12 selected smokes passed; no manual holds
- [x] DCO sign-off on both commits

## Type Of Change

- [x] Bug fix
- [x] Replacement-first TypeScript control-plane refactor

## Boundary Checklist

- [x] No shared Goal Next Action mutation
- [x] No peer Todo fallback for agent-scoped refresh
- [x] No duplicate Markdown status/priority parser
- [x] No credentials, private traces, local paths, or `.loopx/` state committed