### PR TITLE
perf(contract): prefilter public boundary scans

### DIFF
--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -43,29 +44,75 @@ from .control_plane.todos.contract import (
 )
 
 
-LEAK_PATTERNS = {
-    "private_doc_url": re.compile(
-        "|".join(["la" + "rk" + "office", "docs" + r"\." + "internal"]),
-        re.I,
-    ),
-    "credential": re.compile(
-        "|".join(
-            [
-                "Bear" + "er" + r"\s+[A-Za-z0-9._-]+",
-                "AK" + "IA" + r"[0-9A-Z]{16}",
-                r"(?<![A-Za-z0-9_])" + "tok" + "en=",
-                r"(?<![A-Za-z0-9_])" + "pass" + "word=",
-                "Author" + "ization:",
-            ]
+@dataclass(frozen=True)
+class LeakRule:
+    pattern: re.Pattern[str]
+    required_literals: tuple[str, ...]
+
+    def is_candidate(self, folded_text: str) -> bool:
+        return any(literal in folded_text for literal in self.required_literals)
+
+
+# Required literals are only a cheap necessary condition for running a rule.
+# The regular expressions remain the sole authority for classifying a leak.
+LEAK_RULES = {
+    "private_doc_url": LeakRule(
+        pattern=re.compile(
+            "|".join(["la" + "rk" + "office", "docs" + r"\." + "internal"]),
+            re.I,
         ),
-        re.I,
+        required_literals=("lark" + "office", "docs" + ".internal"),
     ),
-    "local_private_path": re.compile(
-        "(" + "/" + "Users" + "/" + r"[^/\s]+/(?:Documents|code" + "-" + r"reading)|" + "/ext" + "_data/" + ")"
+    "credential": LeakRule(
+        pattern=re.compile(
+            "|".join(
+                [
+                    "Bear" + "er" + r"\s+[A-Za-z0-9._-]+",
+                    "AK" + "IA" + r"[0-9A-Z]{16}",
+                    r"(?<![A-Za-z0-9_])" + "tok" + "en=",
+                    r"(?<![A-Za-z0-9_])" + "pass" + "word=",
+                    "Author" + "ization:",
+                ]
+            ),
+            re.I,
+        ),
+        required_literals=(
+            "bear" + "er",
+            "ak" + "ia",
+            "tok" + "en=",
+            "pass" + "word=",
+            "author" + "ization:",
+        ),
     ),
-    "internal_task_id": re.compile(r"\bt-" + r"20\d{12}-[a-z0-9]+\b"),
-    "private_ip": re.compile(r"\b10\.\d+\.\d+\.\d+\b|\b172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+\b|\b192\.168\.\d+\.\d+\b"),
+    "local_private_path": LeakRule(
+        pattern=re.compile(
+            "("
+            + "/"
+            + "Users"
+            + "/"
+            + r"[^/\s]+/(?:Documents|code"
+            + "-"
+            + r"reading)|"
+            + "/ext"
+            + "_data/"
+            + ")"
+        ),
+        required_literals=("/" + "users/", "/ext" + "_data/"),
+    ),
+    "internal_task_id": LeakRule(
+        pattern=re.compile(r"\bt-" + r"20\d{12}-[a-z0-9]+\b"),
+        required_literals=("t-20",),
+    ),
+    "private_ip": LeakRule(
+        pattern=re.compile(
+            r"\b10\.\d+\.\d+\.\d+\b"
+            r"|\b172\.(?:1[6-9]|2\d|3[01])\.\d+\.\d+\b"
+            r"|\b192\.168\.\d+\.\d+\b"
+        ),
+        required_literals=("10.", "172.", "192.168."),
+    ),
 }
+LEAK_PATTERNS = {name: rule.pattern for name, rule in LEAK_RULES.items()}
 
 # The Lark developer console is a public product surface, even though its
 # hostname shares the tenant-document marker used by private workspaces.
@@ -138,7 +185,7 @@ def _credential_match_is_reference(line: str, match: re.Match[str]) -> bool:
 
 
 def _credential_hits_are_all_references(line: str) -> bool:
-    matches = list(LEAK_PATTERNS["credential"].finditer(line))
+    matches = list(LEAK_RULES["credential"].pattern.finditer(line))
     if not matches:
         return False
     return all(_credential_match_is_reference(line, match) for match in matches)
@@ -789,12 +836,23 @@ def scan_public_boundary(
         except OSError as exc:
             unreadable_files.append(f"{rel_or_abs(path, root)}: {exc.strerror or exc}")
             continue
+        folded_text = text.casefold()
+        candidate_rules = [
+            (name, rule)
+            for name, rule in LEAK_RULES.items()
+            if rule.is_candidate(folded_text)
+        ]
+        if not candidate_rules:
+            continue
         for line_no, line in enumerate(text.splitlines(), start=1):
-            for name, pattern in LEAK_PATTERNS.items():
+            folded_line = line.casefold()
+            for name, rule in candidate_rules:
+                if not rule.is_candidate(folded_line):
+                    continue
                 scan_line = line
                 if name == "private_doc_url":
                     scan_line = _PUBLIC_LARK_DEVELOPER_CONSOLE_HOST.sub("", scan_line)
-                if pattern.search(scan_line):
+                if rule.pattern.search(scan_line):
                     hit = f"{rel_or_abs(path, root)}:{line_no}: {name}"
                     if name == "credential" and _credential_hits_are_all_references(line):
                         credential_reference_hits.append(hit)

--- a/tests/test_contract_public_boundary_prefilter.py
+++ b/tests/test_contract_public_boundary_prefilter.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx import contract
+
+
+@pytest.mark.parametrize(
+    ("rule_name", "line"),
+    [
+        ("private_doc_url", "https://tenant.lark" + "office.com/wiki/example"),
+        ("private_doc_url", "https://docs" + ".internal/example"),
+        ("credential", "Bear" + "er literal"),
+        ("credential", "AK" + "IA1234567890ABCDEF"),
+        ("credential", "tok" + "en=literal"),
+        ("credential", "pass" + "word=literal"),
+        ("credential", "Author" + "ization: literal"),
+        ("local_private_path", "/" + "Users/alice/Documents/example.md"),
+        ("local_private_path", "/" + "Users/alice/code-reading/example.md"),
+        ("local_private_path", "/ext" + "_data/example.md"),
+        ("internal_task_id", "ticket t-" + "20260828123456-example"),
+        ("private_ip", "host 10" + ".1.2.3"),
+        ("private_ip", "host 172" + ".31.2.3"),
+        ("private_ip", "host 192" + ".168.2.3"),
+    ],
+)
+def test_every_authoritative_leak_pattern_has_a_matching_prefilter(
+    rule_name: str,
+    line: str,
+) -> None:
+    rule = contract.LEAK_RULES[rule_name]
+
+    assert rule.pattern.search(line)
+    assert rule.is_candidate(line.casefold())
+
+
+def test_prefilter_only_runs_regex_for_candidate_lines(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RecordingPattern:
+        def __init__(self) -> None:
+            self.lines: list[str] = []
+
+        def search(self, line: str) -> None:
+            self.lines.append(line)
+
+    pattern = RecordingPattern()
+    monkeypatch.setattr(
+        contract,
+        "LEAK_RULES",
+        {
+            "private_ip": contract.LeakRule(
+                pattern=pattern,  # type: ignore[arg-type]
+                required_literals=("candidate",),
+            )
+        },
+    )
+    (tmp_path / "sample.md").write_text(
+        "ordinary public line\ncandidate without a regex hit\nanother ordinary line\n",
+        encoding="utf-8",
+    )
+
+    payload = contract.scan_public_boundary([tmp_path])
+
+    assert payload["ok"] is True
+    assert pattern.lines == ["candidate without a regex hit"]
+
+
+def test_prefilter_preserves_all_boundary_hit_categories(tmp_path: Path) -> None:
+    lines = [
+        "https://tenant.lark" + "office.com/wiki/example",
+        "tok" + "en=literal",
+        "/" + "Users/alice/Documents/example.md",
+        "ticket t-" + "20260828123456-example",
+        "host 10" + ".1.2.3",
+    ]
+    (tmp_path / "sample.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    payload: dict[str, Any] = contract.scan_public_boundary([tmp_path])
+
+    assert payload["hits"] == [
+        "sample.md:1: private_doc_url",
+        "sample.md:2: credential",
+        "sample.md:3: local_private_path",
+        "sample.md:4: internal_task_id",
+        "sample.md:5: private_ip",
+    ]


### PR DESCRIPTION
## Summary

- couple each public-boundary regex to a cheap necessary-literal prefilter
- skip line splitting for files that cannot match any rule, then skip impossible regexes per line
- keep the existing regexes, Lark developer-console exception, credential-reference downgrade, policy handling, and output ordering authoritative
- add focused coverage for every regex alternative, candidate-line isolation, and all five hit categories

## Performance

Seven matched runs on the package scan root used by `status` and `quota`:

| Path | Baseline p50 | Candidate p50 | Change |
|---|---:|---:|---:|
| Boundary scanner | 2.274 s | 0.468 s | -79.4% |
| `status --limit 5` | 2.854 s | 1.215 s | -57.4% |
| `quota should-run --dry-run` | 3.113 s | 1.442 s | -53.7% |

Nearest-rank observed tails also improved: scanner 2.938 to 0.712 seconds, status 3.123 to 1.442 seconds, and quota 3.440 to 1.669 seconds.

Baseline and candidate produced byte-identical canonical boundary payloads on the same package corpus (`sha256: 4406507c1f2580ad8a52b379a9a98fd3282146c394ca6d6c7dbb1ef6e27e7e93`).

## Validation

- Ruff check: passed
- focused and contract regression suite: 51 passed
- full pytest run: 4,665 passed, 12 skipped; 26 child-launcher tests selected unsupported system Python 3.9
- failed subset with the supported repository Python propagated to child launchers: 26 passed
- repository hygiene smoke: passed
- full repository contract scan: 2,942 files, zero blocking hits, seven credential references downgraded
- LoopX standard premerge canary: direct diff/compile checks and 7 of 8 catalog smokes passed; no manual holds

The canary's only failure is `quota-plan-smoke.py` with `ValueError: runtime_root must be absolute`. The same command fails with the same stack and message on the exact `origin/main` baseline (`0233a2f3`), so this PR leaves that unrelated quota behavior unchanged.

## Scope and safety

This changes no rule, exception, policy, scan-root, file-discovery, or result contract. The regular expressions remain the classification authority; prefilters only prove that a regex cannot match. The future-facing pass was applied by colocating each regex with its necessary literals in `LeakRule`, preventing a second free-floating rule map while retaining the derived legacy pattern mapping for import compatibility.
