### PR TITLE
fix(upgrade): preserve fine-grained heartbeat digest

### DIFF
--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -299,6 +299,7 @@ def write_registered_fixture(root: Path) -> Path:
                             "registered_agents": [REGISTERED_AGENT_ID],
                             "primary_agent": REGISTERED_AGENT_ID,
                         },
+                        "execution_profile": {"turn_granularity": "fine"},
                         "quota": {"compute": 1.0, "window_hours": 24},
                     }
                 ],
@@ -372,7 +373,9 @@ def assert_registered_agent_activation_is_checked(root: Path) -> None:
         registered_agents=[REGISTERED_AGENT_ID],
         available_capabilities=["network", "external_evidence_poll"],
         runtime_profile="codex_app_heartbeat",
+        turn_granularity="fine",
     )["task_body"]
+    assert "Fine-grained planning contract" in rendered, rendered
     write_registered_codex_app_automation(root / "registered-codex-home", prompt=rendered)
     old_codex_home = os.environ.get("CODEX_HOME")
     os.environ["CODEX_HOME"] = str(root / "registered-codex-home")

--- a/loopx/upgrade.py
+++ b/loopx/upgrade.py
@@ -11,6 +11,7 @@ from .agent_registry import (
     agent_profile_for_goal,
     registered_agent_ids_for_goal,
 )
+from .execution_profile import execution_profile_turn_granularity
 from .heartbeat_prompt import build_heartbeat_prompt
 from .history import load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
@@ -688,6 +689,11 @@ def build_upgrade_plan(
             deferred.append(stage_deferred_goal_summary(goal, state_file))
             continue
         registered_agents = registered_agent_ids_for_goal(goal)
+        turn_granularity = execution_profile_turn_granularity(
+            goal.get("execution_profile")
+            if isinstance(goal.get("execution_profile"), dict)
+            else None
+        )
         prompt_summaries: dict[str, dict[str, Any]] = {}
         installed: dict[str, dict[str, Any]] = {}
         prompt_targets = [
@@ -718,6 +724,7 @@ def build_upgrade_plan(
                 registered_agents=registered_agents or None,
                 available_capabilities=available_capabilities,
                 runtime_profile="codex_app_heartbeat",
+                turn_granularity=turn_granularity,
             )
             summary = prompt_summary(prompt, mode)
             summary["agent_id"] = agent_id


### PR DESCRIPTION
## Summary

- preserve a goal's persisted `execution_profile.turn_granularity` when `upgrade-plan` renders managed heartbeat prompts
- extend the existing registered-agent upgrade smoke so a fine-grained installed prompt must remain `current` and host-loop activated

## Issue Or Task

- Closes #3727
- Contributor task ID: N/A

## Validation

- [x] `python3 -m py_compile loopx/upgrade.py examples/upgrade-plan-smoke.py`
- [x] `loopx check --scan-path loopx/upgrade.py --scan-path examples/upgrade-plan-smoke.py`
- [x] `python3 examples/upgrade-plan-smoke.py`
- [x] `uv run --extra test python -m pytest -q tests/control_plane/test_fine_grained_turn_mode.py` (8 passed)
- [x] `python3 -m loopx.cli --format json canary premerge --from-git-diff --no-progress --timeout-seconds 120` (gate passed; 5 selected checks, 0 failures, 0 warnings, no manual holds)
- [x] Independent code review: APPROVE, no findings

Full-suite diagnostic coverage was also exercised. A serial run completed 4,687 tests with 12 skips and one external `setuptools` download timeout; that exact extension-scaffold test passed immediately on retry. A subsequent CI-style `-n 2` run completed 4,685 tests with 12 skips and three timeout-sensitive failures while host load was about 20; all three passed serially after load subsided. No failure involved the changed upgrade-plan path.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: #3727

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

## Review Notes

- Changed surfaces: upgrade-plan heartbeat projection and its durable smoke fixture.
- Public/private boundary: clean for both changed files.
- Failures or skips: only the environment-sensitive full-suite diagnostics described above; the risk-based merge gate is fully green.
- Manual holds: none reported by `canary premerge`.
- Future-facing scope pass: no adjacent refactor was needed; the existing execution-profile normalizer and heartbeat builder remain the single owners.
- Merge decision: leave this runtime/control-plane fix for maintainer review; do not self-merge.
