### PR TITLE
fix(lark): bound turn-start reaction replay

### DIFF
--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -78,6 +78,9 @@ collection and quota selection.
 - reaction disablement never cancels the first-read obligation. Failed effects
   retry from the owner-private pending-read set rather than relying on the
   bounded provider overlap window; uncertain effects fail closed before create.
+  Replay is bounded by one aggregate per-dispatch attempt budget and a private
+  round-robin cursor, so a large or failing acknowledgement backlog cannot
+  indefinitely block turn admission and every pending read remains eligible.
 - attention classification affects scheduling and reply policy, never whether
   a successfully read pending message receives the acknowledgement.
 - a provider-owned self-message filter may run before inbox ingestion only from
@@ -85,7 +88,9 @@ collection and quota selection.
   unresolved identity fails open to capture and cannot use display-name or body
   heuristics.
 - provider-local cursors are single-flight and advance only after inbox and
-  cursor readback.
+  cursor readback. History ingestion and acknowledgement replay use independent
+  cursor positions: an old topic's new reply is admitted by its new provider
+  message identity even while older acknowledgement debt remains.
 - `partial` multi-route success still requires Agent reading for accepted
   observations while retaining a compact failure code for the incomplete
   routes.

--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -78,9 +78,11 @@ collection and quota selection.
 - reaction disablement never cancels the first-read obligation. Failed effects
   retry from the owner-private pending-read set rather than relying on the
   bounded provider overlap window; uncertain effects fail closed before create.
-  Replay is bounded by one aggregate per-dispatch attempt budget and a private
-  round-robin cursor, so a large or failing acknowledgement backlog cannot
-  indefinitely block turn admission and every pending read remains eligible.
+  Replay is bounded by one aggregate per-dispatch attempt budget. A private
+  collector-scoped cursor rotates route priority across dispatches, while each
+  route keeps a private round-robin message cursor. A large or failing
+  acknowledgement backlog therefore cannot indefinitely block turn admission,
+  and every pending read remains eligible across routes and messages.
 - attention classification affects scheduling and reply policy, never whether
   a successfully read pending message receives the acknowledgement.
 - a provider-owned self-message filter may run before inbox ingestion only from

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -224,13 +224,14 @@ disabled. Failed reactions are retried from this durable pending-read set while
 the message remains unsettled, including after the bounded history cursor has
 moved beyond the message timestamp. Provider failure increments compact
 failure accounting but does not discard the Inbox event or grant execution
-authority. Replay uses a private round-robin cursor and one aggregate bounded
-attempt budget per turn-start dispatch. The public receipt exposes only
-attempt and deferred counts, never cursor or message identities. Messages with
-a durable received/processing receipt are skipped without another provider
-call. A new reply in an old topic has a new provider message identity, so the
-forward history tail captures it independently of topic age and acknowledgement
-backlog.
+authority. Replay uses one aggregate bounded attempt budget per turn-start
+dispatch. A collector-scoped private cursor rotates route priority across
+dispatches, while each route keeps its own private round-robin message cursor.
+The public receipt exposes only attempt and deferred counts, never cursor or
+message identities. Messages with a durable received/processing receipt are
+skipped without another provider call. A new reply in an old topic has a new
+provider message identity, so the forward history tail captures it independently
+of topic age and acknowledgement backlog.
 
 `reply.processing_reaction_emoji` is optional and requires a distinct
 received reaction. The default `Get` satisfies that requirement; when the read

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -224,7 +224,13 @@ disabled. Failed reactions are retried from this durable pending-read set while
 the message remains unsettled, including after the bounded history cursor has
 moved beyond the message timestamp. Provider failure increments compact
 failure accounting but does not discard the Inbox event or grant execution
-authority.
+authority. Replay uses a private round-robin cursor and one aggregate bounded
+attempt budget per turn-start dispatch. The public receipt exposes only
+attempt and deferred counts, never cursor or message identities. Messages with
+a durable received/processing receipt are skipped without another provider
+call. A new reply in an old topic has a new provider message identity, so the
+forward history tail captures it independently of topic age and acknowledgement
+backlog.
 
 `reply.processing_reaction_emoji` is optional and requires a distinct
 received reaction. The default `Get` satisfies that requirement; when the read

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -167,11 +167,15 @@ def lark_inbox_pending_turn_start_read_message_ids(*, inbox: Path) -> list[str]:
     path = _turn_start_reads_path(inbox)
     with exclusive_file_lock(path, operation="lark_inbox_turn_start_reads"):
         message_ids = _load_turn_start_reads(inbox)
-        pending = {
-            message_id
-            for message_id in message_ids
-            if _captured_pending_message(inbox=inbox, message_id=message_id)
+        processed = _load_processed(inbox / "processed.json")
+        captured = {
+            str(event["message_id"])
+            for event_path in (inbox.glob("*.json") if inbox.is_dir() else [])
+            if event_path.name != "processed.json"
+            if (event := _event_from_file(event_path)) is not None
+            if isinstance(event.get("message_id"), str)
         }
+        pending = message_ids.intersection(captured).difference(processed)
         if pending != message_ids:
             write_private_json_atomic(
                 path,
@@ -181,7 +185,12 @@ def lark_inbox_pending_turn_start_read_message_ids(*, inbox: Path) -> list[str]:
                     "updated_at": datetime.now(UTC).isoformat(),
                 },
             )
-        return sorted(pending)
+        receipts = _load_receipts(_receipt_path(inbox))
+        return sorted(
+            message_id
+            for message_id in pending
+            if not REACTION_PHASES.intersection(receipts.get(message_id, {}))
+        )
 
 
 def _load_received_operation(*, inbox: Path, message_id: str) -> dict[str, str] | None:

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -23,6 +23,7 @@ from .private_json import write_private_json_atomic
 REACTION_RECEIPTS_SCHEMA_VERSION = "lark_event_inbox_reaction_receipts_v0"
 TURN_START_READS_SCHEMA_VERSION = "lark_event_inbox_turn_start_reads_v0"
 RECEIVED_OPERATION_SCHEMA_VERSION = "lark_event_inbox_received_operation_v0"
+PROCESSED_STATE_FILENAME = "processed.json"
 REACTION_PHASES = {"received", "processing"}
 RECEIVED_OPERATION_PHASES = {"prepared", "created"}
 REACTION_ID_PATTERN = re.compile(r"[A-Za-z0-9_-]{1,200}")
@@ -167,11 +168,11 @@ def lark_inbox_pending_turn_start_read_message_ids(*, inbox: Path) -> list[str]:
     path = _turn_start_reads_path(inbox)
     with exclusive_file_lock(path, operation="lark_inbox_turn_start_reads"):
         message_ids = _load_turn_start_reads(inbox)
-        processed = _load_processed(inbox / "processed.json")
+        processed = _load_processed(inbox / PROCESSED_STATE_FILENAME)
         captured = {
             str(event["message_id"])
             for event_path in (inbox.glob("*.json") if inbox.is_dir() else [])
-            if event_path.name != "processed.json"
+            if event_path.name != PROCESSED_STATE_FILENAME
             if (event := _event_from_file(event_path)) is not None
             if isinstance(event.get("message_id"), str)
         }
@@ -503,12 +504,12 @@ def _delete_reaction(
 
 
 def _captured_pending_message(*, inbox: Path, message_id: str) -> bool:
-    if message_id in _load_processed(inbox / "processed.json"):
+    if message_id in _load_processed(inbox / PROCESSED_STATE_FILENAME):
         return False
     return any(
         event.get("message_id") == message_id
         for path in (inbox.glob("*.json") if inbox.is_dir() else [])
-        if path.name != "processed.json"
+        if path.name != PROCESSED_STATE_FILENAME
         if (event := _event_from_file(path)) is not None
     )
 

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -25,7 +25,7 @@ from .event_collector_runtime import (
     _profile_app_id,
     _sender_identity,
 )
-from .event_inbox import MESSAGE_ID_PATTERN
+from .event_inbox import MESSAGE_ID_PATTERN, ROUTE_KEY_PATTERN
 from .group_history import (
     _canonical_events,
     _page_digest,
@@ -64,17 +64,16 @@ def _timestamp(value: datetime) -> str:
 
 
 def _cursor_path(project: Path, *, route_key: str, source_fingerprint: str) -> Path:
+    if not ROUTE_KEY_PATTERN.fullmatch(route_key):
+        raise ValueError("Lark turn-start sync route key is invalid")
     match = SOURCE_FINGERPRINT_PATTERN.fullmatch(source_fingerprint)
     if match is None:
         raise ValueError("Lark turn-start sync source fingerprint is invalid")
-    return (
-        project
-        / ".loopx"
-        / "inbox"
-        / ".turn-start"
-        / route_key
-        / f"{match.group(1)}.json"
-    )
+    trusted_root = (project / ".loopx" / "inbox" / ".turn-start").resolve()
+    cursor_path = (trusted_root / route_key / f"{match.group(1)}.json").resolve()
+    if not cursor_path.is_relative_to(trusted_root):
+        raise ValueError("Lark turn-start sync cursor path escapes its private root")
+    return cursor_path
 
 
 def _load_cursor(
@@ -200,6 +199,94 @@ def _bounded_reaction_message_ids(
     return selected, len(message_ids) - len(selected)
 
 
+def _read_provider_events(
+    *,
+    runner: Runner,
+    argv: list[str],
+    route_key: str,
+    chat_id: str,
+    command_prefix: list[str],
+    profile: str,
+) -> tuple[dict[str, Any] | None, tuple[list[dict[str, Any]], bool, str | None, int, int]]:
+    """Read and canonicalize one provider page behind a compact failure contract."""
+
+    try:
+        provider = runner(
+            argv,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return (
+            {
+                "ok": False,
+                "status": "provider_unavailable",
+                "error_code": "provider_unavailable",
+                "external_read_performed": False,
+                "local_private_state_mutated": False,
+            },
+            ([], False, None, 0, 0),
+        )
+    if provider.returncode != 0:
+        failed = _provider_failure(provider, route_key=route_key)
+        return (
+            {
+                "ok": False,
+                "status": str(failed["status"]),
+                "error_code": str(failed["status"]),
+                "external_read_performed": bool(failed["external_read_performed"]),
+                "local_private_state_mutated": False,
+            },
+            ([], False, None, 0, 0),
+        )
+    try:
+        payload = json.loads(provider.stdout)
+        messages, has_more, next_page_token = _provider_page(payload)
+        profile_app_id = (
+            _profile_app_id(
+                runner=runner,
+                command_prefix=command_prefix,
+                profile=profile,
+            )
+            if any(_sender_identity(message)[0] == "app" for message in messages)
+            else None
+        )
+        events, skipped_count, invalid_count, self_message_skipped_count = (
+            _canonical_events(
+                messages,
+                chat_id=chat_id,
+                profile_app_id=profile_app_id,
+            )
+        )
+    except (json.JSONDecodeError, TypeError, ValueError):
+        invalid_count = 1
+        events, has_more, next_page_token = [], False, None
+        skipped_count = self_message_skipped_count = 0
+    if invalid_count:
+        return (
+            {
+                "ok": False,
+                "status": "provider_contract_error",
+                "error_code": "provider_contract_error",
+                "external_read_performed": True,
+                "local_private_state_mutated": False,
+            },
+            ([], False, None, 0, 0),
+        )
+    return (
+        None,
+        (
+            events,
+            has_more,
+            next_page_token,
+            skipped_count,
+            self_message_skipped_count,
+        ),
+    )
+
+
 def _route_receipt(
     *,
     project: str | Path,
@@ -250,72 +337,24 @@ def _route_receipt(
                 state=state,
                 page_size=page_size,
             )
-            try:
-                provider = runner(
-                    argv,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                    timeout=30,
-                )
-            except (OSError, subprocess.SubprocessError):
-                return {
-                    "ok": False,
-                    "status": "provider_unavailable",
-                    "error_code": "provider_unavailable",
-                    "external_read_performed": False,
-                    "local_private_state_mutated": False,
-                }
-            if provider.returncode != 0:
-                failed = _provider_failure(provider, route_key=route_key)
-                return {
-                    "ok": False,
-                    "status": str(failed["status"]),
-                    "error_code": str(failed["status"]),
-                    "external_read_performed": bool(failed["external_read_performed"]),
-                    "local_private_state_mutated": False,
-                }
-            try:
-                payload = json.loads(provider.stdout)
-                messages, has_more, next_page_token = _provider_page(payload)
-                command_prefix = _executable_prefix(lark_cli_executable)
-                profile_app_id = (
-                    _profile_app_id(
-                        runner=runner,
-                        command_prefix=command_prefix,
-                        profile=str(config["profile"]),
-                    )
-                    if any(
-                        _sender_identity(message)[0] == "app" for message in messages
-                    )
-                    else None
-                )
-                (
-                    events,
-                    skipped_count,
-                    invalid_count,
-                    self_message_skipped_count,
-                ) = _canonical_events(
-                    messages,
-                    chat_id=str(route["chat_id"]),
-                    profile_app_id=profile_app_id,
-                )
-            except (json.JSONDecodeError, TypeError, ValueError):
-                return {
-                    "ok": False,
-                    "status": "provider_contract_error",
-                    "error_code": "provider_contract_error",
-                    "external_read_performed": True,
-                    "local_private_state_mutated": False,
-                }
-            if invalid_count:
-                return {
-                    "ok": False,
-                    "status": "provider_contract_error",
-                    "error_code": "provider_contract_error",
-                    "external_read_performed": True,
-                    "local_private_state_mutated": False,
-                }
+            command_prefix = _executable_prefix(lark_cli_executable)
+            failure, provider_page = _read_provider_events(
+                runner=runner,
+                argv=argv,
+                route_key=route_key,
+                chat_id=str(route["chat_id"]),
+                command_prefix=command_prefix,
+                profile=str(config["profile"]),
+            )
+            if failure is not None:
+                return failure
+            (
+                events,
+                has_more,
+                next_page_token,
+                skipped_count,
+                self_message_skipped_count,
+            ) = provider_page
             newly_missing = [
                 event
                 for event in events

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -40,6 +40,7 @@ from .inbox_reactions import (
     lark_inbox_pending_turn_start_read_message_ids,
     record_lark_inbox_turn_start_read,
 )
+from .private_json import write_private_json_atomic
 from .routed_inbox import ingest_routed_lark_event_inbox
 
 CURSOR_SCHEMA_VERSION = "lark_turn_start_sync_cursor_v0"
@@ -131,14 +132,7 @@ def _load_cursor(
 def _write_cursor(path: Path, state: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     os.chmod(path.parent, 0o700)
-    temporary = path.with_suffix(".json.tmp")
-    temporary.write_text(
-        json.dumps(state, sort_keys=True, separators=(",", ":")) + "\n",
-        encoding="utf-8",
-    )
-    os.chmod(temporary, 0o600)
-    temporary.replace(path)
-    os.chmod(path, 0o600)
+    write_private_json_atomic(path, state)
 
 
 def _window_state(

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -6,7 +6,9 @@ import json
 import os
 import re
 import subprocess
+from bisect import bisect_right
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -23,6 +25,7 @@ from .event_collector_runtime import (
     _profile_app_id,
     _sender_identity,
 )
+from .event_inbox import MESSAGE_ID_PATTERN
 from .group_history import (
     _canonical_events,
     _page_digest,
@@ -43,6 +46,17 @@ CURSOR_SCHEMA_VERSION = "lark_turn_start_sync_cursor_v0"
 SYNC_SCHEMA_VERSION = "lark_turn_start_inbox_sync_v0"
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 SOURCE_FINGERPRINT_PATTERN = re.compile(r"^sha256:([0-9a-f]{24})$")
+TURN_START_REACTION_ATTEMPT_LIMIT = 3
+
+
+@dataclass
+class _ReactionAttemptBudget:
+    remaining: int
+
+    def take(self, requested: int) -> int:
+        granted = min(self.remaining, max(0, requested))
+        self.remaining -= granted
+        return granted
 
 
 def _timestamp(value: datetime) -> str:
@@ -95,6 +109,12 @@ def _load_cursor(
         not isinstance(next_page_token, str) or not next_page_token.strip()
     ):
         raise ValueError("Lark turn-start sync cursor page token is invalid")
+    reaction_cursor_message_id = payload.get("reaction_cursor_message_id")
+    if reaction_cursor_message_id is not None and (
+        not isinstance(reaction_cursor_message_id, str)
+        or not MESSAGE_ID_PATTERN.fullmatch(reaction_cursor_message_id)
+    ):
+        raise ValueError("Lark turn-start sync reaction cursor is invalid")
     page_count = payload.get("page_count")
     message_count = payload.get("message_count")
     if (
@@ -143,20 +163,41 @@ def _window_state(
     else:
         start = end - timedelta(seconds=initial_lookback_seconds)
         transition = "initialized"
-    return (
-        {
-            "schema_version": CURSOR_SCHEMA_VERSION,
-            "route_key": route_key,
-            "source_fingerprint": source_fingerprint,
-            "window_start": _timestamp(start),
-            "window_end": _timestamp(end),
-            "next_page_token": None,
-            "page_count": 0,
-            "message_count": 0,
-            "last_page_digest": "",
-        },
-        transition,
-    )
+    state = {
+        "schema_version": CURSOR_SCHEMA_VERSION,
+        "route_key": route_key,
+        "source_fingerprint": source_fingerprint,
+        "window_start": _timestamp(start),
+        "window_end": _timestamp(end),
+        "next_page_token": None,
+        "page_count": 0,
+        "message_count": 0,
+        "last_page_digest": "",
+    }
+    if existing and existing.get("reaction_cursor_message_id"):
+        state["reaction_cursor_message_id"] = str(
+            existing["reaction_cursor_message_id"]
+        )
+    return state, transition
+
+
+def _bounded_reaction_message_ids(
+    message_ids: list[str],
+    *,
+    cursor_message_id: str | None,
+    budget: _ReactionAttemptBudget,
+) -> tuple[list[str], int]:
+    """Select a bounded round-robin slice without exposing private ids."""
+
+    if not message_ids:
+        return [], 0
+    limit = budget.take(len(message_ids))
+    if limit == 0:
+        return [], len(message_ids)
+    start = bisect_right(message_ids, cursor_message_id or "")
+    ordered = message_ids[start:] + message_ids[:start]
+    selected = ordered[:limit]
+    return selected, len(message_ids) - len(selected)
 
 
 def _route_receipt(
@@ -170,6 +211,7 @@ def _route_receipt(
     page_size: int,
     lark_cli_executable: str,
     runner: Runner,
+    reaction_budget: _ReactionAttemptBudget,
 ) -> dict[str, Any]:
     config, route, _, source_fingerprint = _route_context(
         project=project,
@@ -307,8 +349,24 @@ def _route_receipt(
                     )
                     for event in events
                 )
-                reaction_message_ids = lark_inbox_pending_turn_start_read_message_ids(
-                    inbox=route["inbox"]["inbox_path"]
+                reaction_enabled = bool(
+                    route["inbox"]["reply"].get("received_reaction_emoji")
+                )
+                pending_reaction_message_ids = (
+                    lark_inbox_pending_turn_start_read_message_ids(
+                        inbox=route["inbox"]["inbox_path"]
+                    )
+                    if reaction_enabled
+                    else []
+                )
+                reaction_message_ids, reaction_deferred_count = (
+                    _bounded_reaction_message_ids(
+                        pending_reaction_message_ids,
+                        cursor_message_id=(
+                            str(state.get("reaction_cursor_message_id") or "") or None
+                        ),
+                        budget=reaction_budget,
+                    )
                 )
             except (OSError, TypeError, ValueError):
                 return {
@@ -358,6 +416,8 @@ def _route_receipt(
                 "message_count": int(state["message_count"]) + len(events),
                 "last_page_digest": _page_digest(events, next_page_token),
             }
+            if reaction_message_ids:
+                updated["reaction_cursor_message_id"] = reaction_message_ids[-1]
             try:
                 _write_cursor(cursor_path, updated)
                 readback = _load_cursor(
@@ -399,6 +459,7 @@ def _route_receipt(
                     int(result["created_count"]) for result in reaction_results
                 ),
                 "received_reaction_failure_count": len(reaction_failures),
+                "received_reaction_deferred_count": reaction_deferred_count,
                 "read_ack_attempt_count": sum(
                     int(result["read_ack_attempted"] is True)
                     for result in reaction_results
@@ -450,6 +511,7 @@ def sync_lark_turn_start_inbox(
             "provider_payload_returned": False,
         }
     observed_at = (now or datetime.now(UTC)).astimezone(UTC)
+    reaction_budget = _ReactionAttemptBudget(TURN_START_REACTION_ATTEMPT_LIMIT)
     receipts = [
         _route_receipt(
             project=project,
@@ -461,6 +523,7 @@ def sync_lark_turn_start_inbox(
             page_size=int(policy["page_size"]),
             lark_cli_executable=lark_cli_executable,
             runner=runner,
+            reaction_budget=reaction_budget,
         )
         for route in config["routes"]
     ]
@@ -504,6 +567,13 @@ def sync_lark_turn_start_inbox(
         "received_reaction_failure_count": sum(
             int(receipt.get("received_reaction_failure_count") or 0)
             for receipt in receipts
+        ),
+        "received_reaction_deferred_count": sum(
+            int(receipt.get("received_reaction_deferred_count") or 0)
+            for receipt in receipts
+        ),
+        "read_ack_attempt_count": sum(
+            int(receipt.get("read_ack_attempt_count") or 0) for receipt in receipts
         ),
         "self_message_skipped_count": sum(
             int(receipt.get("self_message_skipped_count") or 0) for receipt in receipts

--- a/loopx/extensions/lark/turn_start_sync.py
+++ b/loopx/extensions/lark/turn_start_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -44,6 +45,7 @@ from .private_json import write_private_json_atomic
 from .routed_inbox import ingest_routed_lark_event_inbox
 
 CURSOR_SCHEMA_VERSION = "lark_turn_start_sync_cursor_v0"
+DISPATCH_CURSOR_SCHEMA_VERSION = "lark_turn_start_dispatch_cursor_v0"
 SYNC_SCHEMA_VERSION = "lark_turn_start_inbox_sync_v0"
 Runner = Callable[..., subprocess.CompletedProcess[str]]
 SOURCE_FINGERPRINT_PATTERN = re.compile(r"^sha256:([0-9a-f]{24})$")
@@ -53,10 +55,13 @@ TURN_START_REACTION_ATTEMPT_LIMIT = 3
 @dataclass
 class _ReactionAttemptBudget:
     remaining: int
+    last_consuming_route_key: str | None = None
 
-    def take(self, requested: int) -> int:
+    def take(self, requested: int, *, route_key: str) -> int:
         granted = min(self.remaining, max(0, requested))
         self.remaining -= granted
+        if granted:
+            self.last_consuming_route_key = route_key
         return granted
 
 
@@ -75,6 +80,72 @@ def _cursor_path(project: Path, *, route_key: str, source_fingerprint: str) -> P
     if not cursor_path.is_relative_to(trusted_root):
         raise ValueError("Lark turn-start sync cursor path escapes its private root")
     return cursor_path
+
+
+def _dispatch_source_fingerprint(config: Mapping[str, Any]) -> str:
+    identity = json.dumps(
+        {
+            "config_path": str(Path(config["config_path"]).resolve()),
+            "profile": str(config["profile"]),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
+    return f"sha256:{digest}"
+
+
+def _dispatch_cursor_path(project: Path, *, source_fingerprint: str) -> Path:
+    match = SOURCE_FINGERPRINT_PATTERN.fullmatch(source_fingerprint)
+    if match is None:
+        raise ValueError("Lark turn-start dispatch fingerprint is invalid")
+    trusted_root = (
+        project / ".loopx" / "inbox" / ".turn-start" / ".dispatch"
+    ).resolve()
+    cursor_path = (trusted_root / f"{match.group(1)}.json").resolve()
+    if not cursor_path.is_relative_to(trusted_root):
+        raise ValueError("Lark turn-start dispatch cursor escapes its private root")
+    return cursor_path
+
+
+def _load_dispatch_cursor(
+    path: Path, *, source_fingerprint: str
+) -> dict[str, str] | None:
+    if not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("Lark turn-start dispatch cursor is unreadable") from exc
+    last_route_key = (
+        str(payload.get("last_route_key") or "")
+        if isinstance(payload, Mapping)
+        else ""
+    )
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("schema_version") != DISPATCH_CURSOR_SCHEMA_VERSION
+        or payload.get("source_fingerprint") != source_fingerprint
+        or not ROUTE_KEY_PATTERN.fullmatch(last_route_key)
+    ):
+        raise ValueError("Lark turn-start dispatch cursor schema is invalid")
+    return {
+        "schema_version": DISPATCH_CURSOR_SCHEMA_VERSION,
+        "source_fingerprint": source_fingerprint,
+        "last_route_key": last_route_key,
+    }
+
+
+def _rotate_routes_after(
+    routes: list[Mapping[str, Any]], *, last_route_key: str | None
+) -> list[Mapping[str, Any]]:
+    if not last_route_key:
+        return routes
+    route_keys = [str(route["route_key"]) for route in routes]
+    if last_route_key not in route_keys:
+        return routes
+    start = route_keys.index(last_route_key) + 1
+    return routes[start:] + routes[:start]
 
 
 def _load_cursor(
@@ -177,6 +248,7 @@ def _window_state(
 def _bounded_reaction_message_ids(
     message_ids: list[str],
     *,
+    route_key: str,
     cursor_message_id: str | None,
     budget: _ReactionAttemptBudget,
 ) -> tuple[list[str], int]:
@@ -184,7 +256,7 @@ def _bounded_reaction_message_ids(
 
     if not message_ids:
         return [], 0
-    limit = budget.take(len(message_ids))
+    limit = budget.take(len(message_ids), route_key=route_key)
     if limit == 0:
         return [], len(message_ids)
     start = bisect_right(message_ids, cursor_message_id or "")
@@ -395,6 +467,7 @@ def _route_receipt(
                 reaction_message_ids, reaction_deferred_count = (
                     _bounded_reaction_message_ids(
                         pending_reaction_message_ids,
+                        route_key=route_key,
                         cursor_message_id=(
                             str(state.get("reaction_cursor_message_id") or "") or None
                         ),
@@ -513,6 +586,109 @@ def _route_receipt(
         }
 
 
+def _dispatch_failure(
+    status: str,
+    *,
+    external_read_performed: bool = False,
+    local_private_state_mutated: bool = False,
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "status": status,
+        "error_code": status,
+        "external_read_performed": external_read_performed,
+        "local_private_state_mutated": local_private_state_mutated,
+    }
+
+
+def _dispatch_route_receipts(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    config: Mapping[str, Any],
+    policy: Mapping[str, Any],
+    observed_at: datetime,
+    lark_cli_executable: str,
+    runner: Runner,
+) -> list[dict[str, Any]]:
+    source_fingerprint = _dispatch_source_fingerprint(config)
+    cursor_path = _dispatch_cursor_path(
+        Path(config["project"]),
+        source_fingerprint=source_fingerprint,
+    )
+    try:
+        lock = exclusive_file_lock(
+            cursor_path,
+            policy=LockAcquisitionPolicy.SINGLE_FLIGHT,
+            operation="lark_turn_start_dispatch",
+        )
+        with lock:
+            try:
+                cursor = _load_dispatch_cursor(
+                    cursor_path,
+                    source_fingerprint=source_fingerprint,
+                )
+            except (OSError, TypeError, ValueError):
+                return [_dispatch_failure("dispatch_cursor_unreadable")]
+            routes = _rotate_routes_after(
+                list(config["routes"]),
+                last_route_key=(cursor or {}).get("last_route_key"),
+            )
+            reaction_budget = _ReactionAttemptBudget(
+                TURN_START_REACTION_ATTEMPT_LIMIT
+            )
+            receipts = [
+                _route_receipt(
+                    project=project,
+                    config_path=config_path,
+                    route_key=str(route["route_key"]),
+                    now=observed_at,
+                    initial_lookback_seconds=int(policy["initial_lookback_seconds"]),
+                    overlap_seconds=int(policy["overlap_seconds"]),
+                    page_size=int(policy["page_size"]),
+                    lark_cli_executable=lark_cli_executable,
+                    runner=runner,
+                    reaction_budget=reaction_budget,
+                )
+                for route in routes
+            ]
+            last_route_key = reaction_budget.last_consuming_route_key
+            if not last_route_key:
+                return receipts
+            updated = {
+                "schema_version": DISPATCH_CURSOR_SCHEMA_VERSION,
+                "source_fingerprint": source_fingerprint,
+                "last_route_key": last_route_key,
+            }
+            try:
+                _write_cursor(cursor_path, updated)
+                readback = _load_dispatch_cursor(
+                    cursor_path,
+                    source_fingerprint=source_fingerprint,
+                )
+                if readback != updated:
+                    raise ValueError(
+                        "Lark turn-start dispatch cursor readback mismatch"
+                    )
+            except (OSError, TypeError, ValueError):
+                receipts.append(
+                    _dispatch_failure(
+                        "dispatch_cursor_readback_failed",
+                        external_read_performed=any(
+                            receipt.get("external_read_performed") is True
+                            for receipt in receipts
+                        ),
+                        local_private_state_mutated=any(
+                            receipt.get("local_private_state_mutated") is True
+                            for receipt in receipts
+                        ),
+                    )
+                )
+            return receipts
+    except LockAcquireTimeoutError:
+        return [_dispatch_failure("sync_already_running")]
+
+
 def sync_lark_turn_start_inbox(
     *,
     project: str | Path,
@@ -544,22 +720,15 @@ def sync_lark_turn_start_inbox(
             "provider_payload_returned": False,
         }
     observed_at = (now or datetime.now(UTC)).astimezone(UTC)
-    reaction_budget = _ReactionAttemptBudget(TURN_START_REACTION_ATTEMPT_LIMIT)
-    receipts = [
-        _route_receipt(
-            project=project,
-            config_path=config_path,
-            route_key=str(route["route_key"]),
-            now=observed_at,
-            initial_lookback_seconds=int(policy["initial_lookback_seconds"]),
-            overlap_seconds=int(policy["overlap_seconds"]),
-            page_size=int(policy["page_size"]),
-            lark_cli_executable=lark_cli_executable,
-            runner=runner,
-            reaction_budget=reaction_budget,
-        )
-        for route in config["routes"]
-    ]
+    receipts = _dispatch_route_receipts(
+        project=project,
+        config_path=config_path,
+        config=config,
+        policy=policy,
+        observed_at=observed_at,
+        lark_cli_executable=lark_cli_executable,
+        runner=runner,
+    )
     failures = [receipt for receipt in receipts if receipt["ok"] is not True]
     # A realtime collector may have persisted a message before this hook sees
     # the same provider-history item. The owner-private read receipt is

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -634,7 +634,7 @@ def test_turn_start_sync_captures_new_reply_in_an_existing_topic(
     )
 
 
-def test_turn_start_sync_shares_reaction_budget_across_routes(
+def test_turn_start_sync_shares_budget_and_rotates_routes_across_dispatches(
     tmp_path: Path,
 ) -> None:
     project, config = _project(tmp_path, received_reaction=True)
@@ -669,18 +669,18 @@ def test_turn_start_sync_shares_reaction_budget_across_routes(
                     "content": "First route message one.",
                     "deleted": False,
                 },
+                {
+                    "message_id": "om_first_route_2",
+                    "create_time": "2026-08-26T09:59:02Z",
+                    "content": "First route message two.",
+                    "deleted": False,
+                },
             ),
             _page(
                 {
                     "message_id": "om_second_route_0",
-                    "create_time": "2026-08-26T09:59:02Z",
-                    "content": "Second route message zero.",
-                    "deleted": False,
-                },
-                {
-                    "message_id": "om_second_route_1",
                     "create_time": "2026-08-26T09:59:03Z",
-                    "content": "Second route message one.",
+                    "content": "Second route message zero.",
                     "deleted": False,
                 },
             ),
@@ -699,6 +699,24 @@ def test_turn_start_sync_shares_reaction_budget_across_routes(
     assert len(reaction_calls) == turn_start_sync_module.TURN_START_REACTION_ATTEMPT_LIMIT
     assert result["read_ack_attempt_count"] == 3
     assert result["received_reaction_deferred_count"] == 1
+
+    second_runner = ReactionPageRunner([_page(), _page()], fail_reaction=True)
+    second = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=second_runner,
+        now=SECOND_NOW,
+    )
+
+    second_reactions = [
+        call[call.index("--message-id") + 1]
+        for call in second_runner.calls
+        if "reactions" in call
+    ]
+    assert second_reactions[0] == "om_second_route_0"
+    assert len(second_reactions) == turn_start_sync_module.TURN_START_REACTION_ATTEMPT_LIMIT
+    assert second["read_ack_attempt_count"] == 3
+    assert second["received_reaction_deferred_count"] == 1
 
 
 def test_turn_start_sync_excludes_verified_profile_self_message(
@@ -826,13 +844,17 @@ def test_same_route_key_isolates_cursor_and_lock_for_two_agent_sources(
         )
         assert result["status"] == "empty"
 
-    assert len(lock_targets) == 2
-    assert len(set(lock_targets)) == 2
+    assert len(lock_targets) == 4
+    assert len(set(lock_targets)) == 4
     cursor_paths = sorted(
         (project / ".loopx/inbox/.turn-start/requirements").glob("*.json")
     )
     assert len(cursor_paths) == 2
-    assert set(cursor_paths) == set(lock_targets)
+    assert set(cursor_paths).issubset(lock_targets)
+    dispatch_lock_targets = [
+        path for path in lock_targets if path.parent.name == ".dispatch"
+    ]
+    assert len(dispatch_lock_targets) == 2
 
     for config in (first_config, second_config):
         runner = PageRunner([_page()])
@@ -918,6 +940,37 @@ def test_provider_schema_error_is_distinct_from_a_real_empty_inbox(
     assert result["error_code"] == "provider_contract_error"
     assert result["agent_read_required"] is False
     assert not list((project / ".loopx/inbox/.turn-start").rglob("*.json"))
+
+
+def test_corrupt_dispatch_cursor_fails_closed_before_provider_read(
+    tmp_path: Path,
+) -> None:
+    project, config_path = _project(tmp_path)
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=config_path,
+    )
+    cursor_path = turn_start_sync_module._dispatch_cursor_path(
+        project,
+        source_fingerprint=(
+            turn_start_sync_module._dispatch_source_fingerprint(config)
+        ),
+    )
+    cursor_path.parent.mkdir(parents=True)
+    cursor_path.write_text("{}\n", encoding="utf-8")
+    runner = PageRunner([_page()])
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config_path,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    assert result["status"] == "unavailable"
+    assert result["error_code"] == "dispatch_cursor_unreadable"
+    assert result["external_reads_performed"] is False
+    assert runner.calls == []
 
 
 def test_inbox_write_still_requires_agent_read_when_cursor_commit_fails(

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -525,6 +525,182 @@ def test_turn_start_sync_retries_reaction_from_local_read_beyond_overlap_window(
     assert history_call[history_call.index("--start") + 1] == "2026-08-26T09:59:55Z"
 
 
+def test_turn_start_sync_bounds_failed_reactions_and_resumes_round_robin(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    messages = [
+        {
+            "message_id": f"om_backlog_{index}",
+            "create_time": "2026-08-26T09:59:00Z",
+            "content": f"Pending acknowledgement {index}",
+            "deleted": False,
+        }
+        for index in range(5)
+    ]
+    first_runner = ReactionPageRunner([_page(*messages)], fail_reaction=True)
+
+    first = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=first_runner,
+        now=FIRST_NOW,
+    )
+
+    first_reactions = [
+        call[call.index("--message-id") + 1]
+        for call in first_runner.calls
+        if "reactions" in call
+    ]
+    assert first_reactions == ["om_backlog_0", "om_backlog_1", "om_backlog_2"]
+    assert first["received_reaction_failure_count"] == 3
+    assert first["received_reaction_deferred_count"] == 2
+    assert first["read_ack_attempt_count"] == 3
+
+    second_runner = ReactionPageRunner([_page()], fail_reaction=True)
+    second = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=second_runner,
+        now=SECOND_NOW,
+    )
+
+    second_reactions = [
+        call[call.index("--message-id") + 1]
+        for call in second_runner.calls
+        if "reactions" in call
+    ]
+    assert second_reactions == ["om_backlog_3", "om_backlog_4", "om_backlog_0"]
+    assert second["received_reaction_failure_count"] == 3
+    assert second["received_reaction_deferred_count"] == 2
+    assert second["observation_count"] == 0
+    assert second["agent_read_required"] is False
+    assert "om_backlog_" not in json.dumps(second)
+
+
+def test_turn_start_sync_captures_new_reply_in_an_existing_topic(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    root_id = "om_existing_topic_root"
+    first = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=ReactionPageRunner(
+            [
+                _page(
+                    {
+                        "message_id": root_id,
+                        "root_id": root_id,
+                        "create_time": "2026-08-26T09:59:00Z",
+                        "content": "Existing topic root.",
+                        "deleted": False,
+                    }
+                )
+            ]
+        ),
+        now=FIRST_NOW,
+    )
+    assert first["observation_count"] == 1
+
+    new_reply_id = "om_existing_topic_new_reply"
+    second_runner = ReactionPageRunner(
+        [
+            _page(
+                {
+                    "message_id": new_reply_id,
+                    "root_id": root_id,
+                    "parent_id": root_id,
+                    "create_time": "2026-08-26T10:04:00Z",
+                    "content": "A new reply on the old topic.",
+                    "deleted": False,
+                }
+            )
+        ]
+    )
+    second = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=second_runner,
+        now=SECOND_NOW,
+    )
+
+    assert second["status"] == "observed"
+    assert second["observation_count"] == 1
+    assert second["received_reaction_count"] == 1
+    assert (project / f".loopx/inbox/requirements/{new_reply_id}.json").is_file()
+    assert any(
+        "reactions" in call and new_reply_id in call for call in second_runner.calls
+    )
+
+
+def test_turn_start_sync_shares_reaction_budget_across_routes(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path, received_reaction=True)
+    second_inbox_config = project / ".loopx/config/inbox-second.json"
+    inbox_payload = json.loads(
+        (project / ".loopx/config/inbox.json").read_text(encoding="utf-8")
+    )
+    inbox_payload["inbox_dir"] = ".loopx/inbox/second"
+    inbox_payload["reply"]["chat_id"] = "oc_fixture_second"
+    second_inbox_config.write_text(json.dumps(inbox_payload), encoding="utf-8")
+    collector_payload = json.loads(config.read_text(encoding="utf-8"))
+    collector_payload["routes"].append(
+        {
+            "route_key": "second",
+            "chat_id": "oc_fixture_second",
+            "event_inbox_config": ".loopx/config/inbox-second.json",
+        }
+    )
+    config.write_text(json.dumps(collector_payload), encoding="utf-8")
+    runner = ReactionPageRunner(
+        [
+            _page(
+                {
+                    "message_id": "om_first_route_0",
+                    "create_time": "2026-08-26T09:59:00Z",
+                    "content": "First route message zero.",
+                    "deleted": False,
+                },
+                {
+                    "message_id": "om_first_route_1",
+                    "create_time": "2026-08-26T09:59:01Z",
+                    "content": "First route message one.",
+                    "deleted": False,
+                },
+            ),
+            _page(
+                {
+                    "message_id": "om_second_route_0",
+                    "create_time": "2026-08-26T09:59:02Z",
+                    "content": "Second route message zero.",
+                    "deleted": False,
+                },
+                {
+                    "message_id": "om_second_route_1",
+                    "create_time": "2026-08-26T09:59:03Z",
+                    "content": "Second route message one.",
+                    "deleted": False,
+                },
+            ),
+        ],
+        fail_reaction=True,
+    )
+
+    result = sync_lark_turn_start_inbox(
+        project=project,
+        config_path=config,
+        runner=runner,
+        now=FIRST_NOW,
+    )
+
+    reaction_calls = [call for call in runner.calls if "reactions" in call]
+    assert len(reaction_calls) == turn_start_sync_module.TURN_START_REACTION_ATTEMPT_LIMIT
+    assert result["read_ack_attempt_count"] == 3
+    assert result["received_reaction_deferred_count"] == 1
+
+
 def test_turn_start_sync_excludes_verified_profile_self_message(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- bound received-reaction replay with one aggregate attempt budget per turn-start dispatch
- persist a private round-robin cursor so failed acknowledgement debt resumes fairly
- skip durable reaction receipts without another provider call and preserve new replies in existing topics

## Validation

- 62 focused Python tests
- Ruff and git diff checks
- LoopX premerge: 10/10 selected checks passed, including public-boundary validation

## Note

The host mypy executable is version 2.3.0 while this repository declares mypy <2; that executable exited with an internal tool error before reporting type findings.