### PR TITLE
Migrate governed capability lifecycle validation to TypeScript

### DIFF
--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -752,10 +752,20 @@ function reduceGovernedCapabilityLifecycle(input: {
     };
   }
 
-  requireCondition(
-    input.packet.admission === null,
-    "governed capability lifecycle admission is only valid before provider execution",
-  );
+  if (input.packet.admission !== null) {
+    requireCondition(
+      phase === "inspect",
+      "governed capability lifecycle admission is only valid while inspecting material authority",
+    );
+    validateGovernedCapabilityAdmission({
+      admission: input.packet.admission,
+      todo_id: requiredString(
+        identity.todo_id,
+        "governed capability settlement identity todo_id",
+      ),
+      todo_contract: operationProfile.todo_contract,
+    });
+  }
 
   const validated = validateProviderResult({
     value: rawResult,

--- a/loopx/control_plane/governed_capability.ts
+++ b/loopx/control_plane/governed_capability.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { JsonObject } from "./effect_program.ts";
 import { EffectRuntimeRequestError } from "./effect_runtime_errors.ts";
 import {
@@ -10,6 +12,14 @@ export const EXTERNAL_EFFECT_RECEIPT_SCHEMA_VERSION =
   "loopx_external_effect_receipt_v0";
 export const CONTINUOUS_MONITOR_PROPOSAL_SCHEMA_VERSION =
   "loopx_continuous_monitor_proposal_v0";
+export const GOVERNED_CAPABILITY_LIFECYCLE_PACKET_SCHEMA_VERSION =
+  "loopx_governed_capability_lifecycle_packet_v0";
+export const GOVERNED_CAPABILITY_LIFECYCLE_REDUCTION_SCHEMA_VERSION =
+  "loopx_governed_capability_lifecycle_reduction_v0";
+export const GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION =
+  "loopx_governed_capability_execution_receipt_v0";
+export const GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION =
+  "loopx_governed_capability_run_v0";
 
 const RESULT_FIELDS = new Set([
   "schema_version",
@@ -79,6 +89,24 @@ type ValidatedTransitionProposal =
 const PROPOSAL_ID_RE = /^[a-z][a-z0-9_.:-]{2,95}$/;
 const MONITOR_KEY_RE = /^[a-z][a-z0-9_.-]{0,31}:[a-z][a-z0-9_.:-]{2,95}$/;
 const ACTION_KIND_RE = /^[a-z][a-z0-9_]{0,63}$/;
+const LIFECYCLE_PACKET_FIELDS = new Set([
+  "schema_version",
+  "phase",
+  "dry_run",
+  "canonical_request_digest",
+  "admission",
+  "journal",
+]);
+const LIFECYCLE_PHASES = ["inspect", "observe_result"] as const;
+const JOURNAL_STATUSES = [
+  "ready",
+  "starting",
+  "running",
+  "ready_to_settle",
+  "settlement_failed",
+  "committed",
+] as const;
+type GovernedCapabilityJournalStatus = typeof JOURNAL_STATUSES[number];
 
 function requiredObject(value: unknown, label: string): JsonObject {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -129,6 +157,40 @@ function requireExactFields(
   ) {
     throw new EffectRuntimeRequestError(`${label} fields are invalid`);
   }
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)
+      .map(([key, child]) => [key, stableValue(child)]),
+  );
+}
+
+function canonicalDigest(value: unknown): string {
+  const encoded = JSON.stringify(stableValue(value));
+  if (encoded === undefined) {
+    throw new EffectRuntimeRequestError("governed capability value is not JSON-compatible");
+  }
+  return `sha256:${createHash("sha256").update(encoded, "utf8").digest("hex")}`;
+}
+
+function requiredCanonicalDigest(value: unknown, label: string): string {
+  const digest = requiredString(value, label);
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new EffectRuntimeRequestError(`${label} is invalid`);
+  }
+  return digest;
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return canonicalDigest(left) === canonicalDigest(right);
+}
+
+function requireCondition(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new EffectRuntimeRequestError(message);
 }
 
 function externalEffectReceipt(
@@ -386,7 +448,7 @@ export function validateGovernedCapabilityAdmission(input: {
   return selectedTodo;
 }
 
-export function validateGovernedCapabilityResult(input: {
+function validateProviderResult(input: {
   value: unknown;
   invocation_id: string;
   effect_id: string;
@@ -475,6 +537,361 @@ export function validateGovernedCapabilityResult(input: {
   }
   result.effect_receipt = receipt;
   return { result, journal_status: "ready_to_settle" };
+}
+
+function lifecyclePublicReceipt(input: {
+  journal: JsonObject;
+  status: GovernedCapabilityJournalStatus;
+  result: JsonObject | null;
+  dry_run: boolean;
+}): JsonObject {
+  const transitionReceipts = boundedArray(
+    input.journal.transition_receipts,
+    "governed capability journal transition_receipts",
+  );
+  return {
+    ok: true,
+    schema_version: GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION,
+    status: input.status,
+    dry_run: input.dry_run,
+    executed: !input.dry_run,
+    invocation_id: input.journal.invocation_id,
+    request_digest: input.journal.request_digest,
+    goal_id: input.journal.goal_id,
+    agent_id: input.journal.agent_id,
+    todo_id: input.journal.todo_id,
+    turn_instance_id: input.journal.turn_instance_id,
+    effect_id: input.journal.effect_id,
+    provider_status: input.result?.status ?? null,
+    provider_result_digest: input.result === null
+      ? null
+      : canonicalDigest(input.result),
+    transition_receipts: transitionReceipts,
+    settlement_result: input.journal.settlement_result ?? null,
+    effects: {
+      provider_invoked: input.result !== null,
+      external_write_observed: input.result?.effect_receipt !== null &&
+        input.result?.effect_receipt !== undefined,
+      loopx_transitions_written: transitionReceipts.length > 0,
+      loopx_state_written: typeof input.journal.writeback === "object" &&
+        input.journal.writeback !== null,
+      quota_spent: typeof input.journal.quota_spend === "object" &&
+        input.journal.quota_spend !== null,
+    },
+  };
+}
+
+function validateStoredSettlementCallback(input: {
+  value: unknown;
+  label: string;
+  effect_id: string;
+  effect_receipt_digest: string;
+  require_receipt_digest: boolean;
+}): JsonObject | null {
+  if (input.value === null || input.value === undefined) return null;
+  const payload = requiredObject(input.value, input.label);
+  const checked = validateGovernedCapabilitySettlementCallback({
+    payload,
+    effect_id: input.effect_id,
+    effect_receipt_digest: input.effect_receipt_digest,
+    require_receipt_digest: input.require_receipt_digest,
+  });
+  if (!sameJson(checked, payload)) {
+    throw new EffectRuntimeRequestError(`${input.label} is invalid`);
+  }
+  return payload;
+}
+
+function reduceGovernedCapabilityLifecycle(input: {
+  packet: JsonObject;
+  invocation_id: string;
+  effect_id: string;
+  result_schema: string;
+  effect_class: string;
+  transition_contract?: unknown;
+}): JsonObject {
+  requireExactFields(
+    input.packet,
+    LIFECYCLE_PACKET_FIELDS,
+    "governed capability lifecycle packet",
+  );
+  const phase = requireStringLiteral(
+    input.packet.phase,
+    LIFECYCLE_PHASES,
+    "governed capability lifecycle phase",
+    "governed capability lifecycle phase is unsupported",
+  );
+  requireCondition(
+    typeof input.packet.dry_run === "boolean",
+    "governed capability lifecycle dry_run must be boolean",
+  );
+  const requestDigest = requiredCanonicalDigest(
+    input.packet.canonical_request_digest,
+    "governed capability lifecycle request digest",
+  );
+  const journal = requiredObject(input.packet.journal, "governed capability journal");
+  requireCondition(
+    journal.schema_version === GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION,
+    "governed capability journal schema is invalid",
+  );
+  const currentStatus: GovernedCapabilityJournalStatus = requireStringLiteral(
+    journal.status,
+    JOURNAL_STATUSES,
+    "governed capability journal status",
+    "governed capability journal status is invalid",
+  );
+  requireCondition(
+    journal.invocation_id === input.invocation_id,
+    "governed capability journal invocation identity is invalid",
+  );
+
+  const transactionPlan = requiredObject(
+    journal.transaction_plan,
+    "governed capability transaction plan",
+  );
+  const settlementPlan = requiredObject(
+    transactionPlan.settlement_plan,
+    "governed capability settlement plan",
+  );
+  const identity = requiredObject(
+    settlementPlan.identity,
+    "governed capability settlement identity",
+  );
+  const identityFields = [
+    "goal_id",
+    "agent_id",
+    "todo_id",
+    "turn_instance_id",
+    "effect_id",
+  ];
+  requireCondition(
+    identity.effect_id === input.effect_id &&
+      identityFields.every((field) => journal[field] === identity[field]),
+    "governed capability journal settlement identity is invalid",
+  );
+
+  const request = requiredObject(
+    journal.request,
+    "governed capability provider request",
+  );
+  requireCondition(
+    request.invocation_id === input.invocation_id &&
+      sameJson(request.authority, identity),
+    "governed capability journal request authority is invalid",
+  );
+  const lifecycle = requiredObject(
+    request.lifecycle,
+    "governed capability provider request lifecycle",
+  );
+  requireExactFields(
+    lifecycle,
+    new Set(["phase", "idempotency_key"]),
+    "governed capability provider request lifecycle",
+  );
+  requireCondition(
+    lifecycle.phase === "start" && lifecycle.idempotency_key === input.effect_id,
+    "governed capability journal request start lifecycle is invalid",
+  );
+  requireCondition(
+    journal.request_digest === requestDigest,
+    "governed capability journal request digest is invalid",
+  );
+
+  const operationProfile = requiredObject(
+    journal.operation_profile,
+    "governed capability operation profile",
+  );
+  requireCondition(
+    input.effect_class === "external_write" &&
+      operationProfile.effect_class === input.effect_class &&
+      operationProfile.result_schema === input.result_schema,
+    "governed capability journal operation profile is invalid",
+  );
+  boundedStringArray(
+    journal.completed_phases,
+    "governed capability journal completed_phases",
+    16,
+  );
+  const transitionReceipts = boundedArray(
+    journal.transition_receipts,
+    "governed capability journal transition_receipts",
+  );
+
+  const rawResult = journal.provider_result;
+  if (rawResult === null || rawResult === undefined) {
+    requireCondition(
+      phase === "inspect" &&
+        currentStatus === (input.packet.dry_run ? "ready" : "starting"),
+      "governed capability journal provider state is invalid",
+    );
+    requireCondition(
+      [journal.writeback, journal.quota_spend, journal.settlement_result]
+        .every((value) => value === null) && transitionReceipts.length === 0,
+      "governed capability journal has settlement state before provider result",
+    );
+    if (input.packet.admission !== null) {
+      validateGovernedCapabilityAdmission({
+        admission: input.packet.admission,
+        todo_id: requiredString(
+          identity.todo_id,
+          "governed capability settlement identity todo_id",
+        ),
+        todo_contract: operationProfile.todo_contract,
+      });
+    }
+    return {
+      schema_version: GOVERNED_CAPABILITY_LIFECYCLE_REDUCTION_SCHEMA_VERSION,
+      journal_status: currentStatus,
+      provider_result: null,
+      public_receipt: lifecyclePublicReceipt({
+        journal,
+        status: currentStatus,
+        result: null,
+        dry_run: input.packet.dry_run,
+      }),
+    };
+  }
+
+  requireCondition(
+    input.packet.admission === null,
+    "governed capability lifecycle admission is only valid before provider execution",
+  );
+
+  const validated = validateProviderResult({
+    value: rawResult,
+    invocation_id: input.invocation_id,
+    effect_id: input.effect_id,
+    result_schema: input.result_schema,
+    effect_class: input.effect_class,
+    transition_contract: operationProfile.transition_contract ??
+      input.transition_contract,
+  });
+  let journalStatus: GovernedCapabilityJournalStatus;
+  if (phase === "observe_result") {
+    requireCondition(
+      currentStatus === "starting" || currentStatus === "running",
+      "governed capability observed result has invalid prior status",
+    );
+    journalStatus = validated.journal_status;
+  } else {
+    const allowedStatuses = validated.journal_status === "running"
+      ? new Set<GovernedCapabilityJournalStatus>(["running"])
+      : new Set<GovernedCapabilityJournalStatus>([
+        "ready_to_settle",
+        "settlement_failed",
+        "committed",
+      ]);
+    requireCondition(
+      allowedStatuses.has(currentStatus),
+      "governed capability journal status is invalid for provider result",
+    );
+    journalStatus = currentStatus;
+  }
+
+  let writeback: JsonObject | null = null;
+  let quotaSpend: JsonObject | null = null;
+  if (validated.journal_status === "running") {
+    requireCondition(
+      [journal.writeback, journal.quota_spend, journal.settlement_result]
+        .every((value) => value === null),
+      "running governed capability has settlement receipts",
+    );
+  } else {
+    const effectReceipt = requiredObject(
+      validated.result.effect_receipt,
+      "governed capability effect receipt",
+    );
+    const effectReceiptDigest = canonicalDigest(effectReceipt);
+    writeback = validateStoredSettlementCallback({
+      value: journal.writeback,
+      label: "governed capability journal writeback",
+      effect_id: input.effect_id,
+      effect_receipt_digest: effectReceiptDigest,
+      require_receipt_digest: true,
+    });
+    quotaSpend = validateStoredSettlementCallback({
+      value: journal.quota_spend,
+      label: "governed capability journal quota_spend",
+      effect_id: input.effect_id,
+      effect_receipt_digest: effectReceiptDigest,
+      require_receipt_digest: false,
+    });
+    requireCondition(
+      quotaSpend === null || writeback !== null,
+      "governed capability journal quota_spend precedes writeback",
+    );
+    if (journalStatus === "committed") {
+      requireCondition(
+        writeback?.ok === true &&
+          writeback.appended === true &&
+          quotaSpend?.ok === true &&
+          quotaSpend.appended === true,
+        "committed governed capability is missing settlement receipts",
+      );
+      const settlementResult = requiredObject(
+        journal.settlement_result,
+        "governed capability settlement result",
+      );
+      requireCondition(
+        settlementResult.failure === null,
+        "committed governed capability has no successful settlement result",
+      );
+    } else if (journalStatus === "settlement_failed") {
+      const settlementResult = requiredObject(
+        journal.settlement_result,
+        "governed capability settlement result",
+      );
+      requiredObject(
+        settlementResult.failure,
+        "governed capability settlement failure",
+      );
+    }
+  }
+
+  const reducedJournal = {
+    ...journal,
+    status: journalStatus,
+    provider_result: validated.result,
+    writeback,
+    quota_spend: quotaSpend,
+  };
+  return {
+    schema_version: GOVERNED_CAPABILITY_LIFECYCLE_REDUCTION_SCHEMA_VERSION,
+    journal_status: journalStatus,
+    provider_result: validated.result,
+    public_receipt: lifecyclePublicReceipt({
+      journal: reducedJournal,
+      status: journalStatus,
+      result: validated.result,
+      dry_run: input.packet.dry_run,
+    }),
+  };
+}
+
+export function validateGovernedCapabilityResult(input: {
+  value: unknown;
+  invocation_id: string;
+  effect_id: string;
+  result_schema: string;
+  effect_class: string;
+  transition_contract?: unknown;
+}): JsonObject {
+  if (
+    typeof input.value === "object" &&
+    input.value !== null &&
+    !Array.isArray(input.value) &&
+    (input.value as JsonObject).schema_version ===
+      GOVERNED_CAPABILITY_LIFECYCLE_PACKET_SCHEMA_VERSION
+  ) {
+    return reduceGovernedCapabilityLifecycle({
+      ...input,
+      packet: requiredObject(
+        input.value,
+        "governed capability lifecycle packet",
+      ),
+    });
+  }
+  return validateProviderResult(input);
 }
 
 export function validateGovernedCapabilitySettlementCallback(input: {

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -356,6 +356,30 @@ def _settle_journal_transition_proposals(
     )
 
 
+def _has_unsettled_start_transition(journal: Mapping[str, Any]) -> bool:
+    """Return whether replaying start can still write a monitor transition."""
+
+    provider_result = _mapping(
+        journal.get("provider_result"), "external capability result"
+    )
+    raw_proposals = provider_result.get("transition_proposals")
+    if not isinstance(raw_proposals, list):
+        raise ValueError("external capability transition_proposals must be an array")
+    receipt_ids = {
+        str(receipt["proposal_id"])
+        for receipt in validate_governed_transition_receipts(
+            journal.get("transition_receipts", [])
+        )
+    }
+    return any(
+        str(proposal.get("kind") or "") == "continuous_monitor_upsert"
+        and str(proposal.get("proposal_id") or "") not in receipt_ids
+        for proposal in (
+            _mapping(item, "governed transition proposal") for item in raw_proposals
+        )
+    )
+
+
 def start_governed_external_capability(
     *,
     state_file: str | Path,
@@ -465,6 +489,19 @@ def start_governed_external_capability(
             ):
                 raise ValueError("governed capability invocation replay does not match")
             if current_result is not None:
+                if _has_unsettled_start_transition(current):
+                    _require_admission(
+                        admission,
+                        expected_identity=identity,
+                        require_should_run=True,
+                    )
+                    _reduce_governed_capability_journal(
+                        current,
+                        invocation_id=invocation_id,
+                        phase="inspect",
+                        dry_run=False,
+                        admission=admission,
+                    )
                 _settle_journal_transition_proposals(
                     journal=current,
                     path=path,

--- a/loopx/extensions/governed_capability_execution.py
+++ b/loopx/extensions/governed_capability_execution.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from ..control_plane.effect_program import settlement_result_payload
-from ..control_plane.effect_runtime import effect_runtime_result
+from ..control_plane.effect_runtime import EffectRuntimeRejected, effect_runtime_result
 from ..control_plane.host_adapter_settlement import (
     HostGuardState,
     classify_host_guard_snapshot,
@@ -39,6 +39,12 @@ from .runtime import execute_extension_runtime_binding
 GOVERNED_CAPABILITY_RUN_SCHEMA_VERSION = "loopx_governed_capability_run_v0"
 GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION = (
     "loopx_governed_capability_execution_receipt_v0"
+)
+GOVERNED_CAPABILITY_LIFECYCLE_PACKET_SCHEMA_VERSION = (
+    "loopx_governed_capability_lifecycle_packet_v0"
+)
+GOVERNED_CAPABILITY_LIFECYCLE_REDUCTION_SCHEMA_VERSION = (
+    "loopx_governed_capability_lifecycle_reduction_v0"
 )
 MaterialEffect = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 
@@ -64,6 +70,40 @@ def _canonical_digest(value: object) -> str:
     import hashlib
 
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def validate_governed_capability_result(
+    value: Mapping[str, Any],
+    *,
+    invocation_id: str,
+    effect_id: str,
+    operation: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Adapt the TS-owned standalone provider-result validation."""
+
+    payload = effect_runtime_result(
+        "governed_capability.validate_result",
+        {
+            "value": dict(value),
+            "invocation_id": invocation_id,
+            "effect_id": effect_id,
+            "result_schema": operation.get("result_schema"),
+            "effect_class": operation.get("effect_class"),
+            "transition_contract": operation.get("transition_contract"),
+        },
+    )
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(  # noqa: TRY004 -- remote protocol failure, not caller input
+            "TypeScript governed capability result shape mismatch"
+        )
+    result = _mapping(payload.get("result"), "external capability result")
+    if str(payload.get("journal_status") or "") not in {
+        "running",
+        "ready_to_settle",
+    }:
+        raise RuntimeError("TypeScript governed capability status shape mismatch")
+    validate_public_safe_value(result, path="provider_result")
+    return result
 
 
 def _mapping(value: object, label: str) -> dict[str, Any]:
@@ -143,7 +183,6 @@ def _require_admission(
     *,
     expected_identity: Mapping[str, Any],
     require_should_run: bool,
-    todo_contract: Mapping[str, Any] | None,
 ) -> None:
     if require_should_run and admission.get("should_run") is not True:
         raise ValueError("governed capability admission requires should_run=true")
@@ -163,217 +202,122 @@ def _require_admission(
         raise ValueError(
             "quota guard settlement identity does not match the invocation"
         )
-    if todo_contract is not None:
-        effect_runtime_result(
-            "governed_capability.validate_admission",
-            {
-                "admission": dict(admission),
-                "todo_id": expected["todo_id"],
-                "todo_contract": dict(todo_contract),
-            },
-        )
 
 
-def _validated_governed_capability_result(
-    value: Mapping[str, Any],
-    *,
-    invocation_id: str,
-    effect_id: str,
-    operation: Mapping[str, Any],
-) -> tuple[dict[str, Any], str]:
-    payload = effect_runtime_result(
-        "governed_capability.validate_result",
-        {
-            "value": dict(value),
-            "invocation_id": invocation_id,
-            "effect_id": effect_id,
-            "result_schema": operation.get("result_schema"),
-            "effect_class": operation.get("effect_class"),
-            "transition_contract": operation.get("transition_contract"),
-        },
-    )
-    if not isinstance(payload, Mapping):
-        raise RuntimeError("TypeScript governed capability result shape mismatch")
-    result = _mapping(payload.get("result"), "external capability result")
-    journal_status = str(payload.get("journal_status") or "")
-    if journal_status not in {"running", "ready_to_settle"}:
-        raise RuntimeError("TypeScript governed capability status shape mismatch")
-    validate_public_safe_value(result, path="provider_result")
-    return result, journal_status
-
-
-def validate_governed_capability_result(
-    value: Mapping[str, Any],
-    *,
-    invocation_id: str,
-    effect_id: str,
-    operation: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Adapt the TS-owned material provider state validation."""
-
-    result, _journal_status = _validated_governed_capability_result(
-        value,
-        invocation_id=invocation_id,
-        effect_id=effect_id,
-        operation=operation,
-    )
-    return result
-
-
-def _validate_journal(
+def _reduce_governed_capability_journal(
     journal: Mapping[str, Any],
     *,
     invocation_id: str,
-) -> None:
-    if journal.get("invocation_id") != invocation_id:
-        raise ValueError("governed capability journal invocation identity is invalid")
+    phase: str,
+    dry_run: bool,
+    admission: Mapping[str, Any] | None = None,
+) -> tuple[dict[str, Any] | None, str, dict[str, Any]]:
+    """Validate one lifecycle state and project its canonical public receipt."""
+
     transaction_plan = _mapping(journal.get("transaction_plan"), "transaction plan")
     identity = _settlement_identity(transaction_plan)
-    expected_top_level = {
-        key: identity.get(key)
-        for key in ("goal_id", "agent_id", "todo_id", "turn_instance_id", "effect_id")
-    }
-    if any(journal.get(key) != value for key, value in expected_top_level.items()):
-        raise ValueError("governed capability journal settlement identity is invalid")
     registry_path = _journal_registry_path(journal)
     transition_receipts = validate_governed_transition_receipts(
         journal.get("transition_receipts", [])
     )
     if transition_receipts and registry_path is None:
         raise ValueError("governed transition receipts require Kernel context")
-
     request = _mapping(journal.get("request"), "provider request")
-    if request.get("invocation_id") != invocation_id:
-        raise ValueError("governed capability journal request identity is invalid")
-    if request.get("authority") != identity:
-        raise ValueError("governed capability journal request authority is invalid")
-    lifecycle = _mapping(request.get("lifecycle"), "provider request lifecycle")
-    if set(lifecycle) != {"phase", "idempotency_key"} or not (
-        lifecycle.get("phase") == "start"
-        and lifecycle.get("idempotency_key") == identity.get("effect_id")
-    ):
-        raise ValueError("governed capability journal start lifecycle is invalid")
     validate_public_safe_value(request, path="provider_request")
-    if journal.get("request_digest") != _canonical_digest(request):
-        raise ValueError("governed capability journal request digest is invalid")
-
     operation_profile = _mapping(journal.get("operation_profile"), "operation profile")
-    if operation_profile.get("effect_class") != "external_write":
-        raise ValueError("governed capability journal effect class is invalid")
     _mapping(journal.get("provider_binding"), "provider binding")
-    status = str(journal.get("status") or "")
-    provider_result = journal.get("provider_result")
-    if provider_result is None:
-        if status != "starting":
-            raise ValueError("governed capability journal provider state is invalid")
-        if transition_receipts:
-            raise ValueError(
-                "governed capability has transition receipts before provider result"
-            )
-        return
-    result = _mapping(provider_result, "external capability result")
-    validated, provider_status = _validated_governed_capability_result(
-        result,
-        invocation_id=invocation_id,
-        effect_id=str(identity["effect_id"]),
-        operation=operation_profile,
-    )
-    if validated != result:
-        raise ValueError("governed capability journal provider result is invalid")
-    allowed_statuses = (
-        {"running"}
-        if provider_status == "running"
-        else {"ready_to_settle", "settlement_failed", "committed"}
-    )
-    if status not in allowed_statuses:
-        raise ValueError("governed capability journal status is invalid")
-    if provider_status == "running":
-        if any(
-            journal.get(field) is not None
-            for field in ("writeback", "quota_spend", "settlement_result")
-        ):
-            raise ValueError("running governed capability has settlement receipts")
-        return
-
-    effect_receipt = _mapping(result.get("effect_receipt"), "external effect receipt")
-    effect_receipt_digest = _canonical_digest(effect_receipt)
-    for field, require_receipt_digest in (
-        ("writeback", True),
-        ("quota_spend", False),
-    ):
-        stored = journal.get(field)
-        if stored is None:
-            continue
-        payload = _mapping(stored, f"governed capability {field}")
-        checked = effect_runtime_result(
-            "governed_capability.validate_settlement_callback",
+    raw_result = journal.get("provider_result")
+    try:
+        payload = effect_runtime_result(
+            "governed_capability.validate_result",
             {
-                "payload": payload,
-                "effect_id": identity["effect_id"],
-                "effect_receipt_digest": effect_receipt_digest,
-                "require_receipt_digest": require_receipt_digest,
+                "value": {
+                    "schema_version": GOVERNED_CAPABILITY_LIFECYCLE_PACKET_SCHEMA_VERSION,
+                    "phase": phase,
+                    "dry_run": dry_run,
+                    "canonical_request_digest": _canonical_digest(request),
+                    "admission": dict(admission) if admission is not None else None,
+                    "journal": dict(journal),
+                },
+                "invocation_id": invocation_id,
+                "effect_id": identity.get("effect_id"),
+                "result_schema": operation_profile.get("result_schema"),
+                "effect_class": operation_profile.get("effect_class"),
+                "transition_contract": operation_profile.get("transition_contract"),
             },
         )
-        if checked != payload:
-            raise ValueError(f"governed capability journal {field} is invalid")
-    if status == "committed":
-        for field in ("writeback", "quota_spend"):
-            receipt_payload = journal.get(field)
-            if not (
-                isinstance(receipt_payload, Mapping)
-                and receipt_payload.get("ok") is True
-                and receipt_payload.get("appended") is True
-            ):
-                raise ValueError(
-                    f"committed governed capability has no {field} receipt"
-                )
-        settlement_result = journal.get("settlement_result")
-        if not (
-            isinstance(settlement_result, Mapping)
-            and settlement_result.get("failure") is None
-        ):
-            raise ValueError(
-                "committed governed capability has no successful settlement result"
-            )
-    elif status == "settlement_failed":
-        settlement_result = journal.get("settlement_result")
-        if not (
-            isinstance(settlement_result, Mapping)
-            and isinstance(settlement_result.get("failure"), Mapping)
-        ):
-            raise ValueError(
-                "failed governed capability has no typed settlement failure"
-            )
+    except EffectRuntimeRejected as exc:
+        if phase != "inspect" or admission is not None:
+            raise
+        raise ValueError(str(exc)) from exc
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version")
+        != GOVERNED_CAPABILITY_LIFECYCLE_REDUCTION_SCHEMA_VERSION
+    ):
+        raise RuntimeError("TypeScript governed capability lifecycle shape mismatch")
+    journal_status = str(payload.get("journal_status") or "")
+    if journal_status not in {
+        "ready",
+        "starting",
+        "running",
+        "ready_to_settle",
+        "settlement_failed",
+        "committed",
+    }:
+        raise RuntimeError("TypeScript governed capability status shape mismatch")
+    reduced_result = payload.get("provider_result")
+    result = (
+        _mapping(reduced_result, "external capability result")
+        if reduced_result is not None
+        else None
+    )
+    if phase == "inspect" and isinstance(raw_result, Mapping) and result != raw_result:
+        raise ValueError("governed capability journal provider result is invalid")
+    if (
+        phase == "inspect"
+        and not isinstance(raw_result, Mapping)
+        and result is not None
+    ):
+        raise ValueError("governed capability journal provider state is invalid")
+    if result is not None:
+        validate_public_safe_value(result, path="provider_result")
+    receipt = _mapping(
+        payload.get("public_receipt"),
+        "governed capability public receipt",
+    )
+    if receipt.get("schema_version") != GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION:
+        raise RuntimeError("TypeScript governed capability receipt shape mismatch")
+    return result, journal_status, receipt
 
 
-def _public_receipt(journal: Mapping[str, Any], *, dry_run: bool) -> dict[str, Any]:
+def _receipt_with_local_effects(
+    receipt: Mapping[str, Any],
+    journal: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Overlay outcomes produced by Python-owned I/O and effect adapters."""
+
+    projected = deepcopy(dict(receipt))
+    projected["status"] = journal.get("status")
     provider_result = journal.get("provider_result")
-    result = provider_result if isinstance(provider_result, Mapping) else {}
-    return {
-        "ok": True,
-        "schema_version": GOVERNED_CAPABILITY_RECEIPT_SCHEMA_VERSION,
-        "status": journal.get("status"),
-        "dry_run": dry_run,
-        "executed": not dry_run,
-        "invocation_id": journal.get("invocation_id"),
-        "request_digest": journal.get("request_digest"),
-        "goal_id": journal.get("goal_id"),
-        "agent_id": journal.get("agent_id"),
-        "todo_id": journal.get("todo_id"),
-        "turn_instance_id": journal.get("turn_instance_id"),
-        "effect_id": journal.get("effect_id"),
-        "provider_status": result.get("status"),
-        "provider_result_digest": (_canonical_digest(result) if result else None),
-        "transition_receipts": deepcopy(journal.get("transition_receipts", [])),
-        "settlement_result": journal.get("settlement_result"),
-        "effects": {
-            "provider_invoked": bool(provider_result),
-            "external_write_observed": bool(result.get("effect_receipt")),
+    # Preserve the shipped Python canonical digest after managed-runtime number normalization.
+    projected["provider_result_digest"] = (
+        _canonical_digest(provider_result)
+        if isinstance(provider_result, Mapping)
+        else None
+    )
+    projected["transition_receipts"] = deepcopy(journal.get("transition_receipts", []))
+    projected["settlement_result"] = deepcopy(journal.get("settlement_result"))
+    effects = _mapping(projected.get("effects"), "governed capability effects")
+    effects.update(
+        {
             "loopx_transitions_written": bool(journal.get("transition_receipts")),
             "loopx_state_written": isinstance(journal.get("writeback"), Mapping),
             "quota_spent": isinstance(journal.get("quota_spend"), Mapping),
-        },
-    }
+        }
+    )
+    projected["effects"] = effects
+    return projected
 
 
 def _settle_journal_transition_proposals(
@@ -455,14 +399,6 @@ def start_governed_external_capability(
         admission,
         expected_identity=identity,
         require_should_run=not execute,
-        todo_contract=(
-            _mapping(
-                operation_profile.get("todo_contract"),
-                "operation todo_contract",
-            )
-            if not execute
-            else None
-        ),
     )
     request = _mapping(prepared["request"], "provider request")
     request["lifecycle"] = {
@@ -500,35 +436,54 @@ def start_governed_external_capability(
         "settlement_result": None,
     }
     if not execute:
-        return _public_receipt(journal, dry_run=True)
+        _provider_result, _journal_status, receipt = (
+            _reduce_governed_capability_journal(
+                journal,
+                invocation_id=invocation_id,
+                phase="inspect",
+                dry_run=True,
+                admission=admission,
+            )
+        )
+        return _receipt_with_local_effects(receipt, journal)
 
     path = _journal_path(run_dir, invocation_id)
     with exclusive_file_lock(path, operation="start_governed_external_capability"):
         if path.exists():
             current = _read_journal(path)
-            _validate_journal(current, invocation_id=invocation_id)
+            current_result, _current_status, receipt = (
+                _reduce_governed_capability_journal(
+                    current,
+                    invocation_id=invocation_id,
+                    phase="inspect",
+                    dry_run=False,
+                )
+            )
             if (
                 current.get("request_digest") != request_digest
                 or current.get("effect_id") != identity["effect_id"]
             ):
                 raise ValueError("governed capability invocation replay does not match")
-            if isinstance(current.get("provider_result"), Mapping):
+            if current_result is not None:
                 _settle_journal_transition_proposals(
                     journal=current,
                     path=path,
                     phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
                 )
-                return _public_receipt(current, dry_run=False)
+                return _receipt_with_local_effects(receipt, current)
             journal = current
         else:
             _require_admission(
                 admission,
                 expected_identity=identity,
                 require_should_run=True,
-                todo_contract=_mapping(
-                    operation_profile.get("todo_contract"),
-                    "operation todo_contract",
-                ),
+            )
+            _reduce_governed_capability_journal(
+                journal,
+                invocation_id=invocation_id,
+                phase="inspect",
+                dry_run=False,
+                admission=admission,
             )
             _write_journal(path, journal)
         provider_result = execute_extension_runtime_binding(
@@ -536,12 +491,18 @@ def start_governed_external_capability(
             request=request,
             environment=environment,
         )
-        validated, journal_status = _validated_governed_capability_result(
+        journal["provider_result"] = _mapping(
             provider_result,
-            invocation_id=invocation_id,
-            effect_id=str(identity["effect_id"]),
-            operation=operation_profile,
+            "external capability result",
         )
+        validated, journal_status, receipt = _reduce_governed_capability_journal(
+            journal,
+            invocation_id=invocation_id,
+            phase="observe_result",
+            dry_run=False,
+        )
+        if validated is None:
+            raise RuntimeError("TypeScript governed capability result shape mismatch")
         journal["provider_result"] = validated
         journal["status"] = journal_status
         _write_journal(path, journal)
@@ -550,7 +511,7 @@ def start_governed_external_capability(
             path=path,
             phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
         )
-        return _public_receipt(journal, dry_run=False)
+        return _receipt_with_local_effects(receipt, journal)
 
 
 def _settlement_callback(
@@ -586,17 +547,18 @@ def reconcile_governed_external_capability(
     path = _journal_path(run_dir, invocation_id)
     with exclusive_file_lock(path, operation="reconcile_governed_external_capability"):
         journal = _read_journal(path)
-        _validate_journal(journal, invocation_id=invocation_id)
+        provider_result, _journal_status, receipt = _reduce_governed_capability_journal(
+            journal,
+            invocation_id=invocation_id,
+            phase="inspect",
+            dry_run=False,
+        )
         if journal.get("status") == "committed":
-            return _public_receipt(journal, dry_run=False)
+            return _receipt_with_local_effects(receipt, journal)
         identity = _settlement_identity(
             _mapping(journal.get("transaction_plan"), "transaction plan")
         )
-        operation_profile = _mapping(
-            journal.get("operation_profile"), "operation profile"
-        )
-        provider_result = journal.get("provider_result")
-        if not isinstance(provider_result, Mapping):
+        if provider_result is None:
             raise ValueError("governed capability provider start has no receipt")
         if provider_result.get("status") == "running":
             request = _mapping(journal.get("request"), "provider request")
@@ -610,12 +572,22 @@ def reconcile_governed_external_capability(
                 request=request,
                 environment=environment,
             )
-            provider_result, journal_status = _validated_governed_capability_result(
+            journal["provider_result"] = _mapping(
                 observed,
-                invocation_id=invocation_id,
-                effect_id=str(identity["effect_id"]),
-                operation=operation_profile,
+                "external capability result",
             )
+            provider_result, journal_status, receipt = (
+                _reduce_governed_capability_journal(
+                    journal,
+                    invocation_id=invocation_id,
+                    phase="observe_result",
+                    dry_run=False,
+                )
+            )
+            if provider_result is None:
+                raise RuntimeError(
+                    "TypeScript governed capability result shape mismatch"
+                )
             journal["provider_result"] = provider_result
             journal["status"] = journal_status
             _write_journal(path, journal)
@@ -625,7 +597,7 @@ def reconcile_governed_external_capability(
                 phase=GovernedTransitionSettlementPhase.PRE_SETTLEMENT,
             )
             if provider_result["status"] == "running":
-                return _public_receipt(journal, dry_run=False)
+                return _receipt_with_local_effects(receipt, journal)
 
         _settle_journal_transition_proposals(
             journal=journal,
@@ -695,27 +667,15 @@ def reconcile_governed_external_capability(
             committed_effect_id=str(identity["effect_id"]),
         )
         journal["settlement_result"] = settlement_result_payload(settlement)
-        settlement_status = effect_runtime_result(
-            "governed_capability.settlement_status",
-            {
-                "failure": (
-                    settlement.failure.as_dict()
-                    if settlement.failure is not None
-                    else None
-                )
-            },
-        )
-        if settlement_status == "settlement_failed":
-            journal["status"] = settlement_status
+        if settlement.failure is not None:
+            journal["status"] = "settlement_failed"
             _write_journal(path, journal)
-            return {**_public_receipt(journal, dry_run=False), "ok": False}
-        if settlement_status != "committed":
-            raise RuntimeError("TypeScript governed capability status shape mismatch")
+            return {**_receipt_with_local_effects(receipt, journal), "ok": False}
         _settle_journal_transition_proposals(
             journal=journal,
             path=path,
             phase=GovernedTransitionSettlementPhase.POST_SETTLEMENT,
         )
-        journal["status"] = settlement_status
+        journal["status"] = "committed"
         _write_journal(path, journal)
-        return _public_receipt(journal, dry_run=False)
+        return _receipt_with_local_effects(receipt, journal)

--- a/tests/control_plane_ts/governed_capability.test.ts
+++ b/tests/control_plane_ts/governed_capability.test.ts
@@ -15,6 +15,29 @@ const authority = {
   effect_class: "external_write",
 } as const;
 
+const settlementIdentity = {
+  schema_version: "quota_settlement_identity_v0",
+  goal_id: "fixture-goal",
+  agent_id: "fixture-agent",
+  todo_id: "todo_fixture",
+  turn_instance_id: "fixture-turn",
+  effect_id: authority.effect_id,
+};
+
+const providerRequest = {
+  invocation_id: authority.invocation_id,
+  authority: settlementIdentity,
+  lifecycle: {
+    phase: "start",
+    idempotency_key: authority.effect_id,
+  },
+};
+
+const providerRequestDigest =
+  "sha256:76b78b8c551187420d89b4525a86d06f92d0eb1b4a7aadc65eadc38c8ec03770";
+const effectReceiptDigest =
+  "sha256:8bb4405904cc29c96d4124430ec162409db148b856a57371801848b9bd4e8050";
+
 const transitionContract = {
   proposal_kinds: [
     "continuous_monitor_upsert",
@@ -70,6 +93,56 @@ function result(status: "running" | "succeeded" | "no_change") {
           },
     follow_up: { kind: status === "running" ? "poll" : "none" },
   };
+}
+
+function lifecycleJournal(
+  status: "starting" | "running" | "ready_to_settle" | "settlement_failed" | "committed",
+  providerResult: ReturnType<typeof result> | null,
+) {
+  return {
+    schema_version: "loopx_governed_capability_run_v0",
+    status,
+    invocation_id: authority.invocation_id,
+    request_digest: providerRequestDigest,
+    request: providerRequest,
+    operation_profile: {
+      effect_class: authority.effect_class,
+      result_schema: authority.result_schema,
+      transition_contract: transitionContract,
+    },
+    transaction_plan: {
+      settlement_plan: { identity: settlementIdentity },
+    },
+    goal_id: settlementIdentity.goal_id,
+    agent_id: settlementIdentity.agent_id,
+    todo_id: settlementIdentity.todo_id,
+    turn_instance_id: settlementIdentity.turn_instance_id,
+    effect_id: settlementIdentity.effect_id,
+    completed_phases: [],
+    provider_result: providerResult,
+    transition_receipts: [],
+    writeback: null,
+    quota_spend: null,
+    settlement_result: null,
+  };
+}
+
+function reduceLifecycle(
+  journal: ReturnType<typeof lifecycleJournal>,
+  phase: "inspect" | "observe_result" = "inspect",
+) {
+  return validateGovernedCapabilityResult({
+    ...authority,
+    transition_contract: transitionContract,
+    value: {
+      schema_version: "loopx_governed_capability_lifecycle_packet_v0",
+      phase,
+      dry_run: false,
+      canonical_request_digest: providerRequestDigest,
+      admission: null,
+      journal,
+    },
+  });
 }
 
 test("material admission binds the exact Todo action to the operation", () => {
@@ -326,5 +399,84 @@ test("settlement terminal state is TS-owned", () => {
   assert.equal(
     governedCapabilitySettlementStatus({ kind: "quota_spend_rejected" }),
     "settlement_failed",
+  );
+});
+
+test("one lifecycle packet validates an observed provider result and projects its receipt", () => {
+  const journal = lifecycleJournal("starting", result("succeeded"));
+  const reduction = reduceLifecycle(journal, "observe_result");
+
+  assert.equal(
+    reduction.schema_version,
+    "loopx_governed_capability_lifecycle_reduction_v0",
+  );
+  assert.equal(reduction.journal_status, "ready_to_settle");
+  assert.equal(reduction.provider_result.status, "succeeded");
+  assert.deepEqual(reduction.public_receipt.effects, {
+    provider_invoked: true,
+    external_write_observed: true,
+    loopx_transitions_written: false,
+    loopx_state_written: false,
+    quota_spent: false,
+  });
+});
+
+test("committed lifecycle replay validates the whole journal in one reduction", () => {
+  const journal = lifecycleJournal("committed", result("succeeded"));
+  journal.completed_phases = [
+    "host_execute",
+    "typed_result",
+    "validation",
+    "durable_writeback",
+    "quota_spend",
+  ];
+  journal.writeback = {
+    ok: true,
+    appended: true,
+    settlement_identity: settlementIdentity,
+    effect_receipt_digest: effectReceiptDigest,
+  };
+  journal.quota_spend = {
+    ok: true,
+    appended: true,
+    settlement_identity: settlementIdentity,
+  };
+  journal.settlement_result = { failure: null };
+
+  const reduction = reduceLifecycle(journal);
+
+  assert.equal(reduction.journal_status, "committed");
+  assert.equal(reduction.public_receipt.status, "committed");
+  assert.equal(reduction.public_receipt.effects.loopx_state_written, true);
+  assert.equal(reduction.public_receipt.effects.quota_spent, true);
+});
+
+test("lifecycle packets reject tampered request and callback identity", () => {
+  const tamperedRequest = lifecycleJournal("running", result("running"));
+  tamperedRequest.request = {
+    ...providerRequest,
+    lifecycle: { ...providerRequest.lifecycle, idempotency_key: "different" },
+  };
+  assert.throws(
+    () => reduceLifecycle(tamperedRequest),
+    /request (start lifecycle|digest) is invalid/,
+  );
+
+  const tamperedCallback = lifecycleJournal("committed", result("succeeded"));
+  tamperedCallback.writeback = {
+    ok: true,
+    appended: true,
+    settlement_identity: { effect_id: "different" },
+    effect_receipt_digest: effectReceiptDigest,
+  };
+  tamperedCallback.quota_spend = {
+    ok: true,
+    appended: true,
+    settlement_identity: settlementIdentity,
+  };
+  tamperedCallback.settlement_result = { failure: null };
+  assert.throws(
+    () => reduceLifecycle(tamperedCallback),
+    /journal writeback is invalid/,
   );
 });

--- a/tests/control_plane_ts/governed_capability.test.ts
+++ b/tests/control_plane_ts/governed_capability.test.ts
@@ -108,6 +108,10 @@ function lifecycleJournal(
     operation_profile: {
       effect_class: authority.effect_class,
       result_schema: authority.result_schema,
+      todo_contract: {
+        action_kinds: ["publish_requirement"],
+        target_key_prefixes: ["requirement:"],
+      },
       transition_contract: transitionContract,
     },
     transaction_plan: {
@@ -188,6 +192,43 @@ test("material admission binds the exact Todo action to the operation", () => {
       },
     }),
     /not authorized by selected_todo target_key/,
+  );
+});
+
+test("material journal inspection revalidates authority before recovery writes", () => {
+  const journal = lifecycleJournal("ready_to_settle", result("succeeded"));
+  const admission = {
+    selected_todo: {
+      todo_id: settlementIdentity.todo_id,
+      role: "agent",
+      status: "open",
+      action_kind: "publish_requirement",
+      target_key: "requirement:REQ-1",
+    },
+  };
+  const reduce = (selectedAdmission: unknown) =>
+    validateGovernedCapabilityResult({
+      ...authority,
+      transition_contract: transitionContract,
+      value: {
+        schema_version: "loopx_governed_capability_lifecycle_packet_v0",
+        phase: "inspect",
+        dry_run: false,
+        canonical_request_digest: providerRequestDigest,
+        admission: selectedAdmission,
+        journal,
+      },
+    });
+
+  assert.equal(reduce(admission).provider_result.status, "succeeded");
+  assert.throws(
+    () => reduce({
+      selected_todo: {
+        ...admission.selected_todo,
+        action_kind: "deploy_release",
+      },
+    }),
+    /not authorized by selected_todo action_kind/,
   );
 });
 

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -18,6 +18,7 @@ from loopx.extensions.capability_admission import (
 from loopx.extensions.governed_capability_execution import (
     reconcile_governed_external_capability,
     start_governed_external_capability,
+    validate_governed_capability_result,
 )
 from loopx.extensions.runtime import install_extension
 from loopx.todos import list_goal_todos
@@ -41,7 +42,12 @@ result = {{
     "schema_version": "fixture_material_capability_result_v0",
     "invocation_id": request["invocation_id"],
     "status": "running" if phase == "start" else "succeeded",
-    "observations": [{{"kind": "synthetic-progress", "phase": phase}}],
+    "observations": [{{
+        "kind": "synthetic-progress",
+        "phase": phase,
+        "confidence": 1.0,
+        "label": "材料",
+    }}],
     "domain_state_mutations": [],
     "domain_transition_receipts": [],
     "transition_proposals": [{{
@@ -238,19 +244,50 @@ def _start_arguments(tmp_path: Path) -> dict[str, object]:
                     "digest": "sha256:synthetic-context",
                 }
             ],
-            "input": {"requirement_key": "REQ-1"},
+            "input": {
+                "requirement_key": "REQ-1",
+                "confidence": 1.0,
+                "label": "材料",
+            },
         },
         "admission": _admission(identity),
     }
 
 
-def test_material_start_is_previewable_and_provider_idempotent(tmp_path: Path) -> None:
+def _record_runtime_operations(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    operations: list[str] = []
+    runtime_result = governed_execution.effect_runtime_result
+
+    def record(
+        operation: str,
+        payload: Mapping[str, object],
+    ) -> object:
+        operations.append(operation)
+        return runtime_result(operation, payload)
+
+    monkeypatch.setattr(governed_execution, "effect_runtime_result", record)
+    return operations
+
+
+def test_material_start_is_previewable_and_provider_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     arguments = _start_arguments(tmp_path)
     call_log = tmp_path / "provider-calls.txt"
+    runtime_operations = _record_runtime_operations(monkeypatch)
 
     preview = start_governed_external_capability(**arguments)
+    assert runtime_operations == ["governed_capability.validate_result"]
+    runtime_operations.clear()
     started = start_governed_external_capability(**arguments, execute=True)
+    assert runtime_operations == [
+        "governed_capability.validate_result",
+        "governed_capability.validate_result",
+    ]
+    runtime_operations.clear()
     replay = start_governed_external_capability(**arguments, execute=True)
+    assert runtime_operations == ["governed_capability.validate_result"]
 
     assert preview["status"] == "ready"
     assert preview["executed"] is False
@@ -270,6 +307,44 @@ def test_material_start_is_previewable_and_provider_idempotent(tmp_path: Path) -
     assert monitors[0]["status"] == "open"
     journal = Path(arguments["run_dir"]) / f"{started['invocation_id']}.json"
     assert stat.S_IMODE(journal.stat().st_mode) == 0o600
+    journal_value = json.loads(journal.read_text(encoding="utf-8"))
+    assert started["provider_result_digest"] == governed_execution._canonical_digest(
+        journal_value["provider_result"]
+    )
+
+
+def test_legacy_provider_result_adapter_remains_available() -> None:
+    result = {
+        "schema_version": "fixture_material_capability_result_v0",
+        "invocation_id": "capability-legacy",
+        "status": "no_change",
+        "observations": [],
+        "domain_state_mutations": [],
+        "domain_transition_receipts": [],
+        "transition_proposals": [],
+        "effect_receipt": {
+            "schema_version": "loopx_external_effect_receipt_v0",
+            "invocation_id": "capability-legacy",
+            "idempotency_key": "legacy-effect",
+            "status": "no_change",
+            "external_ref": "legacy-ref",
+            "evidence_digest": "sha256:legacy-evidence",
+        },
+        "follow_up": {},
+    }
+
+    assert (
+        validate_governed_capability_result(
+            result,
+            invocation_id="capability-legacy",
+            effect_id="legacy-effect",
+            operation={
+                "result_schema": "fixture_material_capability_result_v0",
+                "effect_class": "external_write",
+            },
+        )
+        == result
+    )
 
 
 def test_material_start_recovers_monitor_after_pre_receipt_crash(
@@ -340,11 +415,13 @@ def test_material_operation_remains_unavailable_through_direct_invoke(
 
 def test_material_reconcile_writes_receipt_before_spending_and_replays(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     arguments = _start_arguments(tmp_path)
     started = start_governed_external_capability(**arguments, execute=True)
     identity = _identity()
     calls: list[str] = []
+    runtime_operations = _record_runtime_operations(monkeypatch)
 
     def writeback(context: Mapping[str, object]) -> dict[str, object]:
         calls.append("writeback")
@@ -369,12 +446,20 @@ def test_material_reconcile_writes_receipt_before_spending_and_replays(
         writeback=writeback,
         spend=spend,
     )
+    assert runtime_operations == [
+        "governed_capability.validate_result",
+        "governed_capability.validate_result",
+        "governed_capability.validate_settlement_callback",
+        "governed_capability.validate_settlement_callback",
+    ]
+    runtime_operations.clear()
     replay = reconcile_governed_external_capability(
         run_dir=arguments["run_dir"],
         invocation_id=str(started["invocation_id"]),
         writeback=writeback,
         spend=spend,
     )
+    assert runtime_operations == ["governed_capability.validate_result"]
 
     assert committed["status"] == "committed"
     assert committed["effect_id"] == identity.effect_id

--- a/tests/extensions/test_governed_capability_execution.py
+++ b/tests/extensions/test_governed_capability_execution.py
@@ -550,6 +550,72 @@ def test_material_start_recovers_an_existing_journal_without_new_run_authority(
     ).splitlines() == ["start"]
 
 
+@pytest.mark.parametrize(
+    "admission_update, error",
+    [
+        ({"should_run": False}, "requires should_run=true"),
+        ({"selected_todo": None}, "selected_todo must be an object"),
+        (
+            {
+                "selected_todo": {
+                    "todo_id": "todo_fixturematerial1",
+                    "role": "agent",
+                    "status": "open",
+                    "action_kind": "different_material_action",
+                    "target_key": "fixture-material:delivery-1",
+                }
+            },
+            "not authorized by selected_todo action_kind",
+        ),
+    ],
+)
+def test_material_start_requires_current_authority_before_recovering_transitions(
+    tmp_path: Path,
+    admission_update: dict[str, object],
+    error: str,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    journal_path = tmp_path / "runs" / f"{started['invocation_id']}.json"
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    journal["transition_receipts"] = []
+    journal_path.write_text(json.dumps(journal), encoding="utf-8")
+    arguments["admission"] = {
+        **arguments["admission"],
+        **admission_update,
+    }
+    before = journal_path.read_bytes()
+
+    with pytest.raises((ValueError, EffectRuntimeRejected), match=error):
+        start_governed_external_capability(**arguments, execute=True)
+
+    assert journal_path.read_bytes() == before
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start"]
+
+
+def test_material_start_recovers_unsettled_transitions_with_current_authority(
+    tmp_path: Path,
+) -> None:
+    arguments = _start_arguments(tmp_path)
+    started = start_governed_external_capability(**arguments, execute=True)
+    journal_path = tmp_path / "runs" / f"{started['invocation_id']}.json"
+    journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    journal["transition_receipts"] = []
+    journal_path.write_text(json.dumps(journal), encoding="utf-8")
+
+    replay = start_governed_external_capability(**arguments, execute=True)
+
+    assert len(replay["transition_receipts"]) == 1
+    assert replay["transition_receipts"][0]["proposal_id"] == (
+        "fixture_monitor_upsert_1"
+    )
+    assert (tmp_path / "provider-calls.txt").read_text(
+        encoding="utf-8"
+    ).splitlines() == ["start"]
+
+
 def test_material_turn_rejects_a_second_distinct_invocation(tmp_path: Path) -> None:
     arguments = _start_arguments(tmp_path)
     first = start_governed_external_capability(**arguments, execute=True)


### PR DESCRIPTION
## Summary

- Add a versioned whole-journal lifecycle reducer to the existing `governed_capability.validate_result` TypeScript operation.
- Move start admission, journal invariants, provider-result validation, callback validation, terminal-state checks, and public receipt projection into the TypeScript control plane.
- Keep locking, atomic journal I/O, provider execution, transition materialization, writeback, and quota effects in Python while removing duplicate Python lifecycle and receipt authority.
- Preserve the existing request contract and the public Python validation adapter.

Migration economics:

| Path | Before | After |
| --- | ---: | ---: |
| Preview runtime calls | 1 | 1 |
| Execute-start runtime calls | 2 | 2 |
| Terminal reconcile runtime calls | 5 | 4 |
| Committed replay runtime calls | 3 | 1 |

The Python authority file changes by `+195/-235` (net `-40`). The overall product delta is net `+377`, primarily the new typed lifecycle owner in TypeScript.

## Issue Or Task

- Closes: N/A
- Contributor task ID: N/A (contributor-initiated RFC migration slice)

## Validation

- [x] `python3 -m py_compile loopx/*.py` (covered by compile-all verification for the changed Python module)
- [x] `loopx check --scan-root .` (exact changed-file public/private scan: 0 errors, 0 warnings)
- [x] Other:
  - `npm run test:control-plane` — 203 passed
  - Relevant Python test sweep — 197 passed
  - Focused governed-capability suites — 14 TypeScript and 14 Python tests passed
  - Built-wheel content and installed-wheel runtime smoke test passed
  - LoopX premerge qualification — 9/9 selected canaries passed

Known baseline findings outside this diff:

- Control-plane typecheck still reports three existing `TestContext` errors in unrelated tests.
- Ruff still reports two existing `TRY004` findings on untouched lines in the Python module.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: TypeScript control-plane migration RFC

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
