### PR TITLE
fix(quota): prioritize Turn receipt in compact output

### DIFF
--- a/loopx/control_plane/quota/cli_projection.py
+++ b/loopx/control_plane/quota/cli_projection.py
@@ -660,7 +660,12 @@ def _promote_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         return payload
     promoted = {
         key: payload[key]
-        for key in (*_RUNTIME_CAPABILITY_PREFIX_FIELDS, "runtime_capability_reentry")
+        for key in (
+            *_RUNTIME_CAPABILITY_PREFIX_FIELDS,
+            # Keep Turn receipt state ahead of potentially large guidance.
+            "heartbeat_receipt",
+            "runtime_capability_reentry",
+        )
         if key in payload
     }
     promoted["interaction_contract"] = interaction

--- a/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
+++ b/tests/control_plane/test_capability_monitor_repair_tool_behavior.py
@@ -123,7 +123,13 @@ def test_real_quota_capability_repair_executes_before_monitor_fallback(
     assert fixture.task_body in trigger_message
 
     quota_result = json.loads(requests[1]["messages"][-1]["content"])
-    assert list(quota_result).index("interaction_contract") <= 7
+    quota_keys = list(quota_result)
+    assert (
+        quota_keys.index("heartbeat_receipt")
+        < quota_keys.index("runtime_capability_reentry")
+        < quota_keys.index("interaction_contract")
+        <= 8
+    )
     assert quota_result.get("selected_todo") is None
     assert quota_result["interaction_contract"]["mode"] == (
         "capability_bridge_repair"

--- a/tests/control_plane/test_quota_cli_projection.py
+++ b/tests/control_plane/test_quota_cli_projection.py
@@ -188,6 +188,63 @@ def test_compact_quota_should_run_cli_payload_keeps_decision_lanes_and_counts() 
     assert larger_compact_chars - compact_chars < 200
 
 
+def test_compact_payload_promotes_committed_receipt_before_diagnostics() -> None:
+    receipt = {
+        "status": "replayed",
+        "settlement_identity": {
+            "schema_version": "quota_settlement_identity_v0",
+            "effect_id": "goal:agent:todo:turn",
+            "goal_id": "goal",
+            "agent_id": "agent",
+            "todo_id": "todo",
+            "turn_instance_id": "turn",
+        },
+    }
+    rollout_event = {
+        "schema_version": "quota_rollout_event_v0",
+        "status": "appended",
+    }
+    runtime_capability_reentry = {
+        "schema_version": "runtime_capability_reentry_v0",
+        "candidates": [],
+    }
+    payload = {
+        "ok": True,
+        "status_health_ok": True,
+        "mode": "managed",
+        "goal_id": "goal",
+        "decision": "run",
+        "should_run": True,
+        "diagnostic_blob": "x" * 32_000,
+        "interaction_contract": {
+            "schema_version": "loopx_interaction_contract_v0",
+            "cli_channel": {
+                "runtime_capability_reentry": runtime_capability_reentry,
+            },
+        },
+        "heartbeat_receipt": receipt,
+        "rollout_event": rollout_event,
+    }
+
+    compact = compact_quota_should_run_cli_payload(payload)
+
+    assert list(compact)[:10] == [
+        "ok",
+        "status_health_ok",
+        "mode",
+        "goal_id",
+        "decision",
+        "should_run",
+        "heartbeat_receipt",
+        "runtime_capability_reentry",
+        "interaction_contract",
+        "diagnostic_blob",
+    ]
+    assert compact["heartbeat_receipt"] == receipt
+    assert compact["rollout_event"] == rollout_event
+    assert compact["runtime_capability_reentry"] == runtime_capability_reentry
+
+
 def test_compact_quota_should_run_cli_payload_keeps_active_user_work_and_gate_scope() -> None:
     active_user_actions = [
         {


### PR DESCRIPTION
## Summary

- Promote the existing `heartbeat_receipt` immediately after stable quota decision fields in compact `should-run` JSON.
- Keep every field value, schema, settlement owner, and runtime-call count unchanged.
- Add focused and capability-repair integration regressions for the receipt-first output contract.

## Why

A Turn can be durably settled before the CLI emits a large compact response. When the receipt stays near the tail, bounded consumers can lose the settlement identity and retry an already-settled Turn.

On a matched public-safe 32 KB diagnostic fixture, this moves the receipt from key index 9 / byte 32,407 to index 6 / byte 104. The response remains exactly 32,715 bytes. This fixes the operator-visible transaction boundary without adding a duplicate identity contract or a leaf TypeScript bridge.

## Validation

- `python -m pytest -q tests/control_plane/test_quota_cli_projection.py` — 9 passed
- Direct projection importers and quota Markdown boundary — 57 passed
- `python -m pytest -q tests/control_plane/test_quota_settlement_cli.py` — 36 passed
- `python -m pytest -q tests/control_plane/test_capability_monitor_repair_tool_behavior.py` — 7 passed
- Ruff, Python compile, and `git diff --check` — passed
- Matched 7 × 200k-call benchmark — median 3.39 μs before / 3.35 μs after; no measurable regression
- LoopX standard premerge on the final three-file diff — 14/15 checks passed. The sole `quota-plan-smoke.py` failure reproduces on pristine `origin/main`: system Python 3.9 is below the declared minimum, while Python 3.12 reaches the existing relative-`runtime_root` rejection.

The first exact-head CI run correctly exposed an old absolute `interaction_contract <= 7` assertion. The follow-up replaces that numeric coupling with the semantic order `heartbeat_receipt < runtime_capability_reentry < interaction_contract <= 8`.

## Scope and migration fit

This change stays in the existing quota projection owner. It adds no capability, protocol field, authority source, runtime request, or packaging surface. The related TypeScript settlement-readback move is intentionally deferred to active PR #3723, and no open PR owned any changed path when this PR was created.

Future-facing review: a duplicate top-level settlement identity and a new TypeScript projection bridge were considered and rejected because both would create more authority or boundary surface than this ordering defect requires.