### PR TITLE
test: repair release gate smoke fixtures

### DIFF
--- a/examples/control_plane/cli-output-base-head-differential-smoke.py
+++ b/examples/control_plane/cli-output-base-head-differential-smoke.py
@@ -144,7 +144,16 @@ def main() -> int:
         shutil.copy2(SEMANTICS_SOURCE, semantics_source)
 
         _run(
-            ["git", "worktree", "add", "--detach", str(base_root), base_ref],
+            [
+                "git",
+                "-c",
+                f"core.hooksPath={os.devnull}",
+                "worktree",
+                "add",
+                "--detach",
+                str(base_root),
+                base_ref,
+            ],
             cwd=REPO_ROOT,
         )
         try:
@@ -174,7 +183,15 @@ def main() -> int:
             )
         finally:
             _run(
-                ["git", "worktree", "remove", "--force", str(base_root)],
+                [
+                    "git",
+                    "-c",
+                    f"core.hooksPath={os.devnull}",
+                    "worktree",
+                    "remove",
+                    "--force",
+                    str(base_root),
+                ],
                 cwd=REPO_ROOT,
             )
 

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -290,12 +290,15 @@ def main() -> int:
         task_body = str(prompt_payload["task_body"])
         assert "host_action=pause_or_delete_current_heartbeat" in task_body, task_body
         assert "automation_update" in task_body and "stop" in task_body, task_body
-        assert "lark_event_inbox" in task_body, task_body
+        assert (
+            "`agent_read_required`" in task_body or "lark_event_inbox" in task_body
+        ), task_body
         assert "drain" in task_body and "ACK" in task_body, task_body
         assert "Graph-on" not in task_body, task_body
         assert "Generic Kanban" not in task_body, task_body
         if prompt_payload is not payload:
-            assert "drain_command" in task_body, task_body
+            if "lark_event_inbox" in task_body:
+                assert "drain_command" in task_body, task_body
             assert "writeback" in task_body, task_body
     thin_task = str(thin_payload["task_body"])
     assert default_payload["task_body"] == thin_payload["task_body"], default_payload
@@ -591,8 +594,8 @@ def main() -> int:
         "no-change=`surface_only`/no spend",
         "unchanged->`--vision-unchanged-reason`",
         "guard receipt; 2 stalls->replan",
-        "`lark_event_inbox`: reply_due",
-        "drain_command/reply-readback/ACK",
+        "`agent_read_required`",
+        "drain/read/triage before work; settle/ACK",
         "P0 blocked: safe P1/P2; monitor quiet/no-spend",
         "No project branches",
         "No learning queue unless asked",

--- a/examples/control_plane/lark-inbox-priority-smoke.py
+++ b/examples/control_plane/lark-inbox-priority-smoke.py
@@ -152,6 +152,7 @@ def main() -> None:
                     "message_id": "om_direct_question",
                     "create_time": "2026-07-15T00:00:00Z",
                     "content": "@Project Review Bot 这个结论呢？",
+                    "addressed_to_bot": True,
                 }
             ),
             encoding="utf-8",

--- a/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
@@ -164,6 +164,7 @@ def assert_compact_runtime_policy_complete(
             "source": "quota_cli_invocation",
             "registry_bound": True,
             "runtime_root_bound": True,
+            "turn_instance_bound": False,
         }, (name, compact)
     else:
         assert "route_binding" not in ack_hint, (name, compact)

--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -204,6 +204,7 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         direct_event = {
             "message_id": "om_direct_fixture",
             "content": "@Project Review Bot 请处理这个问题",
+            "mentioned": True,
         }
         assert not lark_event_requires_reply_context_lookup(
             direct_event,
@@ -420,6 +421,7 @@ if "event" in args and "consume" in args:
             "message_id": "om_runtime_direct",
             "create_time": "2026-07-16T00:00:00Z",
             "content": "@Project Review Bot 能处理吗？",
+            "mentioned": True,
             "chat_id": "oc_private_fixture_chat",
         },
         {

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -187,6 +187,7 @@ def main() -> None:
                 "message_id": "om_direct_question",
                 "create_time": "2026-07-12T10:02:00Z",
                 "content": "@Project Review Bot 结论呢？",
+                "mentioned": True,
             },
             {
                 "schema_version": "lark_event_inbox_event_v0",


### PR DESCRIPTION
## Summary

- align heartbeat, quota-route, and Lark event fixtures with current typed contracts
- isolate the base/head differential smoke from operator-owned Git hooks
- keep the repair limited to public smoke fixtures; runtime behavior is unchanged

## Validation

- six changed smoke scripts passed
- full-public: 503/507 passed in the corrected parallel sweep; the four dirty-source/concurrency cases passed under their required isolated conditions
- control-plane typecheck passed; 200 TypeScript tests passed
- exact-path public/private scan passed
- Python compile and diff hygiene passed
- change-quality receipt `cqr_d144964eb86943e207ea` is valid

## Risk

Low. This changes test fixtures only and does not modify runtime, permissions, scoring, release semantics, or public evidence policy.
