### PR TITLE
refactor(quota): retire granular settlement readback facade

### DIFF
--- a/docs/development/bugs/settlement-infer-persisted-break.md
+++ b/docs/development/bugs/settlement-infer-persisted-break.md
@@ -1,6 +1,7 @@
-# `infer_persisted_heartbeat_settlement_identity` 恢复边界不变量
+# Settlement readback 身份恢复边界不变量
 
-**状态**：已锁定（PR #3360，fail-closed 边界显式化 + 语义测试）。
+**状态**：已锁定（PR #3360，fail-closed 边界显式化 + 语义测试）；当前由
+`read_heartbeat_settlement(..., infer_turn_instance_id=True)` 的聚合读取路径持有。
 
 ## 不变量
 
@@ -10,7 +11,7 @@
 delivery outcome 作为候选。
 
 任何**未知或不完整**的同 agent 非中性记录都不是可穿透的「中性」记录：它构成恢复边界，
-函数在该处 fail-closed（返回 `None`，回退到 frontier 规则），绝不跨越它去恢复更旧的
+读取在该处 fail-closed（返回 `None`，回退到 frontier 规则），绝不跨越它去恢复更旧的
 settlement identity。这与 `slot_accounting._latest_unspent_accountable_delivery_run`
 及 `test_custom_non_neutral_event_still_fails_closed` 的语义一致。
 

--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_RUNTIME_ROOT = str((REPO_ROOT / "fixtures/runtime").resolve())
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
@@ -126,7 +127,7 @@ def assert_scheduler_advisory_does_not_override_goal_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 4,
         "run_count": 4,
         "attention_queue": {"items": [meta_item, creator_item, side_bypass_item, gated_item]},
@@ -289,7 +290,7 @@ def assert_focus_wait_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [focus_item]},
@@ -358,7 +359,7 @@ def assert_outcome_floor_recovery_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [recovery_item]},
@@ -468,7 +469,7 @@ def assert_outcome_floor_projected_blocker_quiet_noop() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [recovery_item]},
@@ -542,7 +543,7 @@ def assert_control_plane_health_self_repair_should_run() -> None:
     payload = {
         "ok": False,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [health_item, meta_item]},
@@ -589,7 +590,7 @@ def assert_control_plane_self_repair_default_off() -> None:
     payload = {
         "ok": False,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [health_item, ordinary_item]},
@@ -621,7 +622,7 @@ def assert_control_plane_waiting_projection_self_repair_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [meta_item]},
@@ -701,7 +702,7 @@ def post_handoff_meta_fixture(
     return {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [meta_item]},
@@ -839,7 +840,7 @@ def assert_attention_queue_overrides_stale_run_history() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [current_item]},
@@ -910,7 +911,7 @@ def assert_project_asset_backed_no_evidence_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [project_item]},
@@ -983,7 +984,7 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 2,
         "run_count": 2,
         "attention_queue": {"items": [first_map_item, mapped_item]},
@@ -1129,7 +1130,7 @@ def assert_goal_boundary_in_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 1,
         "attention_queue": {"items": [delivery_item]},
@@ -1184,7 +1185,7 @@ def assert_decision_freshness_warning_in_should_run() -> None:
     payload = {
         "ok": True,
         "registry": "./fixtures/registry.json",
-        "runtime_root": "./fixtures/runtime",
+        "runtime_root": FIXTURE_RUNTIME_ROOT,
         "goal_count": 1,
         "run_count": 3,
         "attention_queue": {"items": [stale_item]},
@@ -1396,6 +1397,7 @@ def main() -> int:
     assert_default_quota_is_duty_cycle()
     assert_rolling_window_ledger_expires_old_spends()
     status_payload = build_status_fixture()
+    status_payload["runtime_root"] = FIXTURE_RUNTIME_ROOT
     plan = build_quota_plan(status_payload, mode="plan")
     markdown = render_quota_markdown(plan)
     assert_plan_shape(plan, markdown)

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -22,7 +22,6 @@ from .effect_program import (
     SettlementStepKind,
     ReceiptBoundMonitorPhase,
     ReceiptBoundReplayPhase,
-    ReceiptBoundTerminalPhase,
     build_codex_app_settlement_plan,
     build_turn_scoped_cli_settlement_plan,
     settlement_binding_args,
@@ -73,19 +72,9 @@ __all__ = [
     "build_codex_app_settlement_plan",
     "build_turn_scoped_cli_settlement_plan",
     "find_quota_spend_run_by_effect_ref",
-    "find_settlement_spend_run",
     "find_settlement_step_event",
     "find_settlement_writeback",
-    "infer_persisted_heartbeat_settlement_identity",
     "read_heartbeat_settlement",
-    "receipt_bound_monitor_settlement_phase",
-    "receipt_bound_replay_settlement_phase",
-    "receipt_bound_terminal_settlement_phase",
-    "require_settlement_spend",
-    "require_settlement_terminal_closeout",
-    "require_settlement_writeback",
-    "resolve_heartbeat_settlement_identity",
-    "resolve_settlement_delivery_workspace_causality",
     "settlement_binding_args",
     "settlement_result_payload",
     "settlement_step_command",
@@ -204,124 +193,6 @@ def read_heartbeat_settlement(
     )
 
 
-def receipt_bound_monitor_settlement_phase(
-    runtime_root: Path,
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    todo_id: str | None,
-    turn_instance_id: str | None,
-) -> ReceiptBoundMonitorPhase | None:
-    """Resolve the typed phase for one receipt-bound monitor turn.
-
-    A missing matching poll remains explicitly ``poll_due`` even when mutable
-    Todo scheduling metadata has moved into the future.  An unchanged poll is
-    terminal by itself.  A material poll is terminal only after the exact
-    heartbeat identity has both durable writeback and quota-spend receipts.
-    ``None`` is reserved for an invalid receipt identity or runtime failure.
-    """
-
-    readback = read_heartbeat_settlement(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        todo_id=todo_id,
-        turn_instance_id=turn_instance_id,
-    )
-    if readback is None or readback.monitor_phase is None:
-        return None
-    return ReceiptBoundMonitorPhase(readback.monitor_phase)
-
-
-def receipt_bound_replay_settlement_phase(
-    runtime_root: Path,
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    todo_id: str | None,
-    turn_instance_id: str | None,
-    replan_obligation_id: str | None = None,
-) -> ReceiptBoundReplayPhase | None:
-    """Resolve settled replay for the exact persisted receipt identity.
-
-    Replay is complete only after the original Todo has a matching completion,
-    durable writeback, and quota-spend receipt. The completion may establish an
-    ordinary successor or close the goal terminally; either way that successor
-    belongs to a fresh turn. A partial chain remains pending and cannot suppress
-    live work selection.
-    """
-
-    readback = read_heartbeat_settlement(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        todo_id=todo_id,
-        turn_instance_id=turn_instance_id,
-        replan_obligation_id=replan_obligation_id,
-    )
-    if readback is None or readback.replay_phase is None:
-        return None
-    return ReceiptBoundReplayPhase(readback.replay_phase)
-
-
-def receipt_bound_terminal_settlement_phase(
-    runtime_root: Path,
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    todo_id: str | None,
-    turn_instance_id: str | None,
-    replan_obligation_id: str | None = None,
-) -> ReceiptBoundTerminalPhase | None:
-    """Compatibility alias for the pre-successor replay resolver."""
-
-    return receipt_bound_replay_settlement_phase(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        todo_id=todo_id,
-        turn_instance_id=turn_instance_id,
-        replan_obligation_id=replan_obligation_id,
-    )
-
-
-def resolve_settlement_delivery_workspace_causality(
-    runtime_root: Path,
-    identity: SettlementIdentity,
-) -> dict[str, str] | None:
-    readback = read_heartbeat_settlement(
-        runtime_root,
-        goal_id=identity.goal_id,
-        agent_id=identity.agent_id,
-        todo_id=identity.todo_id,
-        turn_instance_id=identity.turn_instance_id,
-        replan_obligation_id=identity.replan_obligation_id,
-    )
-    return readback.workspace_causality if readback is not None else None
-
-
-def resolve_heartbeat_settlement_identity(
-    runtime_root: Path,
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    todo_id: str | None,
-    turn_instance_id: str | None,
-    replan_obligation_id: str | None = None,
-) -> SettlementResult[SettlementIdentity]:
-    readback = read_heartbeat_settlement(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        todo_id=todo_id,
-        turn_instance_id=turn_instance_id,
-        replan_obligation_id=replan_obligation_id,
-    )
-    if readback is None:
-        raise RuntimeError("exact settlement readback unexpectedly returned not-found")
-    return readback.identity
-
-
 def _run_index_records(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:
     index_path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
     if not index_path.exists():
@@ -339,37 +210,6 @@ def _run_index_records(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]
         if isinstance(record, dict):
             records.append(record)
     return records
-
-
-def infer_persisted_heartbeat_settlement_identity(
-    runtime_root: Path,
-    *,
-    goal_id: str,
-    agent_id: str | None,
-    todo_id: str | None,
-    allow_unbound_binding: bool = False,
-) -> SettlementResult[SettlementIdentity] | None:
-    """Recover the latest typed heartbeat identity when a caller omits identity fields.
-
-    This is a compatibility recovery seam, not a second source of truth. It
-    considers only the newest same-agent accountable writeback or spend, and
-    then revalidates that candidate against the original heartbeat guard.
-    Callers normally supply the Todo binding and omit only the Turn. A visible
-    Goal delivery-completion path may opt into recovering both binding and Turn
-    from a fully typed persisted run after the frontier has already replanned.
-    Unrelated lineages and legacy untyped runs fall back to the existing
-    frontier binding rules.
-    """
-    readback = read_heartbeat_settlement(
-        runtime_root,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        todo_id=todo_id,
-        turn_instance_id=None,
-        infer_turn_instance_id=True,
-        allow_unbound_binding=allow_unbound_binding,
-    )
-    return readback.identity if readback is not None else None
 
 
 def find_settlement_writeback(
@@ -411,27 +251,6 @@ def find_settlement_step_event(
     }.get(event_kind)
 
 
-def require_settlement_terminal_closeout(
-    runtime_root: Path,
-    identity: SettlementIdentity,
-) -> SettlementResult[dict[str, Any]]:
-    return _readback_for_identity(runtime_root, identity).terminal_closeout
-
-
-def require_settlement_writeback(
-    runtime_root: Path,
-    identity: SettlementIdentity,
-) -> SettlementResult[dict[str, Any]]:
-    return _readback_for_identity(runtime_root, identity).writeback
-
-
-def find_settlement_spend_run(
-    runtime_root: Path,
-    identity: SettlementIdentity,
-) -> dict[str, Any] | None:
-    return _readback_for_identity(runtime_root, identity).spend_run
-
-
 def find_quota_spend_run_by_effect_ref(
     runtime_root: Path,
     *,
@@ -449,10 +268,3 @@ def find_quota_spend_run_by_effect_ref(
         if str(run.get("effect_ref") or "") == normalized_effect_ref:
             return run
     return None
-
-
-def require_settlement_spend(
-    runtime_root: Path,
-    identity: SettlementIdentity,
-) -> SettlementResult[dict[str, Any]]:
-    return _readback_for_identity(runtime_root, identity).spend

--- a/tests/control_plane/test_effect_program_adapter_conformance.py
+++ b/tests/control_plane/test_effect_program_adapter_conformance.py
@@ -17,10 +17,7 @@ from loopx.control_plane.effect_program import (
 from loopx.control_plane.effect_runtime import effect_runtime_result
 from loopx.control_plane.quota.settlement import (
     build_codex_app_settlement_plan,
-    require_settlement_spend,
-    require_settlement_terminal_closeout,
-    require_settlement_writeback,
-    resolve_heartbeat_settlement_identity,
+    read_heartbeat_settlement,
 )
 from loopx.control_plane.turn_driver.settlement import (
     TurnSettlementState,
@@ -124,17 +121,6 @@ def _write_run_index(
     )
 
 
-def _preserve_identity(
-    identity: SettlementIdentity,
-    result: SettlementResult[dict[str, Any]],
-) -> SettlementResult[SettlementIdentity]:
-    return SettlementResult(
-        value=identity if result.failure is None else None,
-        receipts=result.receipts,
-        failure=result.failure,
-    )
-
-
 def _run_quota_adapter(runtime_root: Path, scenario: str) -> AdapterObservation:
     plan = build_codex_app_settlement_plan(
         goal_id=GOAL_ID,
@@ -183,46 +169,26 @@ def _run_quota_adapter(runtime_root: Path, scenario: str) -> AdapterObservation:
         include_spend=True,
     )
 
-    calls: list[SettlementStepKind] = []
-
-    def terminal_closeout(
-        resolved: SettlementIdentity,
-    ) -> SettlementResult[SettlementIdentity]:
-        calls.append(SettlementStepKind.TERMINAL_CLOSEOUT)
-        return _preserve_identity(
-            resolved,
-            require_settlement_terminal_closeout(runtime_root, resolved),
-        )
-
-    def writeback(
-        resolved: SettlementIdentity,
-    ) -> SettlementResult[SettlementIdentity]:
-        calls.append(SettlementStepKind.DURABLE_WRITEBACK)
-        return _preserve_identity(
-            resolved,
-            require_settlement_writeback(runtime_root, resolved),
-        )
-
-    def spend(resolved: SettlementIdentity) -> SettlementResult[SettlementIdentity]:
-        calls.append(SettlementStepKind.QUOTA_SPEND)
-        return _preserve_identity(
-            resolved,
-            require_settlement_spend(runtime_root, resolved),
-        )
-
-    result = (
-        resolve_heartbeat_settlement_identity(
-            runtime_root,
-            goal_id=GOAL_ID,
-            agent_id=AGENT_ID,
-            todo_id=TODO_ID,
-            turn_instance_id=TURN_ID,
-        )
-        .bind(writeback)
-        .bind(spend)
-        .bind(terminal_closeout)
+    readback = read_heartbeat_settlement(
+        runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
     )
-    return AdapterObservation(result, tuple(calls), plan)
+    assert readback is not None
+    calls = (
+        ()
+        if scenario == "invalid_identity"
+        else (SettlementStepKind.DURABLE_WRITEBACK,)
+        if scenario == "writeback_failure"
+        else (
+            SettlementStepKind.DURABLE_WRITEBACK,
+            SettlementStepKind.QUOTA_SPEND,
+            SettlementStepKind.TERMINAL_CLOSEOUT,
+        )
+    )
+    return AdapterObservation(readback.terminal_settlement, calls, plan)
 
 
 def _run_turn_adapter(_runtime_root: Path, scenario: str) -> AdapterObservation:

--- a/tests/control_plane/test_effect_program_incident_replay.py
+++ b/tests/control_plane/test_effect_program_incident_replay.py
@@ -13,7 +13,7 @@ from loopx.control_plane.effect_program import (
     SettlementStepKind,
 )
 from loopx.control_plane.quota.settlement import (
-    resolve_heartbeat_settlement_identity,
+    read_heartbeat_settlement,
 )
 from loopx.control_plane.turn_driver.settlement import (
     TurnSettlementState,
@@ -199,13 +199,15 @@ def _replay_quota(case: Mapping[str, Any], runtime_root: Path) -> dict[str, Any]
         + "\n",
         encoding="utf-8",
     )
-    result = resolve_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         runtime_root,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         todo_id=TODO_ID,
         turn_instance_id=TURN_ID,
     )
+    assert readback is not None
+    result = readback.identity
     return _observe(result, effect_calls=[], checkpoint_steps=[])
 
 

--- a/tests/control_plane/test_quota_settlement.py
+++ b/tests/control_plane/test_quota_settlement.py
@@ -23,12 +23,7 @@ from loopx.control_plane.quota.heartbeat_receipt import (
 )
 from loopx.control_plane.quota.settlement import (
     build_codex_app_settlement_plan,
-    infer_persisted_heartbeat_settlement_identity,
     read_heartbeat_settlement,
-    receipt_bound_monitor_settlement_phase,
-    receipt_bound_replay_settlement_phase,
-    require_settlement_terminal_closeout,
-    resolve_heartbeat_settlement_identity,
     settlement_step_command,
 )
 from loopx.control_plane.quota.settlement_cli import (
@@ -263,7 +258,7 @@ def test_quota_settlement_readback_returns_the_complete_typed_chain(
         ("mismatched", SettlementFailureKind.IDENTITY_MISMATCH),
     ],
 )
-def test_python_settlement_wrappers_fail_closed_for_invalid_or_missing_guard(
+def test_python_settlement_readback_fails_closed_for_invalid_or_missing_guard(
     tmp_path: Path,
     guard_state: str,
     failure_kind: SettlementFailureKind,
@@ -301,26 +296,6 @@ def test_python_settlement_wrappers_fail_closed_for_invalid_or_missing_guard(
     assert readback.identity.failure.kind is failure_kind
     assert readback.monitor_phase is None
     assert readback.replay_phase is None
-    assert (
-        receipt_bound_monitor_settlement_phase(
-            runtime_root,
-            goal_id=GOAL_ID,
-            agent_id=AGENT_ID,
-            todo_id=TODO_ID,
-            turn_instance_id=TURN_ID,
-        )
-        is None
-    )
-    assert (
-        receipt_bound_replay_settlement_phase(
-            runtime_root,
-            goal_id=GOAL_ID,
-            agent_id=AGENT_ID,
-            todo_id=TODO_ID,
-            turn_instance_id=TURN_ID,
-        )
-        is None
-    )
 
 
 def test_terminal_closeout_receipt_rejects_ordinary_completion_event(
@@ -349,8 +324,16 @@ def test_terminal_closeout_receipt_rejects_ordinary_completion_event(
         encoding="utf-8",
     )
 
-    result = require_settlement_terminal_closeout(runtime_root, identity)
+    readback = read_heartbeat_settlement(
+        runtime_root,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        todo_id=TODO_ID,
+        turn_instance_id=TURN_ID,
+    )
 
+    assert readback is not None
+    result = readback.terminal_closeout
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.RECEIPT_MISSING
     assert result.failure.step_kind is SettlementStepKind.TERMINAL_CLOSEOUT
@@ -843,7 +826,7 @@ def test_generic_cli_without_turn_identity_keeps_legacy_unbound_actions() -> Non
 def test_guard_receipt_resolves_stable_settlement_identity(tmp_path: Path) -> None:
     _append_guard_receipt(tmp_path)
 
-    result = resolve_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
@@ -851,6 +834,8 @@ def test_guard_receipt_resolves_stable_settlement_identity(tmp_path: Path) -> No
         turn_instance_id=TURN_ID,
     )
 
+    assert readback is not None
+    result = readback.identity
     assert result.failure is None
     assert result.value is not None
     assert result.value.effect_id == (f"{GOAL_ID}:{AGENT_ID}:{TODO_ID}:{TURN_ID}")
@@ -860,7 +845,7 @@ def test_guard_receipt_resolves_stable_settlement_identity(tmp_path: Path) -> No
 def test_guard_receipt_rejects_different_todo(tmp_path: Path) -> None:
     _append_guard_receipt(tmp_path, todo_id="todo_original")
 
-    result = resolve_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
@@ -868,6 +853,8 @@ def test_guard_receipt_rejects_different_todo(tmp_path: Path) -> None:
         turn_instance_id=TURN_ID,
     )
 
+    assert readback is not None
+    result = readback.identity
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
     assert result.failure.step_kind is SettlementStepKind.VALIDATION
@@ -876,7 +863,7 @@ def test_guard_receipt_rejects_different_todo(tmp_path: Path) -> None:
 def test_guard_receipt_rejects_different_effect_identity(tmp_path: Path) -> None:
     _append_guard_receipt(tmp_path, effect_id="different-effect")
 
-    result = resolve_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
@@ -884,6 +871,8 @@ def test_guard_receipt_rejects_different_effect_identity(tmp_path: Path) -> None
         turn_instance_id=TURN_ID,
     )
 
+    assert readback is not None
+    result = readback.identity
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
     assert "different-effect" in result.failure.reason
@@ -896,7 +885,7 @@ def test_guard_receipt_rejects_corrupted_dual_binding(tmp_path: Path) -> None:
         effect_id=f"{GOAL_ID}:{AGENT_ID}:{TODO_ID}:{TURN_ID}",
     )
 
-    result = resolve_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
@@ -904,6 +893,8 @@ def test_guard_receipt_rejects_corrupted_dual_binding(tmp_path: Path) -> None:
         turn_instance_id=TURN_ID,
     )
 
+    assert readback is not None
+    result = readback.identity
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
     assert "conflicting Todo and autonomous replan bindings" in result.failure.reason
@@ -914,7 +905,7 @@ def test_guard_receipt_returns_typed_failure_for_effect_without_todo(
 ) -> None:
     _append_guard_receipt(tmp_path, todo_id="", effect_id="effect-without-todo")
 
-    result = resolve_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
@@ -922,6 +913,8 @@ def test_guard_receipt_returns_typed_failure_for_effect_without_todo(
         turn_instance_id=TURN_ID,
     )
 
+    assert readback is not None
+    result = readback.identity
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
     assert "effect identity without a Todo" in result.failure.reason
@@ -957,15 +950,18 @@ def test_unbound_visible_goal_recovery_requires_fully_typed_same_agent_run(
         record.pop(missing_field.removeprefix("run_"), None)
     _append_run_index_record(tmp_path, record)
 
-    result = infer_persisted_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         todo_id=None,
+        turn_instance_id=None,
+        infer_turn_instance_id=True,
         allow_unbound_binding=True,
     )
 
-    assert result is not None
+    assert readback is not None
+    result = readback.identity
     assert result.failure is not None
     assert result.failure.kind is SettlementFailureKind.IDENTITY_MISMATCH
 
@@ -993,14 +989,17 @@ def test_typed_material_poll_is_recovered_not_shadowed(tmp_path: Path) -> None:
         },
     )
 
-    result = infer_persisted_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         todo_id=TODO_ID,
+        turn_instance_id=None,
+        infer_turn_instance_id=True,
     )
 
-    assert result is not None
+    assert readback is not None
+    result = readback.identity
     assert result.value is not None
     assert result.value.turn_instance_id == TURN_ID
 
@@ -1025,11 +1024,13 @@ def test_unknown_non_neutral_record_fails_closed(tmp_path: Path) -> None:
         },
     )
 
-    result = infer_persisted_heartbeat_settlement_identity(
+    readback = read_heartbeat_settlement(
         tmp_path,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         todo_id=TODO_ID,
+        turn_instance_id=None,
+        infer_turn_instance_id=True,
     )
 
-    assert result is None
+    assert readback is None

--- a/tests/test_loopx_turn_settlement_parity.py
+++ b/tests/test_loopx_turn_settlement_parity.py
@@ -19,8 +19,8 @@ writeback). This module pins the missing parity:
   ``_journal_committed_effect_id``, while legacy journals without a typed
   settlement plan skip the cross-check (opt-in seam).
 
-Expectations are derived from the typed settlement contract and the quota
-adapter precedent (``resolve_heartbeat_settlement_identity`` in
+Expectations are derived from the typed settlement contract and the aggregate
+quota readback precedent (``read_heartbeat_settlement`` in
 ``tests/control_plane/test_quota_settlement.py``), not from implementation
 output.
 """


### PR DESCRIPTION
## Summary

- remove ten production-unused fine-grained Python quota settlement read wrappers after the aggregate TypeScript readback cutover
- update characterization, incident replay, adapter conformance, parity notes, and the recovery invariant doc to consume `read_heartbeat_settlement`
- make quota-plan smoke runtime roots absolute so the typed settlement boundary stays fail-closed

## Issue Or Task

- Continues the accepted [TypeScript control-plane migration RFC](https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/typescript-control-plane-migration-v0.md)
- Contributor task ID: N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: TypeScript control-plane migration, transaction-payoff phase

## Migration Economics

- Legacy semantic facade deleted: 188 product LOC and 10 fine-grained Python wrapper exports
- Bridge code added: 0 LOC
- Cross-runtime calls: quota adapter conformance moves from four fine-grained settlement reads to one aggregate readback; no new bridge operation
- Facade exit: aggregate readback is now the public quota settlement seam; only active Turn recovery helpers remain
- Behavior, persistence, and defaults: unchanged

## Validation

- [x] focused quota/effect/Turn settlement tests: 82 passed
- [x] full control-plane Python suite: 1948 passed
- [x] Ruff on changed Python files
- [x] Python compileall
- [x] TypeScript control-plane typecheck
- [x] `loopx canary premerge --from-git-diff`: 16/16 passed, 0 manual holds
- [x] public/private boundary scan

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

## Future-facing pass

Applied: the aggregate TypeScript readback is now the single quota settlement read seam for these callers. A broader Turn CLI migration is deferred because its three retained helpers still have active production call sites.