### PR TITLE
docs(release): extension doctor recovery guidance for GH-C04

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -28,7 +28,13 @@ loopx update check
 loopx update plan
 loopx update apply
 loopx doctor
+loopx extension doctor --all-enabled --execute
 ```
+
+After `loopx update apply`, revalidate enabled extensions with
+`loopx extension doctor --all-enabled --execute`. Stale extension readiness
+recovers on the next apply or doctor cycle; use per-extension doctor output for
+repair details. See [Extension lifecycle](../reference/extensions.md#runtime-lifecycle).
 
 For a pip or pipx distribution, apply delegates to that owner. For an archive
 snapshot, apply uses the public `stable` ref by default and preserves atomic
@@ -628,6 +634,8 @@ Treat these v0.x surfaces as stable enough for user guides, examples, and
 host integrations when their focused smokes pass:
 
 - `loopx doctor`, `loopx update`, `loopx check`, and the no-clone installer;
+- `loopx extension doctor` for enabled-extension readiness after install or
+  update apply;
 - project lifecycle commands: `bootstrap`, `connect`, `status`,
   `refresh-state`, `registry`, and `sync-global`;
 - todo lifecycle commands: `todo add`, `todo claim`, `todo update`,


### PR DESCRIPTION
## Summary
- Restores the previously **APPROVED** GH-C04 docs slice from closed #3625 after the review-capacity pause (GitHub cannot reopen #3625 after the branch was rebased/force-pushed).
- Adds post-`loopx update apply` recovery guidance: run `loopx extension doctor --all-enabled --execute`, note stale readiness recovery, and list `extension doctor` among stable v0.x surfaces in `docs/product/release-readiness.md`.
- Rebased onto current `main`; content unchanged from the approved #3625 head (`2e850355` → rebased `82d976ec7`).

## Collision / pre-open audit
- No other open PR targets GH-C04 / extension-doctor recovery guidance.
- Owner #3694 also touches `docs/product/release-readiness.md`, but only adds the `v0.5.3` timeline entry — no overlap with these doctor lines.

## Test plan
- [x] Docs-only diff (+8 lines, one file)
- [ ] Maintainer skim of the update-apply → extension doctor paragraph + stable-surfaces bullet

Related: #3625 (closed, previously APPROVED), #3624, GH-C04


Made with [Cursor](https://cursor.com)