### PR TITLE
fix(lark): make turn-start read acknowledgements durable

### DIFF
--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -45,8 +45,9 @@ to a durable effect receipt before inbox ACK.
 
 ```text
 provider-neutral turn_start dispatch
-  -> provider read + owner-private commit/readback
-  -> optional pending-message read acknowledgement + private reaction receipt
+  -> provider read + owner-private inbox commit/readback
+  -> first Agent-read receipt independent of optional provider reaction
+  -> retry optional reaction from durable pending reads
   -> fresh status + quota projection
   -> inbox lane preempts ordinary work when agent_read_required
   -> private drain into the active Agent turn
@@ -64,15 +65,19 @@ collection and quota selection.
 
 ## Failure and replay
 
-- `empty` means a valid provider success envelope was read and no new inbox
-  event was accepted.
+- `empty` means a valid provider success envelope was read and no pending
+  message received its first Agent-owned turn-start read in this dispatch.
 - `provider_contract_error` means the success envelope did not match its
   declared schema; it must never degrade to `empty`.
 - provider permission and availability failures remain typed and isolated.
 - duplicate hook identities run once; duplicate messages collapse by provider
-  message identity, and a private reaction receipt prevents duplicate ACKs.
+  message identity, and separate private read/effect receipts prevent duplicate
+  Agent-read observations and duplicate provider reactions.
 - collector-only capture performs no provider write. The acknowledgement is
   admitted only after the turn-start hook reads and confirms a pending message.
+- reaction disablement never cancels the first-read obligation. Failed effects
+  retry from the owner-private pending-read set rather than relying on the
+  bounded provider overlap window; uncertain effects fail closed before create.
 - attention classification affects scheduling and reply policy, never whether
   a successfully read pending message receives the acknowledgement.
 - a provider-owned self-message filter may run before inbox ingestion only from

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -217,12 +217,14 @@ mean "collector stored the event", "the Bot was mentioned", "a reply is due",
 or "processing completed". Mention, reply, question, and material-review
 classification remain independent scheduling and response decisions.
 
-Failed reactions are retried idempotently from bounded overlap pages while the
-message remains pending. The reaction is a best-effort receipt: provider
-failure increments compact failure accounting but does not discard the Inbox
-event or grant execution authority. A private receipt prevents overlap replay
-from creating a second reaction, and settled or verified Bot-authored messages
-never receive one.
+The hook records its first read in owner-private state independently of this
+optional provider write. Thus a message captured earlier by the realtime
+collector still requires Agent reading even when reactions are explicitly
+disabled. Failed reactions are retried from this durable pending-read set while
+the message remains unsettled, including after the bounded history cursor has
+moved beyond the message timestamp. Provider failure increments compact
+failure accounting but does not discard the Inbox event or grant execution
+authority.
 
 `reply.processing_reaction_emoji` is optional and requires a distinct
 received reaction. The default `Get` satisfies that requirement; when the read
@@ -236,11 +238,13 @@ retryable cleanup status instead of claiming completion.
 
 Reaction ids are stored only in an owner-private receipt ledger under the
 configured inbox. Each message transition is serialized with a private
-per-message lock. LoopX deletes only reaction ids returned by writes made
-through the configured bot profile; it never deletes another participant's
-reaction by emoji type. The receipt ledger is fail-closed: malformed state is
-not ignored, and a provider reaction that cannot be recorded is rolled back
-best-effort.
+per-message lock. A prepared/created operation receipt fences provider creation
+before and after the external effect: a reaction whose normal receipt could not
+be persisted is recovered from the known reaction id without another create;
+an outcome that became uncertain before its id was durably recorded blocks
+replay instead of risking a duplicate. LoopX deletes only reaction ids returned
+by writes made through the configured bot profile; it never deletes another
+participant's reaction by emoji type. Malformed private state fails closed.
 
 The reply path never uses the machine default profile. Before any send it
 verifies that the named profile resolves to the expected bot and that the bot

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -21,7 +21,10 @@ from .event_inbox import (
 from .private_json import write_private_json_atomic
 
 REACTION_RECEIPTS_SCHEMA_VERSION = "lark_event_inbox_reaction_receipts_v0"
+TURN_START_READS_SCHEMA_VERSION = "lark_event_inbox_turn_start_reads_v0"
+RECEIVED_OPERATION_SCHEMA_VERSION = "lark_event_inbox_received_operation_v0"
 REACTION_PHASES = {"received", "processing"}
+RECEIVED_OPERATION_PHASES = {"prepared", "created"}
 REACTION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,200}")
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
 ReactionCreator = Callable[[str, str], str | None]
@@ -99,6 +102,145 @@ def _receipt_path(inbox: Path) -> Path:
 def _operation_lock_target(inbox: Path, message_id: str) -> Path:
     bucket = hashlib.sha256(message_id.encode("utf-8")).hexdigest()[:2]
     return inbox / "reactions" / f"operation-{bucket}"
+
+
+def _turn_start_reads_path(inbox: Path) -> Path:
+    return inbox / "reactions" / "turn-start-reads.json"
+
+
+def _received_operation_path(inbox: Path, message_id: str) -> Path:
+    digest = hashlib.sha256(message_id.encode("utf-8")).hexdigest()
+    return inbox / "reactions" / "received-operations" / f"{digest}.json"
+
+
+def _load_turn_start_reads(inbox: Path) -> set[str]:
+    path = _turn_start_reads_path(inbox)
+    if not path.is_file():
+        return set()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("lark inbox turn-start reads are unreadable") from exc
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != TURN_START_READS_SCHEMA_VERSION
+        or not isinstance(payload.get("message_ids"), list)
+    ):
+        raise ValueError("lark inbox turn-start reads schema is invalid")
+    message_ids = payload["message_ids"]
+    if any(
+        not isinstance(message_id, str) or not MESSAGE_ID_PATTERN.fullmatch(message_id)
+        for message_id in message_ids
+    ):
+        raise ValueError("lark inbox turn-start read entry is invalid")
+    return set(message_ids)
+
+
+def record_lark_inbox_turn_start_read(*, inbox: Path, message_id: str) -> bool:
+    """Record the first Agent-owned turn-start read independently of reactions."""
+
+    normalized = str(message_id or "").strip()
+    if not MESSAGE_ID_PATTERN.fullmatch(normalized):
+        raise ValueError("turn-start read requires a valid Lark message id")
+    path = _turn_start_reads_path(inbox)
+    with exclusive_file_lock(path, operation="lark_inbox_turn_start_reads"):
+        message_ids = _load_turn_start_reads(inbox)
+        if normalized in message_ids:
+            return False
+        if not _captured_pending_message(inbox=inbox, message_id=normalized):
+            return False
+        message_ids.add(normalized)
+        write_private_json_atomic(
+            path,
+            {
+                "schema_version": TURN_START_READS_SCHEMA_VERSION,
+                "message_ids": sorted(message_ids),
+                "updated_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        return True
+
+
+def lark_inbox_pending_turn_start_read_message_ids(*, inbox: Path) -> list[str]:
+    """Return locally durable turn-start reads that remain pending settlement."""
+
+    path = _turn_start_reads_path(inbox)
+    with exclusive_file_lock(path, operation="lark_inbox_turn_start_reads"):
+        message_ids = _load_turn_start_reads(inbox)
+        pending = {
+            message_id
+            for message_id in message_ids
+            if _captured_pending_message(inbox=inbox, message_id=message_id)
+        }
+        if pending != message_ids:
+            write_private_json_atomic(
+                path,
+                {
+                    "schema_version": TURN_START_READS_SCHEMA_VERSION,
+                    "message_ids": sorted(pending),
+                    "updated_at": datetime.now(UTC).isoformat(),
+                },
+            )
+        return sorted(pending)
+
+
+def _load_received_operation(*, inbox: Path, message_id: str) -> dict[str, str] | None:
+    path = _received_operation_path(inbox, message_id)
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("lark inbox received operation is unreadable") from exc
+    phase = str(payload.get("phase") or "") if isinstance(payload, Mapping) else ""
+    emoji_type = (
+        str(payload.get("emoji_type") or "") if isinstance(payload, Mapping) else ""
+    )
+    reaction_id = (
+        str(payload.get("reaction_id") or "") if isinstance(payload, Mapping) else ""
+    )
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != RECEIVED_OPERATION_SCHEMA_VERSION
+        or payload.get("message_id") != message_id
+        or phase not in RECEIVED_OPERATION_PHASES
+        or not REACTION_EMOJI_PATTERN.fullmatch(emoji_type)
+        or (phase == "created" and not REACTION_ID_PATTERN.fullmatch(reaction_id))
+        or (phase == "prepared" and reaction_id)
+    ):
+        raise ValueError("lark inbox received operation schema is invalid")
+    result = {"phase": phase, "emoji_type": emoji_type}
+    if reaction_id:
+        result["reaction_id"] = reaction_id
+    return result
+
+
+def _write_received_operation(
+    *,
+    inbox: Path,
+    message_id: str,
+    phase: str,
+    emoji_type: str,
+    reaction_id: str = "",
+) -> None:
+    payload = {
+        "schema_version": RECEIVED_OPERATION_SCHEMA_VERSION,
+        "message_id": message_id,
+        "phase": phase,
+        "emoji_type": emoji_type,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    if reaction_id:
+        payload["reaction_id"] = reaction_id
+    write_private_json_atomic(_received_operation_path(inbox, message_id), payload)
+
+
+def _clear_received_operation(*, inbox: Path, message_id: str) -> None:
+    path = _received_operation_path(inbox, message_id)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
 
 
 @contextmanager
@@ -443,6 +585,7 @@ def ensure_lark_event_inbox_received_reaction_locked(
             message_id=message_id,
         )
         if receipts.get("received") is not None:
+            _clear_received_operation(inbox=inbox, message_id=message_id)
             return _received_reaction_result(
                 status="already_received",
                 ok=True,
@@ -450,14 +593,65 @@ def ensure_lark_event_inbox_received_reaction_locked(
                 captured_pending=True,
             )
         if receipts.get("processing") is not None:
+            _clear_received_operation(inbox=inbox, message_id=message_id)
             return _received_reaction_result(
                 status="already_processing",
                 ok=True,
                 configured=True,
                 captured_pending=True,
             )
-        reaction_id = create_reaction(message_id, emoji_type)
-        if reaction_id is None:
+        operation = _load_received_operation(inbox=inbox, message_id=message_id)
+        if operation and operation["emoji_type"] != emoji_type:
+            return _received_reaction_result(
+                status="operation_config_changed",
+                ok=False,
+                configured=True,
+                captured_pending=True,
+                blocker="lark_inbox_received_reaction_operation_config_changed",
+            )
+        if operation and operation["phase"] == "prepared":
+            return _received_reaction_result(
+                status="provider_outcome_uncertain",
+                ok=False,
+                configured=True,
+                captured_pending=True,
+                blocker="lark_inbox_received_reaction_provider_outcome_uncertain",
+            )
+        if operation and operation["phase"] == "created":
+            reaction_id = operation["reaction_id"]
+            try:
+                record_lark_inbox_reaction(
+                    inbox=inbox,
+                    message_id=message_id,
+                    phase="received",
+                    reaction_id=reaction_id,
+                    emoji_type=emoji_type,
+                )
+            except (OSError, TypeError, ValueError):
+                return _received_reaction_result(
+                    status="receipt_failed",
+                    ok=False,
+                    configured=True,
+                    captured_pending=True,
+                    external_writes_performed=False,
+                    blocker="lark_inbox_received_reaction_receipt_failed",
+                )
+            _clear_received_operation(inbox=inbox, message_id=message_id)
+            return _received_reaction_result(
+                status="receipt_recovered",
+                ok=True,
+                configured=True,
+                captured_pending=True,
+            )
+        _write_received_operation(
+            inbox=inbox,
+            message_id=message_id,
+            phase="prepared",
+            emoji_type=emoji_type,
+        )
+        created_reaction_id = create_reaction(message_id, emoji_type)
+        if created_reaction_id is None:
+            _clear_received_operation(inbox=inbox, message_id=message_id)
             return _received_reaction_result(
                 status="failed",
                 ok=False,
@@ -466,28 +660,49 @@ def ensure_lark_event_inbox_received_reaction_locked(
                 blocker="lark_inbox_received_reaction_create_failed",
             )
         try:
-            record_lark_inbox_reaction(
+            _write_received_operation(
                 inbox=inbox,
                 message_id=message_id,
-                phase="received",
-                reaction_id=reaction_id,
+                phase="created",
                 emoji_type=emoji_type,
+                reaction_id=created_reaction_id,
             )
         except (OSError, TypeError, ValueError):
-            cleaned_up = delete_reaction(message_id, reaction_id)
+            cleaned_up = delete_reaction(message_id, created_reaction_id)
+            if cleaned_up:
+                _clear_received_operation(inbox=inbox, message_id=message_id)
             return _received_reaction_result(
-                status="receipt_failed",
+                status="operation_receipt_failed",
                 ok=False,
                 configured=True,
                 captured_pending=True,
                 created_count=int(not cleaned_up),
                 external_writes_performed=True,
                 blocker=(
-                    "lark_inbox_received_reaction_receipt_failed"
+                    "lark_inbox_received_reaction_operation_receipt_failed"
                     if cleaned_up
-                    else "lark_inbox_received_reaction_cleanup_failed"
+                    else "lark_inbox_received_reaction_provider_outcome_uncertain"
                 ),
             )
+        try:
+            record_lark_inbox_reaction(
+                inbox=inbox,
+                message_id=message_id,
+                phase="received",
+                reaction_id=created_reaction_id,
+                emoji_type=emoji_type,
+            )
+        except (OSError, TypeError, ValueError):
+            return _received_reaction_result(
+                status="receipt_failed",
+                ok=False,
+                configured=True,
+                captured_pending=True,
+                created_count=1,
+                external_writes_performed=True,
+                blocker="lark_inbox_received_reaction_receipt_failed",
+            )
+        _clear_received_operation(inbox=inbox, message_id=message_id)
         return _received_reaction_result(
             status="received",
             ok=True,

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -32,7 +32,11 @@ from .group_history import (
     _route_context,
     _verify_inbox_events,
 )
-from .inbox_reactions import ensure_lark_event_inbox_received_reaction
+from .inbox_reactions import (
+    ensure_lark_event_inbox_received_reaction,
+    lark_inbox_pending_turn_start_read_message_ids,
+    record_lark_inbox_turn_start_read,
+)
 from .routed_inbox import ingest_routed_lark_event_inbox
 
 CURSOR_SCHEMA_VERSION = "lark_turn_start_sync_cursor_v0"
@@ -293,16 +297,36 @@ def _route_receipt(
                     "external_read_performed": True,
                     "local_private_state_mutated": bool(ingest["write_performed"]),
                 }
-            # Retry every provider-visible pending event in the overlap page,
-            # not only files first accepted by this ingress. The shared
-            # receipt/settlement boundary makes cross-ingress duplicates
-            # idempotent and lets a transient provider failure recover on the
-            # next bounded history pass.
+            try:
+                first_read_count = sum(
+                    int(
+                        record_lark_inbox_turn_start_read(
+                            inbox=route["inbox"]["inbox_path"],
+                            message_id=str(event["message_id"]),
+                        )
+                    )
+                    for event in events
+                )
+                reaction_message_ids = lark_inbox_pending_turn_start_read_message_ids(
+                    inbox=route["inbox"]["inbox_path"]
+                )
+            except (OSError, TypeError, ValueError):
+                return {
+                    "ok": False,
+                    "status": "turn_start_read_receipt_failed",
+                    "error_code": "turn_start_read_receipt_failed",
+                    "accepted_count": int(ingest["accepted_count"]),
+                    "external_read_performed": True,
+                    "local_private_state_mutated": bool(ingest["write_performed"]),
+                }
+            # Retry from the durable Agent-read set, not only the provider's
+            # overlap page. A failed ACK therefore remains recoverable after
+            # the history cursor advances beyond the message timestamp.
             reaction_results = [
                 ensure_lark_event_inbox_received_reaction(
                     project=config["project"],
                     config_path=route["event_inbox_config_ref"],
-                    event=event,
+                    event={"message_id": message_id},
                     create_reaction=lambda message_id, emoji_type: (
                         _create_lark_event_received_reaction(
                             {"message_id": message_id},
@@ -322,7 +346,7 @@ def _route_receipt(
                         )
                     ),
                 )
-                for event in events
+                for message_id in reaction_message_ids
             ]
             reaction_failures = [
                 result for result in reaction_results if result["ok"] is not True
@@ -365,6 +389,7 @@ def _route_receipt(
                     "received_reaction_failed" if reaction_failures else None
                 ),
                 "accepted_count": int(ingest["accepted_count"]),
+                "first_read_count": first_read_count,
                 "duplicate_count": int(ingest["duplicate_count"]),
                 "skipped_count": skipped_count,
                 "self_message_skipped_count": self_message_skipped_count,
@@ -441,16 +466,11 @@ def sync_lark_turn_start_inbox(
     ]
     failures = [receipt for receipt in receipts if receipt["ok"] is not True]
     # A realtime collector may have persisted a message before this hook sees
-    # the same provider-history item.  In that case accepted_count is zero,
-    # but the first read-ack attempt still proves that this turn newly read the
-    # pending message into the Agent processing chain.  Within one route every
-    # newly accepted event is also an ACK candidate when ACKs are configured,
-    # so max() counts the union without double-counting the same message.
+    # the same provider-history item. The owner-private read receipt is
+    # independent of optional provider reactions, so it remains the sole
+    # authority for whether this turn newly placed content in the Agent chain.
     observation_count = sum(
-        max(
-            int(receipt.get("accepted_count") or 0),
-            int(receipt.get("read_ack_attempt_count") or 0),
-        )
+        int(receipt.get("first_read_count") or receipt.get("accepted_count") or 0)
         for receipt in receipts
     )
     agent_read_required = bool(observation_count)

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 
 from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
+from loopx.extensions.lark import inbox_reactions as inbox_reactions_module
 from loopx.extensions.lark.inbox_reactions import (
     complete_lark_event_inbox_reactions,
     ensure_lark_event_inbox_received_reaction,
@@ -225,7 +226,7 @@ def test_received_reaction_receipt_failure_reports_provider_writes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config, _inbox, project = _fixture(tmp_path)
-    deleted: list[tuple[str, str]] = []
+    real_record = inbox_reactions_module.record_lark_inbox_reaction
     monkeypatch.setattr(
         "loopx.extensions.lark.inbox_reactions.record_lark_inbox_reaction",
         lambda **_kwargs: (_ for _ in ()).throw(OSError("fixture receipt failure")),
@@ -239,16 +240,77 @@ def test_received_reaction_receipt_failure_reports_provider_writes(
             "mentions": [{"name": "Project Review Bot"}],
         },
         create_reaction=lambda _message_id, _emoji_type: "reaction_Get",
-        delete_reaction=lambda message_id, reaction_id: (
-            deleted.append((message_id, reaction_id)) or True
-        ),
+        delete_reaction=lambda _message_id, _reaction_id: True,
     )
 
     assert result["status"] == "receipt_failed"
     assert result["blocker"] == "lark_inbox_received_reaction_receipt_failed"
-    assert result["created_count"] == 0
+    assert result["created_count"] == 1
     assert result["external_writes_performed"] is True
-    assert deleted == [("om_reaction_fixture", "reaction_Get")]
+    monkeypatch.setattr(
+        "loopx.extensions.lark.inbox_reactions.record_lark_inbox_reaction",
+        real_record,
+    )
+    created: list[tuple[str, str]] = []
+    recovered = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event={"message_id": "om_reaction_fixture"},
+        create_reaction=lambda message_id, emoji_type: (
+            created.append((message_id, emoji_type)) or "reaction_duplicate"
+        ),
+        delete_reaction=lambda _message_id, _reaction_id: True,
+    )
+
+    assert recovered["status"] == "receipt_recovered"
+    assert recovered["external_writes_performed"] is False
+    assert created == []
+
+
+def test_received_reaction_uncertain_operation_never_repeats_provider_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, _inbox, project = _fixture(tmp_path)
+    real_write = inbox_reactions_module._write_received_operation
+    write_count = 0
+
+    def fail_created_receipt(**kwargs: object) -> None:
+        nonlocal write_count
+        write_count += 1
+        if write_count == 2:
+            raise OSError("fixture operation receipt failure")
+        real_write(**kwargs)
+
+    monkeypatch.setattr(
+        inbox_reactions_module,
+        "_write_received_operation",
+        fail_created_receipt,
+    )
+    created: list[tuple[str, str]] = []
+    first = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event={"message_id": "om_reaction_fixture"},
+        create_reaction=lambda message_id, emoji_type: (
+            created.append((message_id, emoji_type)) or "reaction_Get"
+        ),
+        delete_reaction=lambda _message_id, _reaction_id: False,
+    )
+    second = ensure_lark_event_inbox_received_reaction(
+        project=project,
+        config_path=config,
+        event={"message_id": "om_reaction_fixture"},
+        create_reaction=lambda message_id, emoji_type: (
+            created.append((message_id, emoji_type)) or "reaction_duplicate"
+        ),
+        delete_reaction=lambda _message_id, _reaction_id: False,
+    )
+
+    assert first["status"] == "operation_receipt_failed"
+    assert first["blocker"] == "lark_inbox_received_reaction_provider_outcome_uncertain"
+    assert second["status"] == "provider_outcome_uncertain"
+    assert second["external_writes_performed"] is False
+    assert created == [("om_reaction_fixture", "Get")]
 
 
 class ReplyRunner:

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -412,6 +412,48 @@ def test_turn_start_sync_respects_explicit_received_reaction_disable(
     assert not any("reactions" in call for call in runner.calls)
 
 
+def test_turn_start_sync_collector_capture_still_requires_read_when_reaction_disabled(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    inbox_config = project / ".loopx/config/inbox.json"
+    payload = json.loads(inbox_config.read_text(encoding="utf-8"))
+    payload["reply"]["received_reaction_emoji"] = ""
+    inbox_config.write_text(json.dumps(payload), encoding="utf-8")
+    message = {
+        "message_id": "om_collector_reaction_disabled",
+        "create_time": "2026-08-26T09:59:00Z",
+        "content": "Collector captured this before the turn-start read.",
+        "deleted": False,
+    }
+    inbox = project / ".loopx/inbox/requirements"
+    inbox.mkdir(parents=True)
+    (inbox / "om_collector_reaction_disabled.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "lark_event_inbox_event_v0",
+                "event_id": "om_collector_reaction_disabled",
+                **message,
+            }
+        ),
+        encoding="utf-8",
+    )
+    runner = ReactionPageRunner([_page(message)])
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "observed"
+    assert result["observation_count"] == 1
+    assert result["agent_read_required"] is True
+    assert result["external_writes_performed"] is False
+    assert not any("reactions" in call for call in runner.calls)
+
+
 def test_turn_start_sync_reports_reaction_write_failure_without_losing_message(
     tmp_path: Path,
 ) -> None:
@@ -445,7 +487,7 @@ def test_turn_start_sync_reports_reaction_write_failure_without_losing_message(
     assert (project / ".loopx/inbox/requirements/om_reaction_failure.json").is_file()
 
 
-def test_turn_start_sync_retries_reaction_for_overlapping_pending_duplicate(
+def test_turn_start_sync_retries_reaction_from_local_read_beyond_overlap_window(
     tmp_path: Path,
 ) -> None:
     project, config = _project(tmp_path, received_reaction=True)
@@ -463,7 +505,9 @@ def test_turn_start_sync_retries_reaction_for_overlapping_pending_duplicate(
     )
 
     assert failed["status"] == "partial"
-    retry_runner = ReactionPageRunner([_page(message)])
+    # The real second provider window begins at 09:59:55, so the 09:59:00
+    # message is no longer visible and cannot be recovered from overlap.
+    retry_runner = ReactionPageRunner([_page()])
     retried = sync_lark_turn_start_inbox(
         project=project,
         config_path=config,
@@ -471,12 +515,14 @@ def test_turn_start_sync_retries_reaction_for_overlapping_pending_duplicate(
         now=SECOND_NOW,
     )
 
-    assert retried["status"] == "observed"
-    assert retried["observation_count"] == 1
-    assert retried["agent_read_required"] is True
+    assert retried["status"] == "empty"
+    assert retried["observation_count"] == 0
+    assert retried["agent_read_required"] is False
     assert retried["received_reaction_count"] == 1
     assert retried["external_writes_performed"] is True
     assert any("reactions" in call for call in retry_runner.calls)
+    history_call = next(call for call in retry_runner.calls if "reactions" not in call)
+    assert history_call[history_call.index("--start") + 1] == "2026-08-26T09:59:55Z"
 
 
 def test_turn_start_sync_excludes_verified_profile_self_message(


### PR DESCRIPTION
## Summary

Follow up on the two P1 findings raised after #3708 was merged:

- decouple the first Agent-owned turn-start read receipt from optional provider reactions, so collector-captured messages still require Agent reading when `received_reaction_emoji` is explicitly disabled;
- retry failed reactions from a durable owner-private pending-read set rather than relying on the bounded provider overlap window;
- fence reaction creation with prepared/created private operation state, recovering a known reaction id after receipt persistence failure and failing closed when the provider outcome is uncertain instead of creating a duplicate;
- update the provider-neutral RFC and Lark inbox operator docs.

Addresses review findings:
- https://github.com/huangruiteng/loopx/pull/3708#pullrequestreview-5043683929
- https://github.com/huangruiteng/loopx/pull/3708#pullrequestreview-5043714094

## Validation

- `pytest -q tests/extensions`: 530 passed
- focused mypy on both changed runtime modules: passed
- Ruff check and format check on changed Python files: passed
- `loopx check` public/private boundary scan: 6 files clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, 0 failures/skips/manual holds
- change-quality receipt: `cqr_490ba94256652bceeb7f`, exact-scope valid
- `git diff --check`: passed

## Scope and risk

This remains inside the existing Lark extension owner. It adds no outbound-message authority, no new provider capability, and no generic queue. The realtime collector still only captures; the Agent turn-start hook remains the sole reaction-effect owner. No private state, credentials, local paths, raw logs, or generated evidence are included.
