### PR TITLE
fix: read Bot document comment scopes from published app

### DIFF
--- a/loopx/extensions/lark/document_comment_provider.py
+++ b/loopx/extensions/lark/document_comment_provider.py
@@ -50,6 +50,7 @@ IDEMPOTENCY_KEY_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 CURSOR_PREFIX = "lark-comment-v0."
 REPLY_CHAIN_PREFIX = "lark-reply-v0."
 MAX_PROVIDER_PAGES = 20
+LARK_APP_VERSION_PAGE_SIZE = 2
 
 CommandRunner = Callable[
     [Sequence[str], Path | None, float | None],
@@ -170,6 +171,69 @@ def _json_output(result: Mapping[str, Any], *, operation: str) -> dict[str, Any]
             code = f"lark_document_comment_{operation}_failed"
         raise LarkDocumentCommentProviderError(code)
     return {str(key): item for key, item in payload.items()}
+
+
+def _command_json_mapping(
+    result: Mapping[str, Any],
+    *,
+    error_code: str,
+    allowed_returncodes: frozenset[int] = frozenset({0}),
+) -> dict[str, Any]:
+    try:
+        returncode = int(result.get("returncode", 1))
+    except (TypeError, ValueError) as exc:
+        raise LarkDocumentCommentProviderError(error_code) from exc
+    try:
+        payload = json.loads(str(result.get("stdout") or ""))
+    except json.JSONDecodeError as exc:
+        raise LarkDocumentCommentProviderError(error_code) from exc
+    if returncode not in allowed_returncodes or not isinstance(payload, Mapping):
+        raise LarkDocumentCommentProviderError(error_code)
+    return {str(key): item for key, item in payload.items()}
+
+
+def _published_tenant_scopes(payload: Mapping[str, Any]) -> list[str]:
+    data = payload.get("data")
+    items = data.get("items") if isinstance(data, Mapping) else None
+    if not isinstance(items, list):
+        raise LarkDocumentCommentProviderError(
+            "lark_document_comment_permission_probe_unknown"
+        )
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise LarkDocumentCommentProviderError(
+                "lark_document_comment_permission_probe_unknown"
+            )
+        publish_time = item.get("publish_time")
+        if item.get("status") != 1 or publish_time is None or publish_time == "":
+            continue
+        raw_scopes = item.get("scopes")
+        if not isinstance(raw_scopes, list):
+            raise LarkDocumentCommentProviderError(
+                "lark_document_comment_permission_probe_unknown"
+            )
+        tenant_scopes: list[str] = []
+        for raw_scope in raw_scopes:
+            if not isinstance(raw_scope, Mapping):
+                raise LarkDocumentCommentProviderError(
+                    "lark_document_comment_permission_probe_unknown"
+                )
+            scope = raw_scope.get("scope")
+            token_types = raw_scope.get("token_types")
+            if not isinstance(scope, str) or not isinstance(token_types, list):
+                raise LarkDocumentCommentProviderError(
+                    "lark_document_comment_permission_probe_unknown"
+                )
+            if any(not isinstance(token_type, str) for token_type in token_types):
+                raise LarkDocumentCommentProviderError(
+                    "lark_document_comment_permission_probe_unknown"
+                )
+            if scope and "tenant" in token_types:
+                tenant_scopes.append(scope)
+        return sorted(set(tenant_scopes))
+    raise LarkDocumentCommentProviderError(
+        "lark_document_comment_permission_probe_unknown"
+    )
 
 
 def _encode_private(prefix: str, value: Mapping[str, Any]) -> str:
@@ -426,7 +490,7 @@ class LarkCliDocumentCommentProvider:
         publication_required: bool = True,
         repair_url: str = LARK_DOCUMENT_COMMENT_REPAIR_URL,
     ) -> dict[str, Any]:
-        """Read exact local scope readiness without returning credentials."""
+        """Read identity-appropriate scope readiness without returning secrets."""
 
         requirements = self.permission_requirements(
             response_enabled=response_enabled,
@@ -440,51 +504,99 @@ class LarkCliDocumentCommentProvider:
                 for scope in requirement["required_scopes"]
             }
         )
-        status_result = self._runner(
-            self._args(["auth", "status", "--json"]),
-            None,
-            self._timeout_seconds,
+        status_payload = _command_json_mapping(
+            self._runner(
+                self._args(["auth", "status", "--json"]),
+                None,
+                self._timeout_seconds,
+            ),
+            error_code="lark_document_comment_permission_probe_invalid",
         )
-        try:
-            status_payload = json.loads(str(status_result.get("stdout") or ""))
-        except json.JSONDecodeError as exc:
-            raise LarkDocumentCommentProviderError(
-                "lark_document_comment_permission_probe_invalid"
-            ) from exc
-        if (
-            not isinstance(status_payload, Mapping)
-            or status_payload.get("identity") != self._identity
-        ):
+        if status_payload.get("identity") != self._identity:
             raise LarkDocumentCommentProviderError(
                 "lark_document_comment_permission_probe_identity_mismatch"
             )
-        result = self._runner(
-            self._args(["auth", "check", "--scope", " ".join(scopes), "--json"]),
-            None,
-            self._timeout_seconds,
-        )
-        try:
-            payload = json.loads(str(result.get("stdout") or ""))
-        except json.JSONDecodeError as exc:
-            raise LarkDocumentCommentProviderError(
-                "lark_document_comment_permission_probe_invalid"
-            ) from exc
-        if not isinstance(payload, Mapping):
-            raise LarkDocumentCommentProviderError(
-                "lark_document_comment_permission_probe_invalid"
+
+        if self._identity == "bot":
+            # ``auth check`` reads only a stored user OAuth token.  Bot scope
+            # evidence instead comes from the current published app-version
+            # ledger, whose tenant scopes are the effective Bot permissions.
+            identity_payload = _command_json_mapping(
+                self._runner(
+                    self._args(["whoami", "--json"]),
+                    None,
+                    self._timeout_seconds,
+                ),
+                error_code="lark_document_comment_permission_probe_unknown",
             )
-        granted = payload.get("granted", [])
-        missing = payload.get("missing", [])
-        if (
-            not isinstance(granted, list)
-            or not isinstance(missing, list)
-            or any(not isinstance(scope, str) for scope in [*granted, *missing])
-            or set(granted).intersection(missing)
-            or set(granted).union(missing) != set(scopes)
-        ):
-            raise LarkDocumentCommentProviderError(
-                "lark_document_comment_permission_probe_invalid"
+            if (
+                identity_payload.get("identity") != "bot"
+                or identity_payload.get("available") is not True
+                or (
+                    self._profile is not None
+                    and identity_payload.get("profile") != self._profile
+                )
+            ):
+                raise LarkDocumentCommentProviderError(
+                    "lark_document_comment_permission_probe_identity_mismatch"
+                )
+            try:
+                app_id = _safe_token(
+                    identity_payload.get("appId"),
+                    field="Lark application id",
+                )
+                app_versions = self._call(
+                    [
+                        "api",
+                        "GET",
+                        (
+                            "/open-apis/application/v6/applications/"
+                            f"{app_id}/app_versions"
+                        ),
+                        "--as",
+                        "bot",
+                        "--params",
+                        json.dumps(
+                            {
+                                "lang": "zh_cn",
+                                "page_size": str(LARK_APP_VERSION_PAGE_SIZE),
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                        "--json",
+                    ],
+                    operation="permission_probe",
+                )
+                granted = _published_tenant_scopes(app_versions)
+            except (ValueError, LarkDocumentCommentProviderError) as exc:
+                raise LarkDocumentCommentProviderError(
+                    "lark_document_comment_permission_probe_unknown"
+                ) from exc
+        else:
+            payload = _command_json_mapping(
+                self._runner(
+                    self._args(
+                        ["auth", "check", "--scope", " ".join(scopes), "--json"]
+                    ),
+                    None,
+                    self._timeout_seconds,
+                ),
+                error_code="lark_document_comment_permission_probe_invalid",
+                allowed_returncodes=frozenset({0, 1}),
             )
+            granted = payload.get("granted", [])
+            missing = payload.get("missing", [])
+            if (
+                not isinstance(granted, list)
+                or not isinstance(missing, list)
+                or any(not isinstance(scope, str) for scope in [*granted, *missing])
+                or set(granted).intersection(missing)
+                or set(granted).union(missing) != set(scopes)
+            ):
+                raise LarkDocumentCommentProviderError(
+                    "lark_document_comment_permission_probe_invalid"
+                )
         return dict(
             evaluate_external_connector_permissions(
                 requirements=requirements,

--- a/tests/extensions/test_lark_document_comment_provider.py
+++ b/tests/extensions/test_lark_document_comment_provider.py
@@ -140,21 +140,52 @@ def _reply_page(text: str, *, extra: object | None = None) -> dict[str, Any]:
     }
 
 
-def test_lark_permission_probe_binds_exact_comment_scopes(tmp_path: Path) -> None:
+def _bot_identity(*, profile: str = "fixture-profile") -> dict[str, Any]:
+    return {
+        "identity": "bot",
+        "available": True,
+        "profile": profile,
+        "appId": "cli_fixture",
+    }
+
+
+def _app_version_page(*, scopes: list[str]) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "identity": "bot",
+        "data": {
+            "items": [
+                {
+                    "status": 1,
+                    "publish_time": "1787377000",
+                    "scopes": [
+                        {"scope": scope, "token_types": ["tenant"]} for scope in scopes
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def test_lark_bot_permission_probe_uses_published_app_scope_ledger(
+    tmp_path: Path,
+) -> None:
     calls: list[list[str]] = []
 
     def runner(args, _cwd, _timeout):
         calls.append(list(args))
         if args[-3:] == ["auth", "status", "--json"]:
             return _completed({"identity": "bot"})
+        if args[-2:] == ["whoami", "--json"]:
+            return _completed(_bot_identity())
+        assert "auth" not in args or "check" not in args
         return _completed(
-            {
-                "ok": False,
-                "missing": [
+            _app_version_page(
+                scopes=[
                     LARK_DOCUMENT_COMMENT_CREATE_SCOPE,
                     LARK_DOCUMENT_COMMENT_READ_SCOPE,
-                ],
-            }
+                ]
+            )
         )
 
     provider = LarkCliDocumentCommentProvider(
@@ -167,8 +198,8 @@ def test_lark_permission_probe_binds_exact_comment_scopes(tmp_path: Path) -> Non
         published=True,
     )
 
-    assert guidance["ready"] is False
-    assert guidance["missing_requirement_count"] == 3
+    assert guidance["ready"] is True
+    assert guidance["missing_requirement_count"] == 0
     assert calls == [
         [
             "lark-cli",
@@ -182,15 +213,211 @@ def test_lark_permission_probe_binds_exact_comment_scopes(tmp_path: Path) -> Non
             "lark-cli",
             "--profile",
             "fixture-profile",
-            "auth",
-            "check",
-            "--scope",
-            (
-                f"{LARK_DOCUMENT_COMMENT_CREATE_SCOPE} "
-                f"{LARK_DOCUMENT_COMMENT_READ_SCOPE}"
-            ),
+            "whoami",
             "--json",
         ],
+        [
+            "lark-cli",
+            "--profile",
+            "fixture-profile",
+            "api",
+            "GET",
+            "/open-apis/application/v6/applications/cli_fixture/app_versions",
+            "--as",
+            "bot",
+            "--params",
+            '{"lang":"zh_cn","page_size":"2"}',
+            "--json",
+        ],
+    ]
+
+
+def test_lark_bot_permission_probe_reports_missing_published_scope(
+    tmp_path: Path,
+) -> None:
+    def runner(args, _cwd, _timeout):
+        if args[-3:] == ["auth", "status", "--json"]:
+            return _completed({"identity": "bot"})
+        if args[-2:] == ["whoami", "--json"]:
+            return _completed(_bot_identity())
+        payload = _app_version_page(scopes=[LARK_DOCUMENT_COMMENT_READ_SCOPE])
+        payload["data"]["items"][0]["scopes"].append(
+            {
+                "scope": LARK_DOCUMENT_COMMENT_CREATE_SCOPE,
+                "token_types": ["user"],
+            }
+        )
+        return _completed(payload)
+
+    provider = LarkCliDocumentCommentProvider(
+        target=_target(),
+        reply_store=tmp_path / "reply-receipts.json",
+        runner=runner,
+    )
+    guidance = provider.permission_guidance(
+        response_enabled=True,
+        published=True,
+    )
+
+    assert guidance["ready"] is False
+    assert guidance["missing_requirement_count"] == 1
+    assert guidance["items"][1]["missing_scopes"] == [
+        LARK_DOCUMENT_COMMENT_CREATE_SCOPE
+    ]
+
+
+def test_lark_bot_permission_probe_unknown_fails_closed(tmp_path: Path) -> None:
+    def runner(args, _cwd, _timeout):
+        if args[-3:] == ["auth", "status", "--json"]:
+            return _completed({"identity": "bot"})
+        if args[-2:] == ["whoami", "--json"]:
+            return _completed(_bot_identity())
+        return _completed({"ok": True, "identity": "bot", "data": {"items": []}})
+
+    provider = LarkCliDocumentCommentProvider(
+        target=_target(),
+        reply_store=tmp_path / "reply-receipts.json",
+        runner=runner,
+    )
+
+    try:
+        provider.permission_guidance(response_enabled=True, published=True)
+    except LarkDocumentCommentProviderError as error:
+        assert error.code == "lark_document_comment_permission_probe_unknown"
+    else:
+        raise AssertionError("unknown Bot scope readiness must fail closed")
+
+
+def test_lark_bot_permission_probe_rejects_profile_mismatch(tmp_path: Path) -> None:
+    def runner(args, _cwd, _timeout):
+        if args[-3:] == ["auth", "status", "--json"]:
+            return _completed({"identity": "bot"})
+        return _completed(_bot_identity(profile="different-profile"))
+
+    provider = LarkCliDocumentCommentProvider(
+        target=_target(),
+        reply_store=tmp_path / "reply-receipts.json",
+        runner=runner,
+    )
+
+    try:
+        provider.permission_guidance(response_enabled=True, published=True)
+    except LarkDocumentCommentProviderError as error:
+        assert error.code == (
+            "lark_document_comment_permission_probe_identity_mismatch"
+        )
+    else:
+        raise AssertionError("Bot scope evidence must bind the configured profile")
+
+
+def test_lark_bot_permission_guidance_does_not_return_app_metadata(
+    tmp_path: Path,
+) -> None:
+    def runner(args, _cwd, _timeout):
+        if args[-3:] == ["auth", "status", "--json"]:
+            return _completed({"identity": "bot"})
+        if args[-2:] == ["whoami", "--json"]:
+            return _completed(_bot_identity())
+        payload = _app_version_page(
+            scopes=[
+                LARK_DOCUMENT_COMMENT_CREATE_SCOPE,
+                LARK_DOCUMENT_COMMENT_READ_SCOPE,
+            ]
+        )
+        payload["data"]["private_payload"] = "must-not-escape"
+        return _completed(payload)
+
+    provider = LarkCliDocumentCommentProvider(
+        target=_target(),
+        reply_store=tmp_path / "reply-receipts.json",
+        runner=runner,
+    )
+    serialized = json.dumps(
+        provider.permission_guidance(response_enabled=True, published=True)
+    )
+
+    assert "cli_fixture" not in serialized
+    assert "must-not-escape" not in serialized
+    assert "token" not in serialized.lower()
+
+
+def test_lark_user_permission_probe_still_uses_user_oauth_scopes(
+    tmp_path: Path,
+) -> None:
+    calls: list[list[str]] = []
+
+    def runner(args, _cwd, _timeout):
+        calls.append(list(args))
+        if args[-3:] == ["auth", "status", "--json"]:
+            return _completed({"identity": "user"})
+        return _completed(
+            {
+                "ok": True,
+                "granted": [
+                    LARK_DOCUMENT_COMMENT_CREATE_SCOPE,
+                    LARK_DOCUMENT_COMMENT_READ_SCOPE,
+                ],
+                "missing": [],
+            }
+        )
+
+    target = _target()
+    provider = LarkCliDocumentCommentProvider(
+        target=LarkDocumentCommentTarget(
+            source_ref=target.source_ref,
+            document_url=target.document_url,
+            provider_identity=target.provider_identity,
+            profile=target.profile,
+            identity="user",
+        ),
+        reply_store=tmp_path / "reply-receipts.json",
+        runner=runner,
+    )
+
+    guidance = provider.permission_guidance(response_enabled=True, published=True)
+
+    assert guidance["ready"] is True
+    assert any("auth" in call and "check" in call for call in calls)
+    assert not any("app_versions" in " ".join(call) for call in calls)
+
+
+def test_lark_user_permission_probe_preserves_missing_scope_predicate(
+    tmp_path: Path,
+) -> None:
+    def runner(args, _cwd, _timeout):
+        if args[-3:] == ["auth", "status", "--json"]:
+            return _completed({"identity": "user"})
+        return {
+            "returncode": 1,
+            "stdout": json.dumps(
+                {
+                    "ok": False,
+                    "granted": [LARK_DOCUMENT_COMMENT_READ_SCOPE],
+                    "missing": [LARK_DOCUMENT_COMMENT_CREATE_SCOPE],
+                }
+            ),
+            "stderr": "",
+        }
+
+    target = _target()
+    provider = LarkCliDocumentCommentProvider(
+        target=LarkDocumentCommentTarget(
+            source_ref=target.source_ref,
+            document_url=target.document_url,
+            provider_identity=target.provider_identity,
+            profile=target.profile,
+            identity="user",
+        ),
+        reply_store=tmp_path / "reply-receipts.json",
+        runner=runner,
+    )
+
+    guidance = provider.permission_guidance(response_enabled=True, published=True)
+
+    assert guidance["ready"] is False
+    assert guidance["missing_requirement_count"] == 1
+    assert guidance["items"][1]["missing_scopes"] == [
+        LARK_DOCUMENT_COMMENT_CREATE_SCOPE
     ]
 
 
@@ -253,24 +480,18 @@ def test_lark_document_comment_callsite_runs_read_effect_reply_readback_ack(
         if command[-3:] == ["auth", "status", "--json"]:
             call_order.append("identity_probe")
             return _completed({"identity": "bot"})
-        if command[-3:] == [
-            "--scope",
-            (
-                f"{LARK_DOCUMENT_COMMENT_CREATE_SCOPE} "
-                f"{LARK_DOCUMENT_COMMENT_READ_SCOPE}"
-            ),
-            "--json",
-        ]:
+        if command[-2:] == ["whoami", "--json"]:
+            call_order.append("identity_binding")
+            return _completed(_bot_identity())
+        if "app_versions" in " ".join(command):
             call_order.append("permission_probe")
             return _completed(
-                {
-                    "ok": True,
-                    "granted": [
+                _app_version_page(
+                    scopes=[
                         LARK_DOCUMENT_COMMENT_CREATE_SCOPE,
                         LARK_DOCUMENT_COMMENT_READ_SCOPE,
-                    ],
-                    "missing": [],
-                }
+                    ]
+                )
             )
         if "+list-comments" in command:
             call_order.append("provider_read")
@@ -360,6 +581,7 @@ def test_lark_document_comment_callsite_runs_read_effect_reply_readback_ack(
     assert settlement["response_readback_verified"] is True
     assert call_order == [
         "identity_probe",
+        "identity_binding",
         "permission_probe",
         "provider_read",
         "durable_effect",


### PR DESCRIPTION
## Summary

- make document-comment permission readiness identity-aware
- for Bot profiles, bind evidence with `auth status` plus `whoami`, then read tenant scopes from the current published application version
- keep user profiles on the existing user OAuth `auth check` path
- fail closed when the configured profile/identity does not match, no published version is visible, or the provider response is malformed
- return only normalized readiness and missing-scope results; application metadata, credentials, and provider payloads do not escape

## Problem

`lark-cli auth check` inspects stored user OAuth scopes. A Bot profile can therefore have the required published tenant scopes and still be reported as `not_logged_in` with every scope missing. That false negative blocks a healthy Bot-backed document-comment Connector.

## Behavior after this change

- Bot readiness is derived from the published app-version tenant-scope ledger.
- User readiness remains derived from the user OAuth token.
- User-token scopes cannot satisfy a Bot requirement.
- Missing or ambiguous Bot evidence is `unknown` and fails closed.
- The probe is read-only and does not publish an app version, grant scopes, capture credentials, or mutate provider state.

## Validation

- `python3 -m pytest -q tests/extensions/test_external_connector_provider.py tests/extensions/test_external_connector_runtime.py tests/extensions/test_lark_document_comment_provider.py` (42 passed)
- Ruff check and format check on both changed files
- `loopx canary premerge --from-git-diff` (9 selected checks passed, including 8 extension-runtime risk smokes; zero manual holds)
- public-boundary scans passed for both changed files
- live read-only Bot readiness: 3/3 requirements ready, 0 missing, no credentials captured, no provider payload returned
- control reproduction: the legacy user-token-only check reports `not_logged_in` and both comment scopes missing for the same healthy Bot profile

## Review notes

This changes permission/runtime behavior and must receive independent review; it is not eligible for self-merge even though the standard local premerge packet is green.

Future-facing pass: the identity-specific evidence parsing is isolated in bounded helpers, while the existing provider-neutral permission evaluator remains unchanged. No broader refactor is needed in this PR.
