### PR TITLE
refactor(control-plane): move Vision refresh authority to TypeScript

### DIFF
--- a/loopx/control_plane/goals/goal_vision.py
+++ b/loopx/control_plane/goals/goal_vision.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...feedback import validate_public_safe_text
-from .goal_vision_state import (
-    GOAL_VISION_DEFAULT_STATE,
-    normalize_goal_vision_state,
+from .vision_checkpoint import (
+    GOAL_VISION_BUDGET_ERROR as GOAL_VISION_BUDGET_ERROR,
+    GoalVisionBudgetError as GoalVisionBudgetError,
+    prepare_vision_refresh,
 )
-from .goal_vision_policy import normalize_goal_vision_advancement_policy
 
 
 GOAL_VISION_REPLAN_SCHEMA_VERSION = "goal_vision_replan_contract_v0"
 GOAL_PATH_DELTA_SCHEMA_VERSION = "goal_path_delta_v0"
-GOAL_VISION_BUDGET_ERROR = "vision_budget_exceeded"
 
 
 GOAL_VISION_FIELD_LIMITS: dict[str, int] = {
@@ -24,13 +22,6 @@ GOAL_VISION_FIELD_LIMITS: dict[str, int] = {
     "dreaming_policy": 240,
     "last_patch_summary": 240,
 }
-GOAL_VISION_TOTAL_LIMIT = 1200
-GOAL_VISION_DURABLE_FIELDS = (
-    "vision_summary",
-    "role_scope",
-    "acceptance_summary",
-    "advancement_policy",
-)
 GOAL_PATH_DELTA_OUTCOMES = frozenset(
     {"continue", "replan", "wait", "no_change", "ask_human", "stop"}
 )
@@ -46,17 +37,6 @@ GOAL_PATH_DELTA_LIST_LIMITS: dict[str, tuple[int, int]] = {
     "unresolved_questions": (2, 140),
     "evidence_refs": (4, 140),
 }
-GOAL_PATH_DELTA_BUDGET_LIMITS = {
-    "path_delta.outcome": 32,
-    **{
-        f"path_delta.{field}": limit
-        for field, limit in GOAL_PATH_DELTA_SCALAR_LIMITS.items()
-    },
-    **{
-        f"path_delta.{field}[]": item_limit
-        for field, (_, item_limit) in GOAL_PATH_DELTA_LIST_LIMITS.items()
-    },
-}
 GOAL_VISION_BUDGET_COMPACT_FIELDS = (
     "schema_version",
     "status",
@@ -64,56 +44,6 @@ GOAL_VISION_BUDGET_COMPACT_FIELDS = (
     "total_limit",
     "total_usage",
 )
-
-
-class GoalVisionBudgetError(ValueError):
-    def __init__(
-        self,
-        *,
-        field: str,
-        used: int,
-        limit: int,
-        suggestion: str | None = None,
-    ) -> None:
-        self.field = field
-        self.used = used
-        self.limit = limit
-        self.suggestion = suggestion
-        message = f"{GOAL_VISION_BUDGET_ERROR}: {field} uses {used} chars; limit is {limit}"
-        if suggestion:
-            message += f"; suggested compact value: {suggestion!r}"
-        else:
-            message += "; shorten one or more vision fields before retrying"
-        super().__init__(message)
-
-
-def _suggest_compact_text(text: str, *, limit: int) -> str:
-    if len(text) <= limit:
-        return text
-    if limit <= 3:
-        return text[:limit]
-    return text[: limit - 3].rstrip() + "..."
-
-
-def _bounded_public_text(*, field: str, value: Any, limit: int) -> str:
-    text = " ".join(str(value or "").strip().split())
-    validate_public_safe_text(f"agent_vision.{field}", text)
-    if len(text) > limit:
-        raise GoalVisionBudgetError(
-            field=field,
-            used=len(text),
-            limit=limit,
-            suggestion=_suggest_compact_text(text, limit=limit),
-        )
-    return text
-
-
-def _packet_text(packet: dict[str, Any], field: str, *, limit: int) -> str | None:
-    value = packet.get(field)
-    if value is None:
-        return None
-    text = _bounded_public_text(field=field, value=value, limit=limit)
-    return text or None
 
 
 def _compact_public_text(value: Any, *, limit: int) -> str | None:
@@ -150,72 +80,6 @@ def _compact_goal_path_delta(value: Any) -> dict[str, Any] | None:
         if items:
             compact[field] = items
     return compact if len(compact) > 1 else None
-
-
-def _normalize_goal_path_delta(value: Any) -> tuple[dict[str, Any] | None, dict[str, int]]:
-    if value is None:
-        return None, {}
-    if not isinstance(value, dict):
-        raise ValueError("agent_vision.path_delta must be a JSON object")
-
-    outcome = str(value.get("outcome") or "").strip().lower().replace("-", "_")
-    if outcome not in GOAL_PATH_DELTA_OUTCOMES:
-        raise ValueError(
-            "agent_vision.path_delta.outcome must be one of: "
-            + ", ".join(sorted(GOAL_PATH_DELTA_OUTCOMES))
-        )
-
-    normalized: dict[str, Any] = {
-        "schema_version": GOAL_PATH_DELTA_SCHEMA_VERSION,
-        "outcome": outcome,
-    }
-    field_usage = {"path_delta.outcome": len(outcome)}
-    for field, limit in GOAL_PATH_DELTA_SCALAR_LIMITS.items():
-        raw_value = value.get(field)
-        if raw_value is None:
-            continue
-        text = _bounded_public_text(
-            field=f"path_delta.{field}", value=raw_value, limit=limit
-        )
-        if not text:
-            continue
-        normalized[field] = text
-        field_usage[f"path_delta.{field}"] = len(text)
-
-    for field, (max_items, item_limit) in GOAL_PATH_DELTA_LIST_LIMITS.items():
-        raw_items = value.get(field)
-        if raw_items is None:
-            continue
-        if not isinstance(raw_items, list):
-            raise ValueError(f"agent_vision.path_delta.{field} must be a JSON array")
-        if len(raw_items) > max_items:
-            raise ValueError(
-                f"agent_vision.path_delta.{field} has {len(raw_items)} items; "
-                f"limit is {max_items}"
-            )
-        items: list[str] = []
-        for index, item in enumerate(raw_items):
-            text = _bounded_public_text(
-                field=f"path_delta.{field}[{index}]",
-                value=item,
-                limit=item_limit,
-            )
-            if text:
-                items.append(text)
-                field_usage[f"path_delta.{field}[{index}]"] = len(text)
-        if items:
-            normalized[field] = items
-
-    if "prior_assumption" not in normalized or "observed_reality" not in normalized:
-        raise ValueError(
-            "agent_vision.path_delta requires prior_assumption and observed_reality"
-        )
-    if not any(normalized.get(field) for field in ("retained", "changed", "stopped")):
-        raise ValueError(
-            "agent_vision.path_delta requires at least one retained, changed, or "
-            "stopped item"
-        )
-    return normalized, field_usage
 
 
 def compact_goal_vision_packet(value: Any) -> dict[str, Any] | None:
@@ -279,102 +143,14 @@ def normalize_goal_vision_packet(
     goal_id: str,
     agent_id: str | None,
 ) -> dict[str, Any]:
-    if not isinstance(packet, dict):
-        raise ValueError("agent_vision must be a JSON object")
-
-    source = packet.get("vision_patch") if isinstance(packet.get("vision_patch"), dict) else packet
-    packet_goal_id = str(packet.get("goal_id") or "").strip()
-    if packet_goal_id and packet_goal_id != goal_id:
-        raise ValueError(f"agent_vision goal_id {packet_goal_id!r} does not match {goal_id!r}")
-
-    packet_agent_id = str(packet.get("agent_id") or "").strip()
-    if agent_id and packet_agent_id and packet_agent_id != agent_id:
-        raise ValueError(
-            f"agent_vision agent_id {packet_agent_id!r} does not match {agent_id!r}"
-        )
-    resolved_agent_id = agent_id or packet_agent_id
-    if not resolved_agent_id:
-        raise ValueError("agent_vision requires agent_id from packet or --agent-id")
-    validate_public_safe_text("agent_vision.agent_id", resolved_agent_id)
-
-    state = normalize_goal_vision_state(
-        _bounded_public_text(
-            field="state",
-            value=packet.get("state") or GOAL_VISION_DEFAULT_STATE,
-            limit=80,
-        )
+    return prepare_vision_refresh(
+        packet,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        existing_agent_vision=None,
+        merge_patch=False,
+        require_path_delta_for_durable_change=False,
     )
-    vision_patch: dict[str, str] = {}
-    field_usage: dict[str, int] = {}
-    for field, limit in GOAL_VISION_FIELD_LIMITS.items():
-        text = _packet_text(source, field, limit=limit)
-        if text is None:
-            continue
-        if field == "advancement_policy":
-            text = normalize_goal_vision_advancement_policy(text)
-        vision_patch[field] = text
-        field_usage[field] = len(text)
-
-    if not vision_patch:
-        raise ValueError("agent_vision must include at least one bounded vision field")
-
-    path_delta, path_delta_usage = _normalize_goal_path_delta(packet.get("path_delta"))
-    field_usage.update(path_delta_usage)
-
-    total_usage = sum(field_usage.values())
-    if total_usage > GOAL_VISION_TOTAL_LIMIT:
-        raise GoalVisionBudgetError(
-            field="total_agent_vision",
-            used=total_usage,
-            limit=GOAL_VISION_TOTAL_LIMIT,
-        )
-
-    todo_delta: list[str] = []
-    raw_todo_delta = packet.get("todo_delta")
-    if isinstance(raw_todo_delta, list):
-        for item in raw_todo_delta[:8]:
-            text = _bounded_public_text(field="todo_delta", value=item, limit=80)
-            if text:
-                todo_delta.append(text)
-
-    validation = (
-        dict(packet.get("validation"))
-        if isinstance(packet.get("validation"), dict)
-        else {}
-    )
-    validation.update(
-        {
-            "budget_checked": True,
-            "budget_status": "ok",
-            "write_correctness_checked": bool(
-                validation.get("write_correctness_checked")
-            ),
-        }
-    )
-
-    normalized = {
-        "schema_version": GOAL_VISION_REPLAN_SCHEMA_VERSION,
-        "goal_id": goal_id,
-        "agent_id": resolved_agent_id,
-        "state": state,
-        "vision_patch": vision_patch,
-        "todo_delta": todo_delta,
-        "vision_budget": {
-            "schema_version": "goal_vision_budget_v0",
-            "status": "ok",
-            "field_limits": {
-                **GOAL_VISION_FIELD_LIMITS,
-                **GOAL_PATH_DELTA_BUDGET_LIMITS,
-            },
-            "field_usage": field_usage,
-            "total_limit": GOAL_VISION_TOTAL_LIMIT,
-            "total_usage": total_usage,
-        },
-        "validation": validation,
-    }
-    if path_delta:
-        normalized["path_delta"] = path_delta
-    return normalized
 
 
 def normalize_goal_vision_update(
@@ -386,58 +162,13 @@ def normalize_goal_vision_update(
     merge_patch: bool,
     require_path_delta_for_durable_change: bool,
 ) -> dict[str, Any]:
-    """Normalize one full replacement or field-level vision patch."""
+    """Compatibility entry point for the TS-owned Vision preflight."""
 
-    update_packet = dict(packet)
-    existing = (
-        existing_agent_vision if isinstance(existing_agent_vision, dict) else {}
-    )
-    if merge_patch and existing:
-        existing_patch = (
-            existing.get("vision_patch")
-            if isinstance(existing.get("vision_patch"), dict)
-            else {}
-        )
-        incoming_patch = (
-            packet.get("vision_patch")
-            if isinstance(packet.get("vision_patch"), dict)
-            else packet
-        )
-        update_packet["vision_patch"] = {
-            **existing_patch,
-            **incoming_patch,
-        }
-        if not str(packet.get("state") or "").strip():
-            update_packet["state"] = existing.get("state")
-
-    normalized = normalize_goal_vision_packet(
-        update_packet,
+    return prepare_vision_refresh(
+        packet,
         goal_id=goal_id,
         agent_id=agent_id,
+        existing_agent_vision=existing_agent_vision,
+        merge_patch=merge_patch,
+        require_path_delta_for_durable_change=require_path_delta_for_durable_change,
     )
-    if not require_path_delta_for_durable_change or not existing:
-        return normalized
-
-    existing_patch = (
-        existing.get("vision_patch")
-        if isinstance(existing.get("vision_patch"), dict)
-        else {}
-    )
-    normalized_patch = normalized["vision_patch"]
-    changed_fields = [
-        field
-        for field in GOAL_VISION_DURABLE_FIELDS
-        if existing_patch.get(field) != normalized_patch.get(field)
-    ]
-    path_delta = (
-        normalized.get("path_delta")
-        if isinstance(normalized.get("path_delta"), dict)
-        else {}
-    )
-    if changed_fields and path_delta.get("outcome") != "replan":
-        raise ValueError(
-            "autonomous agent vision replan changes durable fields "
-            f"{', '.join(changed_fields)}; provide goal_path_delta_v0 with "
-            "outcome=replan so the mainline change is explicit"
-        )
-    return normalized

--- a/loopx/control_plane/goals/vision_checkpoint.py
+++ b/loopx/control_plane/goals/vision_checkpoint.py
@@ -17,9 +17,7 @@ _VISION_BUDGET_MESSAGE = re.compile(
     r"^vision_budget_exceeded: (?P<field>.+) uses (?P<used>\d+) chars; "
     r"limit is (?P<limit>\d+)"
 )
-_VISION_BUDGET_SUGGESTION = re.compile(
-    r"; suggested compact value: (?P<suggestion>\"(?:\\.|[^\"])*\")$"
-)
+_VISION_BUDGET_SUGGESTION_MARKER = "; suggested compact value: "
 
 
 class GoalVisionBudgetError(ValueError):
@@ -47,20 +45,24 @@ class GoalVisionBudgetError(ValueError):
 
 def _raise_rejection(exc: EffectRuntimeRejected) -> NoReturn:
     if exc.diagnostic_code == GOAL_VISION_BUDGET_ERROR:
-        matched = _VISION_BUDGET_MESSAGE.match(str(exc))
+        message = str(exc)
+        matched = _VISION_BUDGET_MESSAGE.match(message)
         if matched:
-            suggestion_match = _VISION_BUDGET_SUGGESTION.search(str(exc))
-            suggestion = (
-                json.loads(suggestion_match.group("suggestion"))
-                if suggestion_match
-                else None
-            )
+            suggestion = None
+            suggestion_prefix = matched.group(0) + _VISION_BUDGET_SUGGESTION_MARKER
+            if message.startswith(suggestion_prefix):
+                try:
+                    candidate = json.loads(message[len(suggestion_prefix) :])
+                except json.JSONDecodeError:
+                    candidate = None
+                if isinstance(candidate, str):
+                    suggestion = candidate
             raise GoalVisionBudgetError(
                 field=matched.group("field"),
                 used=int(matched.group("used")),
                 limit=int(matched.group("limit")),
                 suggestion=suggestion,
-                message=str(exc),
+                message=message,
             ) from None
     raise ValueError(str(exc)) from None
 

--- a/loopx/control_plane/goals/vision_checkpoint.py
+++ b/loopx/control_plane/goals/vision_checkpoint.py
@@ -2,30 +2,115 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+import re
+from typing import Any, NoReturn
 
-from ...feedback import validate_public_safe_text
 from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
-from ..turn_driver.delivery_continuity import normalize_delivery_boundary
 
 VISION_CHECKPOINT_SCHEMA_VERSION = "vision_checkpoint_v0"
-VISION_CHECKPOINT_REQUEST_SCHEMA = "loopx_vision_checkpoint_request_v0"
-VISION_UNCHANGED_REASON_LIMIT = 240
+VISION_REFRESH_REQUEST_SCHEMA = "loopx_vision_refresh_request_v0"
+VISION_REFRESH_PREPARED_SCHEMA_VERSION = "vision_refresh_prepared_v0"
+VISION_CHECKPOINT_REQUEST_SCHEMA = VISION_REFRESH_REQUEST_SCHEMA
+GOAL_VISION_BUDGET_ERROR = "vision_budget_exceeded"
+_VISION_BUDGET_MESSAGE = re.compile(
+    r"^vision_budget_exceeded: (?P<field>.+) uses (?P<used>\d+) chars; "
+    r"limit is (?P<limit>\d+)"
+)
+_VISION_BUDGET_SUGGESTION = re.compile(
+    r"; suggested compact value: (?P<suggestion>\"(?:\\.|[^\"])*\")$"
+)
 
 
-def normalize_vision_unchanged_reason(value: str | None) -> str:
-    """Normalize and validate a vision closeout reason before state mutation."""
+class GoalVisionBudgetError(ValueError):
+    """A typed compatibility error for TypeScript-owned Vision budgets."""
 
-    unchanged = " ".join(str(value or "").strip().split())
-    if not unchanged:
-        return ""
-    validate_public_safe_text("vision_unchanged_reason", unchanged)
-    if len(unchanged) > VISION_UNCHANGED_REASON_LIMIT:
-        raise ValueError(
-            "vision_unchanged_reason exceeds "
-            f"{VISION_UNCHANGED_REASON_LIMIT} chars"
+    def __init__(
+        self,
+        *,
+        field: str,
+        used: int,
+        limit: int,
+        suggestion: str | None = None,
+        message: str | None = None,
+    ) -> None:
+        self.field = field
+        self.used = used
+        self.limit = limit
+        self.suggestion = suggestion
+        super().__init__(
+            message
+            or f"{GOAL_VISION_BUDGET_ERROR}: {field} uses {used} chars; "
+            f"limit is {limit}; shorten one or more vision fields before retrying"
         )
-    return unchanged
+
+
+def _raise_rejection(exc: EffectRuntimeRejected) -> NoReturn:
+    if exc.diagnostic_code == GOAL_VISION_BUDGET_ERROR:
+        matched = _VISION_BUDGET_MESSAGE.match(str(exc))
+        if matched:
+            suggestion_match = _VISION_BUDGET_SUGGESTION.search(str(exc))
+            suggestion = (
+                json.loads(suggestion_match.group("suggestion"))
+                if suggestion_match
+                else None
+            )
+            raise GoalVisionBudgetError(
+                field=matched.group("field"),
+                used=int(matched.group("used")),
+                limit=int(matched.group("limit")),
+                suggestion=suggestion,
+                message=str(exc),
+            ) from None
+    raise ValueError(str(exc)) from None
+
+
+def prepare_vision_refresh(
+    packet: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    existing_agent_vision: dict[str, Any] | None,
+    merge_patch: bool,
+    require_path_delta_for_durable_change: bool,
+) -> dict[str, Any]:
+    """Run the TS-owned Vision preflight before semantic-replan qualification."""
+
+    try:
+        result = effect_runtime_result(
+            "goal.vision_checkpoint.evaluate",
+            {
+                "schema_version": VISION_REFRESH_REQUEST_SCHEMA,
+                "phase": "prepare",
+                "goal_id": goal_id,
+                "agent_id": agent_id,
+                "agent_vision_packet": packet,
+                "existing_agent_vision": existing_agent_vision,
+                "merge_patch": bool(merge_patch),
+                "require_path_delta_for_durable_change": bool(
+                    require_path_delta_for_durable_change
+                ),
+            },
+        )
+    except EffectRuntimeRejected as exc:
+        _raise_rejection(exc)
+    if not isinstance(result, dict):
+        raise RuntimeError("TypeScript Vision prepared result must be an object")
+    agent_vision = result.get("agent_vision")
+    if (
+        result.get("schema_version") != VISION_REFRESH_PREPARED_SCHEMA_VERSION
+        or not isinstance(agent_vision, dict)
+        or agent_vision.get("schema_version") != "goal_vision_replan_contract_v0"
+        or not isinstance(agent_vision.get("goal_id"), str)
+        or not isinstance(agent_vision.get("agent_id"), str)
+        or not isinstance(agent_vision.get("state"), str)
+        or not isinstance(agent_vision.get("vision_patch"), dict)
+        or not isinstance(agent_vision.get("todo_delta"), list)
+        or not isinstance(agent_vision.get("vision_budget"), dict)
+        or not isinstance(agent_vision.get("validation"), dict)
+    ):
+        raise RuntimeError("TypeScript Vision prepared result shape mismatch")
+    return agent_vision
 
 
 def build_vision_checkpoint(
@@ -41,31 +126,31 @@ def build_vision_checkpoint(
     completion_todo_id: str | None = None,
     autonomous_replan_recorded: bool = False,
 ) -> dict[str, Any]:
-    """Return the TS-owned vision closeout decision for this refresh run."""
+    """Finalize the TS-owned Vision transaction after replan qualification."""
 
-    unchanged = normalize_vision_unchanged_reason(vision_unchanged_reason)
     try:
         result = effect_runtime_result(
             "goal.vision_checkpoint.evaluate",
             {
-                "schema_version": VISION_CHECKPOINT_REQUEST_SCHEMA,
+                "schema_version": VISION_REFRESH_REQUEST_SCHEMA,
+                "phase": "finalize",
                 "agent_id": agent_id,
                 "agent_vision": agent_vision,
                 "existing_agent_vision": existing_agent_vision,
-                "vision_unchanged_reason": unchanged or None,
+                "vision_unchanged_reason": vision_unchanged_reason,
                 "delivery_outcome": delivery_outcome,
                 "active_state_next_action_would_update": bool(
                     active_state_next_action_update
                     and active_state_next_action_update.get("would_update")
                 ),
-                "delivery_boundary": normalize_delivery_boundary(delivery_boundary),
+                "delivery_boundary": delivery_boundary,
                 "todo_id": todo_id,
                 "completion_todo_id": completion_todo_id,
                 "autonomous_replan_recorded": bool(autonomous_replan_recorded),
             },
         )
     except EffectRuntimeRejected as exc:
-        raise ValueError(str(exc)) from None
+        _raise_rejection(exc)
     if not isinstance(result, dict):
         raise RuntimeError("TypeScript vision checkpoint result must be an object")
     if (

--- a/loopx/control_plane/goals/vision_checkpoint.ts
+++ b/loopx/control_plane/goals/vision_checkpoint.ts
@@ -10,12 +10,89 @@ import {
   type DeliveryOutcome,
 } from "../work_items/delivery_outcome.ts";
 
-export const VISION_CHECKPOINT_REQUEST_SCHEMA =
-  "loopx_vision_checkpoint_request_v0";
+export const VISION_REFRESH_REQUEST_SCHEMA = "loopx_vision_refresh_request_v0";
+export const VISION_REFRESH_PREPARED_SCHEMA_VERSION =
+  "vision_refresh_prepared_v0";
+export const VISION_CHECKPOINT_REQUEST_SCHEMA = VISION_REFRESH_REQUEST_SCHEMA;
 export const VISION_CHECKPOINT_SCHEMA_VERSION = "vision_checkpoint_v0";
 
-interface VisionCheckpointRequest {
-  schema_version: typeof VISION_CHECKPOINT_REQUEST_SCHEMA;
+const GOAL_VISION_REPLAN_SCHEMA_VERSION = "goal_vision_replan_contract_v0";
+const GOAL_PATH_DELTA_SCHEMA_VERSION = "goal_path_delta_v0";
+const GOAL_VISION_BUDGET_ERROR = "vision_budget_exceeded";
+const GOAL_VISION_TOTAL_LIMIT = 1_200;
+const VISION_UNCHANGED_REASON_LIMIT = 240;
+const VISION_BUDGET_SUGGESTION_LIMIT = 96;
+
+const GOAL_VISION_FIELD_LIMITS = {
+  vision_summary: 420,
+  role_scope: 280,
+  acceptance_summary: 420,
+  advancement_policy: 32,
+  replan_trigger_summary: 240,
+  dreaming_policy: 240,
+  last_patch_summary: 240,
+} as const;
+const GOAL_VISION_DURABLE_FIELDS = [
+  "vision_summary",
+  "role_scope",
+  "acceptance_summary",
+  "advancement_policy",
+] as const;
+const GOAL_PATH_DELTA_OUTCOMES = [
+  "ask_human",
+  "continue",
+  "no_change",
+  "replan",
+  "stop",
+  "wait",
+] as const;
+const GOAL_PATH_DELTA_SCALAR_LIMITS = {
+  prior_assumption: 220,
+  observed_reality: 220,
+  reentry_condition: 180,
+} as const;
+const GOAL_PATH_DELTA_LIST_LIMITS = {
+  retained: [3, 120],
+  changed: [3, 120],
+  stopped: [3, 120],
+  unresolved_questions: [2, 140],
+  evidence_refs: [4, 140],
+} as const;
+const GOAL_VISION_STATE_ALIASES: Readonly<Record<string, string>> = {
+  closed: "vision_closed",
+  satisfied: "vision_closed",
+  vision_satisfied: "vision_closed",
+  vision_retired: "retired",
+  vision_superseded: "superseded",
+  vision_no_followup: "no_followup",
+  closed_no_followup: "no_followup",
+  no_follow_up: "no_followup",
+};
+const PRIVATE_TEXT_PATTERNS = [
+  /\/Users\//,
+  /\/ext_data\//,
+  /larkoffice/i,
+  /docs\.internal/i,
+  /\bt-20\d{12}-[a-z0-9]+\b/,
+  /\bBearer\b/i,
+  /\bAuthorization\b/i,
+  /\btoken\s*=/i,
+  /\bpassword\b/i,
+  /\bsecret\b/i,
+] as const;
+
+interface VisionRefreshPrepareRequest {
+  phase: "prepare";
+  goal_id: string;
+  agent_id: string | null;
+  agent_vision_packet: JsonObject;
+  existing_agent_vision: JsonObject | null;
+  merge_patch: boolean;
+  require_path_delta_for_durable_change: boolean;
+}
+
+interface VisionRefreshFinalizeRequest {
+  phase: "finalize";
   agent_id: string | null;
   agent_vision: JsonObject | null;
   existing_agent_vision: JsonObject | null;
@@ -66,6 +143,382 @@ function requiredBoolean(value: unknown, label: string): boolean {
   return value;
 }
 
+function requiredString(value: unknown, label: string): string {
+  const decoded = optionalString(value, label);
+  if (decoded === null) {
+    throw new EffectRuntimeRequestError(`${label} must be a non-empty string`);
+  }
+  return decoded;
+}
+
+// v0 accepted JSON values through Python's str(value or ""). Preserve that
+// compatibility while the existing protocol remains versioned as v0.
+function pythonStringLiteral(value: string): string {
+  const doubleQuoted = JSON.stringify(value);
+  if (value.includes("'") && !value.includes('"')) return doubleQuoted;
+  const content = doubleQuoted
+    .slice(1, -1)
+    .replaceAll('\\"', '"')
+    .replaceAll("'", "\\'")
+    .replaceAll("\\b", "\\x08")
+    .replaceAll("\\f", "\\x0c");
+  return `'${content}'`;
+}
+
+function pythonJsonRepr(value: unknown): string {
+  if (value === null || value === undefined) return "None";
+  if (typeof value === "string") return pythonStringLiteral(value);
+  if (typeof value === "boolean") return value ? "True" : "False";
+  if (typeof value === "number") return String(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(pythonJsonRepr).join(", ")}]`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).map(
+      ([key, item]) => `${pythonStringLiteral(key)}: ${pythonJsonRepr(item)}`,
+    );
+    return `{${entries.join(", ")}}`;
+  }
+  return String(value);
+}
+
+function pythonTruthyJsonValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === false || value === "") {
+    return false;
+  }
+  if (typeof value === "number") return value !== 0 && !Number.isNaN(value);
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+}
+
+function compactText(value: unknown): string {
+  const compatible = pythonTruthyJsonValue(value) ? pythonJsonRepr(value) : "";
+  const text = typeof value === "string" ? value : compatible;
+  return text.trim().split(/\s+/).filter(Boolean).join(" ");
+}
+
+function publicSafeTextGuidance(label: string): string {
+  const normalized = label.toLowerCase().replaceAll("-", "_");
+  if (normalized.includes("next_action") || normalized.includes("recommended_action")) {
+    return "this field is usually local-control state; use validate_local_control_text for private project routing, or a public-safe alias only on exported surfaces";
+  }
+  if (normalized.includes("todo")) {
+    return "use a compact public-safe todo alias or summary here; keep raw local paths, private URLs, task bodies, and logs in evidence/private payloads";
+  }
+  if (normalized.includes("evidence")) {
+    return "use a compact public-safe evidence pointer here; keep raw logs, local paths, and private URLs in private payloads";
+  }
+  return "use a public-safe summary or alias here; keep raw local paths, private URLs, and raw evidence in private payloads";
+}
+
+function validatePublicSafeText(label: string, value: string): void {
+  for (const pattern of PRIVATE_TEXT_PATTERNS) {
+    if (pattern.test(value)) {
+      throw new EffectRuntimeRequestError(
+        `${label} contains a private-looking value; ${publicSafeTextGuidance(label)}`,
+      );
+    }
+  }
+}
+
+function suggestedCompactText(text: string, limit: number): string {
+  if (text.length <= limit) return text;
+  if (limit <= 3) return text.slice(0, limit);
+  return `${text.slice(0, limit - 3).trimEnd()}...`;
+}
+
+function visionBudgetError(
+  field: string,
+  used: number,
+  limit: number,
+  suggestion: string | null = null,
+): EffectRuntimeRequestError {
+  let message = `${GOAL_VISION_BUDGET_ERROR}: ${field} uses ${used} chars; limit is ${limit}`;
+  message += suggestion === null
+    ? "; shorten one or more vision fields before retrying"
+    : `; suggested compact value: ${JSON.stringify(suggestion)}`;
+  return new EffectRuntimeRequestError(message, GOAL_VISION_BUDGET_ERROR);
+}
+
+function boundedPublicText(field: string, value: unknown, limit: number): string {
+  const text = compactText(value);
+  validatePublicSafeText(`agent_vision.${field}`, text);
+  if (text.length > limit) {
+    throw visionBudgetError(
+      field,
+      text.length,
+      limit,
+      suggestedCompactText(
+        text,
+        Math.min(limit, VISION_BUDGET_SUGGESTION_LIMIT),
+      ),
+    );
+  }
+  return text;
+}
+
+function packetText(
+  packet: JsonObject,
+  field: string,
+  limit: number,
+): string | null {
+  const value = packet[field];
+  if (value === null || value === undefined) return null;
+  return boundedPublicText(field, value, limit) || null;
+}
+
+function normalizeGoalVisionState(value: unknown): string {
+  const state = compactText(value || "vision_patch_proposed")
+    .toLowerCase()
+    .replaceAll("-", "_");
+  if (!/^[a-z][a-z0-9_]{0,79}$/.test(state)) {
+    throw new EffectRuntimeRequestError(
+      "agent_vision.state must be a lower snake_case lifecycle token such as vision_patch_proposed or vision_closed",
+    );
+  }
+  return GOAL_VISION_STATE_ALIASES[state] ?? state;
+}
+
+function normalizeAdvancementPolicy(value: unknown): string {
+  const candidate = compactText(value).toLowerCase().replaceAll("-", "_");
+  if (candidate !== "as_needed" && candidate !== "repeat_until_closed") {
+    throw new EffectRuntimeRequestError(
+      "agent_vision.advancement_policy must be one of: as_needed, repeat_until_closed",
+    );
+  }
+  return candidate;
+}
+
+function normalizeGoalPathDelta(
+  value: unknown,
+): [JsonObject | null, Record<string, number>] {
+  if (value === null || value === undefined) return [null, {}];
+  const source = requiredObject(value, "agent_vision.path_delta");
+  const outcome = compactText(source.outcome).toLowerCase().replaceAll("-", "_");
+  if (!(GOAL_PATH_DELTA_OUTCOMES as readonly string[]).includes(outcome)) {
+    throw new EffectRuntimeRequestError(
+      `agent_vision.path_delta.outcome must be one of: ${GOAL_PATH_DELTA_OUTCOMES.join(", ")}`,
+    );
+  }
+
+  const normalized: JsonObject = {
+    schema_version: GOAL_PATH_DELTA_SCHEMA_VERSION,
+    outcome,
+  };
+  const fieldUsage: Record<string, number> = {
+    "path_delta.outcome": outcome.length,
+  };
+  for (const [field, limit] of Object.entries(GOAL_PATH_DELTA_SCALAR_LIMITS)) {
+    const rawValue = source[field];
+    if (rawValue === null || rawValue === undefined) continue;
+    const text = boundedPublicText(`path_delta.${field}`, rawValue, limit);
+    if (!text) continue;
+    normalized[field] = text;
+    fieldUsage[`path_delta.${field}`] = text.length;
+  }
+
+  for (const [field, limits] of Object.entries(GOAL_PATH_DELTA_LIST_LIMITS)) {
+    const rawItems = source[field];
+    if (rawItems === null || rawItems === undefined) continue;
+    if (!Array.isArray(rawItems)) {
+      throw new EffectRuntimeRequestError(
+        `agent_vision.path_delta.${field} must be a JSON array`,
+      );
+    }
+    const [maxItems, itemLimit] = limits;
+    if (rawItems.length > maxItems) {
+      throw new EffectRuntimeRequestError(
+        `agent_vision.path_delta.${field} has ${rawItems.length} items; limit is ${maxItems}`,
+      );
+    }
+    const items: string[] = [];
+    rawItems.forEach((item, index) => {
+      const text = boundedPublicText(
+        `path_delta.${field}[${index}]`,
+        item,
+        itemLimit,
+      );
+      if (!text) return;
+      items.push(text);
+      fieldUsage[`path_delta.${field}[${index}]`] = text.length;
+    });
+    if (items.length > 0) normalized[field] = items;
+  }
+
+  if (!("prior_assumption" in normalized) || !("observed_reality" in normalized)) {
+    throw new EffectRuntimeRequestError(
+      "agent_vision.path_delta requires prior_assumption and observed_reality",
+    );
+  }
+  if (!["retained", "changed", "stopped"].some((field) => normalized[field])) {
+    throw new EffectRuntimeRequestError(
+      "agent_vision.path_delta requires at least one retained, changed, or stopped item",
+    );
+  }
+  return [normalized, fieldUsage];
+}
+
+function decodePrepareRequest(request: JsonObject): VisionRefreshPrepareRequest {
+  return {
+    phase: "prepare",
+    goal_id: requiredString(request.goal_id, "goal_id"),
+    agent_id: optionalString(request.agent_id, "agent_id"),
+    agent_vision_packet: requiredObject(
+      request.agent_vision_packet,
+      "agent_vision_packet",
+    ),
+    existing_agent_vision: optionalObject(
+      request.existing_agent_vision,
+      "existing_agent_vision",
+    ),
+    merge_patch: requiredBoolean(request.merge_patch, "merge_patch"),
+    require_path_delta_for_durable_change: requiredBoolean(
+      request.require_path_delta_for_durable_change,
+      "require_path_delta_for_durable_change",
+    ),
+  };
+}
+
+function prepareVisionRefresh(request: VisionRefreshPrepareRequest): JsonObject {
+  const packet = request.agent_vision_packet;
+  const existing = request.existing_agent_vision ?? {};
+  const updatePacket: JsonObject = { ...packet };
+  if (request.merge_patch && Object.keys(existing).length > 0) {
+    const existingPatch = typeof existing.vision_patch === "object" &&
+        existing.vision_patch !== null && !Array.isArray(existing.vision_patch)
+      ? existing.vision_patch as JsonObject
+      : {};
+    const incomingPatch = typeof packet.vision_patch === "object" &&
+        packet.vision_patch !== null && !Array.isArray(packet.vision_patch)
+      ? packet.vision_patch as JsonObject
+      : packet;
+    updatePacket.vision_patch = { ...existingPatch, ...incomingPatch };
+    if (!compactText(packet.state)) updatePacket.state = existing.state;
+  }
+
+  const source = typeof updatePacket.vision_patch === "object" &&
+      updatePacket.vision_patch !== null && !Array.isArray(updatePacket.vision_patch)
+    ? updatePacket.vision_patch as JsonObject
+    : updatePacket;
+  const packetGoalId = compactText(updatePacket.goal_id);
+  if (packetGoalId && packetGoalId !== request.goal_id) {
+    throw new EffectRuntimeRequestError(
+      `agent_vision goal_id ${JSON.stringify(packetGoalId)} does not match ${JSON.stringify(request.goal_id)}`,
+    );
+  }
+  const packetAgentId = compactText(updatePacket.agent_id);
+  if (request.agent_id !== null && packetAgentId && packetAgentId !== request.agent_id) {
+    throw new EffectRuntimeRequestError(
+      `agent_vision agent_id ${JSON.stringify(packetAgentId)} does not match ${JSON.stringify(request.agent_id)}`,
+    );
+  }
+  const resolvedAgentId = request.agent_id ?? (packetAgentId || null);
+  if (resolvedAgentId === null) {
+    throw new EffectRuntimeRequestError(
+      "agent_vision requires agent_id from packet or --agent-id",
+    );
+  }
+  validatePublicSafeText("agent_vision.agent_id", resolvedAgentId);
+
+  const visionPatch: JsonObject = {};
+  const fieldUsage: Record<string, number> = {};
+  for (const [field, limit] of Object.entries(GOAL_VISION_FIELD_LIMITS)) {
+    let text = packetText(source, field, limit);
+    if (text === null) continue;
+    if (field === "advancement_policy") text = normalizeAdvancementPolicy(text);
+    visionPatch[field] = text;
+    fieldUsage[field] = text.length;
+  }
+  if (Object.keys(visionPatch).length === 0) {
+    throw new EffectRuntimeRequestError(
+      "agent_vision must include at least one bounded vision field",
+    );
+  }
+
+  const [pathDelta, pathDeltaUsage] = normalizeGoalPathDelta(updatePacket.path_delta);
+  Object.assign(fieldUsage, pathDeltaUsage);
+  const totalUsage = Object.values(fieldUsage).reduce((total, used) => total + used, 0);
+  if (totalUsage > GOAL_VISION_TOTAL_LIMIT) {
+    throw visionBudgetError(
+      "total_agent_vision",
+      totalUsage,
+      GOAL_VISION_TOTAL_LIMIT,
+    );
+  }
+
+  const todoDelta: string[] = [];
+  if (Array.isArray(updatePacket.todo_delta)) {
+    for (const item of updatePacket.todo_delta.slice(0, 8)) {
+      const text = boundedPublicText("todo_delta", item, 80);
+      if (text) todoDelta.push(text);
+    }
+  }
+  const rawValidation = typeof updatePacket.validation === "object" &&
+      updatePacket.validation !== null && !Array.isArray(updatePacket.validation)
+    ? updatePacket.validation as JsonObject
+    : {};
+  const validation: JsonObject = {
+    ...rawValidation,
+    budget_checked: true,
+    budget_status: "ok",
+    write_correctness_checked: Boolean(rawValidation.write_correctness_checked),
+  };
+
+  const fieldLimits: JsonObject = {
+    ...GOAL_VISION_FIELD_LIMITS,
+    "path_delta.outcome": 32,
+  };
+  for (const [field, limit] of Object.entries(GOAL_PATH_DELTA_SCALAR_LIMITS)) {
+    fieldLimits[`path_delta.${field}`] = limit;
+  }
+  for (const [field, [, itemLimit]] of Object.entries(GOAL_PATH_DELTA_LIST_LIMITS)) {
+    fieldLimits[`path_delta.${field}[]`] = itemLimit;
+  }
+
+  const agentVision: JsonObject = {
+    schema_version: GOAL_VISION_REPLAN_SCHEMA_VERSION,
+    goal_id: request.goal_id,
+    agent_id: resolvedAgentId,
+    state: normalizeGoalVisionState(updatePacket.state),
+    vision_patch: visionPatch,
+    todo_delta: todoDelta,
+    vision_budget: {
+      schema_version: "goal_vision_budget_v0",
+      status: "ok",
+      field_limits: fieldLimits,
+      field_usage: fieldUsage,
+      total_limit: GOAL_VISION_TOTAL_LIMIT,
+      total_usage: totalUsage,
+    },
+    validation,
+  };
+  if (pathDelta !== null) agentVision.path_delta = pathDelta;
+
+  if (
+    request.require_path_delta_for_durable_change &&
+    Object.keys(existing).length > 0
+  ) {
+    const existingPatch = typeof existing.vision_patch === "object" &&
+        existing.vision_patch !== null && !Array.isArray(existing.vision_patch)
+      ? existing.vision_patch as JsonObject
+      : {};
+    const changedFields = GOAL_VISION_DURABLE_FIELDS.filter(
+      (field) => existingPatch[field] !== visionPatch[field],
+    );
+    if (changedFields.length > 0 && pathDelta?.outcome !== "replan") {
+      throw new EffectRuntimeRequestError(
+        `autonomous agent vision replan changes durable fields ${changedFields.join(", ")}; provide goal_path_delta_v0 with outcome=replan so the mainline change is explicit`,
+      );
+    }
+  }
+
+  return {
+    schema_version: VISION_REFRESH_PREPARED_SCHEMA_VERSION,
+    agent_vision: agentVision,
+  };
+}
+
 function existingVisionContinuityBasis(
   vision: JsonObject | null,
 ): ExistingVisionContinuityBasis | null {
@@ -88,24 +541,38 @@ function deliveryBoundary(value: unknown): DeliveryBoundary {
   throw new EffectRuntimeRequestError("delivery_boundary is unsupported");
 }
 
+function normalizeVisionUnchangedReason(value: unknown): string | null {
+  const unchanged = compactText(value);
+  if (!unchanged) return null;
+  validatePublicSafeText("vision_unchanged_reason", unchanged);
+  if (unchanged.length > VISION_UNCHANGED_REASON_LIMIT) {
+    throw new EffectRuntimeRequestError(
+      `vision_unchanged_reason exceeds ${VISION_UNCHANGED_REASON_LIMIT} chars`,
+    );
+  }
+  return unchanged;
+}
+
 export function decodeVisionCheckpointRequest(
   value: unknown,
-): VisionCheckpointRequest {
+): VisionRefreshFinalizeRequest {
   const request = requiredObject(value, "goal.vision_checkpoint params");
-  if (request.schema_version !== VISION_CHECKPOINT_REQUEST_SCHEMA) {
-    throw new EffectRuntimeRequestError("Vision checkpoint request schema mismatch");
+  if (request.schema_version !== VISION_REFRESH_REQUEST_SCHEMA) {
+    throw new EffectRuntimeRequestError("Vision refresh request schema mismatch");
+  }
+  if (request.phase !== "finalize") {
+    throw new EffectRuntimeRequestError("Vision refresh phase is unsupported");
   }
   return {
-    schema_version: VISION_CHECKPOINT_REQUEST_SCHEMA,
+    phase: "finalize",
     agent_id: optionalString(request.agent_id, "agent_id"),
     agent_vision: optionalObject(request.agent_vision, "agent_vision"),
     existing_agent_vision: optionalObject(
       request.existing_agent_vision,
       "existing_agent_vision",
     ),
-    vision_unchanged_reason: optionalString(
+    vision_unchanged_reason: normalizeVisionUnchangedReason(
       request.vision_unchanged_reason,
-      "vision_unchanged_reason",
     ),
     delivery_outcome: decodeOptionalDeliveryOutcome(request.delivery_outcome),
     active_state_next_action_would_update: requiredBoolean(
@@ -125,7 +592,7 @@ export function decodeVisionCheckpointRequest(
   };
 }
 
-function validateInFlightBoundary(request: VisionCheckpointRequest): void {
+function validateInFlightBoundary(request: VisionRefreshFinalizeRequest): void {
   if (request.delivery_boundary !== "in_flight_continuation") return;
   if (request.delivery_outcome !== "outcome_progress") {
     throw new EffectRuntimeRequestError(
@@ -155,6 +622,13 @@ function validateInFlightBoundary(request: VisionCheckpointRequest): void {
 }
 
 export function buildVisionCheckpoint(value: unknown): JsonObject {
+  const envelope = requiredObject(value, "goal.vision_checkpoint params");
+  if (envelope.schema_version !== VISION_REFRESH_REQUEST_SCHEMA) {
+    throw new EffectRuntimeRequestError("Vision refresh request schema mismatch");
+  }
+  if (envelope.phase === "prepare") {
+    return prepareVisionRefresh(decodePrepareRequest(envelope));
+  }
   const request = decodeVisionCheckpointRequest(value);
   validateInFlightBoundary(request);
   const triggers: JsonObject[] = [];

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -55,10 +55,9 @@ from .history import (
 )
 from .control_plane.runtime.local_state_write_correctness import build_local_state_write_correctness_dry_run_packet
 from .paths import resolve_runtime_root
-from .control_plane.goals.goal_vision import normalize_goal_vision_update
 from .control_plane.goals.vision_checkpoint import (
     build_vision_checkpoint,
-    normalize_vision_unchanged_reason,
+    prepare_vision_refresh,
 )
 from .control_plane.goals.goal_frontier import latest_agent_vision_from_runs
 from .registry import registry_goals, resolve_state_file
@@ -1065,9 +1064,6 @@ def refresh_state_run(
             raise ValueError("--agent-lane requires --progress-scope agent_lane")
     if (agent_vision_packet is not None or vision_unchanged_reason) and not normalized_agent_id:
         raise ValueError("vision writeback requires --agent-id")
-    normalized_vision_unchanged_reason = normalize_vision_unchanged_reason(
-        vision_unchanged_reason
-    )
     agent_vision: dict[str, Any] | None = None
     existing_agent_vision: dict[str, Any] | None = None
     autonomous_replan_frontier_identity: str | None = None
@@ -1090,7 +1086,7 @@ def refresh_state_run(
             agent_id=normalized_agent_id,
         )
     if agent_vision_packet is not None:
-        agent_vision = normalize_goal_vision_update(
+        agent_vision = prepare_vision_refresh(
             agent_vision_packet,
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id or None,
@@ -1158,7 +1154,7 @@ def refresh_state_run(
         agent_id=normalized_agent_id or None,
         agent_vision=agent_vision,
         existing_agent_vision=existing_agent_vision,
-        vision_unchanged_reason=normalized_vision_unchanged_reason,
+        vision_unchanged_reason=vision_unchanged_reason,
         delivery_outcome=normalized_delivery_outcome,
         active_state_next_action_update=active_state_next_action_update,
         delivery_boundary=delivery_boundary,

--- a/tests/control_plane/test_vision_checkpoint_runtime.py
+++ b/tests/control_plane/test_vision_checkpoint_runtime.py
@@ -19,6 +19,70 @@ def _runtime_result(**overrides: object) -> dict[str, object]:
     }
 
 
+def _prepared_result(**overrides: object) -> dict[str, object]:
+    return {
+        "schema_version": vision_checkpoint.VISION_REFRESH_PREPARED_SCHEMA_VERSION,
+        "agent_vision": {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "goal_id": "goal-main",
+            "agent_id": "codex-main",
+            "state": "vision_patch_proposed",
+            "vision_patch": {"vision_summary": "Ship one bounded route."},
+            "todo_delta": [],
+            "vision_budget": {
+                "schema_version": "goal_vision_budget_v0",
+                "status": "ok",
+                "field_limits": {"vision_summary": 420},
+                "field_usage": {"vision_summary": 23},
+                "total_limit": 1200,
+                "total_usage": 23,
+            },
+            "validation": {
+                "budget_checked": True,
+                "budget_status": "ok",
+                "write_correctness_checked": False,
+            },
+        },
+        **overrides,
+    }
+
+
+def test_python_prepare_facade_sends_raw_provider_context(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def call(method: str, params: dict[str, object]) -> dict[str, object]:
+        captured["method"] = method
+        captured["params"] = params
+        return _prepared_result()
+
+    monkeypatch.setattr(vision_checkpoint, "effect_runtime_result", call)
+    result = vision_checkpoint.prepare_vision_refresh(
+        {"vision_summary": " Ship one bounded route. "},
+        goal_id="goal-main",
+        agent_id="codex-main",
+        existing_agent_vision=None,
+        merge_patch=True,
+        require_path_delta_for_durable_change=True,
+    )
+
+    assert result == _prepared_result()["agent_vision"]
+    assert captured == {
+        "method": "goal.vision_checkpoint.evaluate",
+        "params": {
+            "schema_version": vision_checkpoint.VISION_REFRESH_REQUEST_SCHEMA,
+            "phase": "prepare",
+            "goal_id": "goal-main",
+            "agent_id": "codex-main",
+            "agent_vision_packet": {
+                "vision_summary": " Ship one bounded route. "
+            },
+            "existing_agent_vision": None,
+            "merge_patch": True,
+            "require_path_delta_for_durable_change": True,
+        },
+    }
+
+
 def test_python_facade_sends_explicit_boundary_context(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
@@ -42,7 +106,8 @@ def test_python_facade_sends_explicit_boundary_context(monkeypatch) -> None:
     assert result == _runtime_result()
     assert captured["method"] == "goal.vision_checkpoint.evaluate"
     assert captured["params"] == {
-        "schema_version": vision_checkpoint.VISION_CHECKPOINT_REQUEST_SCHEMA,
+        "schema_version": vision_checkpoint.VISION_REFRESH_REQUEST_SCHEMA,
+        "phase": "finalize",
         "agent_id": "codex-main",
         "agent_vision": None,
         "existing_agent_vision": None,
@@ -54,6 +119,82 @@ def test_python_facade_sends_explicit_boundary_context(monkeypatch) -> None:
         "completion_todo_id": None,
         "autonomous_replan_recorded": False,
     }
+
+
+@pytest.mark.parametrize(
+    "malformed",
+    [
+        None,
+        {},
+        _prepared_result(agent_vision=None),
+        _prepared_result(agent_vision={}),
+        _prepared_result(
+            agent_vision={
+                **_prepared_result()["agent_vision"],
+                "vision_budget": None,
+            }
+        ),
+    ],
+)
+def test_python_prepare_facade_rejects_malformed_runtime_results(
+    monkeypatch, malformed: object
+) -> None:
+    monkeypatch.setattr(
+        vision_checkpoint,
+        "effect_runtime_result",
+        lambda _method, _params: malformed,
+    )
+    with pytest.raises(RuntimeError, match="prepared result (must be|shape mismatch)"):
+        vision_checkpoint.prepare_vision_refresh(
+            {"vision_summary": "Ship one bounded route."},
+            goal_id="goal-main",
+            agent_id="codex-main",
+            existing_agent_vision=None,
+            merge_patch=False,
+            require_path_delta_for_durable_change=False,
+        )
+
+
+def test_python_prepare_facade_preserves_typed_budget_rejection(monkeypatch) -> None:
+    def reject(_method: str, _params: dict[str, object]) -> object:
+        raise effect_runtime.EffectRuntimeRejected(
+            "vision_budget_exceeded: vision_summary uses 421 chars; limit is 420; "
+            'suggested compact value: "xxxxxxxxx..."',
+            diagnostic_code="vision_budget_exceeded",
+        )
+
+    monkeypatch.setattr(vision_checkpoint, "effect_runtime_result", reject)
+    with pytest.raises(vision_checkpoint.GoalVisionBudgetError) as error:
+        vision_checkpoint.prepare_vision_refresh(
+            {"vision_summary": "x" * 421},
+            goal_id="goal-main",
+            agent_id="codex-main",
+            existing_agent_vision=None,
+            merge_patch=False,
+            require_path_delta_for_durable_change=False,
+        )
+    assert error.value.field == "vision_summary"
+    assert error.value.used == 421
+    assert error.value.limit == 420
+    assert error.value.suggestion == "xxxxxxxxx..."
+
+
+def test_runtime_budget_rejection_keeps_actionable_suggestion() -> None:
+    with pytest.raises(vision_checkpoint.GoalVisionBudgetError) as error:
+        vision_checkpoint.prepare_vision_refresh(
+            {"vision_summary": "x" * 421},
+            goal_id="goal-main",
+            agent_id="codex-main",
+            existing_agent_vision=None,
+            merge_patch=False,
+            require_path_delta_for_durable_change=False,
+        )
+
+    assert error.value.field == "vision_summary"
+    assert error.value.used == 421
+    assert error.value.limit == 420
+    assert error.value.suggestion == "x" * 93 + "..."
+    assert len(str(error.value)) <= 240
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_vision_checkpoint_runtime.py
+++ b/tests/control_plane/test_vision_checkpoint_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from loopx.control_plane import effect_runtime
@@ -156,10 +158,12 @@ def test_python_prepare_facade_rejects_malformed_runtime_results(
 
 
 def test_python_prepare_facade_preserves_typed_budget_rejection(monkeypatch) -> None:
+    suggestion = 'compact "quoted" \\ value'
+
     def reject(_method: str, _params: dict[str, object]) -> object:
         raise effect_runtime.EffectRuntimeRejected(
             "vision_budget_exceeded: vision_summary uses 421 chars; limit is 420; "
-            'suggested compact value: "xxxxxxxxx..."',
+            f"suggested compact value: {json.dumps(suggestion)}",
             diagnostic_code="vision_budget_exceeded",
         )
 
@@ -176,7 +180,7 @@ def test_python_prepare_facade_preserves_typed_budget_rejection(monkeypatch) -> 
     assert error.value.field == "vision_summary"
     assert error.value.used == 421
     assert error.value.limit == 420
-    assert error.value.suggestion == "xxxxxxxxx..."
+    assert error.value.suggestion == suggestion
 
 
 def test_runtime_budget_rejection_keeps_actionable_suggestion() -> None:

--- a/tests/control_plane_ts/vision_checkpoint.test.ts
+++ b/tests/control_plane_ts/vision_checkpoint.test.ts
@@ -3,12 +3,14 @@ import test from "node:test";
 
 import {
   buildVisionCheckpoint,
-  VISION_CHECKPOINT_REQUEST_SCHEMA,
+  VISION_REFRESH_PREPARED_SCHEMA_VERSION,
+  VISION_REFRESH_REQUEST_SCHEMA,
 } from "../../loopx/control_plane/goals/vision_checkpoint.ts";
 
-function request(overrides: Record<string, unknown> = {}) {
+function finalizeRequest(overrides: Record<string, unknown> = {}) {
   return {
-    schema_version: VISION_CHECKPOINT_REQUEST_SCHEMA,
+    schema_version: VISION_REFRESH_REQUEST_SCHEMA,
+    phase: "finalize",
     agent_id: "codex-main",
     agent_vision: null,
     existing_agent_vision: null,
@@ -23,8 +25,223 @@ function request(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function prepareRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: VISION_REFRESH_REQUEST_SCHEMA,
+    phase: "prepare",
+    goal_id: "goal-main",
+    agent_id: "codex-main",
+    agent_vision_packet: {
+      state: "vision_patch_proposed",
+      vision_patch: {
+        vision_summary: "Ship one bounded route.",
+      },
+    },
+    existing_agent_vision: null,
+    merge_patch: false,
+    require_path_delta_for_durable_change: false,
+    ...overrides,
+  };
+}
+
+test("prepare owns packet normalization, budgets, and path delta", () => {
+  const result = buildVisionCheckpoint(prepareRequest({
+    agent_vision_packet: {
+      goal_id: "goal-main",
+      agent_id: "codex-main",
+      state: "closed",
+      vision_patch: {
+        vision_summary: "  Ship   one bounded route.  ",
+        role_scope: "Own the route.",
+        acceptance_summary: "The route produces evidence.",
+        advancement_policy: "repeat-until-closed",
+      },
+      path_delta: {
+        outcome: "replan",
+        prior_assumption: "The old route remained viable.",
+        observed_reality: "Fresh evidence invalidated it.",
+        changed: ["Use the bounded successor."],
+      },
+      todo_delta: [" create_successor "],
+      validation: { write_correctness_checked: true },
+    },
+  }));
+
+  assert.equal(result.schema_version, VISION_REFRESH_PREPARED_SCHEMA_VERSION);
+  const vision = result.agent_vision as Record<string, unknown>;
+  assert.equal(vision.state, "vision_closed");
+  assert.deepEqual(vision.vision_patch, {
+    vision_summary: "Ship one bounded route.",
+    role_scope: "Own the route.",
+    acceptance_summary: "The route produces evidence.",
+    advancement_policy: "repeat_until_closed",
+  });
+  assert.deepEqual(vision.todo_delta, ["create_successor"]);
+  assert.deepEqual(vision.path_delta, {
+    schema_version: "goal_path_delta_v0",
+    outcome: "replan",
+    prior_assumption: "The old route remained viable.",
+    observed_reality: "Fresh evidence invalidated it.",
+    changed: ["Use the bounded successor."],
+  });
+  assert.deepEqual(vision.validation, {
+    write_correctness_checked: true,
+    budget_checked: true,
+    budget_status: "ok",
+  });
+});
+
+test("prepare preserves v0 JSON-to-text compatibility", () => {
+  const result = buildVisionCheckpoint(prepareRequest({
+    agent_vision_packet: {
+      vision_summary: true,
+      todo_delta: [["one", "two"], { route: "bounded" }, {}],
+      path_delta: {
+        outcome: "replan",
+        prior_assumption: { route: "old" },
+        observed_reality: "Fresh evidence invalidated it.",
+        changed: ["Use the bounded successor."],
+      },
+    },
+  }));
+
+  const vision = result.agent_vision as Record<string, unknown>;
+  assert.deepEqual(vision.vision_patch, { vision_summary: "True" });
+  assert.deepEqual(vision.todo_delta, [
+    "['one', 'two']",
+    "{'route': 'bounded'}",
+  ]);
+  assert.equal(
+    (vision.path_delta as Record<string, unknown>).prior_assumption,
+    "{'route': 'old'}",
+  );
+});
+
+test("prepare merges a patch and requires an explicit durable replan", () => {
+  const existing = {
+    state: "vision_active",
+    vision_patch: {
+      vision_summary: "Old route.",
+      role_scope: "Own framing.",
+      acceptance_summary: "Produce evidence.",
+      advancement_policy: "as_needed",
+    },
+  };
+  const agentVisionPacket = {
+    vision_patch: { vision_summary: "New route." },
+    path_delta: {
+      outcome: "replan",
+      prior_assumption: "The old route would hold.",
+      observed_reality: "New evidence changed the route.",
+      changed: ["Use the new route."],
+    },
+  };
+  const result = buildVisionCheckpoint(prepareRequest({
+    agent_vision_packet: agentVisionPacket,
+    existing_agent_vision: existing,
+    merge_patch: true,
+    require_path_delta_for_durable_change: true,
+  }));
+  assert.deepEqual(
+    (result.agent_vision as Record<string, unknown>).vision_patch,
+    {
+      vision_summary: "New route.",
+      role_scope: "Own framing.",
+      acceptance_summary: "Produce evidence.",
+      advancement_policy: "as_needed",
+    },
+  );
+
+  assert.throws(
+    () => buildVisionCheckpoint(prepareRequest({
+      agent_vision_packet: { vision_patch: { vision_summary: "New route." } },
+      existing_agent_vision: existing,
+      merge_patch: true,
+      require_path_delta_for_durable_change: true,
+    })),
+    /provide goal_path_delta_v0 with outcome=replan/,
+  );
+});
+
+test("prepare rejects identity drift, private text, and typed budget overflow", () => {
+  assert.throws(
+    () => buildVisionCheckpoint(prepareRequest({
+      agent_vision_packet: {
+        goal_id: "other-goal",
+        vision_summary: "Bounded route.",
+      },
+    })),
+    /does not match/,
+  );
+  assert.throws(
+    () => buildVisionCheckpoint(prepareRequest({
+      agent_vision_packet: {
+        vision_summary: "Read \/Users\/owner\/private.txt",
+      },
+    })),
+    /contains a private-looking value/,
+  );
+  assert.throws(
+    () => buildVisionCheckpoint(prepareRequest({
+      agent_vision_packet: { vision_summary: "x".repeat(421) },
+    })),
+    (error: unknown) => {
+      const rejection = error as { code?: string; message?: string };
+      assert.equal(
+        rejection.code,
+        "vision_budget_exceeded",
+      );
+      assert.match(rejection.message ?? "", /suggested compact value/);
+      assert.ok((rejection.message ?? "").length <= 240);
+      return true;
+    },
+  );
+});
+
+test("prepare rejects incomplete and over-wide path deltas", () => {
+  assert.throws(
+    () => buildVisionCheckpoint(prepareRequest({
+      agent_vision_packet: {
+        vision_summary: "Bounded route.",
+        path_delta: { outcome: "replan" },
+      },
+    })),
+    /requires prior_assumption and observed_reality/,
+  );
+  assert.throws(
+    () => buildVisionCheckpoint(prepareRequest({
+      agent_vision_packet: {
+        vision_summary: "Bounded route.",
+        path_delta: {
+          outcome: "replan",
+          prior_assumption: "Old assumption.",
+          observed_reality: "New reality.",
+          retained: ["one", "two", "three", "four"],
+        },
+      },
+    })),
+    /path_delta.retained has 4 items; limit is 3/,
+  );
+});
+
+test("pure prepare and finalize reductions replay deterministically", () => {
+  const prepare = prepareRequest();
+  assert.deepEqual(
+    buildVisionCheckpoint(prepare),
+    buildVisionCheckpoint(prepare),
+  );
+  const finalize = finalizeRequest({
+    agent_vision: (buildVisionCheckpoint(prepare) as Record<string, unknown>)
+      .agent_vision,
+  });
+  assert.deepEqual(
+    buildVisionCheckpoint(finalize),
+    buildVisionCheckpoint(finalize),
+  );
+});
+
 test("semantic closeout retains the strict material vision checkpoint", () => {
-  const result = buildVisionCheckpoint(request());
+  const result = buildVisionCheckpoint(finalizeRequest());
   assert.equal(result.required, true);
   assert.equal(result.satisfied, false);
   assert.equal(result.decision, "missing_required");
@@ -34,7 +251,7 @@ test("semantic closeout retains the strict material vision checkpoint", () => {
 });
 
 test("explicit in-flight progress records continuity without vision repetition", () => {
-  const result = buildVisionCheckpoint(request({
+  const result = buildVisionCheckpoint(finalizeRequest({
     delivery_boundary: "in_flight_continuation",
   }));
   assert.equal(result.required, false);
@@ -46,7 +263,7 @@ test("explicit in-flight progress records continuity without vision repetition",
 });
 
 test("non-material delivery remains valid without opening a vision checkpoint", () => {
-  const result = buildVisionCheckpoint(request({
+  const result = buildVisionCheckpoint(finalizeRequest({
     delivery_outcome: "surface_only",
   }));
   assert.equal(result.required, false);
@@ -56,7 +273,7 @@ test("non-material delivery remains valid without opening a vision checkpoint", 
 });
 
 test("unchanged closeout binds the exact persisted vision revision", () => {
-  const result = buildVisionCheckpoint(request({
+  const result = buildVisionCheckpoint(finalizeRequest({
     existing_agent_vision: {
       state: "vision_active",
       generated_at: "2026-08-22T18:30:17+08:00",
@@ -73,7 +290,7 @@ test("unchanged closeout binds the exact persisted vision revision", () => {
 });
 
 test("legacy vision without a revision cannot claim outcome continuity", () => {
-  const result = buildVisionCheckpoint(request({
+  const result = buildVisionCheckpoint(finalizeRequest({
     existing_agent_vision: { state: "vision_active" },
     vision_unchanged_reason: "The legacy route is still current.",
   }));
@@ -83,21 +300,21 @@ test("legacy vision without a revision cannot claim outcome continuity", () => {
 
 test("completion, replan, and durable route changes reject in-flight claims", () => {
   assert.throws(
-    () => buildVisionCheckpoint(request({
+    () => buildVisionCheckpoint(finalizeRequest({
       delivery_boundary: "in_flight_continuation",
       completion_todo_id: "todo_current001",
     })),
     /conflicts with Todo completion/,
   );
   assert.throws(
-    () => buildVisionCheckpoint(request({
+    () => buildVisionCheckpoint(finalizeRequest({
       delivery_boundary: "in_flight_continuation",
       autonomous_replan_recorded: true,
     })),
     /conflicts with autonomous replan/,
   );
   assert.throws(
-    () => buildVisionCheckpoint(request({
+    () => buildVisionCheckpoint(finalizeRequest({
       delivery_boundary: "in_flight_continuation",
       active_state_next_action_would_update: true,
     })),
@@ -107,17 +324,32 @@ test("completion, replan, and durable route changes reject in-flight claims", ()
 
 test("only accountable agent-bound progress may be in flight", () => {
   assert.throws(
-    () => buildVisionCheckpoint(request({
+    () => buildVisionCheckpoint(finalizeRequest({
       delivery_boundary: "in_flight_continuation",
       delivery_outcome: "outcome_gap",
     })),
     /requires delivery_outcome=outcome_progress/,
   );
   assert.throws(
-    () => buildVisionCheckpoint(request({
+    () => buildVisionCheckpoint(finalizeRequest({
       delivery_boundary: "in_flight_continuation",
       todo_id: null,
     })),
     /requires an agent-bound Todo settlement/,
+  );
+});
+
+test("finalize owns unchanged-reason public safety and budget", () => {
+  assert.throws(
+    () => buildVisionCheckpoint(finalizeRequest({
+      vision_unchanged_reason: "Read \/Users\/owner\/private.txt",
+    })),
+    /contains a private-looking value/,
+  );
+  assert.throws(
+    () => buildVisionCheckpoint(finalizeRequest({
+      vision_unchanged_reason: "x".repeat(241),
+    })),
+    /vision_unchanged_reason exceeds 240 chars/,
   );
 });


### PR DESCRIPTION
## Summary

- Move the Vision refresh preflight and checkpoint reduction behind the TypeScript-owned `goal.vision_checkpoint.evaluate` transaction, with explicit `prepare` and `finalize` phases.
- Keep Python as a typed transport/compatibility adapter plus the existing semantic-replan qualification boundary, while deleting the duplicate Python authority for Vision identity, merge, visibility, budget, path-delta, todo-delta, and checkpoint rules.
- Rewire `refresh_state` to use the new transaction and add parity/negative coverage for the public contract, including Python-v0 JSON coercion behavior.

This is an independent follow-up to #3715 and is based directly on `main`. It intentionally leaves the bilingual RFC mirrors to #3715 so either PR can merge first.

## Migration economics

| Measure | Result |
| --- | --- |
| Replaced Python semantic code deleted | 308 lines |
| Bounded Python bridge/call-site additions | 129 lines |
| TypeScript owner change | +485 / -11 lines |
| Product diff | +614 / -326 lines |
| Focused test diff | +391 / -14 lines |
| New modules/handlers/framework layers | 0 |

- A refresh without a Vision proposal performs one TypeScript finalization request. A proposal performs prepare + finalize (two requests), because the retained Python semantic-replan qualifier must run between them today.
- The complete material-replan Turn path remains three managed-runtime requests when the existing host-result normalization request is included. The measured persistent-runtime cost did not regress: 64 interleaved pairs gave p50 `-0.48%` and p95 `-5.35%` versus `origin/main` (nearest-rank; negative is faster).
- Facade exit is explicit: the refresh CLI and Turn caller now enter the TypeScript kernel through this transaction. Once the Turn host runs the kernel in-process, prepare/finalize can collapse without moving domain authority again.

## Issue Or Task

- Accepted TypeScript control-plane migration RFC: https://github.com/huangruiteng/loopx/blob/main/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
- Contributor task ID: N/A (RFC migration follow-up)

## Compatibility

- No intended default or public behavior change.
- Differential fixtures are byte-identical for full packets, merge patches, aliases, budgets, private-source rejection, malformed inputs, and boolean/number/list/object coercions.
- Python callers retain `GoalVisionBudgetError` fields and compatible error text; TypeScript now owns the budget decision and compact suggestion.
- The existing public read compactor stays in Python; it is not write authority.

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .` — the source runtime starts and completes 7 checks, then reports one unrelated pre-existing global-registry user-gate error outside this repository.
- [x] Other:
  - 199 relevant Python tests passed (Vision, refresh/replan gates, Goal Vision lifecycle, projections, observations, run-context retention, and Turn executor).
  - `npm run test:control-plane` — 226/226 passed.
  - `npm run typecheck:control-plane` passed.
  - Ruff on all touched Python files passed.
  - Configured mypy suite passed (15 source files).
  - Path-delta and refresh-state budget smokes passed.
  - Wheel and sdist built; an isolated installed-wheel semantic probe passed and confirmed the required TypeScript runtime sources are packaged.
  - `loopx canary premerge --from-git-diff` passed 4 direct and 12 risk-selected checks with zero failures, warnings, or manual holds.
  - `git diff --check`, DCO verification, exact-path public/private scan, and merge-tree prechecks against #3693 and #3662 passed.

CI follow-up: the first SonarCloud analysis reported `python:S5852` on the budget-suggestion regex. Commit `3d8698ac` removes that backtracking parser in favor of linear prefix extraction plus `json.loads`, adds escaped-string coverage, and passed the focused 17-test file plus the full 199-test relevant suite, Ruff, mypy, and the complete premerge canary set. The exact-head SonarCloud Code Analysis rerun now passes.

Environment note: the first canary invocation used a stale user-installed wheel and failed before check selection because that installation lacked source documentation. The branch-source rerun above passed completely. No validation was skipped.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: TypeScript control-plane migration v0 RFC

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked RFC migration task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

## Future-facing scope pass

No adjacent abstraction was added. The cohesive boundary considered was the retained Python semantic-replan qualifier; moving it here would broaden this PR into a separate control-plane migration. The current two-phase contract makes that later cutover local and reversible without creating an unused framework now.

Opened for maintainer review; this PR is intentionally left unmerged.
