### PR TITLE
perf(cli): lazily load common command owners

### DIFF
--- a/examples/cli-control-plane-command-modularization-smoke.py
+++ b/examples/cli-control-plane-command-modularization-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CLI_PATH = REPO_ROOT / "loopx" / "cli.py"
+CLI_RUNTIME_PATH = REPO_ROOT / "loopx" / "cli_runtime.py"
 INIT_PATH = REPO_ROOT / "loopx" / "cli_commands" / "__init__.py"
 TODO_MODULE = REPO_ROOT / "loopx" / "cli_commands" / "todo.py"
 QUOTA_MODULE = REPO_ROOT / "loopx" / "cli_commands" / "quota.py"
@@ -35,6 +36,7 @@ def assert_contains(text: str, needle: str, label: str) -> None:
 
 def assert_source_shape() -> None:
     cli_text = CLI_PATH.read_text(encoding="utf-8")
+    runtime_text = CLI_RUNTIME_PATH.read_text(encoding="utf-8")
     init_text = INIT_PATH.read_text(encoding="utf-8")
     todo_text = TODO_MODULE.read_text(encoding="utf-8")
     quota_text = QUOTA_MODULE.read_text(encoding="utf-8")
@@ -51,8 +53,11 @@ def assert_source_shape() -> None:
         "cli.py",
     )
     assert_contains(cli_text, "register_quota_command(sub)", "cli.py")
-    assert_contains(cli_text, "handle_todo_command(", "cli.py")
-    assert_contains(cli_text, "handle_quota_command(", "cli.py")
+    assert_contains(cli_text, "dispatch_common_command(", "cli.py")
+    assert "handle_todo_command(" not in cli_text
+    assert "handle_quota_command(" not in cli_text
+    assert_contains(runtime_text, "handle_todo_command(", "cli_runtime.py")
+    assert_contains(runtime_text, "handle_quota_command(", "cli_runtime.py")
     assert_contains(todo_text, "render_todo_markdown", "todo module")
     assert_contains(todo_text, "append_cli_rollout_event", "todo module")
     assert_contains(quota_text, "render_quota_should_run_markdown", "quota module")

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
 import argparse
-import json
-import os
 import sys
-from pathlib import Path
 
-from . import __version__
 from .capabilities.content_ops.cli import (
     handle_content_ops_command,
     register_content_ops_commands,
@@ -65,8 +61,6 @@ from .cli_commands import (
     handle_bootstrap_connect_command,
     handle_canary_command,
     handle_capability_command,
-    handle_check_command,
-    handle_diagnose_command,
     handle_doctor_command,
     handle_dreaming_command,
     handle_evidence_log_command,
@@ -85,19 +79,15 @@ from .cli_commands import (
     handle_project_lifecycle_command,
     handle_pr_review_command,
     handle_deepresearch_command,
-    handle_quota_command,
     handle_ready_score_command,
     handle_review_batch_command,
     handle_registry_admin_command,
-    handle_review_packet_command,
     handle_slash_commands_command,
-    handle_status_command,
     handle_starter_command,
     handle_summary_all_command,
     handle_support_control_command,
     handle_handoff_mode_command,
     handle_task_lease_command,
-    handle_todo_command,
     handle_version_command,
     handle_host_mode_plan_command,
     handle_worker_bridge_command,
@@ -162,47 +152,18 @@ from .help_surface import (
     render_concise_help,
     top_level_help_requested,
 )
-from .paths import DEFAULT_RUNTIME_ROOT, default_registry_path, global_registry_path
-
-
-class LoopXArgumentParser(argparse.ArgumentParser):
-    """Require complete option names across the automation-facing CLI."""
-
-    def __init__(self, *args, **kwargs) -> None:
-        kwargs.setdefault("allow_abbrev", False)
-        super().__init__(*args, **kwargs)
-
-
-def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> None:
-    if fmt == "json":
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
-    else:
-        print(markdown_renderer(payload))
-
-
-def add_subcommand_format(arg_parser: argparse.ArgumentParser) -> None:
-    arg_parser.add_argument(
-        "--format",
-        dest="subcommand_format",
-        choices=["markdown", "json"],
-        help="Output format for this subcommand. Equivalent to global --format before the command.",
-    )
-
-
-def output_format(args: argparse.Namespace, *local_dests: str) -> str:
-    for dest in (*local_dests, "subcommand_format"):
-        value = getattr(args, dest, None)
-        if value:
-            return str(value)
-    return str(getattr(args, "format", None) or "markdown")
-
-
-def resolve_global_output_format(args: argparse.Namespace) -> str:
-    if getattr(args, "format", None):
-        return str(args.format)
-    if args.command == "quota" and getattr(args, "quota_command", None) == "should-run":
-        return "json"
-    return "markdown"
+from .cli_runtime import (
+    LoopXArgumentParser,
+    add_subcommand_format,
+    build_cli_parser,
+    dispatch_common_command,
+    enforce_native_controller_guard,
+    output_format,
+    print_payload,
+    resolve_cli_registry,
+    resolve_global_output_format,
+    user_supplied_registry,
+)
 
 
 def _demo_not_available_message(command: str) -> str:
@@ -245,18 +206,8 @@ def _register_demo_commands(
             add_subcommand_format(stub)
 
 
-def user_supplied_registry(argv: list[str] | None) -> bool:
-    values = sys.argv[1:] if argv is None else argv
-    return any(value == "--registry" or value.startswith("--registry=") for value in values)
-
-
 def build_parser() -> LoopXArgumentParser:
-    parser = LoopXArgumentParser(description="LoopX control-plane helper.")
-    parser.add_argument("--version", action="version", version=f"loopx {__version__}")
-    parser.add_argument("--registry", default=str(default_registry_path()), help="Path to a project-local registry.")
-    parser.add_argument("--runtime-root", help="Override registry common_runtime_root.")
-    parser.add_argument("--format", choices=["markdown", "json"])
-    sub = parser.add_subparsers(dest="command", required=True)
+    parser, sub = build_cli_parser()
 
     register_version_command(sub, add_subcommand_format)
 
@@ -374,76 +325,18 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(raw_argv)
     args.format = resolve_global_output_format(args)
-    if os.environ.get("LOOPX_KUNLUNCODE_OUTER_CONTROLLER") == "1":
-        from .kunluncode_goal_mode.guards import native_controller_cli_write_block
+    guard_result = enforce_native_controller_guard(args)
+    if guard_result is not None:
+        return guard_result
+    registry_path, registry_was_configured = resolve_cli_registry(args, raw_argv)
 
-        native_write_block = native_controller_cli_write_block(args)
-        if native_write_block is not None:
-            print(
-                json.dumps(native_write_block, ensure_ascii=False, indent=2),
-                file=sys.stderr,
-            )
-            return 2
-    registry_path = Path(args.registry).expanduser()
-    registry_was_configured = user_supplied_registry(raw_argv) or bool(
-        os.environ.get("LOOPX_REGISTRY")
+    common_command_result = dispatch_common_command(
+        args,
+        registry_path=registry_path,
+        allow_missing_registry=not user_supplied_registry(raw_argv),
     )
-    project_register_uses_default_registry = (
-        args.command == "project"
-        and args.project_command == "register"
-        and not registry_was_configured
-    )
-    if project_register_uses_default_registry:
-        registry_path = (
-            Path(args.knowledge_root).expanduser() / ".loopx" / "registry.json"
-        )
-    if (
-        args.command
-        not in {
-            "bootstrap",
-            "bootstrap-command-pack",
-            "agent-onboard",
-            "connect",
-            "codex-cli-bootstrap-message",
-            "codex-cli-bounded-visible-pilot-adapter",
-            "codex-cli-exec-handoff",
-            "codex-cli-visible-first-response-capture-plan",
-            "codex-cli-local-driver-plan",
-            "codex-cli-local-scheduler-exec",
-            "codex-cli-local-scheduler-tick",
-            "codex-cli-one-message-loop-pilot",
-            "codex-cli-runtime-idle-detector",
-            "codex-cli-session-probe",
-            "codex-cli-visible-attach-acceptance",
-            "codex-cli-visible-local-driver-pilot",
-            "codex-cli-visible-driver-run",
-            "codex-cli-visible-driver-plan",
-            "codex-cli-visible-session-proof",
-            "demo",
-            "doctor",
-            "first-run-report",
-            "new-project-prompt",
-            "resolve-agent-thread",
-            "start-goal",
-            "slash-commands",
-            "workflow-skills",
-            "heartbeat-prompt",
-            "supervisor-event",
-            "supervisor-observe",
-            "supervisor-prompt",
-            "sync-global",
-            "uninstall-project",
-            "version",
-            "host-mode-plan",
-        }
-        and not project_register_uses_default_registry
-        and not registry_was_configured
-        and not registry_path.exists()
-    ):
-        runtime_root = Path(args.runtime_root).expanduser() if args.runtime_root else DEFAULT_RUNTIME_ROOT
-        fallback_registry = global_registry_path(runtime_root)
-        if fallback_registry.exists():
-            registry_path = fallback_registry
+    if common_command_result is not None:
+        return common_command_result
 
     version_result = handle_version_command(args, output_format=output_format, print_payload=print_payload)
     if version_result is not None:
@@ -788,42 +681,6 @@ def main(argv: list[str] | None = None) -> int:
     if lark_inbox_result is not None:
         return lark_inbox_result
 
-    if args.command == "check":
-        return handle_check_command(
-            args,
-            registry_path=registry_path,
-            runtime_root_arg=args.runtime_root,
-            allow_missing_registry=not user_supplied_registry(raw_argv),
-            print_payload=print_payload,
-        )
-
-    if args.command == "status":
-        return handle_status_command(
-            args,
-            registry_path=registry_path,
-            runtime_root_arg=args.runtime_root,
-            output_format=output_format,
-            print_payload=print_payload,
-        )
-
-    if args.command == "diagnose":
-        return handle_diagnose_command(
-            args,
-            registry_path=registry_path,
-            runtime_root_arg=args.runtime_root,
-            output_format=output_format,
-            print_payload=print_payload,
-        )
-
-    if args.command == "review-packet":
-        return handle_review_packet_command(
-            args,
-            registry_path=registry_path,
-            runtime_root_arg=args.runtime_root,
-            output_format=output_format,
-            print_payload=print_payload,
-        )
-
     summary_all_result = handle_summary_all_command(
         args,
         registry_path=registry_path,
@@ -888,16 +745,6 @@ def main(argv: list[str] | None = None) -> int:
     if explore_result is not None:
         return explore_result
 
-    if args.command == "todo":
-        return handle_todo_command(
-            args,
-            registry_path=registry_path,
-            runtime_root_arg=args.runtime_root,
-            format_name=output_format(args),
-            print_payload=print_payload,
-            append_cli_rollout_event=append_cli_rollout_event,
-        )
-
     task_lease_result = handle_task_lease_command(
         args,
         registry_path=registry_path,
@@ -916,15 +763,6 @@ def main(argv: list[str] | None = None) -> int:
     )
     if handoff_mode_result is not None:
         return handoff_mode_result
-
-    if args.command == "quota":
-        return handle_quota_command(
-            args,
-            registry_path=registry_path,
-            runtime_root_arg=args.runtime_root,
-            print_payload=print_payload,
-            append_cli_rollout_event=append_cli_rollout_event,
-        )
 
     if args.command == "auto-research":
         try:

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F401
 """Modular CLI command registrations.
 
 Command modules expose two small functions:
@@ -6,131 +7,149 @@ Command modules expose two small functions:
 - ``handle_*_command(args, print_payload)`` executes the parsed command.
 
 The top-level CLI keeps global options, registry fallback, and dispatch order.
+
+The historical function re-exports remain available, but they are loaded only
+when a caller requests one. Importing a command-owned submodule must not import
+every other CLI command first.
 """
 
-from .turn import handle_turn_command, register_turn_commands
-from .host_mode_plan import (
-    handle_host_mode_plan_command,
-    register_host_mode_plan_command,
-)
-from .benchmark_boundary import (
-    handle_benchmark_boundary_command,
-    register_benchmark_boundary_commands,
-)
-from .benchmark_dispatch import (
-    handle_benchmark_command,
-    register_benchmark_command_group,
-)
-from .benchmark_external_agent import (
-    handle_benchmark_external_agent_command,
-    register_benchmark_external_agent_commands,
-)
-from .bootstrap_connect import (
-    handle_bootstrap_connect_command,
-    register_bootstrap_connect_command,
-)
-from .canary import handle_canary_command, register_canary_commands
-from .capability import handle_capability_command, register_capability_commands
-from .extension import handle_extension_command, register_extension_commands
-from .doctor import handle_doctor_command, register_doctor_command
-from .first_run_report import (
-    handle_first_run_report_command,
-    register_first_run_report_command,
-)
-from .dreaming import handle_dreaming_command, register_dreaming_commands
-from .evidence_log import handle_evidence_log_command, register_evidence_log_command
-from .explore import handle_explore_command, register_explore_commands
-from .handoff_mode import handle_handoff_mode_command, register_handoff_mode_command
-from .history import handle_history_command, register_history_command
-from .goal_channel import handle_goal_channel_command, register_goal_channel_commands
-from .lark_inbox import (
-    build_lark_issue_fix_reviewer_provider_hooks,
-    handle_lark_inbox_command,
-    register_lark_inbox_commands,
-)
-from .lark_kanban import handle_lark_kanban_command, register_lark_kanban_commands
-from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
-from .project_lifecycle import (
-    handle_project_lifecycle_command,
-    register_project_lifecycle_commands,
-)
-from .project import handle_project_command, register_project_commands
-from .preset import handle_preset_command, register_preset_commands
-from .presentation import handle_presentation_command, register_presentation_commands
-from .dash import handle_dash_command, register_dash_commands
-from .pr_review import handle_pr_review_command, register_pr_review_command
-from .deepresearch import handle_deepresearch_command, register_deepresearch_command
-from .quota import handle_quota_command, register_quota_command
-from .ready_score import handle_ready_score_command, register_ready_score_command
-from .review_batch import handle_review_batch_command, register_review_batch_commands
-from .registry_admin import (
-    handle_registry_admin_command,
-    register_registry_admin_commands,
-)
-from .slash_commands import handle_slash_commands_command, register_slash_commands_command
-from .starter import (
-    handle_demo_command,
-    handle_starter_command,
-    register_starter_commands,
-)
-from .starter_bootstrap import (
-    handle_codex_cli_bootstrap_message_command,
-    handle_codex_cli_exec_handoff_command,
-    handle_codex_cli_tui_bootstrap_smoke_bundle_command,
-    handle_loopx_bootstrap_command_pack_command,
-    handle_new_project_prompt_command,
-    handle_starter_bootstrap_command,
-)
-from .starter_bootstrap_registration import register_starter_bootstrap_commands
-from .starter_scheduler import (
-    handle_codex_cli_local_scheduler_exec_command,
-    handle_codex_cli_local_scheduler_tick_command,
-    handle_starter_scheduler_command,
-    register_starter_scheduler_commands,
-)
-from .starter_session_runtime import (
-    handle_codex_cli_runtime_idle_detector_command,
-    handle_codex_cli_session_probe_command,
-    handle_codex_cli_visible_session_proof_command,
-    handle_starter_session_runtime_command,
-    register_starter_session_runtime_commands,
-)
-from .starter_visible_driver import (
-    handle_codex_cli_local_driver_plan_command,
-    handle_codex_cli_visible_driver_plan_command,
-    handle_codex_cli_visible_driver_run_command,
-    handle_starter_visible_driver_command,
-    register_starter_visible_driver_commands,
-)
-from .starter_visible_pilot import (
-    handle_codex_cli_bounded_visible_pilot_adapter_command,
-    handle_codex_cli_one_message_loop_pilot_command,
-    handle_codex_cli_visible_attach_acceptance_command,
-    handle_codex_cli_visible_first_response_capture_plan_command,
-    handle_codex_cli_visible_local_driver_pilot_command,
-    handle_starter_visible_pilot_command,
-    register_starter_visible_pilot_commands,
-)
-from .summary_all import handle_summary_all_command, register_summary_all_command
-from .status import (
-    handle_check_command,
-    handle_diagnose_command,
-    handle_review_packet_command,
-    handle_status_command,
-    register_status_commands,
-)
-from .support_control import (
-    handle_support_control_command,
-    register_support_control_commands,
-)
-from .task_lease import handle_task_lease_command, register_task_lease_command
-from .todo import handle_todo_command, register_todo_command
-from .version import handle_version_command, register_version_command
-from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_commands
-from .workflow_skills import (
-    handle_workflow_skills_command,
-    register_workflow_skills_command,
-)
+_EXPORTS_LOADED = False
+
+
+def _load_exports() -> None:
+    """Load the legacy function facade on first attribute access."""
+
+    global _EXPORTS_LOADED
+    if _EXPORTS_LOADED:
+        return
+
+    from .turn import handle_turn_command, register_turn_commands
+    from .host_mode_plan import (
+        handle_host_mode_plan_command,
+        register_host_mode_plan_command,
+    )
+    from .benchmark_boundary import (
+        handle_benchmark_boundary_command,
+        register_benchmark_boundary_commands,
+    )
+    from .benchmark_dispatch import (
+        handle_benchmark_command,
+        register_benchmark_command_group,
+    )
+    from .benchmark_external_agent import (
+        handle_benchmark_external_agent_command,
+        register_benchmark_external_agent_commands,
+    )
+    from .bootstrap_connect import (
+        handle_bootstrap_connect_command,
+        register_bootstrap_connect_command,
+    )
+    from .canary import handle_canary_command, register_canary_commands
+    from .capability import handle_capability_command, register_capability_commands
+    from .extension import handle_extension_command, register_extension_commands
+    from .doctor import handle_doctor_command, register_doctor_command
+    from .first_run_report import (
+        handle_first_run_report_command,
+        register_first_run_report_command,
+    )
+    from .dreaming import handle_dreaming_command, register_dreaming_commands
+    from .evidence_log import handle_evidence_log_command, register_evidence_log_command
+    from .explore import handle_explore_command, register_explore_commands
+    from .handoff_mode import handle_handoff_mode_command, register_handoff_mode_command
+    from .history import handle_history_command, register_history_command
+    from .goal_channel import handle_goal_channel_command, register_goal_channel_commands
+    from .lark_inbox import (
+        build_lark_issue_fix_reviewer_provider_hooks,
+        handle_lark_inbox_command,
+        register_lark_inbox_commands,
+    )
+    from .lark_kanban import handle_lark_kanban_command, register_lark_kanban_commands
+    from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
+    from .project_lifecycle import (
+        handle_project_lifecycle_command,
+        register_project_lifecycle_commands,
+    )
+    from .project import handle_project_command, register_project_commands
+    from .preset import handle_preset_command, register_preset_commands
+    from .presentation import handle_presentation_command, register_presentation_commands
+    from .dash import handle_dash_command, register_dash_commands
+    from .pr_review import handle_pr_review_command, register_pr_review_command
+    from .deepresearch import handle_deepresearch_command, register_deepresearch_command
+    from .quota import handle_quota_command, register_quota_command
+    from .ready_score import handle_ready_score_command, register_ready_score_command
+    from .review_batch import handle_review_batch_command, register_review_batch_commands
+    from .registry_admin import (
+        handle_registry_admin_command,
+        register_registry_admin_commands,
+    )
+    from .slash_commands import handle_slash_commands_command, register_slash_commands_command
+    from .starter import (
+        handle_demo_command,
+        handle_starter_command,
+        register_starter_commands,
+    )
+    from .starter_bootstrap import (
+        handle_codex_cli_bootstrap_message_command,
+        handle_codex_cli_exec_handoff_command,
+        handle_codex_cli_tui_bootstrap_smoke_bundle_command,
+        handle_loopx_bootstrap_command_pack_command,
+        handle_new_project_prompt_command,
+        handle_starter_bootstrap_command,
+    )
+    from .starter_bootstrap_registration import register_starter_bootstrap_commands
+    from .starter_scheduler import (
+        handle_codex_cli_local_scheduler_exec_command,
+        handle_codex_cli_local_scheduler_tick_command,
+        handle_starter_scheduler_command,
+        register_starter_scheduler_commands,
+    )
+    from .starter_session_runtime import (
+        handle_codex_cli_runtime_idle_detector_command,
+        handle_codex_cli_session_probe_command,
+        handle_codex_cli_visible_session_proof_command,
+        handle_starter_session_runtime_command,
+        register_starter_session_runtime_commands,
+    )
+    from .starter_visible_driver import (
+        handle_codex_cli_local_driver_plan_command,
+        handle_codex_cli_visible_driver_plan_command,
+        handle_codex_cli_visible_driver_run_command,
+        handle_starter_visible_driver_command,
+        register_starter_visible_driver_commands,
+    )
+    from .starter_visible_pilot import (
+        handle_codex_cli_bounded_visible_pilot_adapter_command,
+        handle_codex_cli_one_message_loop_pilot_command,
+        handle_codex_cli_visible_attach_acceptance_command,
+        handle_codex_cli_visible_first_response_capture_plan_command,
+        handle_codex_cli_visible_local_driver_pilot_command,
+        handle_starter_visible_pilot_command,
+        register_starter_visible_pilot_commands,
+    )
+    from .summary_all import handle_summary_all_command, register_summary_all_command
+    from .status import (
+        handle_check_command,
+        handle_diagnose_command,
+        handle_review_packet_command,
+        handle_status_command,
+        register_status_commands,
+    )
+    from .support_control import (
+        handle_support_control_command,
+        register_support_control_commands,
+    )
+    from .task_lease import handle_task_lease_command, register_task_lease_command
+    from .todo import handle_todo_command, register_todo_command
+    from .version import handle_version_command, register_version_command
+    from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_commands
+    from .workflow_skills import (
+        handle_workflow_skills_command,
+        register_workflow_skills_command,
+    )
+
+    namespace = locals()
+    globals().update({name: namespace[name] for name in __all__})
+    _EXPORTS_LOADED = True
 
 __all__ = [
     "handle_turn_command",
@@ -249,3 +268,14 @@ __all__ = [
     "register_worker_bridge_commands",
     "register_workflow_skills_command",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    _load_exports()
+    return globals()[name]
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))

--- a/loopx/cli_runtime.py
+++ b/loopx/cli_runtime.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+from . import __version__
+from .paths import DEFAULT_RUNTIME_ROOT, default_registry_path, global_registry_path
+
+
+GLOBAL_OPTIONS_WITH_VALUE = frozenset({"--registry", "--runtime-root", "--format"})
+GLOBAL_OPTIONS_WITH_EQUALS = tuple(
+	f"{option}=" for option in sorted(GLOBAL_OPTIONS_WITH_VALUE)
+)
+
+_REGISTRY_OPTIONAL_COMMANDS = frozenset(
+	{
+		"bootstrap",
+		"bootstrap-command-pack",
+		"agent-onboard",
+		"connect",
+		"codex-cli-bootstrap-message",
+		"codex-cli-bounded-visible-pilot-adapter",
+		"codex-cli-exec-handoff",
+		"codex-cli-visible-first-response-capture-plan",
+		"codex-cli-local-driver-plan",
+		"codex-cli-local-scheduler-exec",
+		"codex-cli-local-scheduler-tick",
+		"codex-cli-one-message-loop-pilot",
+		"codex-cli-runtime-idle-detector",
+		"codex-cli-session-probe",
+		"codex-cli-visible-attach-acceptance",
+		"codex-cli-visible-local-driver-pilot",
+		"codex-cli-visible-driver-run",
+		"codex-cli-visible-driver-plan",
+		"codex-cli-visible-session-proof",
+		"demo",
+		"doctor",
+		"first-run-report",
+		"new-project-prompt",
+		"resolve-agent-thread",
+		"start-goal",
+		"slash-commands",
+		"workflow-skills",
+		"heartbeat-prompt",
+		"supervisor-event",
+		"supervisor-observe",
+		"supervisor-prompt",
+		"sync-global",
+		"uninstall-project",
+		"version",
+		"host-mode-plan",
+	}
+)
+
+_STATUS_COMMANDS = frozenset({"check", "status", "diagnose", "review-packet"})
+_SELECTED_COMMANDS = _STATUS_COMMANDS | {"todo", "quota"}
+
+
+class LoopXArgumentParser(argparse.ArgumentParser):
+	"""Require complete option names across the automation-facing CLI."""
+
+	def __init__(self, *args, **kwargs) -> None:
+		kwargs.setdefault("allow_abbrev", False)
+		super().__init__(*args, **kwargs)
+
+
+class _SelectedParseRejected(Exception):
+	"""Signal that the complete parser must render the canonical diagnostic."""
+
+
+class _SelectedArgumentParser(LoopXArgumentParser):
+	def error(self, message: str) -> None:
+		raise _SelectedParseRejected(message)
+
+
+def print_payload(
+	payload: dict[str, object],
+	fmt: str,
+	markdown_renderer: Callable[[dict[str, object]], str],
+) -> None:
+	if fmt == "json":
+		print(json.dumps(payload, ensure_ascii=False, indent=2))
+	else:
+		print(markdown_renderer(payload))
+
+
+def add_subcommand_format(arg_parser: argparse.ArgumentParser) -> None:
+	arg_parser.add_argument(
+		"--format",
+		dest="subcommand_format",
+		choices=["markdown", "json"],
+		help="Output format for this subcommand. Equivalent to global --format before the command.",
+	)
+
+
+def output_format(args: argparse.Namespace, *local_dests: str) -> str:
+	for dest in (*local_dests, "subcommand_format"):
+		value = getattr(args, dest, None)
+		if value:
+			return str(value)
+	return str(getattr(args, "format", None) or "markdown")
+
+
+def resolve_global_output_format(args: argparse.Namespace) -> str:
+	if getattr(args, "format", None):
+		return str(args.format)
+	if args.command == "quota" and getattr(args, "quota_command", None) == "should-run":
+		return "json"
+	return "markdown"
+
+
+def build_cli_parser(
+	*, parser_class: type[LoopXArgumentParser] = LoopXArgumentParser
+) -> tuple[LoopXArgumentParser, argparse._SubParsersAction]:
+	"""Build the one canonical global grammar and return its command registrar."""
+
+	parser = parser_class(description="LoopX control-plane helper.")
+	parser.add_argument("--version", action="version", version=f"loopx {__version__}")
+	parser.add_argument(
+		"--registry",
+		default=str(default_registry_path()),
+		help="Path to a project-local registry.",
+	)
+	parser.add_argument("--runtime-root", help="Override registry common_runtime_root.")
+	parser.add_argument("--format", choices=["markdown", "json"])
+	return parser, parser.add_subparsers(dest="command", required=True)
+
+
+def user_supplied_registry(argv: list[str] | None) -> bool:
+	values = sys.argv[1:] if argv is None else argv
+	return any(value == "--registry" or value.startswith("--registry=") for value in values)
+
+
+def resolve_cli_registry(
+	args: argparse.Namespace, raw_argv: list[str]
+) -> tuple[Path, bool]:
+	"""Resolve the shared registry path after canonical argument parsing."""
+
+	registry_path = Path(args.registry).expanduser()
+	registry_was_configured = user_supplied_registry(raw_argv) or bool(
+		os.environ.get("LOOPX_REGISTRY")
+	)
+	project_register_uses_default_registry = (
+		args.command == "project"
+		and args.project_command == "register"
+		and not registry_was_configured
+	)
+	if project_register_uses_default_registry:
+		registry_path = Path(args.knowledge_root).expanduser() / ".loopx" / "registry.json"
+	if (
+		args.command not in _REGISTRY_OPTIONAL_COMMANDS
+		and not project_register_uses_default_registry
+		and not registry_was_configured
+		and not registry_path.exists()
+	):
+		runtime_root = (
+			Path(args.runtime_root).expanduser()
+			if args.runtime_root
+			else DEFAULT_RUNTIME_ROOT
+		)
+		fallback_registry = global_registry_path(runtime_root)
+		if fallback_registry.exists():
+			registry_path = fallback_registry
+	return registry_path, registry_was_configured
+
+
+def enforce_native_controller_guard(args: argparse.Namespace) -> int | None:
+	if os.environ.get("LOOPX_KUNLUNCODE_OUTER_CONTROLLER") != "1":
+		return None
+	from .kunluncode_goal_mode.guards import native_controller_cli_write_block
+
+	native_write_block = native_controller_cli_write_block(args)
+	if native_write_block is None:
+		return None
+	print(json.dumps(native_write_block, ensure_ascii=False, indent=2), file=sys.stderr)
+	return 2
+
+
+def _top_level_command(argv: list[str]) -> str | None:
+	index = 0
+	while index < len(argv):
+		value = argv[index]
+		if value in GLOBAL_OPTIONS_WITH_VALUE:
+			if index + 1 >= len(argv):
+				return None
+			index += 2
+			continue
+		if value.startswith(GLOBAL_OPTIONS_WITH_EQUALS):
+			index += 1
+			continue
+		if value.startswith("-"):
+			return None
+		return value
+	return None
+
+
+def _build_selected_parser(command: str) -> LoopXArgumentParser:
+	parser, subparsers = build_cli_parser(parser_class=_SelectedArgumentParser)
+	if command in _STATUS_COMMANDS:
+		from .cli_commands.status_registration import register_status_commands
+
+		register_status_commands(subparsers, add_subcommand_format)
+	elif command == "todo":
+		from .cli_commands.todo import register_todo_command
+
+		register_todo_command(subparsers, add_subcommand_format)
+	elif command == "quota":
+		from .cli_commands.quota_registration import register_quota_command
+
+		register_quota_command(subparsers)
+	else:  # pragma: no cover - caller guards the private interface
+		raise ValueError(f"unsupported selected command: {command}")
+	return parser
+
+
+def dispatch_common_command(
+	args: argparse.Namespace,
+	*,
+	registry_path: Path,
+	allow_missing_registry: bool,
+) -> int | None:
+	"""Dispatch one selected command through the shared canonical wiring."""
+
+	if args.command in _STATUS_COMMANDS:
+		from .cli_commands.status import (
+			handle_check_command,
+			handle_diagnose_command,
+			handle_review_packet_command,
+			handle_status_command,
+		)
+
+		if args.command == "check":
+			return handle_check_command(
+				args,
+				registry_path=registry_path,
+				runtime_root_arg=args.runtime_root,
+				allow_missing_registry=allow_missing_registry,
+				print_payload=print_payload,
+			)
+		if args.command == "status":
+			return handle_status_command(
+				args,
+				registry_path=registry_path,
+				runtime_root_arg=args.runtime_root,
+				output_format=output_format,
+				print_payload=print_payload,
+			)
+		if args.command == "diagnose":
+			return handle_diagnose_command(
+				args,
+				registry_path=registry_path,
+				runtime_root_arg=args.runtime_root,
+				output_format=output_format,
+				print_payload=print_payload,
+			)
+		return handle_review_packet_command(
+			args,
+			registry_path=registry_path,
+			runtime_root_arg=args.runtime_root,
+			output_format=output_format,
+			print_payload=print_payload,
+		)
+	if args.command == "todo":
+		from .cli_commands.todo import handle_todo_command
+		from .cli_rollout import append_cli_rollout_event
+
+		return handle_todo_command(
+			args,
+			registry_path=registry_path,
+			runtime_root_arg=args.runtime_root,
+			format_name=output_format(args),
+			print_payload=print_payload,
+			append_cli_rollout_event=append_cli_rollout_event,
+		)
+	if args.command == "quota":
+		from .cli_commands.quota import handle_quota_command
+		from .cli_rollout import append_cli_rollout_event
+
+		return handle_quota_command(
+			args,
+			registry_path=registry_path,
+			runtime_root_arg=args.runtime_root,
+			print_payload=print_payload,
+			append_cli_rollout_event=append_cli_rollout_event,
+		)
+	return None
+
+
+def _dispatch_selected(args: argparse.Namespace, raw_argv: list[str]) -> int:
+	args.format = resolve_global_output_format(args)
+	guard_result = enforce_native_controller_guard(args)
+	if guard_result is not None:
+		return guard_result
+	registry_path, _registry_was_configured = resolve_cli_registry(args, raw_argv)
+	result = dispatch_common_command(
+		args,
+		registry_path=registry_path,
+		allow_missing_registry=not user_supplied_registry(raw_argv),
+	)
+	if result is None:  # pragma: no cover - caller guards the private interface
+		raise AssertionError(f"selected command was not dispatched: {args.command}")
+	return result
+
+
+def _run_full_cli(raw_argv: list[str]) -> int:
+	from .cli import main as cli_main
+
+	return cli_main(raw_argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+	raw_argv = sys.argv[1:] if argv is None else list(argv)
+	if raw_argv == ["--version"]:
+		print(f"loopx {__version__}")
+		return 0
+
+	from .help_surface import render_concise_help, top_level_help_requested
+
+	if top_level_help_requested(raw_argv):
+		print(render_concise_help(sys.argv[0] if argv is None else "loopx"), end="")
+		return 0
+	command = _top_level_command(raw_argv)
+	if command in _SELECTED_COMMANDS:
+		try:
+			args = _build_selected_parser(command).parse_args(raw_argv)
+		except _SelectedParseRejected:
+			return _run_full_cli(raw_argv)
+		return _dispatch_selected(args, raw_argv)
+	return _run_full_cli(raw_argv)
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/loopx/entrypoint.py
+++ b/loopx/entrypoint.py
@@ -6,11 +6,17 @@ from . import __version__
 
 
 def main(argv: list[str] | None = None) -> int:
+	"""Keep the version path tiny, then load the selected CLI runtime."""
+
 	raw_argv = sys.argv[1:] if argv is None else list(argv)
 	if raw_argv == ["--version"]:
 		print(f"loopx {__version__}")
 		return 0
 
-	from .cli import main as cli_main
+	from .cli_runtime import main as runtime_main
 
-	return cli_main(raw_argv)
+	return runtime_main(argv)
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -4,9 +4,8 @@ import re
 from typing import Any
 
 from . import __version__
+from .cli_runtime import GLOBAL_OPTIONS_WITH_EQUALS, GLOBAL_OPTIONS_WITH_VALUE
 
-GLOBAL_OPTIONS_WITH_VALUE = {"--registry", "--runtime-root", "--format"}
-GLOBAL_OPTIONS_WITH_EQUALS = tuple(f"{option}=" for option in sorted(GLOBAL_OPTIONS_WITH_VALUE))
 HELP_FLAGS = {"-h", "--help"}
 
 

--- a/scripts/loopx
+++ b/scripts/loopx
@@ -89,5 +89,10 @@ for entry in sys.path:
     filtered_path.append(entry)
 sys.path[:] = [release_root, *filtered_path]
 sys.argv[0] = os.path.join(release_root, "scripts", "loopx")
-runpy.run_module("loopx.cli", run_name="__main__")
+module = (
+    "loopx.entrypoint"
+    if os.path.isfile(os.path.join(release_root, "loopx", "entrypoint.py"))
+    else "loopx.cli"
+)
+runpy.run_module(module, run_name="__main__")
 ' "$@"

--- a/scripts/loopx_entry.py
+++ b/scripts/loopx_entry.py
@@ -37,7 +37,12 @@ def main() -> int:
         filtered_path.append(entry)
     sys.path[:] = [str(release_root), *filtered_path]
     sys.argv[0] = str(release_root / "scripts" / "loopx")
-    runpy.run_module("loopx.cli", run_name="__main__")
+    module = (
+        "loopx.entrypoint"
+        if (release_root / "loopx" / "entrypoint.py").is_file()
+        else "loopx.cli"
+    )
+    runpy.run_module(module, run_name="__main__")
     return 0
 
 

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -47,6 +47,40 @@ raise SystemExit(exit_code)
 	return run_isolated_script(script)
 
 
+def run_cli_batch(module: str, argv_cases: list[list[str]]) -> list[dict[str, object]]:
+	script = f"""
+import contextlib
+import io
+import json
+import sys
+
+from {module} import main
+
+sys.argv[0] = "loopx"
+results = []
+for argv in {argv_cases!r}:
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+        try:
+            exit_code = main(argv)
+        except SystemExit as exc:
+            exit_code = exc.code
+    results.append(
+        {{
+            "returncode": 0 if exit_code is None else exit_code,
+            "stdout": stdout.getvalue(),
+            "stderr": stderr.getvalue(),
+        }}
+    )
+print(json.dumps(results))
+"""
+	completed = run_isolated_script(script)
+
+	assert completed.returncode == 0, completed.stderr
+	return json.loads(completed.stdout)
+
+
 def write_command_fixture(tmp_path: Path) -> tuple[Path, Path]:
 	project = tmp_path / "project"
 	runtime_root = tmp_path / "runtime"
@@ -221,9 +255,8 @@ assert "loopx.capabilities.content_ops.cli" not in sys.modules
 	assert completed.returncode == 0, completed.stderr
 
 
-@pytest.mark.parametrize(
-	"argv",
-	[
+def test_selected_parser_matches_full_help_and_diagnostics() -> None:
+	argv_cases = [
 		["check", "--help"],
 		["status", "--help"],
 		["diagnose", "--help"],
@@ -234,15 +267,11 @@ assert "loopx.capabilities.content_ops.cli" not in sys.modules
 		["todo", "list"],
 		["quota", "unknown-command"],
 		["--format", "unknown", "status"],
-	],
-)
-def test_selected_parser_matches_full_help_and_diagnostics(argv: list[str]) -> None:
-	selected = run_cli_main("loopx.entrypoint", argv)
-	full = run_cli_main("loopx.cli", argv)
+	]
+	selected = run_cli_batch("loopx.entrypoint", argv_cases)
+	full = run_cli_batch("loopx.cli", argv_cases)
 
-	assert selected.returncode == full.returncode
-	assert selected.stdout == full.stdout
-	assert selected.stderr == full.stderr
+	assert selected == full
 
 
 def test_selected_todo_execution_matches_full_cli(tmp_path: Path) -> None:

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -7,6 +7,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -20,6 +22,86 @@ def run_isolated_script(script: str) -> subprocess.CompletedProcess[str]:
 		capture_output=True,
 		check=False,
 	)
+
+
+def run_cli_main(
+	module: str,
+	argv: list[str],
+	*,
+	forbidden_modules: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
+	script = f"""
+import sys
+
+sys.argv[0] = "loopx"
+from {module} import main
+
+try:
+    exit_code = main({argv!r})
+except SystemExit as exc:
+    exit_code = exc.code
+for forbidden_module in {forbidden_modules!r}:
+    assert forbidden_module not in sys.modules
+raise SystemExit(exit_code)
+"""
+	return run_isolated_script(script)
+
+
+def write_command_fixture(tmp_path: Path) -> tuple[Path, Path]:
+	project = tmp_path / "project"
+	runtime_root = tmp_path / "runtime"
+	registry = project / ".loopx" / "registry.json"
+	state_file = project / ".codex" / "goals" / "perf-goal" / "ACTIVE_GOAL_STATE.md"
+	state_file.parent.mkdir(parents=True)
+	state_file.write_text(
+		"""---
+status: active-read-only
+owner_mode: goal
+objective: "Exercise selected CLI dispatch."
+updated_at: 2026-08-28T00:00:00+00:00
+---
+
+# CLI Dispatch Fixture
+
+## Agent Todo
+
+- [ ] [P0] Read one bounded command projection.
+  <!-- loopx:todo todo_id=todo_cli_dispatch status=open task_class=advancement_task action_kind=read_projection claimed_by=perf-agent required_capabilities=filesystem_read -->
+""",
+		encoding="utf-8",
+	)
+	registry.parent.mkdir(parents=True)
+	registry.write_text(
+		json.dumps(
+			{
+				"schema_version": "0.1",
+				"updated_at": "2026-08-28T00:00:00+00:00",
+				"common_runtime_root": str(runtime_root),
+				"goals": [
+					{
+						"id": "perf-goal",
+						"domain": "cli-dispatch-test",
+						"status": "active-read-only",
+						"repo": str(project),
+						"state_file": ".codex/goals/perf-goal/ACTIVE_GOAL_STATE.md",
+						"adapter": {
+							"kind": "read_only_project_map_v0",
+							"status": "connected-read-only",
+						},
+						"coordination": {
+							"registered_agents": ["perf-agent"],
+							"agent_model": "peer_v1",
+						},
+						"authority_sources": [],
+					},
+				],
+			},
+			indent=2,
+		)
+		+ "\n",
+		encoding="utf-8",
+	)
+	return registry, runtime_root
 
 
 def test_version_flag_skips_full_cli_import() -> None:
@@ -36,6 +118,7 @@ with contextlib.redirect_stdout(output):
 
 assert exit_code == 0
 assert output.getvalue().startswith("loopx ")
+assert "loopx.cli_runtime" not in sys.modules
 assert "loopx.cli" not in sys.modules
 """
 	completed = run_isolated_script(script)
@@ -56,7 +139,152 @@ raise SystemExit(main(["--format", "json", "version"]))
 	assert payload["schema_version"] == "loopx_version_v0"
 
 
+def test_top_level_help_skips_full_cli_import() -> None:
+	script = """
+import contextlib
+import io
+import sys
+
+from loopx.entrypoint import main
+
+output = io.StringIO()
+with contextlib.redirect_stdout(output):
+    exit_code = main([])
+
+assert exit_code == 0
+assert output.getvalue().startswith("LoopX keeps long-running agent work moving")
+assert "loopx.cli" not in sys.modules
+"""
+	completed = run_isolated_script(script)
+
+	assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+	("argv", "registration_module", "handler_module"),
+	[
+		(["check", "--help"], "loopx.cli_commands.status_registration", "loopx.cli_commands.status"),
+		(["status", "--help"], "loopx.cli_commands.status_registration", "loopx.cli_commands.status"),
+		(["diagnose", "--help"], "loopx.cli_commands.status_registration", "loopx.cli_commands.status"),
+		(["review-packet", "--help"], "loopx.cli_commands.status_registration", "loopx.cli_commands.status"),
+		(["quota", "--help"], "loopx.cli_commands.quota_registration", "loopx.cli_commands.quota"),
+		(["todo", "--help"], "loopx.cli_commands.todo", "loopx.cli_commands.todo"),
+	],
+)
+def test_common_command_help_loads_only_its_owner(
+	argv: list[str],
+	registration_module: str,
+	handler_module: str,
+) -> None:
+	script = f"""
+import contextlib
+import io
+import sys
+
+from loopx.entrypoint import main
+
+output = io.StringIO()
+try:
+    with contextlib.redirect_stdout(output):
+        main({argv!r})
+except SystemExit as exc:
+    assert exc.code == 0
+else:
+    raise AssertionError("command help must exit through argparse")
+
+assert output.getvalue().startswith("usage:")
+assert "loopx.cli" not in sys.modules
+assert {registration_module!r} in sys.modules
+assert "loopx.cli_commands.benchmark_dispatch" not in sys.modules
+assert "loopx.capabilities.content_ops.cli" not in sys.modules
+if {registration_module!r} != {handler_module!r}:
+    assert {handler_module!r} not in sys.modules
+"""
+	completed = run_isolated_script(script)
+
+	assert completed.returncode == 0, completed.stderr
+
+
+def test_command_submodule_import_does_not_expand_all_cli_commands() -> None:
+	script = """
+import sys
+
+import loopx.cli_commands.status_registration
+
+assert "loopx.cli_commands.status_registration" in sys.modules
+assert "loopx.cli_commands.quota" not in sys.modules
+assert "loopx.cli_commands.todo" not in sys.modules
+assert "loopx.capabilities.content_ops.cli" not in sys.modules
+"""
+	completed = run_isolated_script(script)
+
+	assert completed.returncode == 0, completed.stderr
+
+
+@pytest.mark.parametrize(
+	"argv",
+	[
+		["check", "--help"],
+		["status", "--help"],
+		["diagnose", "--help"],
+		["review-packet", "--help"],
+		["todo", "--help"],
+		["quota", "--help"],
+		["status", "--unknown-option"],
+		["todo", "list"],
+		["quota", "unknown-command"],
+		["--format", "unknown", "status"],
+	],
+)
+def test_selected_parser_matches_full_help_and_diagnostics(argv: list[str]) -> None:
+	selected = run_cli_main("loopx.entrypoint", argv)
+	full = run_cli_main("loopx.cli", argv)
+
+	assert selected.returncode == full.returncode
+	assert selected.stdout == full.stdout
+	assert selected.stderr == full.stderr
+
+
+def test_selected_todo_execution_matches_full_cli(tmp_path: Path) -> None:
+	registry, runtime_root = write_command_fixture(tmp_path)
+	argv = [
+		"--registry",
+		str(registry),
+		"--runtime-root",
+		str(runtime_root),
+		"--format",
+		"json",
+		"todo",
+		"list",
+		"--goal-id",
+		"perf-goal",
+		"--agent-id",
+		"perf-agent",
+	]
+
+	selected = run_cli_main(
+		"loopx.entrypoint",
+		argv,
+		forbidden_modules=("loopx.cli",),
+	)
+	full = run_cli_main("loopx.cli", argv)
+
+	assert selected.returncode == full.returncode == 0
+	assert selected.stdout == full.stdout
+	assert selected.stderr == full.stderr == ""
+
+
 def test_console_script_uses_lightweight_entrypoint() -> None:
 	project = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
 	assert project["project"]["scripts"]["loopx"] == "loopx.entrypoint:main"
+
+
+def test_release_launchers_use_lightweight_entrypoint() -> None:
+	posix_launcher = (REPO_ROOT / "scripts" / "loopx").read_text(encoding="utf-8")
+	windows_entry = (REPO_ROOT / "scripts" / "loopx_entry.py").read_text(encoding="utf-8")
+
+	assert '"loopx.entrypoint"' in posix_launcher
+	assert '"loopx.entrypoint"' in windows_entry
+	assert 'else "loopx.cli"' in posix_launcher
+	assert 'else "loopx.cli"' in windows_entry


### PR DESCRIPTION
## Summary

- keep `loopx.entrypoint` as a tiny `--version` shim and load the CLI runtime only for other commands
- build canonical selected parsers for status/check/diagnose/review-packet, todo, and quota, then lazily import only the chosen command owner
- preserve the complete `loopx.cli` parser as the explicit cold compatibility path and share one common-command dispatch authority between both entry paths
- route POSIX and Windows release launchers through the lightweight entrypoint, with a compatibility fallback for older release roots
- retain the tested `loopx.cli_commands` function facade through lazy attribute loading instead of eager package fan-out

## Performance

Fresh-process measurements used alternating baseline/candidate order against `origin/main@0233a2f3`. Quota runs used isolated state because `quota should-run` appends a rollout receipt.

| Command path | Baseline | Candidate | Change |
|---|---:|---:|---:|
| direct entrypoint `--version` p50 / p95 (30 pairs) | 23.783 / 34.876 ms | 21.507 / 24.477 ms | no fast-path regression |
| release wrapper `--version` p50 / p95 (30 pairs) | 688.445 / 870.460 ms | 34.767 / 84.146 ms | -94.9% / -90.3% |
| `todo list` p50 / p95 (50 pairs) | 669.456 / 1272.637 ms | 306.099 / 462.555 ms | -54.3% / -63.7% |
| `status` p50 / p95 (50 pairs) | 2989.334 / 4366.038 ms | 2664.379 / 3589.446 ms | -325 / -777 ms |
| `quota should-run` p50 (50 pairs) | 2939.480 ms | 2707.604 ms | -232 ms |

Quota p95 was noisy and regressed in this local run, so this PR claims the reproducible median/import reduction rather than a uniform tail improvement.

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-goal`: 17/17 selected checks passed at exact head `60d439f1`, including install, packaged-entry, CLI output, maintainability, and public-boundary profiles
- `pytest -q tests/test_cli_entrypoint.py tests/test_cli_argument_diagnostics.py`: 102 passed
- focused todo/output tests: 37 passed
- focused quota/task-lease tests: 43 passed
- CLI modularization/help/release-wrapper smokes and module-contract regression passed
- Ruff 0.15.7, `compileall`, and `git diff --check` passed
- final wheel and sdist contain both `entrypoint.py` and `cli_runtime.py`; clean-wheel version/status/quota probes passed
- native PowerShell tests were unavailable on the local host (`tests/test_windows_install.py`: 4 skipped); exact-head `windows-powershell` CI passed
- exact-head GitHub checks passed: pytest, Windows, DCO, dependency review, build, and SonarCloud

The first CI run exposed two existing external-scheduler test cases whose fake CLI processes exceeded their 1-second timeout under xdist/coverage contention. Scheduler product code was unchanged. The follow-up keeps every one of the 10 CLI parity cases and exact exit/stdout/stderr assertions, but executes them in two batched subprocesses instead of 20; the relevant xdist/coverage run dropped from 22.92s to 11.07s, and the scheduler tests passed locally under that configuration.

## Scope review

The future-facing refactor pass consolidated duplicate common-command wiring into `cli_runtime.dispatch_common_command`. Splitting todo's combined grammar/handler module remains a separate profiling-driven follow-up; this PR does not add a generic command catalog or claim the RFC's native TypeScript CLI stage is complete.
