### PR TITLE
test: align Lark collector lifecycle smoke

### DIFF
--- a/examples/lark-event-collector-lifecycle-smoke.py
+++ b/examples/lark-event-collector-lifecycle-smoke.py
@@ -12,13 +12,6 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from loopx.cli_commands.lark_inbox import (
-    _collector_permissions,
-)
-from loopx.extensions.lark import (
-    LARK_COLLECTOR_PERMISSION,
-    LARK_REPLY_PERMISSION,
-)
 from loopx.extensions.lark.event_collector import (
     inspect_lark_event_collector,
     install_lark_event_collector,
@@ -141,13 +134,6 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
             project=project,
             config_path=collector_config,
             runtime_root=runtime_root,
-        )
-        assert _collector_permissions(
-            project=project,
-            config_path=collector_config,
-        ) == (
-            LARK_COLLECTOR_PERMISSION,
-            LARK_REPLY_PERMISSION,
         )
         assert plan["status"] == "install_ready", plan
         assert plan["thread_complete"] is True, plan
@@ -283,10 +269,6 @@ with tempfile.TemporaryDirectory(prefix="loopx-lark-collector-") as raw:
         invalid_inbox["reply"].pop("received_reaction_emoji")
         invalid_inbox["reply"].pop("processing_reaction_emoji")
         inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
-        assert _collector_permissions(
-            project=project,
-            config_path=collector_config,
-        ) == (LARK_COLLECTOR_PERMISSION,)
         invalid_inbox["reply"]["received_reaction_emoji"] = "Get"
         invalid_inbox["reply"]["processing_reaction_emoji"] = "OnIt"
         inbox_config.write_text(json.dumps(invalid_inbox), encoding="utf-8")
@@ -468,18 +450,16 @@ else:
         assert runtime_result["captured_count"] == 3, runtime_result
         assert runtime_result["reply_context_verified_count"] == 2, runtime_result
         assert runtime_result["reply_to_bot_count"] == 1, runtime_result
-        assert runtime_result["received_reaction_count"] == 1, runtime_result
-        assert runtime_result["received_reaction_failure_count"] == 1, runtime_result
-        assert runtime_result["external_writes_performed"] is True, runtime_result
-        assert lark_inbox_reaction_receipts(
-            inbox=project / ".loopx" / "inbox" / "team-feedback",
-            message_id="om_runtime_reply",
-        ) == {
-            "received": {
-                "reaction_id": "reaction_runtime",
-                "emoji_type": "Get",
-            }
-        }
+        assert runtime_result["received_reaction_count"] == 0, runtime_result
+        assert runtime_result["received_reaction_failure_count"] == 0, runtime_result
+        assert runtime_result["external_writes_performed"] is False, runtime_result
+        assert (
+            lark_inbox_reaction_receipts(
+                inbox=project / ".loopx" / "inbox" / "team-feedback",
+                message_id="om_runtime_reply",
+            )
+            == {}
+        )
         runtime_urgency = project_lark_event_inbox_urgency(
             project=project,
             config_path=inbox_config,


### PR DESCRIPTION
## Summary

- remove the lifecycle smoke's dependency on the deleted private collector-permission helper
- assert the shipped collector contract through public runtime behavior
- keep reaction writes out of the collector path; the turn-start inbox sync owns those effects
- preserve collector capture, reply-context, and urgency coverage

## Validation

- `python3 examples/lark-event-collector-lifecycle-smoke.py`
- `python3 -m pytest -q tests/architecture/test_control_plane_import_boundaries.py tests/extensions/test_lark_event_collector_routing.py tests/extensions/test_lark_event_collector_runtime.py tests/extensions/test_lark_goal_topic_runtime.py tests/extensions/test_lark_group_history.py tests/extensions/test_lark_inbox_reactions.py tests/extensions/test_lark_turn_start_sync.py tests/extensions/test_lark_urgency_composition.py` (110 passed)
- `python3 -m ruff check examples/lark-event-collector-lifecycle-smoke.py`
- `python3 -m ruff format --check examples/lark-event-collector-lifecycle-smoke.py`
- `loopx canary premerge --from-git-diff` (`merge_gate_passed=true`, `self_merge_allowed=true`)

## Review notes

This is a one-file durable smoke cleanup. It does not change runtime behavior or permission policy; it updates the integration contract after runtime ownership moved reaction handling to the turn-start hook. The adjacent boundary is already narrow, so no additional future-facing refactor is needed.
