### PR TITLE
fix(goal): make guided selection packet consumption explicit

### DIFF
--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -173,6 +173,8 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 ),
                 "Treat the returned `ordered_steps` and `goal_start_contract` as authoritative. Follow their identity, capability-route, Todo, writeback, host-loop, quota, and stop/gate rules before substantive work; do not reconstruct those rules from skill memory.",
                 "If the packet exposes a goal-selection gate, rerun one exact choice before any mutation.",
+                "When authoring task Todos, treat `--action-kind` as the documented extensible public-safe token: choose a short task-relevant value such as `implement`, `test`, or `review`; do not search the LoopX source for an allowlist.",
+                "Consume a turn-start quota JSON packet exactly once: read the complete output directly or save it and query it with `jq`; never pipe a `--begin-turn` call through `head` or `tail`, and never rerun `--begin-turn` to recover hidden fields. When selection is required, choose the Todo and use `interaction_contract.cli_channel.selection_command` with the returned Turn identity before mutation.",
                 f"If arguments are empty and the host already identifies an active LoopX goal, follow its exact CLI `interaction_contract` or quota command first; otherwise inspect `{cli_bin} status` and `{cli_bin} bootstrap-command-pack --project .` before changing files.",
                 "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of claiming autonomous setup.",
             ],

--- a/tests/test_slash_command_install.py
+++ b/tests/test_slash_command_install.py
@@ -155,6 +155,11 @@ def test_codex_install_upgrades_managed_loopx_facade(tmp_path: Path) -> None:
     assert "use `codex-ide` for the IDE" not in skill_text
     assert "surface the exact pasteable gate" in skill_text
     assert "follow its exact CLI `interaction_contract` or quota command first" in skill_text
+    assert "treat `--action-kind` as the documented extensible public-safe token" in skill_text
+    assert "do not search the LoopX source for an allowlist" in skill_text
+    assert "never pipe a `--begin-turn` call through `head` or `tail`" in skill_text
+    assert "never rerun `--begin-turn` to recover hidden fields" in skill_text
+    assert "interaction_contract.cli_channel.selection_command" in skill_text
     assert "do not return merely after setup, planning, or claim" not in skill_text
     metadata_text = metadata.read_text(encoding="utf-8")
     assert 'display_name: "LoopX"' in metadata_text


### PR DESCRIPTION
## Summary

- document `action_kind` as an extensible public-safe token in the managed LoopX entry facade
- require one complete turn-start quota read and prohibit lossy `head`/`tail` consumption or `--begin-turn` replay
- require callers to reuse the projected selection command and exact Turn identity before mutation

## Why

The CLI already returns an exact typed selection command and Turn identity, but the managed entry facade did not make the consumption constraints explicit. A weak caller could search source code for an allowlist that does not exist, truncate the quota packet, or replay turn start to recover fields, delaying task work and rotating the settlement identity. This keeps the fail-closed CLI contract unchanged and repairs the nearest caller guidance.

## Validation

- `pytest -q tests/test_slash_command_install.py` — 39 passed
- `loopx canary premerge --from-git-diff --format json` — passed
  - diff checks and changed-file Python compile passed
  - install-local, packaged Codex CLI install, update, and maintainability canaries passed
- candidate diff scanned for credentials, private paths, raw benchmark evidence, and organization-specific context; none added

## Boundary

This changes only the managed entry prompt and its installer regression. It does not weaken Todo selection, Turn identity, quota, scoring, permissions, or benchmark runner behavior.