### PR TITLE
fix(lark): acknowledge inbox reads at turn start

### DIFF
--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -13,7 +13,10 @@
 
 LoopX adds a provider-neutral `turn_start` capability-hook phase. An enabled
 provider hook runs before status and quota projection. It may perform bounded
-external reads and mutate only declared owner-private inbox/cursor state. The
+external reads, mutate declared owner-private inbox/cursor state, and—only when
+the provider registration explicitly requests `provider_message_reaction`—add
+one idempotent acknowledgement reaction to a captured, still-pending,
+provider-typed mention or verified reply. The
 public result contains counts, booleans, status, and an error code; it cannot
 contain message content, provider payloads, credentials, destinations, profile
 names, or private cursor values.
@@ -41,6 +44,7 @@ to a durable effect receipt before inbox ACK.
 ```text
 provider-neutral turn_start dispatch
   -> provider read + owner-private commit/readback
+  -> optional typed-address acknowledgement + private reaction receipt
   -> fresh status + quota projection
   -> inbox lane preempts ordinary work when agent_read_required
   -> private drain into the active Agent turn
@@ -64,7 +68,11 @@ collection and quota selection.
   declared schema; it must never degrade to `empty`.
 - provider permission and availability failures remain typed and isolated.
 - duplicate hook identities run once; duplicate messages collapse by provider
-  message identity.
+  message identity, and a private reaction receipt prevents duplicate ACKs.
+- a provider-owned self-message filter may run before inbox ingestion only from
+  a typed sender and an exact identity verified for the configured profile;
+  unresolved identity fails open to capture and cannot use display-name or body
+  heuristics.
 - provider-local cursors are single-flight and advance only after inbox and
   cursor readback.
 - `partial` multi-route success still requires Agent reading for accepted
@@ -73,4 +81,8 @@ collection and quota selection.
 
 The hook grants no repository, production, outbound-message, or arbitrary
 external-write authority. Its only allowed local writes are the registered
-owner-private inbox and cursor scopes.
+owner-private inbox and cursor scopes. Its only admitted external write is the
+explicit `provider_message_reaction` scope: one configured reaction on a
+captured, still-pending typed mention or verified reply. The public receipt
+must expose `external_writes_performed`; provider or private-receipt failure is
+`partial`, never a false success, and cannot discard the captured inbox event.

--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -16,7 +16,9 @@ provider hook runs before status and quota projection. It may perform bounded
 external reads, mutate declared owner-private inbox/cursor state, and—only when
 the provider registration explicitly requests `provider_message_reaction`—add
 one idempotent acknowledgement reaction to a captured, still-pending,
-provider-typed mention or verified reply. The
+human-authored message that the hook has read into the Agent's turn-start
+processing chain. This read acknowledgement is independent of mention, reply,
+question, and other attention classifications. The
 public result contains counts, booleans, status, and an error code; it cannot
 contain message content, provider payloads, credentials, destinations, profile
 names, or private cursor values.
@@ -44,7 +46,7 @@ to a durable effect receipt before inbox ACK.
 ```text
 provider-neutral turn_start dispatch
   -> provider read + owner-private commit/readback
-  -> optional typed-address acknowledgement + private reaction receipt
+  -> optional pending-message read acknowledgement + private reaction receipt
   -> fresh status + quota projection
   -> inbox lane preempts ordinary work when agent_read_required
   -> private drain into the active Agent turn
@@ -69,6 +71,10 @@ collection and quota selection.
 - provider permission and availability failures remain typed and isolated.
 - duplicate hook identities run once; duplicate messages collapse by provider
   message identity, and a private reaction receipt prevents duplicate ACKs.
+- collector-only capture performs no provider write. The acknowledgement is
+  admitted only after the turn-start hook reads and confirms a pending message.
+- attention classification affects scheduling and reply policy, never whether
+  a successfully read pending message receives the acknowledgement.
 - a provider-owned self-message filter may run before inbox ingestion only from
   a typed sender and an exact identity verified for the configured profile;
   unresolved identity fails open to capture and cannot use display-name or body
@@ -83,6 +89,7 @@ The hook grants no repository, production, outbound-message, or arbitrary
 external-write authority. Its only allowed local writes are the registered
 owner-private inbox and cursor scopes. Its only admitted external write is the
 explicit `provider_message_reaction` scope: one configured reaction on a
-captured, still-pending typed mention or verified reply. The public receipt
+captured, still-pending message read by the Agent turn-start hook. Realtime
+collection cannot consume that scope. The public receipt
 must expose `external_writes_performed`; provider or private-receipt failure is
 `partial`, never a false success, and cannot discard the captured inbox event.

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -24,7 +24,6 @@ from ..extensions.lark import (
 from ..extensions.lark.event_collector import (
     inspect_lark_event_collector,
     install_lark_event_collector,
-    load_lark_event_collector_config,
     plan_lark_event_collector,
 )
 from ..extensions.lark.event_collector_runtime import run_lark_event_collector
@@ -280,21 +279,6 @@ def _required_extension_permissions(command: str) -> tuple[str, ...]:
     return (LARK_COLLECTOR_PERMISSION,)
 
 
-def _collector_permissions(
-    *, project: str | Path, config_path: str | Path
-) -> tuple[str, ...]:
-    config = load_lark_event_collector_config(
-        project=project,
-        config_path=config_path,
-    )
-    if any(
-        route["inbox"]["reply"].get("received_reaction_emoji")
-        for route in config["routes"]
-    ):
-        return (LARK_COLLECTOR_PERMISSION, LARK_REPLY_PERMISSION)
-    return (LARK_COLLECTOR_PERMISSION,)
-
-
 def _resolve_lark_activation(
     command: str,
     *,
@@ -372,7 +356,7 @@ def build_lark_turn_start_inbox_hook(
             "status": status,
             "observation_count": int(result.get("observation_count") or 0),
             "agent_read_required": bool(
-                int(result.get("observation_count") or 0)
+                result.get("agent_read_required") is True
                 and status in {"observed", "partial"}
             ),
             "external_reads_performed": (
@@ -520,17 +504,6 @@ def handle_lark_inbox_command(
             args.lark_inbox_command,
             runtime_root_arg=runtime_root_arg,
         )
-        if args.lark_inbox_command.startswith("collector-"):
-            required_permissions = _collector_permissions(
-                project=args.project,
-                config_path=args.config,
-            )
-            if len(required_permissions) > 1:
-                activation = resolve_extension_activation(
-                    LARK_EXTENSION_ID,
-                    state_file=default_extension_state_file(runtime_root_arg),
-                    required_permissions=required_permissions,
-                )
         if args.lark_inbox_command == "drain":
             payload = inspect_routed_lark_event_inbox(
                 project=project,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -378,6 +378,9 @@ def build_lark_turn_start_inbox_hook(
             "external_reads_performed": (
                 result.get("external_reads_performed") is True
             ),
+            "external_writes_performed": (
+                result.get("external_writes_performed") is True
+            ),
             "local_private_state_mutated": (
                 result.get("local_private_state_mutated") is True
             ),
@@ -396,6 +399,7 @@ def build_lark_turn_start_inbox_hook(
         requested_write_scope=(
             "owner_private_inbox",
             "owner_private_cursor",
+            "provider_message_reaction",
         ),
         producer=produce,
     )

--- a/loopx/control_plane/capability_hooks.ts
+++ b/loopx/control_plane/capability_hooks.ts
@@ -59,6 +59,7 @@ const TURN_START_RESULT_FIELDS = new Set([
   "observation_count",
   "agent_read_required",
   "external_reads_performed",
+  "external_writes_performed",
   "local_private_state_mutated",
   "private_content_returned",
   "provider_payload_returned",
@@ -67,6 +68,7 @@ const TURN_START_RESULT_FIELDS = new Set([
 const TURN_START_WRITE_SCOPES = new Set([
   "owner_private_inbox",
   "owner_private_cursor",
+  "provider_message_reaction",
 ]);
 const TURN_START_STATUSES = new Set([
   "not_applicable",
@@ -287,7 +289,7 @@ export function validateTurnStartHookRegistration(
     8,
   );
   if (writeScope.some((scope) => !TURN_START_WRITE_SCOPES.has(scope))) {
-    throw new Error("turn-start hook requested_write_scope is not owner-private");
+    throw new Error("turn-start hook requested_write_scope is not admitted");
   }
   const budget = requiredObject(registration.budget, "turn-start hook budget");
   requireExactFields(budget, BUDGET_FIELDS, "turn-start hook budget");
@@ -346,6 +348,7 @@ export function validateTurnStartHookInvocation(input: {
   for (const field of [
     "agent_read_required",
     "external_reads_performed",
+    "external_writes_performed",
     "local_private_state_mutated",
     "private_content_returned",
     "provider_payload_returned",
@@ -362,6 +365,12 @@ export function validateTurnStartHookInvocation(input: {
     registration.requested_write_scope.length === 0
   ) {
     throw new Error("turn-start hook mutated undeclared local-private state");
+  }
+  if (
+    result.external_writes_performed &&
+    !registration.requested_write_scope.includes("provider_message_reaction")
+  ) {
+    throw new Error("turn-start hook performed an undeclared external write");
   }
   const errorCode = result.error_code;
   if (errorCode !== null && (typeof errorCode !== "string" || !TOKEN_RE.test(errorCode))) {
@@ -385,6 +394,7 @@ export function validateTurnStartHookInvocation(input: {
     observationCount !== 0 ||
     result.agent_read_required ||
     result.external_reads_performed ||
+    result.external_writes_performed ||
     result.local_private_state_mutated ||
     errorCode !== null
   )) {

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -42,6 +42,7 @@ sync: it is a pre-decision capability hook with the following ordering:
 turn-start hook
   -> read one bounded provider page per route
   -> commit and read back owner-private inbox events and cursor
+  -> optionally ACK a provider-typed mention with one idempotent reaction
   -> recompute quota inbox urgency in the same CLI invocation
   -> agent_read_required=true when new events were accepted
   -> selected inbox lane drains private message content before ordinary work
@@ -51,7 +52,8 @@ turn-start hook
 ```
 
 Core owns the provider-neutral hook registration, output budget, allowed
-owner-private write scopes, failure isolation, and `agent_read_required`
+owner-private write scopes, the narrow `provider_message_reaction` external
+write scope, failure isolation, and `agent_read_required`
 contract. The Lark extension owns history pagination, provider-envelope
 validation, private cursors, and inbox readback. The CLI composition root runs
 the hook before status/quota projection. Raw content remains only in the local
@@ -206,12 +208,15 @@ messages; use `configured_chat_all` for complete collaboration threads:
 ```
 
 `reply.received_reaction_emoji` is optional and belongs to the same explicit
-sender boundary as source-thread replies. When configured, the collector adds
-that reaction only after an event is accepted into the inbox and classified as
-a direct mention, direct question, or verified reply to the configured bot.
-The reaction is a best-effort receipt: provider failure increments compact
-failure accounting but does not discard the inbox event or grant execution
-authority. Ordinary group conversation does not receive the reaction.
+sender boundary as source-thread replies. When configured, realtime collection
+and turn-start history sync share one receipt-backed boundary that adds the
+reaction only after an event is accepted into the inbox, remains pending, and
+is classified from provider-typed evidence as a direct mention or verified
+reply to the configured bot. Failed reactions are retried idempotently from
+bounded overlap pages while the message remains pending. The reaction is a
+best-effort receipt: provider failure increments compact failure accounting but
+does not discard the inbox event or grant execution authority. Ordinary group
+conversation does not receive the reaction.
 
 `reply.processing_reaction_emoji` is optional and requires a distinct
 `received_reaction_emoji`. When both are configured, the host should run
@@ -325,8 +330,13 @@ Missing `lark-cli` produces a non-blocking install hint. Reply-target
 verification also requires the configured bot to read messages in the selected
 chat. Bot-identity group-history catch-up requires the application scopes
 `im:message.group_msg` and `im:message.group_msg.include_bot:read`; the latter
-keeps Bot-authored messages in the paginated result. When the Bot list-messages
-history path reports provider error `230027`, LoopX must surface both scopes
+keeps Bot-authored messages in the provider result. Before inbox ingestion,
+realtime collection and bounded history sync both compare a provider-typed
+`app` sender with the exact app identity verified for the configured profile.
+An exact self match is counted and skipped; other apps and unresolved
+identities remain visible so an identity lookup failure cannot silently lose a
+message. When the Bot list-messages history path reports provider error `230027`,
+LoopX must surface both scopes
 and an official API page bound to the selected App id. The operator enables
 the application scopes and publishes a new App
 version; this is not a user OAuth login. These requirements belong to the
@@ -519,7 +529,9 @@ or NDJSON into the generic importer:
 Ingest validates ids and schema, deduplicates by `message_id`, writes only to
 the configured local-private inbox, and returns counts rather than message
 content. It does not acknowledge imported messages; the domain agent must still
-write each actionable effect before ACK.
+write each actionable effect before ACK. Provider-backed realtime and history
+ingress also report `self_message_skipped_count`; raw generic imports cannot
+claim this verification because they do not own the configured Bot identity.
 
 Reviewer notification dedupe uses durable lifecycle receipts first, then exact
 PR-link evidence in the persisted `configured_chat_all` inbox, and finally a

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -42,9 +42,9 @@ sync: it is a pre-decision capability hook with the following ordering:
 turn-start hook
   -> read one bounded provider page per route
   -> commit and read back owner-private inbox events and cursor
-  -> optionally ACK a provider-typed mention with one idempotent reaction
+  -> ACK each newly read pending human message with one idempotent reaction
   -> recompute quota inbox urgency in the same CLI invocation
-  -> agent_read_required=true when new events were accepted
+  -> agent_read_required=true when pending messages were newly read by the hook
   -> selected inbox lane drains private message content before ordinary work
   -> Agent chooses steering / Goal replan / context capture /
      continue-current-work / no-follow-up
@@ -201,25 +201,33 @@ messages; use `configured_chat_all` for complete collaboration threads:
     "sender_identity": "bot",
     "bot_display_name": "Project Review Bot",
     "chat_id": "oc_<local-private-chat-id>",
-    "received_reaction_emoji": "Get",
     "processing_reaction_emoji": "OnIt"
   }
 }
 ```
 
-`reply.received_reaction_emoji` is optional and belongs to the same explicit
-sender boundary as source-thread replies. When configured, realtime collection
-and turn-start history sync share one receipt-backed boundary that adds the
-reaction only after an event is accepted into the inbox, remains pending, and
-is classified from provider-typed evidence as a direct mention or verified
-reply to the configured bot. Failed reactions are retried idempotently from
-bounded overlap pages while the message remains pending. The reaction is a
-best-effort receipt: provider failure increments compact failure accounting but
-does not discard the inbox event or grant execution authority. Ordinary group
-conversation does not receive the reaction.
+For every reply-enabled Inbox, a missing `reply.received_reaction_emoji`
+defaults to `Get`. Set it explicitly to the empty string to disable this
+provider write. The reaction belongs to the same explicit sender boundary as
+source-thread replies, but only the Agent's turn-start hook may create it:
+realtime collection persists events without reacting, and the hook writes the
+reaction only after it has read and confirmed a still-pending human message.
+The receipt therefore means "read into the Agent processing chain"; it does not
+mean "collector stored the event", "the Bot was mentioned", "a reply is due",
+or "processing completed". Mention, reply, question, and material-review
+classification remain independent scheduling and response decisions.
+
+Failed reactions are retried idempotently from bounded overlap pages while the
+message remains pending. The reaction is a best-effort receipt: provider
+failure increments compact failure accounting but does not discard the Inbox
+event or grant execution authority. A private receipt prevents overlap replay
+from creating a second reaction, and settled or verified Bot-authored messages
+never receive one.
 
 `reply.processing_reaction_emoji` is optional and requires a distinct
-`received_reaction_emoji`. When both are configured, the host should run
+received reaction. The default `Get` satisfies that requirement; when the read
+acknowledgement is explicitly disabled, processing reaction must also be
+disabled. When both are configured, the host should run
 `lark-inbox processing` immediately before interpreting an actionable item.
 LoopX first adds the processing reaction and then removes the received
 reaction. A verified source-thread reply removes any remaining lifecycle

--- a/loopx/extensions/lark/event_collector.py
+++ b/loopx/extensions/lark/event_collector.py
@@ -309,7 +309,9 @@ def _jq_projection(chat_ids: str | Sequence[str]) -> str:
         "event_id:(.event_id // .message_id // .id),"
         "message_id:(.message_id // .id),"
         "create_time:.create_time,content:.content,"
-        "attachment_count:(.attachment_count // 0),sender_id:.sender_id,"
+        "attachment_count:(.attachment_count // 0),"
+        "sender_type:(.sender_type // .sender.sender_type),"
+        "sender_id:(.sender_id // .sender.id // .sender.sender_id),"
         "chat_id:.chat_id}"
     )
 

--- a/loopx/extensions/lark/event_collector_runtime.py
+++ b/loopx/extensions/lark/event_collector_runtime.py
@@ -20,8 +20,8 @@ from .event_inbox import (
     ingest_lark_event_inbox,
 )
 from .inbox_reactions import (
+    ensure_lark_event_inbox_received_reaction_locked,
     lark_inbox_reaction_lock,
-    record_lark_inbox_reaction,
 )
 
 APP_ID_PATTERN = re.compile(r"cli_[A-Za-z0-9_-]+")
@@ -43,7 +43,7 @@ def _run_json(
             check=False,
             timeout=timeout_seconds,
         )
-    except subprocess.TimeoutExpired:
+    except (OSError, subprocess.SubprocessError):
         return {}
     if result.returncode != 0:
         return {}
@@ -223,6 +223,17 @@ def _sender_identity(message: Mapping[str, Any]) -> tuple[str, str]:
     return sender_type, sender_id
 
 
+def _is_profile_self_message(
+    message: Mapping[str, Any], *, profile_app_id: str | None
+) -> bool:
+    """Match only a provider-typed app sender to the verified profile app id."""
+
+    if profile_app_id is None:
+        return False
+    sender_type, sender_id = _sender_identity(message)
+    return sender_type == "app" and sender_id == profile_app_id
+
+
 def enrich_lark_event_reply_context(
     event: Mapping[str, Any],
     *,
@@ -266,6 +277,8 @@ def enrich_lark_event_reply_context(
         if field in current:
             enriched[field] = current[field]
     current_sender_type, current_sender_id = _sender_identity(current)
+    if current_sender_type:
+        enriched["sender_type"] = current_sender_type
     if current_sender_id:
         enriched["sender_id"] = current_sender_id
 
@@ -468,6 +481,8 @@ def run_lark_event_collector(
     reply_to_bot_count = 0
     received_reaction_count = 0
     received_reaction_failure_count = 0
+    external_writes_performed = False
+    self_message_skipped_count = 0
     routed_chat_ids: set[str] = set()
     profile_app_id: str | None = None
     profile_identity_checked = False
@@ -485,6 +500,20 @@ def run_lark_event_collector(
             if route is None:
                 continue
             inbox = route["inbox"]
+            sender_type, _sender_id = _sender_identity(payload)
+            if sender_type == "app" and not profile_identity_checked:
+                profile_app_id = _profile_app_id(
+                    runner=runner,
+                    command_prefix=command_prefix,
+                    profile=str(config["profile"]),
+                )
+                profile_identity_checked = True
+            if _is_profile_self_message(
+                payload,
+                profile_app_id=profile_app_id,
+            ):
+                self_message_skipped_count += 1
+                continue
             needs_reply_lookup = lark_event_requires_reply_context_lookup(
                 payload,
                 bot_display_name=str(inbox["reply"].get("bot_display_name") or ""),
@@ -519,6 +548,12 @@ def run_lark_event_collector(
                         "reply_to_bot": False,
                     }
                 )
+            if _is_profile_self_message(
+                enriched,
+                profile_app_id=profile_app_id,
+            ):
+                self_message_skipped_count += 1
+                continue
             message_id = str(enriched.get("message_id") or "")
             if not MESSAGE_ID_PATTERN.fullmatch(message_id):
                 continue
@@ -544,42 +579,34 @@ def run_lark_event_collector(
                 routed_chat_ids.add(chat_id)
                 verified_count += int(enriched.get("reply_context_verified") is True)
                 reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
-                attention_kind = _event_attention_kind(
-                    enriched,
-                    bot_display_name=str(inbox["reply"].get("bot_display_name") or ""),
-                    capture_scope="configured_chat_all",
+                reaction = ensure_lark_event_inbox_received_reaction_locked(
+                    config=inbox,
+                    event=enriched,
+                    create_reaction=lambda candidate_message_id, emoji_type: (
+                        _create_lark_event_received_reaction(
+                            {"message_id": candidate_message_id},
+                            runner=runner,
+                            command_prefix=command_prefix,
+                            profile=str(config["profile"]),
+                            emoji_type=emoji_type,
+                        )
+                    ),
+                    delete_reaction=lambda candidate_message_id, reaction_id: (
+                        _delete_lark_event_reaction(
+                            runner=runner,
+                            command_prefix=command_prefix,
+                            profile=str(config["profile"]),
+                            message_id=candidate_message_id,
+                            reaction_id=reaction_id,
+                        )
+                    ),
                 )
-                received_reaction_emoji = str(
-                    inbox["reply"].get("received_reaction_emoji") or ""
+                received_reaction_count += int(reaction["created_count"])
+                received_reaction_failure_count += int(reaction["ok"] is not True)
+                external_writes_performed = bool(
+                    external_writes_performed
+                    or reaction["external_writes_performed"] is True
                 )
-                if attention_kind is not None and received_reaction_emoji:
-                    reaction_id = _create_lark_event_received_reaction(
-                        enriched,
-                        runner=runner,
-                        command_prefix=command_prefix,
-                        profile=str(config["profile"]),
-                        emoji_type=received_reaction_emoji,
-                    )
-                    if reaction_id:
-                        try:
-                            record_lark_inbox_reaction(
-                                inbox=inbox["inbox_path"],
-                                message_id=message_id,
-                                phase="received",
-                                reaction_id=reaction_id,
-                                emoji_type=received_reaction_emoji,
-                            )
-                        except (OSError, ValueError):
-                            _delete_lark_event_reaction(
-                                runner=runner,
-                                command_prefix=command_prefix,
-                                profile=str(config["profile"]),
-                                message_id=message_id,
-                                reaction_id=reaction_id,
-                            )
-                            reaction_id = None
-                    received_reaction_count += int(reaction_id is not None)
-                    received_reaction_failure_count += int(reaction_id is None)
         returncode = process.wait()
     finally:
         if process.poll() is None:
@@ -607,7 +634,8 @@ def run_lark_event_collector(
         "reply_to_bot_count": reply_to_bot_count,
         "received_reaction_count": received_reaction_count,
         "received_reaction_failure_count": received_reaction_failure_count,
-        "external_writes_performed": received_reaction_count > 0,
+        "self_message_skipped_count": self_message_skipped_count,
+        "external_writes_performed": external_writes_performed,
         "profile_identity_checked": profile_identity_checked,
         "profile_identity_verified": profile_app_id is not None,
         "chat_ids_returned": False,

--- a/loopx/extensions/lark/event_collector_runtime.py
+++ b/loopx/extensions/lark/event_collector_runtime.py
@@ -19,10 +19,6 @@ from .event_inbox import (
     _event_attention_kind,
     ingest_lark_event_inbox,
 )
-from .inbox_reactions import (
-    ensure_lark_event_inbox_received_reaction_locked,
-    lark_inbox_reaction_lock,
-)
 
 APP_ID_PATTERN = re.compile(r"cli_[A-Za-z0-9_-]+")
 CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
@@ -479,9 +475,6 @@ def run_lark_event_collector(
     captured_count = 0
     verified_count = 0
     reply_to_bot_count = 0
-    received_reaction_count = 0
-    received_reaction_failure_count = 0
-    external_writes_performed = False
     self_message_skipped_count = 0
     routed_chat_ids: set[str] = set()
     profile_app_id: str | None = None
@@ -557,56 +550,24 @@ def run_lark_event_collector(
             message_id = str(enriched.get("message_id") or "")
             if not MESSAGE_ID_PATTERN.fullmatch(message_id):
                 continue
-            with lark_inbox_reaction_lock(
-                inbox=inbox["inbox_path"],
-                message_id=message_id,
-            ):
-                result = ingest_lark_event_inbox(
-                    project=config["project"],
-                    config_path=route["event_inbox_config_ref"],
-                    events=[
-                        {
-                            "schema_version": "lark_event_inbox_event_v0",
-                            **enriched,
-                            "route_key": route["route_key"],
-                        }
-                    ],
-                    execute=True,
-                )
-                if int(result.get("accepted_count") or 0) == 0:
-                    continue
-                captured_count += 1
-                routed_chat_ids.add(chat_id)
-                verified_count += int(enriched.get("reply_context_verified") is True)
-                reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
-                reaction = ensure_lark_event_inbox_received_reaction_locked(
-                    config=inbox,
-                    event=enriched,
-                    create_reaction=lambda candidate_message_id, emoji_type: (
-                        _create_lark_event_received_reaction(
-                            {"message_id": candidate_message_id},
-                            runner=runner,
-                            command_prefix=command_prefix,
-                            profile=str(config["profile"]),
-                            emoji_type=emoji_type,
-                        )
-                    ),
-                    delete_reaction=lambda candidate_message_id, reaction_id: (
-                        _delete_lark_event_reaction(
-                            runner=runner,
-                            command_prefix=command_prefix,
-                            profile=str(config["profile"]),
-                            message_id=candidate_message_id,
-                            reaction_id=reaction_id,
-                        )
-                    ),
-                )
-                received_reaction_count += int(reaction["created_count"])
-                received_reaction_failure_count += int(reaction["ok"] is not True)
-                external_writes_performed = bool(
-                    external_writes_performed
-                    or reaction["external_writes_performed"] is True
-                )
+            result = ingest_lark_event_inbox(
+                project=config["project"],
+                config_path=route["event_inbox_config_ref"],
+                events=[
+                    {
+                        "schema_version": "lark_event_inbox_event_v0",
+                        **enriched,
+                        "route_key": route["route_key"],
+                    }
+                ],
+                execute=True,
+            )
+            if int(result.get("accepted_count") or 0) == 0:
+                continue
+            captured_count += 1
+            routed_chat_ids.add(chat_id)
+            verified_count += int(enriched.get("reply_context_verified") is True)
+            reply_to_bot_count += int(enriched.get("reply_to_bot") is True)
         returncode = process.wait()
     finally:
         if process.poll() is None:
@@ -632,10 +593,14 @@ def run_lark_event_collector(
         "multi_chat_routing": len(config["routes"]) > 1,
         "reply_context_verified_count": verified_count,
         "reply_to_bot_count": reply_to_bot_count,
-        "received_reaction_count": received_reaction_count,
-        "received_reaction_failure_count": received_reaction_failure_count,
+        # Retain the collector receipt shape while making its no-write
+        # boundary explicit. Read acknowledgements are emitted by turn-start.
+        "received_reaction_count": 0,
+        "received_reaction_failure_count": 0,
         "self_message_skipped_count": self_message_skipped_count,
-        "external_writes_performed": external_writes_performed,
+        # Collection proves durable capture only.  Provider acknowledgement is
+        # owned by the Agent's next turn-start read boundary.
+        "external_writes_performed": False,
         "profile_identity_checked": profile_identity_checked,
         "profile_identity_verified": profile_app_id is not None,
         "chat_ids_returned": False,

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -121,9 +121,15 @@ def load_lark_event_inbox_config(
         raise ValueError(
             "lark inbox editorial_style must be concise or bullet_points_preferred"
         )
-    received_reaction_emoji = str(
-        reply_payload.get("received_reaction_emoji") or ""
-    ).strip()
+    # A reply-capable Inbox acknowledges Agent consumption by default.  Keep
+    # the missing field distinct from an explicit empty value so operators can
+    # disable the provider write without inventing a second config switch.
+    if "received_reaction_emoji" in reply_payload:
+        received_reaction_emoji = str(
+            reply_payload.get("received_reaction_emoji") or ""
+        ).strip()
+    else:
+        received_reaction_emoji = "Get" if reply_enabled else ""
     processing_reaction_emoji = str(
         reply_payload.get("processing_reaction_emoji") or ""
     ).strip()
@@ -164,9 +170,7 @@ def load_lark_event_inbox_config(
     ):
         raise ValueError("lark inbox material_review config must be an object")
     material_review_payload = (
-        material_review_payload
-        if isinstance(material_review_payload, Mapping)
-        else {}
+        material_review_payload if isinstance(material_review_payload, Mapping) else {}
     )
     material_review_enabled = material_review_payload.get("enabled") is True
     material_review_drain_limit = material_review_payload.get("drain_limit", 20)
@@ -542,8 +546,7 @@ def _material_review_ledger(inbox: Path) -> tuple[Path, dict[str, Any]]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if (
         not isinstance(payload, dict)
-        or payload.get("schema_version")
-        != MATERIAL_REVIEW_LEDGER_SCHEMA_VERSION
+        or payload.get("schema_version") != MATERIAL_REVIEW_LEDGER_SCHEMA_VERSION
         or not isinstance(payload.get("receipts"), dict)
     ):
         raise ValueError("lark material-review receipt ledger is invalid")

--- a/loopx/extensions/lark/group_history.py
+++ b/loopx/extensions/lark/group_history.py
@@ -18,6 +18,11 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from .event_collector import _executable_prefix, load_lark_event_collector_config
+from .event_collector_runtime import (
+    _is_profile_self_message,
+    _profile_app_id,
+    _sender_identity,
+)
 from .event_inbox import EVENT_SCHEMA_VERSION, MESSAGE_ID_PATTERN
 from .group_history_cursor import (
     group_history_cursor_digest,
@@ -181,12 +186,20 @@ def _provider_page(payload: object) -> tuple[list[Mapping[str, Any]], bool, str 
 
 
 def _canonical_events(
-    messages: Sequence[Mapping[str, Any]], *, chat_id: str
-) -> tuple[list[dict[str, Any]], int, int]:
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    chat_id: str,
+    profile_app_id: str | None = None,
+) -> tuple[list[dict[str, Any]], int, int, int]:
     events: list[dict[str, Any]] = []
     skipped_count = 0
     invalid_count = 0
+    self_message_skipped_count = 0
     for message in messages:
+        if _is_profile_self_message(message, profile_app_id=profile_app_id):
+            skipped_count += 1
+            self_message_skipped_count += 1
+            continue
         if message.get("deleted") is True:
             skipped_count += 1
             continue
@@ -216,7 +229,7 @@ def _canonical_events(
             if field in message:
                 event[field] = message[field]
         events.append(event)
-    return events, skipped_count, invalid_count
+    return events, skipped_count, invalid_count, self_message_skipped_count
 
 
 def _normalized_url(raw: str) -> str | None:
@@ -452,9 +465,24 @@ def catch_up_lark_group_history(
     try:
         payload = json.loads(result.stdout)
         messages, has_more, next_page_token = _provider_page(payload)
-        events, skipped_count, invalid_count = _canonical_events(
+        profile_app_id = (
+            _profile_app_id(
+                runner=runner,
+                command_prefix=command_prefix,
+                profile=str(config["profile"]),
+            )
+            if any(_sender_identity(message)[0] == "app" for message in messages)
+            else None
+        )
+        (
+            events,
+            skipped_count,
+            invalid_count,
+            self_message_skipped_count,
+        ) = _canonical_events(
             messages,
             chat_id=str(route["chat_id"]),
+            profile_app_id=profile_app_id,
         )
     except (json.JSONDecodeError, TypeError, ValueError):
         return _failed_receipt(
@@ -491,6 +519,7 @@ def catch_up_lark_group_history(
             "accepted_count": int(ingest["accepted_count"]),
             "duplicate_count": int(ingest["duplicate_count"]),
             "skipped_count": skipped_count,
+            "self_message_skipped_count": self_message_skipped_count,
             "history_complete": not has_more,
             "link_evidence": evidence,
             "external_read_performed": True,
@@ -555,6 +584,7 @@ def catch_up_lark_group_history(
         "accepted_count": int(ingest["accepted_count"]),
         "duplicate_count": int(ingest["duplicate_count"]),
         "skipped_count": skipped_count,
+        "self_message_skipped_count": self_message_skipped_count,
         "history_complete": not has_more,
         "link_evidence": evidence,
         "external_read_performed": True,

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -4,35 +4,37 @@ import hashlib
 import json
 import re
 import subprocess
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Iterator, Sequence
+from typing import Any
 
 from ...file_lock import exclusive_file_lock
 from .event_inbox import (
     MESSAGE_ID_PATTERN,
     REACTION_EMOJI_PATTERN,
+    _event_attention_kind,
     _event_from_file,
     _load_processed,
     load_lark_event_inbox_config,
 )
 from .private_json import write_private_json_atomic
 
-
 REACTION_RECEIPTS_SCHEMA_VERSION = "lark_event_inbox_reaction_receipts_v0"
 REACTION_PHASES = {"received", "processing"}
 REACTION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,200}")
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
+ReactionCreator = Callable[[str, str], str | None]
+ReactionDeleter = Callable[[str, str], bool]
 
 
 def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
     result = subprocess.run(
         list(args),
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
+        check=False,
         timeout=10,
     )
     return {
@@ -72,11 +74,7 @@ def _find_string_by_key(value: object, key: str) -> str | None:
         )
     if isinstance(value, list):
         return next(
-            (
-                found
-                for child in value
-                if (found := _find_string_by_key(child, key))
-            ),
+            (found for child in value if (found := _find_string_by_key(child, key))),
             None,
         )
     return None
@@ -88,13 +86,10 @@ def _contains_string_by_key(value: object, key: str, expected: str) -> bool:
         if isinstance(candidate, str) and candidate.strip() == expected:
             return True
         return any(
-            _contains_string_by_key(child, key, expected)
-            for child in value.values()
+            _contains_string_by_key(child, key, expected) for child in value.values()
         )
     if isinstance(value, list):
-        return any(
-            _contains_string_by_key(child, key, expected) for child in value
-        )
+        return any(_contains_string_by_key(child, key, expected) for child in value)
     return False
 
 
@@ -108,9 +103,7 @@ def _operation_lock_target(inbox: Path, message_id: str) -> Path:
 
 
 @contextmanager
-def lark_inbox_reaction_lock(
-    *, inbox: Path, message_id: str
-) -> Iterator[None]:
+def lark_inbox_reaction_lock(*, inbox: Path, message_id: str) -> Iterator[None]:
     normalized = str(message_id or "").strip()
     if not MESSAGE_ID_PATTERN.fullmatch(normalized):
         raise ValueError("reaction lock requires a valid Lark message id")
@@ -150,7 +143,7 @@ def _load_receipts(path: Path) -> dict[str, dict[str, dict[str, str]]]:
         raise ValueError("lark inbox reaction receipts schema is invalid")
     raw_receipts = payload.get("receipts")
     if not isinstance(raw_receipts, Mapping):
-        raise ValueError("lark inbox reaction receipts payload is invalid")
+        raise TypeError("lark inbox reaction receipts payload is invalid")
     receipts: dict[str, dict[str, dict[str, str]]] = {}
     for raw_message_id, raw_phases in raw_receipts.items():
         message_id = str(raw_message_id)
@@ -196,7 +189,7 @@ def _update_receipts(
             {
                 "schema_version": REACTION_RECEIPTS_SCHEMA_VERSION,
                 "receipts": receipts,
-                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": datetime.now(UTC).isoformat(),
             },
         )
 
@@ -359,9 +352,7 @@ def _delete_reaction(
     )
 
 
-def _captured_pending_message(
-    *, inbox: Path, message_id: str
-) -> bool:
+def _captured_pending_message(*, inbox: Path, message_id: str) -> bool:
     if message_id in _load_processed(inbox / "processed.json"):
         return False
     return any(
@@ -370,6 +361,193 @@ def _captured_pending_message(
         if path.name != "processed.json"
         if (event := _event_from_file(path)) is not None
     )
+
+
+def _typed_lark_event_attention_kind(
+    event: Mapping[str, Any], *, bot_display_name: str
+) -> str | None:
+    """Return only provider-typed mention or verified reply attention."""
+
+    attention_kind = _event_attention_kind(
+        event,
+        bot_display_name=bot_display_name,
+        capture_scope="configured_chat_all",
+    )
+    if attention_kind == "reply_to_bot":
+        return attention_kind
+    if attention_kind is not None and ("mentions" in event or "mentioned" in event):
+        return attention_kind
+    return None
+
+
+def _received_reaction_result(
+    *,
+    status: str,
+    ok: bool,
+    configured: bool,
+    addressed: bool,
+    created_count: int = 0,
+    external_writes_performed: bool | None = None,
+    blocker: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "ok": ok,
+        "schema_version": "lark_event_inbox_received_reaction_v0",
+        "status": status,
+        "configured": configured,
+        "addressed": addressed,
+        "created_count": created_count,
+        "external_writes_performed": (
+            created_count > 0
+            if external_writes_performed is None
+            else external_writes_performed
+        ),
+        "private_sender_profile_captured": False,
+        "private_message_id_captured": False,
+        "private_reaction_id_captured": False,
+        "raw_provider_payload_captured": False,
+    }
+    if blocker:
+        result["blocker"] = blocker
+    return result
+
+
+def ensure_lark_event_inbox_received_reaction_locked(
+    *,
+    config: Mapping[str, Any],
+    event: Mapping[str, Any],
+    create_reaction: ReactionCreator,
+    delete_reaction: ReactionDeleter,
+) -> dict[str, Any]:
+    """Idempotently ACK one captured, provider-addressed message.
+
+    The caller owns the per-message reaction lock.  This boundary is shared by
+    realtime collection and bounded history sync so receipt semantics do not
+    depend on which ingress first captured the message.
+    """
+
+    message_id = str(event.get("message_id") or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(message_id):
+        raise ValueError("received reaction requires a valid Lark message id")
+    inbox = config["inbox_path"]
+    # Settlement and provider reaction creation must be one lifecycle
+    # transition. Otherwise an Agent can ACK the message after the pending
+    # check but before the reaction receipt is persisted, leaving a reaction on
+    # an already-settled message.
+    with exclusive_file_lock(
+        inbox / ".state" / "settlement",
+        operation="lark_inbox_received_reaction_settlement",
+    ):
+        reply = config["reply"]
+        emoji_type = str(reply.get("received_reaction_emoji") or "")
+        if not emoji_type:
+            return _received_reaction_result(
+                status="not_configured",
+                ok=True,
+                configured=False,
+                addressed=False,
+            )
+        attention_kind = _typed_lark_event_attention_kind(
+            event,
+            bot_display_name=str(reply.get("bot_display_name") or ""),
+        )
+        if attention_kind is None:
+            return _received_reaction_result(
+                status="not_addressed",
+                ok=True,
+                configured=True,
+                addressed=False,
+            )
+        if not _captured_pending_message(inbox=inbox, message_id=message_id):
+            return _received_reaction_result(
+                status="already_settled",
+                ok=True,
+                configured=True,
+                addressed=True,
+            )
+        receipts = lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id=message_id,
+        )
+        if receipts.get("received") is not None:
+            return _received_reaction_result(
+                status="already_received",
+                ok=True,
+                configured=True,
+                addressed=True,
+            )
+        if receipts.get("processing") is not None:
+            return _received_reaction_result(
+                status="already_processing",
+                ok=True,
+                configured=True,
+                addressed=True,
+            )
+        reaction_id = create_reaction(message_id, emoji_type)
+        if reaction_id is None:
+            return _received_reaction_result(
+                status="failed",
+                ok=False,
+                configured=True,
+                addressed=True,
+                blocker="lark_inbox_received_reaction_create_failed",
+            )
+        try:
+            record_lark_inbox_reaction(
+                inbox=inbox,
+                message_id=message_id,
+                phase="received",
+                reaction_id=reaction_id,
+                emoji_type=emoji_type,
+            )
+        except (OSError, TypeError, ValueError):
+            cleaned_up = delete_reaction(message_id, reaction_id)
+            return _received_reaction_result(
+                status="receipt_failed",
+                ok=False,
+                configured=True,
+                addressed=True,
+                created_count=int(not cleaned_up),
+                external_writes_performed=True,
+                blocker=(
+                    "lark_inbox_received_reaction_receipt_failed"
+                    if cleaned_up
+                    else "lark_inbox_received_reaction_cleanup_failed"
+                ),
+            )
+        return _received_reaction_result(
+            status="received",
+            ok=True,
+            configured=True,
+            addressed=True,
+            created_count=1,
+        )
+
+
+def ensure_lark_event_inbox_received_reaction(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    event: Mapping[str, Any],
+    create_reaction: ReactionCreator,
+    delete_reaction: ReactionDeleter,
+) -> dict[str, Any]:
+    """Lock and ACK one captured pending message through the shared boundary."""
+
+    config = load_lark_event_inbox_config(project=project, config_path=config_path)
+    if not config["enabled"]:
+        raise ValueError("lark event inbox is not enabled")
+    message_id = str(event.get("message_id") or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(message_id):
+        raise ValueError("received reaction requires a valid Lark message id")
+    inbox = config["inbox_path"]
+    with lark_inbox_reaction_lock(inbox=inbox, message_id=message_id):
+        return ensure_lark_event_inbox_received_reaction_locked(
+            config=config,
+            event=event,
+            create_reaction=create_reaction,
+            delete_reaction=delete_reaction,
+        )
 
 
 def _operation_result(

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -14,7 +14,6 @@ from ...file_lock import exclusive_file_lock
 from .event_inbox import (
     MESSAGE_ID_PATTERN,
     REACTION_EMOJI_PATTERN,
-    _event_attention_kind,
     _event_from_file,
     _load_processed,
     load_lark_event_inbox_config,
@@ -363,29 +362,12 @@ def _captured_pending_message(*, inbox: Path, message_id: str) -> bool:
     )
 
 
-def _typed_lark_event_attention_kind(
-    event: Mapping[str, Any], *, bot_display_name: str
-) -> str | None:
-    """Return only provider-typed mention or verified reply attention."""
-
-    attention_kind = _event_attention_kind(
-        event,
-        bot_display_name=bot_display_name,
-        capture_scope="configured_chat_all",
-    )
-    if attention_kind == "reply_to_bot":
-        return attention_kind
-    if attention_kind is not None and ("mentions" in event or "mentioned" in event):
-        return attention_kind
-    return None
-
-
 def _received_reaction_result(
     *,
     status: str,
     ok: bool,
     configured: bool,
-    addressed: bool,
+    captured_pending: bool,
     created_count: int = 0,
     external_writes_performed: bool | None = None,
     blocker: str | None = None,
@@ -395,7 +377,8 @@ def _received_reaction_result(
         "schema_version": "lark_event_inbox_received_reaction_v0",
         "status": status,
         "configured": configured,
-        "addressed": addressed,
+        "captured_pending": captured_pending,
+        "read_ack_attempted": status in {"received", "failed", "receipt_failed"},
         "created_count": created_count,
         "external_writes_performed": (
             created_count > 0
@@ -419,11 +402,12 @@ def ensure_lark_event_inbox_received_reaction_locked(
     create_reaction: ReactionCreator,
     delete_reaction: ReactionDeleter,
 ) -> dict[str, Any]:
-    """Idempotently ACK one captured, provider-addressed message.
+    """Idempotently acknowledge one message read by the turn-start hook.
 
-    The caller owns the per-message reaction lock.  This boundary is shared by
-    realtime collection and bounded history sync so receipt semantics do not
-    depend on which ingress first captured the message.
+    The caller owns the per-message reaction lock.  The message may have been
+    captured by any ingress, but only Agent turn-start consumption invokes this
+    boundary.  Attention classification remains independent and decides reply
+    priority rather than whether the read acknowledgement is written.
     """
 
     message_id = str(event.get("message_id") or "").strip()
@@ -445,25 +429,14 @@ def ensure_lark_event_inbox_received_reaction_locked(
                 status="not_configured",
                 ok=True,
                 configured=False,
-                addressed=False,
-            )
-        attention_kind = _typed_lark_event_attention_kind(
-            event,
-            bot_display_name=str(reply.get("bot_display_name") or ""),
-        )
-        if attention_kind is None:
-            return _received_reaction_result(
-                status="not_addressed",
-                ok=True,
-                configured=True,
-                addressed=False,
+                captured_pending=False,
             )
         if not _captured_pending_message(inbox=inbox, message_id=message_id):
             return _received_reaction_result(
                 status="already_settled",
                 ok=True,
                 configured=True,
-                addressed=True,
+                captured_pending=False,
             )
         receipts = lark_inbox_reaction_receipts(
             inbox=inbox,
@@ -474,14 +447,14 @@ def ensure_lark_event_inbox_received_reaction_locked(
                 status="already_received",
                 ok=True,
                 configured=True,
-                addressed=True,
+                captured_pending=True,
             )
         if receipts.get("processing") is not None:
             return _received_reaction_result(
                 status="already_processing",
                 ok=True,
                 configured=True,
-                addressed=True,
+                captured_pending=True,
             )
         reaction_id = create_reaction(message_id, emoji_type)
         if reaction_id is None:
@@ -489,7 +462,7 @@ def ensure_lark_event_inbox_received_reaction_locked(
                 status="failed",
                 ok=False,
                 configured=True,
-                addressed=True,
+                captured_pending=True,
                 blocker="lark_inbox_received_reaction_create_failed",
             )
         try:
@@ -506,7 +479,7 @@ def ensure_lark_event_inbox_received_reaction_locked(
                 status="receipt_failed",
                 ok=False,
                 configured=True,
-                addressed=True,
+                captured_pending=True,
                 created_count=int(not cleaned_up),
                 external_writes_performed=True,
                 blocker=(
@@ -519,7 +492,7 @@ def ensure_lark_event_inbox_received_reaction_locked(
             status="received",
             ok=True,
             configured=True,
-            addressed=True,
+            captured_pending=True,
             created_count=1,
         )
 
@@ -532,7 +505,7 @@ def ensure_lark_event_inbox_received_reaction(
     create_reaction: ReactionCreator,
     delete_reaction: ReactionDeleter,
 ) -> dict[str, Any]:
-    """Lock and ACK one captured pending message through the shared boundary."""
+    """Lock and ACK one turn-start-read pending message."""
 
     config = load_lark_event_inbox_config(project=project, config_path=config_path)
     if not config["enabled"]:

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -17,6 +17,12 @@ from ...file_lock import (
     exclusive_file_lock,
 )
 from .event_collector import _executable_prefix, load_lark_event_collector_config
+from .event_collector_runtime import (
+    _create_lark_event_received_reaction,
+    _delete_lark_event_reaction,
+    _profile_app_id,
+    _sender_identity,
+)
 from .group_history import (
     _canonical_events,
     _page_digest,
@@ -26,6 +32,7 @@ from .group_history import (
     _route_context,
     _verify_inbox_events,
 )
+from .inbox_reactions import ensure_lark_event_inbox_received_reaction
 from .routed_inbox import ingest_routed_lark_event_inbox
 
 CURSOR_SCHEMA_VERSION = "lark_turn_start_sync_cursor_v0"
@@ -225,9 +232,27 @@ def _route_receipt(
             try:
                 payload = json.loads(provider.stdout)
                 messages, has_more, next_page_token = _provider_page(payload)
-                events, skipped_count, invalid_count = _canonical_events(
+                command_prefix = _executable_prefix(lark_cli_executable)
+                profile_app_id = (
+                    _profile_app_id(
+                        runner=runner,
+                        command_prefix=command_prefix,
+                        profile=str(config["profile"]),
+                    )
+                    if any(
+                        _sender_identity(message)[0] == "app" for message in messages
+                    )
+                    else None
+                )
+                (
+                    events,
+                    skipped_count,
+                    invalid_count,
+                    self_message_skipped_count,
+                ) = _canonical_events(
                     messages,
                     chat_id=str(route["chat_id"]),
+                    profile_app_id=profile_app_id,
                 )
             except (json.JSONDecodeError, TypeError, ValueError):
                 return {
@@ -268,6 +293,40 @@ def _route_receipt(
                     "external_read_performed": True,
                     "local_private_state_mutated": bool(ingest["write_performed"]),
                 }
+            # Retry every provider-visible pending event in the overlap page,
+            # not only files first accepted by this ingress. The shared
+            # receipt/settlement boundary makes cross-ingress duplicates
+            # idempotent and lets a transient provider failure recover on the
+            # next bounded history pass.
+            reaction_results = [
+                ensure_lark_event_inbox_received_reaction(
+                    project=config["project"],
+                    config_path=route["event_inbox_config_ref"],
+                    event=event,
+                    create_reaction=lambda message_id, emoji_type: (
+                        _create_lark_event_received_reaction(
+                            {"message_id": message_id},
+                            runner=runner,
+                            command_prefix=command_prefix,
+                            profile=str(config["profile"]),
+                            emoji_type=emoji_type,
+                        )
+                    ),
+                    delete_reaction=lambda message_id, reaction_id: (
+                        _delete_lark_event_reaction(
+                            runner=runner,
+                            command_prefix=command_prefix,
+                            profile=str(config["profile"]),
+                            message_id=message_id,
+                            reaction_id=reaction_id,
+                        )
+                    ),
+                )
+                for event in events
+            ]
+            reaction_failures = [
+                result for result in reaction_results if result["ok"] is not True
+            ]
             updated = {
                 **state,
                 "next_page_token": next_page_token,
@@ -294,14 +353,31 @@ def _route_receipt(
                     "local_private_state_mutated": bool(ingest["write_performed"]),
                 }
             return {
-                "ok": True,
-                "status": "page_pending" if has_more else "synced",
-                "error_code": None,
+                "ok": not reaction_failures,
+                "status": (
+                    "received_reaction_failed"
+                    if reaction_failures
+                    else "page_pending"
+                    if has_more
+                    else "synced"
+                ),
+                "error_code": (
+                    "received_reaction_failed" if reaction_failures else None
+                ),
                 "accepted_count": int(ingest["accepted_count"]),
                 "duplicate_count": int(ingest["duplicate_count"]),
                 "skipped_count": skipped_count,
+                "self_message_skipped_count": self_message_skipped_count,
                 "verified_count": verified_count,
                 "external_read_performed": True,
+                "received_reaction_count": sum(
+                    int(result["created_count"]) for result in reaction_results
+                ),
+                "received_reaction_failure_count": len(reaction_failures),
+                "external_writes_performed": any(
+                    result["external_writes_performed"] is True
+                    for result in reaction_results
+                ),
                 "local_private_state_mutated": True,
             }
     except LockAcquireTimeoutError:
@@ -337,6 +413,8 @@ def sync_lark_turn_start_inbox(
             "observation_count": 0,
             "agent_read_required": False,
             "external_reads_performed": False,
+            "external_writes_performed": False,
+            "self_message_skipped_count": 0,
             "local_private_state_mutated": False,
             "error_code": None,
             "private_content_returned": False,
@@ -384,6 +462,19 @@ def sync_lark_turn_start_inbox(
         "agent_read_required": bool(observation_count),
         "external_reads_performed": any(
             receipt.get("external_read_performed") is True for receipt in receipts
+        ),
+        "received_reaction_count": sum(
+            int(receipt.get("received_reaction_count") or 0) for receipt in receipts
+        ),
+        "received_reaction_failure_count": sum(
+            int(receipt.get("received_reaction_failure_count") or 0)
+            for receipt in receipts
+        ),
+        "self_message_skipped_count": sum(
+            int(receipt.get("self_message_skipped_count") or 0) for receipt in receipts
+        ),
+        "external_writes_performed": any(
+            receipt.get("external_writes_performed") is True for receipt in receipts
         ),
         "local_private_state_mutated": any(
             receipt.get("local_private_state_mutated") is True for receipt in receipts

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -374,6 +374,10 @@ def _route_receipt(
                     int(result["created_count"]) for result in reaction_results
                 ),
                 "received_reaction_failure_count": len(reaction_failures),
+                "read_ack_attempt_count": sum(
+                    int(result["read_ack_attempted"] is True)
+                    for result in reaction_results
+                ),
                 "external_writes_performed": any(
                     result["external_writes_performed"] is True
                     for result in reaction_results
@@ -436,10 +440,21 @@ def sync_lark_turn_start_inbox(
         for route in config["routes"]
     ]
     failures = [receipt for receipt in receipts if receipt["ok"] is not True]
+    # A realtime collector may have persisted a message before this hook sees
+    # the same provider-history item.  In that case accepted_count is zero,
+    # but the first read-ack attempt still proves that this turn newly read the
+    # pending message into the Agent processing chain.  Within one route every
+    # newly accepted event is also an ACK candidate when ACKs are configured,
+    # so max() counts the union without double-counting the same message.
     observation_count = sum(
-        int(receipt.get("accepted_count") or 0) for receipt in receipts
+        max(
+            int(receipt.get("accepted_count") or 0),
+            int(receipt.get("read_ack_attempt_count") or 0),
+        )
+        for receipt in receipts
     )
-    if failures and observation_count:
+    agent_read_required = bool(observation_count)
+    if failures and agent_read_required:
         status = "partial"
         error_code = "route_sync_partial"
     elif failures and len(failures) == len(receipts):
@@ -448,7 +463,7 @@ def sync_lark_turn_start_inbox(
     elif failures:
         status = "partial"
         error_code = "route_sync_partial"
-    elif observation_count:
+    elif agent_read_required:
         status = "observed"
         error_code = None
     else:
@@ -459,7 +474,7 @@ def sync_lark_turn_start_inbox(
         "schema_version": SYNC_SCHEMA_VERSION,
         "status": status,
         "observation_count": observation_count,
-        "agent_read_required": bool(observation_count),
+        "agent_read_required": agent_read_required,
         "external_reads_performed": any(
             receipt.get("external_read_performed") is True for receipt in receipts
         ),

--- a/tests/control_plane/test_turn_start_capability_hooks.py
+++ b/tests/control_plane/test_turn_start_capability_hooks.py
@@ -17,6 +17,7 @@ def _result(**overrides: object) -> dict[str, object]:
         "observation_count": 1,
         "agent_read_required": True,
         "external_reads_performed": True,
+        "external_writes_performed": False,
         "local_private_state_mutated": True,
         "private_content_returned": False,
         "provider_payload_returned": False,
@@ -68,3 +69,28 @@ def test_turn_start_hooks_are_single_flight_by_identity() -> None:
 
     assert dispatch["invoked_count"] == 1
     assert dispatch["failures"][0]["error_code"] == "duplicate_hook_id"
+
+
+def test_turn_start_external_write_requires_reaction_scope() -> None:
+    rejected = dispatch_turn_start_hooks(
+        [_hook(lambda: _result(external_writes_performed=True))]
+    )
+
+    assert rejected["results"] == []
+    assert rejected["failures"][0]["error_code"] == "contract_rejected"
+
+    admitted = TurnStartHookRegistration(
+        hook_id="operator_inbox.turn_start_sync",
+        capability_id="operator-inbox",
+        requested_read_scope=("provider_history",),
+        requested_write_scope=(
+            "owner_private_inbox",
+            "owner_private_cursor",
+            "provider_message_reaction",
+        ),
+        producer=lambda: _result(external_writes_performed=True),
+    )
+    dispatch = dispatch_turn_start_hooks([admitted])
+
+    assert dispatch["failures"] == []
+    assert dispatch["results"][0]["external_writes_performed"] is True

--- a/tests/control_plane_ts/capability_hooks.test.ts
+++ b/tests/control_plane_ts/capability_hooks.test.ts
@@ -171,6 +171,7 @@ function turnStartResult(overrides: Record<string, unknown> = {}) {
     observation_count: 2,
     agent_read_required: true,
     external_reads_performed: true,
+    external_writes_performed: false,
     local_private_state_mutated: true,
     private_content_returned: false,
     provider_payload_returned: false,
@@ -235,6 +236,26 @@ test("turn-start empty, provider failure, and owner-private write scopes stay di
       }),
       result: turnStartResult(),
     }),
-    /not owner-private/,
+    /not admitted/,
   );
+
+  assert.throws(
+    () => validateTurnStartHookInvocation({
+      registration: turnStartRegistration(),
+      result: turnStartResult({ external_writes_performed: true }),
+    }),
+    /undeclared external write/,
+  );
+
+  const reacted = validateTurnStartHookInvocation({
+    registration: turnStartRegistration({
+      requested_write_scope: [
+        "owner_private_inbox",
+        "owner_private_cursor",
+        "provider_message_reaction",
+      ],
+    }),
+    result: turnStartResult({ external_writes_performed: true }),
+  });
+  assert.equal(reacted.external_writes_performed, true);
 });

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -324,7 +324,7 @@ def test_cli_drain_accepts_routed_collector_config(
     assert rendered[0]["extension_activation"] == {"enabled": True}
 
 
-def test_runtime_consumes_once_and_routes_each_chat_to_its_own_inbox(
+def test_runtime_collector_captures_without_provider_acknowledgement(
     tmp_path: Path,
 ) -> None:
     project, collector, first_chat, second_chat = _two_route_config(tmp_path)

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -14,7 +14,10 @@ from loopx.extensions.lark.event_collector import (
     load_lark_event_collector_config,
     plan_lark_event_collector,
 )
-from loopx.extensions.lark.event_collector_runtime import run_lark_event_collector
+from loopx.extensions.lark.event_collector_runtime import (
+    _is_profile_self_message,
+    run_lark_event_collector,
+)
 from loopx.extensions.lark.event_inbox import inspect_lark_event_inbox
 from loopx.extensions.lark.routed_inbox import (
     acknowledge_routed_lark_event_inbox,
@@ -237,6 +240,29 @@ def test_jq_projection_filters_one_stream_to_all_configured_chats() -> None:
     assert '.chat_id == "oc_public_fixture_beta"' in projection
     assert " or " in projection
     assert "chat_id:.chat_id" in projection
+    assert "sender_type:(.sender_type // .sender.sender_type)" in projection
+    assert "sender_id:(.sender_id // .sender.id // .sender.sender_id)" in projection
+
+
+def test_self_message_match_requires_typed_app_and_exact_verified_identity() -> None:
+    identity = "cli_public_fixture_bot"
+
+    assert _is_profile_self_message(
+        {"sender_type": "app", "sender_id": identity},
+        profile_app_id=identity,
+    )
+    assert not _is_profile_self_message(
+        {"sender_type": "user", "sender_id": identity},
+        profile_app_id=identity,
+    )
+    assert not _is_profile_self_message(
+        {"sender_type": "app", "sender_id": identity},
+        profile_app_id=None,
+    )
+    assert not _is_profile_self_message(
+        {"sender_type": "app", "sender_id": "cli_public_fixture_other"},
+        profile_app_id=identity,
+    )
 
 
 def test_cli_drain_accepts_routed_collector_config(
@@ -373,6 +399,7 @@ def test_runtime_consumes_once_and_routes_each_chat_to_its_own_inbox(
         "reply_to_bot_count": 0,
         "received_reaction_count": 0,
         "received_reaction_failure_count": 0,
+        "self_message_skipped_count": 0,
         "external_writes_performed": False,
         "profile_identity_checked": False,
         "profile_identity_verified": False,
@@ -454,6 +481,70 @@ def test_runtime_consumes_once_and_routes_each_chat_to_its_own_inbox(
         )["pending_count"]
         == 1
     )
+
+
+def test_runtime_excludes_only_verified_profile_self_messages(tmp_path: Path) -> None:
+    project, collector, first_chat, _second_chat = _two_route_config(tmp_path)
+    profile_app_id = "cli_public_fixture_bot"
+    events = [
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-self",
+            "message_id": "om_public_self",
+            "create_time": "2026-08-25T00:00:00Z",
+            "content": "Bot delivery status",
+            "chat_id": first_chat,
+            "sender_type": "app",
+            "sender_id": profile_app_id,
+        },
+        {
+            "schema_version": "lark_event_inbox_event_v0",
+            "event_id": "evt-other-app",
+            "message_id": "om_public_other_app",
+            "create_time": "2026-08-25T00:01:00Z",
+            "content": "@Shared Context Bot please review",
+            "chat_id": first_chat,
+            "sender_type": "app",
+            "sender_id": "cli_public_fixture_other",
+            "mentions": [{"name": "Shared Context Bot"}],
+        },
+    ]
+    runtime_cli = tmp_path / "runtime-lark-cli-self-filter"
+    runtime_cli.write_text(
+        "#!/usr/bin/env python3\n"
+        "import json\n"
+        f"events = {events!r}\n"
+        "for event in events:\n"
+        "    print(json.dumps(event), flush=True)\n",
+        encoding="utf-8",
+    )
+    runtime_cli.chmod(0o755)
+
+    def identity_runner(
+        argv: list[str], **_: object
+    ) -> subprocess.CompletedProcess[str]:
+        assert "whoami" in argv
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout=json.dumps({"appId": profile_app_id}),
+            stderr="",
+        )
+
+    result = run_lark_event_collector(
+        project=project,
+        config_path=collector,
+        lark_cli_executable=str(runtime_cli),
+        runner=identity_runner,
+    )
+
+    assert result["self_message_skipped_count"] == 1
+    assert result["captured_count"] == 1
+    assert result["profile_identity_checked"] is True
+    assert result["profile_identity_verified"] is True
+    inbox = project / ".loopx/inbox/requirements-alpha"
+    assert not (inbox / "om_public_self.json").exists()
+    assert (inbox / "om_public_other_app.json").is_file()
 
 
 @pytest.mark.parametrize("tampered_route_key", [None, "requirements-beta"])

--- a/tests/extensions/test_lark_event_collector_runtime.py
+++ b/tests/extensions/test_lark_event_collector_runtime.py
@@ -5,6 +5,7 @@ import subprocess
 
 from loopx.extensions.lark.event_collector_runtime import (
     _run_json_with_status,
+    enrich_lark_event_reply_context,
     lark_event_requires_reply_context_lookup,
 )
 
@@ -69,3 +70,38 @@ def test_json_status_preserves_success_payload_from_stdout() -> None:
 
     assert payload == expected
     assert status == "message_context_available"
+
+
+def test_reply_context_hydration_preserves_provider_sender_type() -> None:
+    def runner(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        message = {
+            "message_id": "om_self_fixture",
+            "chat_id": "oc_fixture",
+            "content": "Bot delivery status",
+            "sender": {
+                "sender_type": "app",
+                "id": "cli_fixture_bot",
+            },
+        }
+        return subprocess.CompletedProcess(
+            args=["lark-cli"],
+            returncode=0,
+            stdout=json.dumps({"ok": True, "data": {"messages": [message]}}),
+            stderr="",
+        )
+
+    enriched = enrich_lark_event_reply_context(
+        {
+            "message_id": "om_self_fixture",
+            "chat_id": "oc_fixture",
+        },
+        runner=runner,
+        command_prefix=["lark-cli"],
+        profile="fixture-bot",
+        profile_app_id="cli_fixture_bot",
+        configured_chat_id="oc_fixture",
+        sleeper=lambda _seconds: None,
+    )
+
+    assert enriched["sender_type"] == "app"
+    assert enriched["sender_id"] == "cli_fixture_bot"

--- a/tests/extensions/test_lark_group_history.py
+++ b/tests/extensions/test_lark_group_history.py
@@ -103,6 +103,30 @@ class PageRunner:
         )
 
 
+class IdentityPageRunner(PageRunner):
+    def __init__(
+        self,
+        pages: Sequence[dict[str, object]],
+        *,
+        profile_app_id: str,
+    ) -> None:
+        super().__init__(pages)
+        self.profile_app_id = profile_app_id
+
+    def __call__(
+        self, argv: Sequence[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if "whoami" in argv:
+            self.calls.append(list(argv))
+            return subprocess.CompletedProcess(
+                args=list(argv),
+                returncode=0,
+                stdout=json.dumps({"appId": self.profile_app_id}),
+                stderr="",
+            )
+        return super().__call__(argv, **kwargs)
+
+
 def _message(
     message_id: str,
     content: str,
@@ -235,6 +259,40 @@ def test_execute_commits_inbox_before_advancing_cursor(tmp_path: Path) -> None:
         "requirements-a",
         "requirements-a",
     ]
+
+
+def test_history_catch_up_excludes_verified_profile_self_message(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    runner = IdentityPageRunner(
+        [
+            {
+                "messages": [
+                    {
+                        **_message("om_history_self", "Bot delivery status"),
+                        "sender": {
+                            "sender_type": "app",
+                            "id": "cli_fixture_bot",
+                        },
+                    },
+                    _message("om_history_human", "Human follow-up"),
+                ],
+                "total": 2,
+                "has_more": False,
+                "page_token": None,
+            }
+        ],
+        profile_app_id="cli_fixture_bot",
+    )
+
+    receipt = _catch_up(project, config, runner, execute=True)
+
+    assert receipt["accepted_count"] == 1
+    assert receipt["self_message_skipped_count"] == 1
+    inbox = project / ".loopx/inbox/requirements-a"
+    assert not (inbox / "om_history_self.json").exists()
+    assert (inbox / "om_history_human.json").is_file()
 
 
 def test_history_preserves_structured_negative_mention_evidence(

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -40,6 +40,8 @@ def _fixture(tmp_path: Path, *, lifecycle: bool = True) -> tuple[Path, Path, Pat
                 "processing_reaction_emoji": "OnIt",
             }
         )
+    else:
+        reply["received_reaction_emoji"] = ""
     config.write_text(
         json.dumps(
             {
@@ -121,7 +123,9 @@ class ReactionRunner:
         raise AssertionError(call)
 
 
-def test_received_reaction_boundary_is_typed_and_idempotent(tmp_path: Path) -> None:
+def test_received_reaction_boundary_acknowledges_pending_message_once(
+    tmp_path: Path,
+) -> None:
     config, inbox, project = _fixture(tmp_path)
     created: list[tuple[str, str]] = []
 
@@ -132,10 +136,7 @@ def test_received_reaction_boundary_is_typed_and_idempotent(tmp_path: Path) -> N
     def delete(_message_id: str, _reaction_id: str) -> bool:
         return True
 
-    event = {
-        "message_id": "om_reaction_fixture",
-        "mentions": [{"name": "Project Review Bot"}],
-    }
+    event = {"message_id": "om_reaction_fixture"}
     first = ensure_lark_event_inbox_received_reaction(
         project=project,
         config_path=config,
@@ -163,7 +164,7 @@ def test_received_reaction_boundary_is_typed_and_idempotent(tmp_path: Path) -> N
     )
 
 
-def test_received_reaction_boundary_ignores_unrelated_typed_mention(
+def test_received_reaction_boundary_is_independent_of_attention_kind(
     tmp_path: Path,
 ) -> None:
     config, _inbox, project = _fixture(tmp_path)
@@ -182,8 +183,9 @@ def test_received_reaction_boundary_ignores_unrelated_typed_mention(
         delete_reaction=lambda _message_id, _reaction_id: True,
     )
 
-    assert result["status"] == "not_addressed"
-    assert created == []
+    assert result["status"] == "received"
+    assert result["captured_pending"] is True
+    assert created == [("om_reaction_fixture", "Get")]
 
 
 def test_received_reaction_boundary_does_not_react_after_settlement(
@@ -851,7 +853,7 @@ def test_processing_config_requires_distinct_received_reaction(
     else:
         raise AssertionError("equal lifecycle reactions must fail closed")
 
-    payload["reply"].pop("received_reaction_emoji")
+    payload["reply"]["received_reaction_emoji"] = ""
     payload["reply"]["processing_reaction_emoji"] = "OnIt"
     config.write_text(json.dumps(payload), encoding="utf-8")
     try:
@@ -860,6 +862,24 @@ def test_processing_config_requires_distinct_received_reaction(
         assert "requires received_reaction_emoji" in str(exc)
     else:
         raise AssertionError("processing without received must fail closed")
+
+
+def test_received_reaction_defaults_to_get_and_can_be_explicitly_disabled(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path)
+    payload = json.loads(config.read_text(encoding="utf-8"))
+    payload["reply"].pop("received_reaction_emoji")
+    payload["reply"].pop("processing_reaction_emoji")
+    config.write_text(json.dumps(payload), encoding="utf-8")
+
+    defaulted = load_lark_event_inbox_config(project=project, config_path=config)
+    assert defaulted["reply"]["received_reaction_emoji"] == "Get"
+
+    payload["reply"]["received_reaction_emoji"] = ""
+    config.write_text(json.dumps(payload), encoding="utf-8")
+    disabled = load_lark_event_inbox_config(project=project, config_path=config)
+    assert disabled["reply"]["received_reaction_emoji"] == ""
 
 
 def test_malformed_receipt_ledger_fails_closed(tmp_path: Path) -> None:

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -8,9 +8,12 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
 from loopx.extensions.lark.inbox_reactions import (
     complete_lark_event_inbox_reactions,
+    ensure_lark_event_inbox_received_reaction,
     lark_inbox_reaction_receipts,
     mark_lark_event_inbox_processing,
     record_lark_inbox_reaction,
@@ -116,6 +119,134 @@ class ReactionRunner:
                 "stderr": "",
             }
         raise AssertionError(call)
+
+
+def test_received_reaction_boundary_is_typed_and_idempotent(tmp_path: Path) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    created: list[tuple[str, str]] = []
+
+    def create(message_id: str, emoji_type: str) -> str:
+        created.append((message_id, emoji_type))
+        return "reaction_Get"
+
+    def delete(_message_id: str, _reaction_id: str) -> bool:
+        return True
+
+    event = {
+        "message_id": "om_reaction_fixture",
+        "mentions": [{"name": "Project Review Bot"}],
+    }
+    first = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event=event,
+        create_reaction=create,
+        delete_reaction=delete,
+    )
+    duplicate = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event=event,
+        create_reaction=create,
+        delete_reaction=delete,
+    )
+
+    assert first["status"] == "received"
+    assert duplicate["status"] == "already_received"
+    assert created == [("om_reaction_fixture", "Get")]
+    assert (
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_reaction_fixture",
+        )["received"]["reaction_id"]
+        == "reaction_Get"
+    )
+
+
+def test_received_reaction_boundary_ignores_unrelated_typed_mention(
+    tmp_path: Path,
+) -> None:
+    config, _inbox, project = _fixture(tmp_path)
+    created: list[tuple[str, str]] = []
+
+    result = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event={
+            "message_id": "om_reaction_fixture",
+            "mentions": [{"name": "Another Bot"}],
+        },
+        create_reaction=lambda message_id, emoji_type: (
+            created.append((message_id, emoji_type)) or "reaction_Get"
+        ),
+        delete_reaction=lambda _message_id, _reaction_id: True,
+    )
+
+    assert result["status"] == "not_addressed"
+    assert created == []
+
+
+def test_received_reaction_boundary_does_not_react_after_settlement(
+    tmp_path: Path,
+) -> None:
+    config, inbox, project = _fixture(tmp_path)
+    (inbox / "processed.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_processed_v0",
+                "message_ids": ["om_reaction_fixture"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    created: list[tuple[str, str]] = []
+
+    result = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event={
+            "message_id": "om_reaction_fixture",
+            "mentions": [{"name": "Project Review Bot"}],
+        },
+        create_reaction=lambda message_id, emoji_type: (
+            created.append((message_id, emoji_type)) or "reaction_Get"
+        ),
+        delete_reaction=lambda _message_id, _reaction_id: True,
+    )
+
+    assert result["status"] == "already_settled"
+    assert result["external_writes_performed"] is False
+    assert created == []
+
+
+def test_received_reaction_receipt_failure_reports_provider_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, _inbox, project = _fixture(tmp_path)
+    deleted: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "loopx.extensions.lark.inbox_reactions.record_lark_inbox_reaction",
+        lambda **_kwargs: (_ for _ in ()).throw(OSError("fixture receipt failure")),
+    )
+
+    result = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event={
+            "message_id": "om_reaction_fixture",
+            "mentions": [{"name": "Project Review Bot"}],
+        },
+        create_reaction=lambda _message_id, _emoji_type: "reaction_Get",
+        delete_reaction=lambda message_id, reaction_id: (
+            deleted.append((message_id, reaction_id)) or True
+        ),
+    )
+
+    assert result["status"] == "receipt_failed"
+    assert result["blocker"] == "lark_inbox_received_reaction_receipt_failed"
+    assert result["created_count"] == 0
+    assert result["external_writes_performed"] is True
+    assert deleted == [("om_reaction_fixture", "reaction_Get")]
 
 
 class ReplyRunner:

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -13,6 +13,7 @@ from loopx.control_plane.work_items.work_lane import (
 )
 from loopx.extensions.lark import turn_start_sync as turn_start_sync_module
 from loopx.extensions.lark.event_collector import load_lark_event_collector_config
+from loopx.extensions.lark.inbox_reactions import lark_inbox_reaction_receipts
 from loopx.extensions.lark.routed_inbox import project_routed_lark_event_inbox_urgency
 from loopx.extensions.lark.turn_start_sync import sync_lark_turn_start_inbox
 
@@ -20,7 +21,12 @@ FIRST_NOW = datetime(2026, 8, 26, 10, 0, tzinfo=UTC)
 SECOND_NOW = datetime(2026, 8, 26, 10, 5, tzinfo=UTC)
 
 
-def _project(tmp_path: Path, *, material_review: bool = True) -> tuple[Path, Path]:
+def _project(
+    tmp_path: Path,
+    *,
+    material_review: bool = True,
+    received_reaction: bool = False,
+) -> tuple[Path, Path]:
     project = tmp_path / "project"
     project.mkdir()
     subprocess.run(
@@ -41,7 +47,18 @@ def _project(tmp_path: Path, *, material_review: bool = True) -> tuple[Path, Pat
                 "inbox_dir": ".loopx/inbox/requirements",
                 "capture_scope": "configured_chat_all",
                 "material_review": {"enabled": material_review, "drain_limit": 20},
-                "reply": {"enabled": False},
+                "reply": (
+                    {
+                        "enabled": True,
+                        "sender_profile": "fixture-bot",
+                        "sender_identity": "bot",
+                        "bot_display_name": "Fixture Bot",
+                        "chat_id": "oc_fixture",
+                        "received_reaction_emoji": "Get",
+                    }
+                    if received_reaction
+                    else {"enabled": False}
+                ),
             }
         ),
         encoding="utf-8",
@@ -147,6 +164,47 @@ class PageRunner:
         )
 
 
+class ReactionPageRunner(PageRunner):
+    def __init__(
+        self,
+        pages: Sequence[dict[str, object]],
+        *,
+        fail_reaction: bool = False,
+    ) -> None:
+        super().__init__(pages)
+        self.fail_reaction = fail_reaction
+        self.profile_app_id = "cli_fixture_bot"
+
+    def __call__(
+        self, argv: Sequence[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        call = list(argv)
+        if "whoami" in call:
+            self.calls.append(call)
+            return subprocess.CompletedProcess(
+                args=call,
+                returncode=0,
+                stdout=json.dumps({"appId": self.profile_app_id}),
+                stderr="",
+            )
+        if "reactions" not in call:
+            return super().__call__(argv, **kwargs)
+        self.calls.append(call)
+        if self.fail_reaction:
+            return subprocess.CompletedProcess(
+                args=call,
+                returncode=1,
+                stdout=json.dumps({"ok": False}),
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=call,
+            returncode=0,
+            stdout=json.dumps({"ok": True, "data": {"reaction_id": "reaction_Get"}}),
+            stderr="",
+        )
+
+
 def _page(*messages: dict[str, object]) -> dict[str, object]:
     return {
         "messages": list(messages),
@@ -208,6 +266,164 @@ def test_turn_start_sync_captures_then_requires_same_turn_agent_read(
     assert lane["semantic_triage_required"] is True
     assert "replan_goal" in lane["allowed_dispositions"]
     assert "before ordinary work" in str(lane["action"])
+
+
+def test_turn_start_sync_acknowledges_typed_mention_once(tmp_path: Path) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    message = {
+        "message_id": "om_typed_mention",
+        "create_time": "2026-08-26T09:59:00Z",
+        "content": "@Fixture Bot please take a look.",
+        "mentions": [{"name": "Fixture Bot"}],
+        "deleted": False,
+    }
+    first = ReactionPageRunner([_page(message)])
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=first,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "observed"
+    assert result["received_reaction_count"] == 1
+    assert result["received_reaction_failure_count"] == 0
+    assert result["external_writes_performed"] is True
+    inbox = project / ".loopx/inbox/requirements"
+    assert (
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_typed_mention",
+        )["received"]["emoji_type"]
+        == "Get"
+    )
+
+    duplicate = ReactionPageRunner([_page(message)])
+    duplicate_result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=duplicate,
+        now=SECOND_NOW,
+    )
+
+    assert duplicate_result["status"] == "empty"
+    assert duplicate_result["received_reaction_count"] == 0
+    assert not any("reactions" in call for call in duplicate.calls)
+
+
+def test_turn_start_sync_reports_reaction_write_failure_without_losing_message(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    runner = ReactionPageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_reaction_failure",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "@Fixture Bot please take a look.",
+                    "mentions": [{"name": "Fixture Bot"}],
+                    "deleted": False,
+                }
+            )
+        ],
+        fail_reaction=True,
+    )
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "partial"
+    assert result["observation_count"] == 1
+    assert result["agent_read_required"] is True
+    assert result["received_reaction_count"] == 0
+    assert result["received_reaction_failure_count"] == 1
+    assert (project / ".loopx/inbox/requirements/om_reaction_failure.json").is_file()
+
+
+def test_turn_start_sync_retries_reaction_for_overlapping_pending_duplicate(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    message = {
+        "message_id": "om_reaction_retry",
+        "create_time": "2026-08-26T09:59:00Z",
+        "content": "@Fixture Bot please retry the acknowledgement.",
+        "mentions": [{"name": "Fixture Bot"}],
+        "deleted": False,
+    }
+    failed = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=ReactionPageRunner([_page(message)], fail_reaction=True),
+        now=FIRST_NOW,
+    )
+
+    assert failed["status"] == "partial"
+    retry_runner = ReactionPageRunner([_page(message)])
+    retried = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=retry_runner,
+        now=SECOND_NOW,
+    )
+
+    assert retried["status"] == "empty"
+    assert retried["observation_count"] == 0
+    assert retried["received_reaction_count"] == 1
+    assert retried["external_writes_performed"] is True
+    assert any("reactions" in call for call in retry_runner.calls)
+
+
+def test_turn_start_sync_excludes_verified_profile_self_message(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    runner = ReactionPageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_self_delivery",
+                    "create_time": "2026-08-26T09:58:00Z",
+                    "content": "Bot delivery status",
+                    "sender": {
+                        "sender_type": "app",
+                        "id": "cli_fixture_bot",
+                    },
+                    "deleted": False,
+                },
+                {
+                    "message_id": "om_human_follow_up",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "Please keep investigating",
+                    "sender": {
+                        "sender_type": "user",
+                        "id": "ou_fixture_user",
+                    },
+                    "deleted": False,
+                },
+            )
+        ]
+    )
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "observed"
+    assert result["observation_count"] == 1
+    assert result["self_message_skipped_count"] == 1
+    inbox = project / ".loopx/inbox/requirements"
+    assert not (inbox / "om_self_delivery.json").exists()
+    assert (inbox / "om_human_follow_up.json").is_file()
 
 
 def test_completed_sync_opens_a_new_overlapping_tail_window(tmp_path: Path) -> None:

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+from loopx.cli_commands import lark_inbox as lark_inbox_cli
+from loopx.control_plane.capability_hooks import dispatch_turn_start_hooks
 from loopx.control_plane.work_items.work_lane import (
     operator_inbox_material_review_due_work_lane_contract,
 )
@@ -54,7 +56,6 @@ def _project(
                         "sender_identity": "bot",
                         "bot_display_name": "Fixture Bot",
                         "chat_id": "oc_fixture",
-                        "received_reaction_emoji": "Get",
                     }
                     if received_reaction
                     else {"enabled": False}
@@ -268,13 +269,14 @@ def test_turn_start_sync_captures_then_requires_same_turn_agent_read(
     assert "before ordinary work" in str(lane["action"])
 
 
-def test_turn_start_sync_acknowledges_typed_mention_once(tmp_path: Path) -> None:
+def test_turn_start_sync_acknowledges_ordinary_pending_message_once_by_default(
+    tmp_path: Path,
+) -> None:
     project, config = _project(tmp_path, received_reaction=True)
     message = {
-        "message_id": "om_typed_mention",
+        "message_id": "om_ordinary_pending",
         "create_time": "2026-08-26T09:59:00Z",
-        "content": "@Fixture Bot please take a look.",
-        "mentions": [{"name": "Fixture Bot"}],
+        "content": "Please keep the current investigation moving.",
         "deleted": False,
     }
     first = ReactionPageRunner([_page(message)])
@@ -294,7 +296,7 @@ def test_turn_start_sync_acknowledges_typed_mention_once(tmp_path: Path) -> None
     assert (
         lark_inbox_reaction_receipts(
             inbox=inbox,
-            message_id="om_typed_mention",
+            message_id="om_ordinary_pending",
         )["received"]["emoji_type"]
         == "Get"
     )
@@ -312,6 +314,104 @@ def test_turn_start_sync_acknowledges_typed_mention_once(tmp_path: Path) -> None
     assert not any("reactions" in call for call in duplicate.calls)
 
 
+def test_turn_start_sync_acknowledges_message_previously_captured_by_collector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    message = {
+        "message_id": "om_collector_captured",
+        "create_time": "2026-08-26T09:59:00Z",
+        "content": "Collector stored this before the Agent turn began.",
+        "deleted": False,
+    }
+    inbox = project / ".loopx/inbox/requirements"
+    inbox.mkdir(parents=True)
+    (inbox / "om_collector_captured.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "event_id": "om_collector_captured",
+                **message,
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = ReactionPageRunner([_page(message)])
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "observed"
+    assert result["observation_count"] == 1
+    assert result["agent_read_required"] is True
+    assert result["received_reaction_count"] == 1
+    assert result["external_writes_performed"] is True
+    assert any("reactions" in call for call in runner.calls)
+
+    monkeypatch.setattr(
+        lark_inbox_cli,
+        "_resolve_lark_activation",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        lark_inbox_cli,
+        "sync_lark_turn_start_inbox",
+        lambda **_kwargs: result,
+    )
+    dispatch = dispatch_turn_start_hooks(
+        [
+            lark_inbox_cli.build_lark_turn_start_inbox_hook(
+                project=project,
+                config_path=config,
+                runtime_root_arg=None,
+            )
+        ]
+    )
+    assert dispatch["failures"] == []
+    assert dispatch["results"][0]["observation_count"] == 1
+    assert dispatch["results"][0]["agent_read_required"] is True
+
+
+def test_turn_start_sync_respects_explicit_received_reaction_disable(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    inbox_config = project / ".loopx/config/inbox.json"
+    payload = json.loads(inbox_config.read_text(encoding="utf-8"))
+    payload["reply"]["received_reaction_emoji"] = ""
+    inbox_config.write_text(json.dumps(payload), encoding="utf-8")
+    runner = ReactionPageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_reaction_disabled",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "Read this without a provider acknowledgement.",
+                    "deleted": False,
+                }
+            )
+        ]
+    )
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["observation_count"] == 1
+    assert result["agent_read_required"] is True
+    assert result["received_reaction_count"] == 0
+    assert result["external_writes_performed"] is False
+    assert not any("reactions" in call for call in runner.calls)
+
+
 def test_turn_start_sync_reports_reaction_write_failure_without_losing_message(
     tmp_path: Path,
 ) -> None:
@@ -322,8 +422,7 @@ def test_turn_start_sync_reports_reaction_write_failure_without_losing_message(
                 {
                     "message_id": "om_reaction_failure",
                     "create_time": "2026-08-26T09:59:00Z",
-                    "content": "@Fixture Bot please take a look.",
-                    "mentions": [{"name": "Fixture Bot"}],
+                    "content": "Please take a look.",
                     "deleted": False,
                 }
             )
@@ -353,8 +452,7 @@ def test_turn_start_sync_retries_reaction_for_overlapping_pending_duplicate(
     message = {
         "message_id": "om_reaction_retry",
         "create_time": "2026-08-26T09:59:00Z",
-        "content": "@Fixture Bot please retry the acknowledgement.",
-        "mentions": [{"name": "Fixture Bot"}],
+        "content": "Please retry the acknowledgement.",
         "deleted": False,
     }
     failed = sync_lark_turn_start_inbox(
@@ -373,8 +471,9 @@ def test_turn_start_sync_retries_reaction_for_overlapping_pending_duplicate(
         now=SECOND_NOW,
     )
 
-    assert retried["status"] == "empty"
-    assert retried["observation_count"] == 0
+    assert retried["status"] == "observed"
+    assert retried["observation_count"] == 1
+    assert retried["agent_read_required"] is True
     assert retried["received_reaction_count"] == 1
     assert retried["external_writes_performed"] is True
     assert any("reactions" in call for call in retry_runner.calls)
@@ -421,9 +520,16 @@ def test_turn_start_sync_excludes_verified_profile_self_message(
     assert result["status"] == "observed"
     assert result["observation_count"] == 1
     assert result["self_message_skipped_count"] == 1
+    assert result["received_reaction_count"] == 1
     inbox = project / ".loopx/inbox/requirements"
     assert not (inbox / "om_self_delivery.json").exists()
     assert (inbox / "om_human_follow_up.json").is_file()
+    assert set(
+        lark_inbox_reaction_receipts(
+            inbox=inbox,
+            message_id="om_human_follow_up",
+        )
+    ) == {"received"}
 
 
 def test_completed_sync_opens_a_new_overlapping_tail_window(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

This PR makes the Lark Inbox `Get` reaction an Agent read acknowledgement with one precise lifecycle boundary:

- the realtime collector only validates and durably captures events; it never creates `Get`;
- the Agent's turn-start Lark Inbox hook creates `Get` after it reads and confirms a still-pending human message;
- mention, verified reply, question, and material-review classification affect attention and response policy, not whether a read message is acknowledged;
- every reply-enabled Inbox defaults to `Get`; an explicit empty `received_reaction_emoji` disables the provider write;
- reaction failure cannot discard the Inbox event or falsely report successful reading.

The PR also keeps the exact typed-profile self-message filter: a verified Bot-authored message is excluded, while identity lookup failure remains fail-open and captures the message.

## Final semantic contract

`Get` means:

> This pending human message was read into the Agent's turn-start processing chain.

It does **not** mean:

- the background collector stored the event;
- the Bot was mentioned;
- a reply is required or has been sent;
- domain processing is complete;
- the message has been settled.

The hook's public `observation_count` counts messages newly read by that turn. This includes a message already persisted by the realtime collector when the hook performs its first read-ack attempt, without double-counting a message that was both newly persisted and acknowledged in the same hook invocation.

## Recommended review order

1. `d478992ec` — introduces the receipt-backed reaction and exact typed self-message boundary.
2. `db47e91c2` — documents the original provider-neutral authority boundary.
3. `daabf87ca` — covers cross-ingress identity, failure, and idempotency behavior.
4. `67f30eb88` — applies the final semantics: collector-only capture, default `Get`, attention-independent turn-start read ACK, correct observation projection, and focused regressions.
5. `3263d1593` — updates the architecture and Lark operator contract to the final semantics.

Reviewers should treat commits 4–5 as the semantic correction to the earlier shared collector/history implementation.

## Ownership and authority

- **Core control plane** owns the provider-neutral turn-start hook contract, validates `external_writes_performed`, and admits only the narrow `provider_message_reaction` write scope.
- **Lark turn-start sync** owns bounded provider-history reading, Inbox/cursor readback, pending-message confirmation, reaction creation, and private reaction receipts.
- **Realtime collector** owns provider event consumption, routing, exact typed self-message filtering, and durable Inbox capture. It no longer consumes reaction authority or requires reply permission.
- **Inbox settlement** remains the source of truth for whether a message is pending. A settled message cannot receive a late read acknowledgement.
- **Attention classification** remains a separate scheduling/reply concern.

No repository authority, arbitrary provider writes, general outbound-message authority, or automatic reply authority is granted.

## Behavior matrix

| Situation | Inbox capture | `Get` write | Hook result |
| --- | --- | --- | --- |
| Realtime collector receives a human message | persisted | none | collector receipt remains write-free |
| Turn-start reads a newly captured ordinary human message | persisted/read back | once | `observed`, `agent_read_required=true` |
| Turn-start reads a message previously captured by collector | existing pending file | once | one observation even when new-ingest count is zero |
| Mention / verified reply / ordinary configured-chat message | pending | same read-ACK rule | attention only changes priority/reply policy |
| Overlap replay after a successful private reaction receipt | duplicate | none | no duplicate observation or provider write |
| Reaction provider call fails | message retained | failed attempt | `partial`; retry remains eligible while pending |
| Reaction succeeds on a later overlap retry | existing pending file | once | `observed`, Agent reading remains required |
| Message was already settled | not pending | none | `already_settled` |
| Verified profile self-message | skipped | none | counted only in compact self-skip accounting |
| Profile identity cannot be verified | captured fail-open | normal human-message path | no heuristic self-drop |
| `received_reaction_emoji: ""` | normal capture/read | none | acknowledgement explicitly disabled |

## Configuration

For a reply-enabled Inbox, omitting the field now uses the default:

```json
{
  "reply": {
    "enabled": true,
    "received_reaction_emoji": "Get"
  }
}
```

The explicit field is optional because missing already means `Get`. To disable the provider write:

```json
{
  "reply": {
    "enabled": true,
    "received_reaction_emoji": ""
  }
}
```

A processing reaction still requires a distinct received reaction. If read acknowledgement is disabled, processing reaction must also be disabled.

## Failure and idempotency rules

- The per-message reaction lock serializes read acknowledgement against processing and settlement.
- A private receipt prevents overlap replay and cross-ingress duplicates from creating a second reaction.
- Provider reaction failure preserves the Inbox event and reports typed partial accounting.
- If private receipt persistence fails after provider creation, LoopX attempts provider cleanup and accurately reports whether an external write occurred.
- A transient failure is retryable only while the message remains pending.
- Public results contain bounded counts, booleans, status, and error codes only; no message content, sender identity, chat destination, profile name, cursor, credential, or provider payload crosses the public boundary.

## Validation matrix

| Surface | Result |
| --- | --- |
| Focused reaction / turn-start / collector / hook contract tests | 57 passed |
| Full Lark extension test selection | 201 passed |
| Ruff check | passed |
| Ruff format check | passed |
| Diff hygiene | passed |
| Risk-selected pre-merge canary | 13/13 passed |
| Repository contract and public-boundary scan | passed; 2,923 files scanned |
| Previous pushed head CI | all required checks passed |
| New head CI | triggered by this push; maintainer review still required |

## Non-goals

- No automatic text reply policy change.
- No acknowledgement from the realtime collector.
- No acknowledgement restricted to mentions or replies.
- No display-name or message-body self-detection heuristic.
- No public persistence of provider identities or private message contents.
- No expansion beyond the existing provider-neutral turn-start capability hook.
- No change to processing/completion reaction meaning beyond preserving their lifecycle ordering.

## Review hold

This PR performs a narrow provider external write and changes the default for reply-enabled Inboxes. Maintainer review is required. Do not self-merge even when local risk validation and CI are green.
