### PR TITLE
test(ci): run the Personal Workspace contract smoke on Python Tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -65,6 +65,10 @@ jobs:
           npm run typecheck:control-plane
           npm run test:control-plane
 
+      - name: Qualify the Personal Workspace contract smoke
+        run: >-
+          node apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+
       - name: Lint test suite
         run: >-
           python -m ruff check

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -263,7 +263,7 @@ assert.match(page, /当前本地工作区（未绑定 Repository）/, "Create Go
 assert.doesNotMatch(model, /kind: "agent"/, "The drawer model omits the read-only Agent settings variant");
 assert.match(
   dashboard,
-  /statusRequestActive = Boolean\(activeStatusRequestUrl\) && Boolean\(loadError && requestedStatusUrl\)/,
+  /statusRequestActive = source\.kind === "example"[\s\S]*?&& Boolean\(activeStatusRequestUrl\)[\s\S]*?&& Boolean\(loadError && requestedStatusUrl\)/,
   "Initial load and refresh keep the workspace shell visible, while failed authoritative status requests surface recovery",
 );
 


### PR DESCRIPTION
## Summary

- The Personal Workspace contract smoke (`personal-workspace-contract.test.mjs`) only ran locally: when its `statusRequestActive` assertion drifted behind the example-source guard in `dashboard-page.tsx`, nothing on CI caught it.
- This aligns the stale assertion with the shipped condition and runs the smoke as a step of the Python Tests workflow (node 22.6 is already set up there), so drawer/board contract drift fails fast.

## Issue Or Task

- No public issue yet — this came out of a brainstorm audit while fixing #3560-adjacent dashboard work; happy to file one if maintainers want it tracked.

## Validation

- [x] `node apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs` passes on this branch (it fails on current `main` before the assertion fix)
- [x] workflow YAML parses (`python -c "import yaml; yaml.safe_load(...)"`)

## Type of Change

- [x] Test update

## LoopX Area

- [x] Build, packaging, installer, or CI

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] No `.loopx/`, credentials, private traces, or local machine paths committed
- [x] Change scoped to the contract smoke + CI wiring
- [x] DCO `Signed-off-by` trailer