### PR TITLE
fix: preserve periodic replan history under neutral runs

### DIFF
--- a/loopx/status.py
+++ b/loopx/status.py
@@ -362,7 +362,10 @@ MAX_AUTONOMOUS_REPLAN_TRIGGERS = _MAX_AUTONOMOUS_REPLAN_TRIGGERS_READ_MODEL
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = _AUTONOMOUS_REPLAN_STALL_THRESHOLD_READ_MODEL
 DEAD_MONITOR_REPEAT_THRESHOLD = 6
 AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW
-AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = 30
+# A normal delivery appends both a durable run and a neutral quota-spend run.
+# Keep enough internal history to observe the full material-run threshold even
+# when those records are interleaved, with headroom for other neutral events.
+AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD * 3
 BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
 BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
 BACKLOG_HYGIENE_HINT_PATTERN = re.compile(

--- a/tests/control_plane/test_autonomous_replan_periodic_lookback.py
+++ b/tests/control_plane/test_autonomous_replan_periodic_lookback.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from loopx.cli_commands.status import (
+    _status_collection_limit_for_agent_lane,
+    _trim_run_history_for_status_display,
+)
+from loopx.status import (
+    AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK,
+    AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
+    autonomous_replan_periodic_review_from_runs,
+)
+
+
+def test_periodic_replan_lookback_survives_interleaved_neutral_runs() -> None:
+    latest_runs: list[dict[str, object]] = []
+    for index in range(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD):
+        latest_runs.extend(
+            [
+                {
+                    "classification": "quota_slot_spent",
+                    "generated_at": f"2026-08-27T00:{59 - index:02d}:01Z",
+                    "agent_id": "codex-fixture",
+                },
+                {
+                    "classification": f"bounded_delivery_{index:02d}",
+                    "generated_at": f"2026-08-27T00:{59 - index:02d}:00Z",
+                    "agent_id": "codex-fixture",
+                },
+            ]
+        )
+
+    selected_runs = latest_runs[:AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK]
+    obligation = autonomous_replan_periodic_review_from_runs(
+        selected_runs,
+        agent_todos=None,
+    )
+
+    assert len(selected_runs) == len(latest_runs)
+    assert obligation is not None
+    trigger = obligation["triggers"][0]
+    assert trigger["kind"] == "periodic_review_due"
+    assert trigger["run_count"] == AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD
+
+
+def test_agent_lane_keeps_periodic_control_history_off_the_display_path() -> None:
+    display_limit = 5
+    collection_limit = _status_collection_limit_for_agent_lane(
+        requested_limit=display_limit,
+        agent_id="codex-fixture",
+    )
+    rows = [
+        {"classification": f"bounded_delivery_{index:02d}"}
+        for index in range(collection_limit)
+    ]
+    payload: dict[str, object] = {
+        "run_history": {
+            "recent_runs": list(rows),
+            "goals": [{"id": "fixture-goal", "latest_runs": list(rows)}],
+        }
+    }
+
+    _trim_run_history_for_status_display(
+        payload,
+        display_limit=display_limit,
+        collection_limit=collection_limit,
+    )
+
+    run_history = payload["run_history"]
+    assert isinstance(run_history, dict)
+    assert len(run_history["recent_runs"]) == display_limit
+    assert len(run_history["goals"][0]["latest_runs"]) == display_limit
+    assert payload["agent_lane_projection_lookback"] == {
+        "schema_version": "agent_lane_projection_lookback_v0",
+        "collection_limit": AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK,
+        "display_limit": display_limit,
+        "reason": (
+            "status --agent-id collected quota-equivalent run history for "
+            "agent-lane frontier projection, then restored the requested "
+            "status display limit"
+        ),
+    }


### PR DESCRIPTION
## Summary

- derive the internal periodic-replan history lookback from the durable-run threshold with enough headroom for neutral accounting rows;
- add a deterministic regression with 20 durable deliveries interleaved by 20 `quota_slot_spent` rows;
- prove agent-scoped status still restores the caller's requested display limit after the wider internal projection.

Closes #3696.

## Root cause

Periodic review requires 20 durable runs, while quota/status previously collected only 30 raw rows. A normal completed turn appends both one durable delivery and one neutral spend row, so the default sample held only 15 durable records. The read path therefore projected normal continuation while full-history write-time refresh required an autonomous replan delta.

## Contract

The control-plane lookback must be wider than the public display window and large enough to observe the durable-run threshold under normal neutral-row interleaving. Neutral rows remain excluded from the periodic count. No CLI field or status display budget changes.

The new lookback is `AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD * 3` (currently 60): enough for the common delivery/spend pair plus bounded headroom for other neutral records, while retaining the existing bounded raw-history design.

## Validation

- `python -m pytest -q tests/control_plane/test_autonomous_replan_periodic_lookback.py` — 2 passed;
- focused scheduler lookback test — passed;
- status markdown, quota replan decision-plane, and monitor poll writeback smokes — passed;
- supported-range Ruff on both changed files — passed;
- focused Mypy with imported modules skipped — passed;
- `loopx canary premerge --from-git-diff` — 17/17 selected checks passed, including CLI output budget, quota/status parity, maintainability ratchet, and canary-runner profiles;
- public/private boundary scan — 2 files scanned, 0 errors;
- `git diff --check` — passed.

## Review notes

The semantic oracle is independent of the implementation constant: after 20 completed turns with one neutral spend record per turn, periodic review must be due. The second test separately asserts that the larger control window never widens the requested status display. No provider calls, private state, raw trajectories, or local paths are included.