### PR TITLE
fix(ci): isolate Frontstage Pages PR validation

### DIFF
--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -74,10 +74,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: frontstage-pages
-  # A stalled Pages deployment previously occupied this group for two days and
-  # starved every later run (all queued runs were cancelled). Pages deploys are
-  # quick and idempotent, so a newer run may safely supersede a stale one.
+  group: frontstage-pages-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || 'deployment' }}
+  # Keep production deploys in one lane, but isolate each pull request so an
+  # unrelated PR or main push cannot cancel its validation run.
   cancel-in-progress: true
 
 jobs:

--- a/examples/frontstage-pages-workflow-smoke.py
+++ b/examples/frontstage-pages-workflow-smoke.py
@@ -72,6 +72,10 @@ def main() -> int:
         "contents: read",
         "pages: write",
         "id-token: write",
+        "github.event_name == 'pull_request'",
+        "github.event.pull_request.number",
+        "|| 'deployment'",
+        "cancel-in-progress: true",
         'node-version: "20"',
         "npm install -g npm@11",
         "npm ci --include=dev --no-audit --no-fund --registry=https://registry.npmjs.org",
@@ -124,6 +128,7 @@ def main() -> int:
         "stargazerCount",
         "gh api graphql",
         "pageInfo { hasNextPage endCursor }",
+        "\n  group: frontstage-pages\n",
     ]:
         assert_absent(text, forbidden)
 


### PR DESCRIPTION
## Summary

- isolate Frontstage Pages pull-request runs by PR number
- keep push, schedule, and manual deployment runs globally serialized
- cover the concurrency contract in the existing workflow smoke

## Why

PR #3725 completed its Pages export successfully, then an unrelated pull-request run cancelled it through the workflow-wide concurrency group. A later main push cancelled that run in turn. Per-PR lanes preserve same-PR supersession without allowing unrelated work to erase validation.

## Validation

- `python3 examples/frontstage-pages-workflow-smoke.py`
- workflow YAML parse
- `python3 -m py_compile examples/frontstage-pages-workflow-smoke.py`
- `loopx canary premerge --from-git-diff` (4/4 selected checks passed, no manual holds)
- public-boundary scan passed