### PR TITLE
fix(quota): settle typed blocker outcomes

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -216,6 +216,13 @@ from `classification`. New writes should use one of:
 execution-profile hints only as a compatibility fallback for historical runs;
 new control-plane decisions should be driven by the enum above.
 
+An `outcome_gap` does not become delivery progress. It may settle and spend one
+exact Todo-bound Turn only when the same writeback includes a
+`typed_progress_observation_v0` with `result_class=blocked`, the matching
+`work_item_id`, a stable `blocker_id`, and a non-empty array of stable
+`evidence_ids`. Missing schemas, prose-only blockers, malformed evidence, and
+Todo identity mismatches remain fail-closed.
+
 `quota should-run` also separates long-running observation from work that should
 advance the selected goal. When the selected goal's current projection is a
 dependency-only observation, the payload includes `work_lane_contract` with

--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -1250,7 +1250,7 @@ def assert_safe_bypass_slot_preview(status_payload: dict) -> None:
         slots=1,
     )
     assert rejected["ok"] is False, rejected
-    assert "accountable delivery writeback" in rejected["reason"], rejected
+    assert "Turn settlement writeback" in rejected["reason"], rejected
 
     with tempfile.TemporaryDirectory(prefix="loopx-safe-bypass-spend-") as tmp:
         runtime_root = Path(tmp)

--- a/loopx/control_plane/quota/settlement_readback.ts
+++ b/loopx/control_plane/quota/settlement_readback.ts
@@ -28,6 +28,7 @@ import {
   receiptBoundMonitorPhase,
   receiptBoundReplayPhase,
 } from "./settlement_phase.ts";
+import { isTurnScopedSettlementOutcome } from "../work_items/delivery_outcome.ts";
 
 export const QUOTA_SETTLEMENT_READBACK_REQUEST_SCHEMA =
   "loopx_quota_settlement_readback_request_v0";
@@ -39,38 +40,6 @@ const TURN_INSTANCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
 const AGENT_ID_PATTERN = /^[a-z][a-z0-9_.:@-]{0,79}$/;
 const REPLAN_OBLIGATION_ID_PATTERN = /^replan-[a-f0-9]{16}$/;
-const STABLE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
-const ACCOUNTABLE_DELIVERY_OUTCOMES = new Set([
-  "outcome_progress",
-  "primary_goal_outcome",
-]);
-
-function isTurnScopedSettlementWriteback(
-  run: JsonObject,
-  expectedTodoId: string | null = null,
-): boolean {
-  const deliveryOutcome = String(run.delivery_outcome ?? "");
-  if (ACCOUNTABLE_DELIVERY_OUTCOMES.has(deliveryOutcome)) return true;
-  if (deliveryOutcome !== "outcome_gap" || expectedTodoId === null) return false;
-  const observation = jsonObject(run.progress_observation);
-  if (
-    !observation ||
-    observation.schema_version !== "typed_progress_observation_v0" ||
-    observation.result_class !== "blocked"
-  ) return false;
-  const rawBlockerId = optionalString(observation.blocker_id);
-  const blockerId = rawBlockerId && STABLE_ID_PATTERN.test(rawBlockerId)
-    ? rawBlockerId
-    : null;
-  const workItemId = normalizeTodoId(observation.work_item_id);
-  const evidenceIds = Array.isArray(observation.evidence_ids)
-    ? observation.evidence_ids
-      .map(optionalString)
-      .filter((value) => value !== null && STABLE_ID_PATTERN.test(value))
-    : [];
-  return blockerId !== null && workItemId !== null && evidenceIds.length > 0 &&
-    workItemId === expectedTodoId;
-}
 
 interface ReadbackRequest {
   runtime_root: string;
@@ -256,7 +225,11 @@ function findWriteback(
     String(run.turn_instance_id ?? "") === identity.turn_instance_id &&
     runMatchesBinding(run, identity) &&
     normalizeAgentId(run.agent_id) === identity.agent_id &&
-    isTurnScopedSettlementWriteback(run, identity.todo_id)
+    isTurnScopedSettlementOutcome(
+      run.delivery_outcome,
+      run.progress_observation,
+      identity.todo_id,
+    )
   ) ?? null;
 }
 
@@ -362,13 +335,21 @@ function inferPersistedIdentity(
       classification === "quota_scheduler_ack" ||
       (classification === "quota_monitor_poll" && run.material_change !== true) ||
       (classification === "state_refreshed" &&
-        !isTurnScopedSettlementWriteback(run, normalizeTodoId(run.todo_id)))
+        !isTurnScopedSettlementOutcome(
+          run.delivery_outcome,
+          run.progress_observation,
+          normalizeTodoId(run.todo_id),
+        ))
     ) {
       continue;
     }
     if (
       classification !== "quota_slot_spent" &&
-      !isTurnScopedSettlementWriteback(run, normalizeTodoId(run.todo_id))
+      !isTurnScopedSettlementOutcome(
+        run.delivery_outcome,
+        run.progress_observation,
+        normalizeTodoId(run.todo_id),
+      )
     ) {
       return null;
     }

--- a/loopx/control_plane/quota/settlement_readback.ts
+++ b/loopx/control_plane/quota/settlement_readback.ts
@@ -39,10 +39,38 @@ const TURN_INSTANCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const TODO_ID_PATTERN = /^todo_[a-z0-9_-]{3,64}$/;
 const AGENT_ID_PATTERN = /^[a-z][a-z0-9_.:@-]{0,79}$/;
 const REPLAN_OBLIGATION_ID_PATTERN = /^replan-[a-f0-9]{16}$/;
+const STABLE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
 const ACCOUNTABLE_DELIVERY_OUTCOMES = new Set([
   "outcome_progress",
   "primary_goal_outcome",
 ]);
+
+function isTurnScopedSettlementWriteback(
+  run: JsonObject,
+  expectedTodoId: string | null = null,
+): boolean {
+  const deliveryOutcome = String(run.delivery_outcome ?? "");
+  if (ACCOUNTABLE_DELIVERY_OUTCOMES.has(deliveryOutcome)) return true;
+  if (deliveryOutcome !== "outcome_gap" || expectedTodoId === null) return false;
+  const observation = jsonObject(run.progress_observation);
+  if (
+    !observation ||
+    observation.schema_version !== "typed_progress_observation_v0" ||
+    observation.result_class !== "blocked"
+  ) return false;
+  const rawBlockerId = optionalString(observation.blocker_id);
+  const blockerId = rawBlockerId && STABLE_ID_PATTERN.test(rawBlockerId)
+    ? rawBlockerId
+    : null;
+  const workItemId = normalizeTodoId(observation.work_item_id);
+  const evidenceIds = Array.isArray(observation.evidence_ids)
+    ? observation.evidence_ids
+      .map(optionalString)
+      .filter((value) => value !== null && STABLE_ID_PATTERN.test(value))
+    : [];
+  return blockerId !== null && workItemId !== null && evidenceIds.length > 0 &&
+    workItemId === expectedTodoId;
+}
 
 interface ReadbackRequest {
   runtime_root: string;
@@ -228,7 +256,7 @@ function findWriteback(
     String(run.turn_instance_id ?? "") === identity.turn_instance_id &&
     runMatchesBinding(run, identity) &&
     normalizeAgentId(run.agent_id) === identity.agent_id &&
-    ACCOUNTABLE_DELIVERY_OUTCOMES.has(String(run.delivery_outcome ?? ""))
+    isTurnScopedSettlementWriteback(run, identity.todo_id)
   ) ?? null;
 }
 
@@ -329,19 +357,18 @@ function inferPersistedIdentity(
     const runAgentId = normalizeAgentId(run.agent_id);
     if (runAgentId && runAgentId !== agentId) continue;
     const classification = String(run.classification ?? "").trim();
-    const deliveryOutcome = String(run.delivery_outcome ?? "").trim();
     if (
       classification === "quota_slot_voided" ||
       classification === "quota_scheduler_ack" ||
       (classification === "quota_monitor_poll" && run.material_change !== true) ||
       (classification === "state_refreshed" &&
-        !ACCOUNTABLE_DELIVERY_OUTCOMES.has(deliveryOutcome))
+        !isTurnScopedSettlementWriteback(run, normalizeTodoId(run.todo_id)))
     ) {
       continue;
     }
     if (
       classification !== "quota_slot_spent" &&
-      !ACCOUNTABLE_DELIVERY_OUTCOMES.has(deliveryOutcome)
+      !isTurnScopedSettlementWriteback(run, normalizeTodoId(run.todo_id))
     ) {
       return null;
     }

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -342,19 +342,20 @@ def _is_quota_neutral_state_refresh(run: dict[str, Any]) -> bool:
     )
 
 
-def _latest_unspent_accountable_delivery_run(
+def _latest_unspent_turn_settlement_run(
     runtime_root: Path,
     goal_id: str,
     *,
     agent_id: str | None = None,
 ) -> dict[str, Any] | None:
-    """Return the latest same-agent delivery that still needs accounting.
+    """Return the latest same-agent Turn settlement that still needs accounting.
 
     Unchanged monitor polls, scheduler acknowledgements, and plain state
     refreshes are quota-neutral. They may occur after validation and before
     accounting, so they must not hide the accountable run. A state refresh
-    with an explicit non-accountable delivery outcome and other non-delivery
-    events remain fail closed.
+    with a non-settling delivery outcome and other non-delivery events remain
+    fail closed. A typed blocked ``outcome_gap`` settles the Turn without being
+    reclassified as delivery progress.
     """
 
     safe_agent_id = normalize_todo_claimed_by(agent_id)
@@ -382,7 +383,7 @@ def _latest_unspent_accountable_delivery_run(
             run.get("progress_observation")
             if isinstance(run.get("progress_observation"), dict)
             else None,
-            work_item_id=str(run.get("todo_id") or "") or None,
+            work_item_id=normalize_todo_id(run.get("todo_id")),
         ):
             return run
         return None
@@ -564,7 +565,7 @@ def build_quota_slot_preview_for_decision(
         and before.get("capability_repair_allowed") is True
     )
     delivery_completion_run = delivery_completion_run or (
-        _latest_unspent_accountable_delivery_run(
+        _latest_unspent_turn_settlement_run(
             Path(str(raw_runtime_root)).expanduser(),
             safe_goal_id,
             agent_id=safe_requested_agent_id,
@@ -593,7 +594,7 @@ def build_quota_slot_preview_for_decision(
             "registry_mutated": False,
             "reason": (
                 "safe-bypass quota spend requires a latest "
-                "unspent accountable delivery writeback"
+                "unspent Turn settlement writeback"
             ),
             "before": before,
             "after": None,

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -22,8 +22,8 @@ from ..todos.contract import (
     normalize_todo_replan_obligation_id,
 )
 from ..work_items.delivery_outcome import (
-    ACCOUNTABLE_DELIVERY_OUTCOMES,
     normalize_delivery_outcome,
+    qualifies_turn_scoped_settlement,
 )
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
@@ -377,7 +377,13 @@ def _latest_unspent_accountable_delivery_run(
         if _is_quota_neutral_state_refresh(run):
             continue
         delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
-        if delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:
+        if qualifies_turn_scoped_settlement(
+            delivery_outcome,
+            run.get("progress_observation")
+            if isinstance(run.get("progress_observation"), dict)
+            else None,
+            work_item_id=str(run.get("todo_id") or "") or None,
+        ):
             return run
         return None
     return None

--- a/loopx/control_plane/work_items/delivery_outcome.py
+++ b/loopx/control_plane/work_items/delivery_outcome.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any
+
+from .progress_result import (
+    PROGRESS_OBSERVATION_SCHEMA_VERSION,
+    ProgressResultClass,
+)
 
 
 class DeliveryOutcome(str, Enum):
@@ -49,6 +55,58 @@ FOLLOWTHROUGH_REQUIRED_DELIVERY_OUTCOMES = frozenset(
     }
 )
 PROGRESS_DELIVERY_OUTCOMES = ACCOUNTABLE_DELIVERY_OUTCOMES
+
+
+def qualifies_turn_scoped_blocker_settlement(
+    delivery_outcome: Any,
+    progress_observation: Mapping[str, Any] | None,
+    *,
+    work_item_id: str | None = None,
+) -> bool:
+    """Return whether an outcome gap is a typed, attributable blocker receipt.
+
+    ``outcome_gap`` remains outside the progress outcomes: it can settle one
+    exact Turn only when the same writeback carries a blocked observation with
+    a stable blocker, evidence, and matching work-item identity.
+    """
+
+    if (
+        normalize_delivery_outcome(delivery_outcome) != DeliveryOutcome.OUTCOME_GAP
+        or not isinstance(progress_observation, Mapping)
+        or not str(work_item_id or "").strip()
+    ):
+        return False
+    observation = dict(progress_observation)
+    if observation.get("schema_version") != PROGRESS_OBSERVATION_SCHEMA_VERSION:
+        return False
+    if (
+        observation.get("result_class") != ProgressResultClass.BLOCKED.value
+        or not observation.get("blocker_id")
+        or observation.get("work_item_id") != str(work_item_id).strip()
+    ):
+        return False
+    evidence_ids = observation.get("evidence_ids")
+    return isinstance(evidence_ids, list) and any(
+        str(evidence_id or "").strip() for evidence_id in evidence_ids
+    )
+
+
+def qualifies_turn_scoped_settlement(
+    delivery_outcome: Any,
+    progress_observation: Mapping[str, Any] | None,
+    *,
+    work_item_id: str | None = None,
+) -> bool:
+    """Return whether one delivery record may satisfy a Turn settlement."""
+
+    normalized = normalize_delivery_outcome(delivery_outcome)
+    return normalized in ACCOUNTABLE_DELIVERY_OUTCOMES or (
+        qualifies_turn_scoped_blocker_settlement(
+            normalized,
+            progress_observation,
+            work_item_id=work_item_id,
+        )
+    )
 
 
 def normalize_delivery_outcome(value: Any) -> DeliveryOutcome | None:

--- a/loopx/control_plane/work_items/delivery_outcome.py
+++ b/loopx/control_plane/work_items/delivery_outcome.py
@@ -7,6 +7,7 @@ from typing import Any
 from .progress_result import (
     PROGRESS_OBSERVATION_SCHEMA_VERSION,
     ProgressResultClass,
+    normalize_progress_identifier,
 )
 
 
@@ -73,21 +74,25 @@ def qualifies_turn_scoped_blocker_settlement(
     if (
         normalize_delivery_outcome(delivery_outcome) != DeliveryOutcome.OUTCOME_GAP
         or not isinstance(progress_observation, Mapping)
-        or not str(work_item_id or "").strip()
+        or progress_observation.get("schema_version")
+        != PROGRESS_OBSERVATION_SCHEMA_VERSION
+        or not isinstance(progress_observation.get("evidence_ids"), list)
+        or normalize_progress_identifier(work_item_id) is None
     ):
         return False
     observation = dict(progress_observation)
-    if observation.get("schema_version") != PROGRESS_OBSERVATION_SCHEMA_VERSION:
-        return False
+    normalized_work_item_id = normalize_progress_identifier(work_item_id)
     if (
         observation.get("result_class") != ProgressResultClass.BLOCKED.value
-        or not observation.get("blocker_id")
-        or observation.get("work_item_id") != str(work_item_id).strip()
+        or normalize_progress_identifier(observation.get("blocker_id")) is None
+        or normalize_progress_identifier(observation.get("work_item_id"))
+        != normalized_work_item_id
     ):
         return False
     evidence_ids = observation.get("evidence_ids")
-    return isinstance(evidence_ids, list) and any(
-        str(evidence_id or "").strip() for evidence_id in evidence_ids
+    return isinstance(evidence_ids, list) and bool(evidence_ids) and all(
+        normalize_progress_identifier(evidence_id) is not None
+        for evidence_id in evidence_ids
     )
 
 

--- a/loopx/control_plane/work_items/delivery_outcome.ts
+++ b/loopx/control_plane/work_items/delivery_outcome.ts
@@ -17,6 +17,51 @@ export type DeliveryOutcome = (typeof DELIVERY_OUTCOMES)[number];
 export type MaterialDeliveryOutcome =
   (typeof MATERIAL_DELIVERY_OUTCOMES)[number];
 
+const STABLE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
+const PROGRESS_DELIVERY_OUTCOMES = new Set<DeliveryOutcome>([
+  "outcome_progress",
+  "primary_goal_outcome",
+]);
+
+function jsonObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function stableIdentifier(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const candidate = String(value).trim();
+  return candidate && STABLE_ID_PATTERN.test(candidate) ? candidate : null;
+}
+
+export function isTurnScopedSettlementOutcome(
+  deliveryOutcome: unknown,
+  progressObservation: unknown,
+  expectedWorkItemId: string | null,
+): boolean {
+  const normalizedOutcome = String(deliveryOutcome ?? "").trim() as DeliveryOutcome;
+  if (PROGRESS_DELIVERY_OUTCOMES.has(normalizedOutcome)) return true;
+  if (normalizedOutcome !== "outcome_gap" || expectedWorkItemId === null) {
+    return false;
+  }
+  const observation = jsonObject(progressObservation);
+  if (
+    !observation ||
+    observation.schema_version !== "typed_progress_observation_v0" ||
+    observation.result_class !== "blocked" ||
+    stableIdentifier(observation.work_item_id) !== expectedWorkItemId ||
+    stableIdentifier(observation.blocker_id) === null ||
+    !Array.isArray(observation.evidence_ids) ||
+    observation.evidence_ids.length === 0
+  ) {
+    return false;
+  }
+  return observation.evidence_ids.every(
+    (evidenceId) => stableIdentifier(evidenceId) !== null,
+  );
+}
+
 export function decodeOptionalDeliveryOutcome(
   value: unknown,
   label = "delivery_outcome",

--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -5,7 +5,6 @@ import json
 import re
 import shlex
 from collections.abc import Iterable, Mapping
-from enum import StrEnum
 from typing import Any
 
 from ...turn_identity import normalize_turn_instance_id
@@ -14,8 +13,11 @@ from ..todos.contract import (
     normalize_todo_task_domain,
     replan_successor_semantic_binding,
 )
+from .progress_result import (
+    PROGRESS_OBSERVATION_SCHEMA_VERSION,
+    ProgressResultClass,
+)
 
-PROGRESS_OBSERVATION_SCHEMA_VERSION = "typed_progress_observation_v0"
 REPLAN_CONTEXT_SCHEMA_VERSION = "replan_context_v0"
 REPLAN_CONTEXT_RECEIPT_SCHEMA_VERSION = "replan_context_delivery_receipt_v0"
 REPLAN_ACTION_PACKET_SCHEMA_VERSION = "replan_action_packet_v0"
@@ -27,14 +29,6 @@ MAX_COVERAGE_LEDGER_ITEMS = 6
 # This expression validates opaque public-safe identifiers. It is deliberately
 # not used to classify prose or infer progress semantics.
 _STABLE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
-
-
-class ProgressResultClass(StrEnum):
-    ADVANCED = "advanced"
-    UNCHANGED = "unchanged"
-    BLOCKED = "blocked"
-    EXPLORATION_EXHAUSTED = "exploration_exhausted"
-    NO_FOLLOWUP = "no_followup"
 
 
 SEMANTIC_DIMENSIONS = (

--- a/loopx/control_plane/work_items/progress_observation.py
+++ b/loopx/control_plane/work_items/progress_observation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import shlex
 from collections.abc import Iterable, Mapping
 from typing import Any
@@ -16,6 +15,7 @@ from ..todos.contract import (
 from .progress_result import (
     PROGRESS_OBSERVATION_SCHEMA_VERSION,
     ProgressResultClass,
+    normalize_progress_identifier,
 )
 
 REPLAN_CONTEXT_SCHEMA_VERSION = "replan_context_v0"
@@ -25,11 +25,6 @@ PROGRESS_REPEAT_TRIGGER_KIND = "typed_progress_repeat"
 PROGRESS_REPEAT_THRESHOLD = 2
 MAX_PROGRESS_EVIDENCE_IDS = 12
 MAX_COVERAGE_LEDGER_ITEMS = 6
-
-# This expression validates opaque public-safe identifiers. It is deliberately
-# not used to classify prose or infer progress semantics.
-_STABLE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
-
 
 SEMANTIC_DIMENSIONS = (
     "surface_id",
@@ -77,7 +72,7 @@ def _stable_id(value: Any, *, field: str, required: bool = False) -> str | None:
         if required:
             raise ValueError(f"{field} is required")
         return None
-    if not _STABLE_ID.fullmatch(normalized):
+    if normalize_progress_identifier(normalized) is None:
         raise ValueError(
             f"{field} must be an opaque 1-128 character public-safe identifier"
         )

--- a/loopx/control_plane/work_items/progress_result.py
+++ b/loopx/control_plane/work_items/progress_result.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+PROGRESS_OBSERVATION_SCHEMA_VERSION = "typed_progress_observation_v0"
+
+
+class ProgressResultClass(StrEnum):
+    """Typed result classes shared by progress writers and settlement readers."""
+
+    ADVANCED = "advanced"
+    UNCHANGED = "unchanged"
+    BLOCKED = "blocked"
+    EXPLORATION_EXHAUSTED = "exploration_exhausted"
+    NO_FOLLOWUP = "no_followup"

--- a/loopx/control_plane/work_items/progress_result.py
+++ b/loopx/control_plane/work_items/progress_result.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+import re
 from enum import StrEnum
+from typing import Any
 
 
 PROGRESS_OBSERVATION_SCHEMA_VERSION = "typed_progress_observation_v0"
+_STABLE_PROGRESS_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+
+
+def normalize_progress_identifier(value: Any) -> str | None:
+    """Return one opaque public-safe progress identifier or ``None``."""
+
+    normalized = str(value or "").strip()
+    return normalized if _STABLE_PROGRESS_ID.fullmatch(normalized) else None
 
 
 class ProgressResultClass(StrEnum):

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -15,6 +15,7 @@ from .control_plane.work_items.delivery_batch_scale import (
 from .control_plane.work_items.delivery_outcome import (
     ACCOUNTABLE_DELIVERY_OUTCOMES,
     DELIVERY_OUTCOME_CHOICES as DELIVERY_OUTCOME_CHOICES,
+    qualifies_turn_scoped_settlement,
     require_delivery_outcome,
 )
 from .control_plane.agents.workspace_guard import (
@@ -897,12 +898,6 @@ def refresh_state_run(
     normalized_delivery_outcome = (
         require_delivery_outcome(delivery_outcome).value if delivery_outcome else None
     )
-    if delivery_workspace_path is not None and (
-        normalized_delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES
-    ):
-        raise ValueError(
-            "--delivery-workspace-path requires an accountable --delivery-outcome"
-        )
     normalized_repair_delta_kinds = normalize_repair_delta_kinds(repair_delta_kinds)
     normalized_progress_observation = (
         normalize_progress_observation(
@@ -912,15 +907,26 @@ def refresh_state_run(
         if progress_observation is not None
         else None
     )
+    turn_scoped_settlement_qualified = qualifies_turn_scoped_settlement(
+        normalized_delivery_outcome,
+        normalized_progress_observation,
+        work_item_id=todo_id,
+    )
+    if delivery_workspace_path is not None and not turn_scoped_settlement_qualified:
+        raise ValueError(
+            "--delivery-workspace-path requires a progress outcome or a typed "
+            "blocked outcome_gap settlement"
+        )
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_override)
     settlement_identity = None
     settlement_result = None
     delivery_workspace_causality = None
     if todo_id or normalized_replan_obligation_id or turn_instance_id:
-        if normalized_delivery_outcome not in ACCOUNTABLE_DELIVERY_OUTCOMES:
+        if not turn_scoped_settlement_qualified:
             raise ValueError(
-                "turn-scoped refresh-state requires an accountable --delivery-outcome"
+                "turn-scoped refresh-state requires a progress outcome or a typed "
+                "blocked outcome_gap settlement"
             )
         settlement_readback = read_heartbeat_settlement(
             runtime_root,
@@ -1182,7 +1188,7 @@ def refresh_state_run(
             "explicit non-delivery settlement contract"
         )
     if (
-        normalized_delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES
+        turn_scoped_settlement_qualified
         and workspace_requirement != "not_required"
     ):
         delivery_workspace = capture_delivery_workspace(

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -11,6 +11,10 @@ from typing import Any
 import pytest
 
 from loopx.bootstrap_command_pack import build_start_goal_guided_packet
+from loopx.control_plane.work_items.delivery_outcome import (
+    PROGRESS_DELIVERY_OUTCOMES,
+    DeliveryOutcome,
+)
 from loopx.heartbeat_prompt import build_heartbeat_prompt
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -574,6 +578,145 @@ def test_gitless_goal_refresh_and_quota_spend_settle_end_to_end(
     assert spend["appended"] is True
     assert spend["delivery_workspace_validated"] is True
     assert spend["delivery_workspace"]["workspace_identity"] == f"loopx:{GOAL_ID}"
+    assert _spend_run_count(runtime) == 1
+
+
+def test_typed_outcome_gap_settles_exact_turn_without_becoming_progress(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(
+        tmp_path,
+        required_capability="filesystem_write",
+    )
+    turn_id = "turn-typed-blocker-settlement"
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        turn_id,
+    )
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        *binding,
+        "--scan-path",
+        str(project),
+        cwd=project,
+    )
+    assert guard_rc == 0, guard
+    assert guard["heartbeat_receipt"]["settlement_identity"]["todo_id"] == TODO_ID
+    assert DeliveryOutcome.OUTCOME_GAP not in PROGRESS_DELIVERY_OUTCOMES
+
+    common_refresh_args = (
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "typed_blocker_writeback",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_gap",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+    bare_rc, bare = _run_cli(
+        registry_path,
+        runtime,
+        *common_refresh_args,
+        cwd=project,
+    )
+    assert bare_rc == 1, bare
+    assert "typed blocked outcome_gap settlement" in bare["error"]
+    assert _classification_count(runtime, "typed_blocker_writeback") == 0
+
+    surface_args = list(common_refresh_args)
+    outcome_index = surface_args.index("outcome_gap")
+    surface_args[outcome_index] = "surface_only"
+    surface_rc, surface = _run_cli(
+        registry_path,
+        runtime,
+        *surface_args,
+        "--progress-result-class",
+        "blocked",
+        "--progress-blocker-id",
+        "blocker:runtime-boundary",
+        "--progress-evidence-id",
+        "evidence:runtime-boundary",
+        cwd=project,
+    )
+    assert surface_rc == 1, surface
+    assert "typed blocked outcome_gap settlement" in surface["error"]
+
+    mismatch_args = list(common_refresh_args)
+    todo_index = mismatch_args.index(TODO_ID)
+    mismatch_args[todo_index] = ALTERNATIVE_TODO_ID
+    mismatch_rc, mismatch = _run_cli(
+        registry_path,
+        runtime,
+        *mismatch_args,
+        "--progress-result-class",
+        "blocked",
+        "--progress-blocker-id",
+        "blocker:runtime-boundary",
+        "--progress-evidence-id",
+        "evidence:runtime-boundary",
+        cwd=project,
+    )
+    assert mismatch_rc == 1, mismatch
+    assert "settlement binding does not match" in mismatch["error"]
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        *common_refresh_args,
+        "--progress-result-class",
+        "blocked",
+        "--progress-blocker-id",
+        "blocker:runtime-boundary",
+        "--progress-evidence-id",
+        "evidence:runtime-boundary",
+        cwd=project,
+    )
+    assert refresh_rc == 0, refresh
+    assert refresh["delivery_outcome"] == "outcome_gap"
+    assert refresh["progress_observation"]["result_class"] == "blocked"
+    assert refresh["progress_observation"]["work_item_id"] == TODO_ID
+    assert [
+        receipt["step_kind"]
+        for receipt in refresh["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback"]
+
+    spend_rc, spend = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        GOAL_ID,
+        "--slots",
+        "1",
+        "--source",
+        "heartbeat",
+        "--execute",
+        *binding,
+        "--scan-path",
+        str(project),
+        cwd=project,
+    )
+    assert spend_rc == 0, spend
+    assert [
+        receipt["step_kind"]
+        for receipt in spend["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback", "quota_spend"]
     assert _spend_run_count(runtime) == 1
 
 

--- a/tests/control_plane/test_quota_slot_accounting.py
+++ b/tests/control_plane/test_quota_slot_accounting.py
@@ -122,6 +122,8 @@ def _run(
     classification: str,
     agent_id: str | None = None,
     delivery_outcome: str | None = None,
+    todo_id: str | None = None,
+    progress_observation: dict[str, Any] | None = None,
     refresh_state: bool = False,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -133,6 +135,10 @@ def _run(
         payload["agent_id"] = agent_id
     if delivery_outcome:
         payload["delivery_outcome"] = delivery_outcome
+    if todo_id:
+        payload["todo_id"] = todo_id
+    if progress_observation:
+        payload["progress_observation"] = progress_observation
     if refresh_state:
         payload.update(
             {
@@ -144,7 +150,23 @@ def _run(
     return payload
 
 
-def test_unchanged_monitor_poll_is_not_accountable_delivery(tmp_path: Path) -> None:
+def _blocked_gap(evidence_ids: object) -> dict[str, Any]:
+    return _run(
+        "2026-01-01T00:01:00+00:00",
+        classification="blocked_writeback",
+        delivery_outcome="outcome_gap",
+        todo_id="todo_exact",
+        progress_observation={
+            "schema_version": "typed_progress_observation_v0",
+            "result_class": "blocked",
+            "work_item_id": "todo_exact",
+            "blocker_id": "blocker:runtime-boundary",
+            "evidence_ids": evidence_ids,
+        },
+    )
+
+
+def test_unchanged_monitor_poll_is_not_turn_settlement(tmp_path: Path) -> None:
     runtime = tmp_path / "runtime"
     _write_run_index(runtime, [_poll("2026-01-01T00:00:00+00:00", material=False)])
 
@@ -152,7 +174,7 @@ def test_unchanged_monitor_poll_is_not_accountable_delivery(tmp_path: Path) -> N
 
 
 @pytest.mark.parametrize("before_overrides", SAFE_BYPASS_CASES)
-def test_safe_bypass_rejects_no_accountable_writeback(
+def test_safe_bypass_rejects_missing_turn_settlement(
     tmp_path: Path,
     before_overrides: dict[str, Any],
 ) -> None:
@@ -161,9 +183,48 @@ def test_safe_bypass_rejects_no_accountable_writeback(
     preview = _preview(runtime, before_overrides=before_overrides)
 
     assert preview["ok"] is False
-    assert "requires a latest unspent accountable delivery writeback" in preview[
-        "reason"
-    ]
+    assert "requires a latest unspent Turn settlement writeback" in preview["reason"]
+
+
+def test_safe_bypass_accepts_typed_blocker_settlement_without_progress(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    _write_run_index(
+        runtime,
+        [_blocked_gap(["evidence:runtime-boundary"])],
+    )
+
+    preview = _preview(
+        runtime,
+        before_overrides={"state": "operator_gate", "safe_bypass_allowed": True},
+    )
+
+    assert preview["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "evidence_ids",
+    [
+        "evidence:runtime-boundary",
+        {"evidence:runtime-boundary": True},
+        ["evidence:runtime-boundary", "invalid evidence id"],
+    ],
+)
+def test_safe_bypass_rejects_malformed_blocker_evidence(
+    tmp_path: Path,
+    evidence_ids: object,
+) -> None:
+    runtime = tmp_path / "runtime"
+    _write_run_index(runtime, [_blocked_gap(evidence_ids)])
+
+    preview = _preview(
+        runtime,
+        before_overrides={"state": "operator_gate", "safe_bypass_allowed": True},
+    )
+
+    assert preview["ok"] is False
+    assert "requires a latest unspent Turn settlement writeback" in preview["reason"]
 
 
 @pytest.mark.parametrize("before_overrides", SAFE_BYPASS_CASES)

--- a/tests/control_plane_ts/quota_settlement_readback.test.ts
+++ b/tests/control_plane_ts/quota_settlement_readback.test.ts
@@ -234,6 +234,26 @@ test("accepts only an attributable typed blocker as an outcome-gap writeback", a
   });
   const mismatched = await readQuotaSettlement(request(mismatchedRuntime));
   assert.equal((mismatched.writeback as any).payload.ok, false);
+
+  for (const evidenceIds of [
+    "evidence-runtime-boundary",
+    { evidence: "runtime-boundary" },
+    ["evidence-runtime-boundary", "invalid evidence id"],
+  ]) {
+    const malformedRuntime = await fixture({
+      writeback: true,
+      writebackOutcome: "outcome_gap",
+      progressObservation: {
+        schema_version: "typed_progress_observation_v0",
+        result_class: "blocked",
+        work_item_id: todoId,
+        blocker_id: "blocker-runtime-boundary",
+        evidence_ids: evidenceIds,
+      },
+    });
+    const malformed = await readQuotaSettlement(request(malformedRuntime));
+    assert.equal((malformed.writeback as any).payload.ok, false);
+  }
 });
 
 test("rejects a guard bound to another Todo", async () => {

--- a/tests/control_plane_ts/quota_settlement_readback.test.ts
+++ b/tests/control_plane_ts/quota_settlement_readback.test.ts
@@ -29,6 +29,8 @@ async function fixture(options: {
   noFollowup?: boolean;
   workspace?: boolean;
   monitor?: boolean;
+  writebackOutcome?: string;
+  progressObservation?: Record<string, unknown>;
 } = {}) {
   const runtimeRoot = await mkdtemp(join(tmpdir(), "loopx-settlement-readback-"));
   const goalRoot = join(runtimeRoot, "goals", goalId);
@@ -72,12 +74,15 @@ async function fixture(options: {
     });
     runs.push({
       classification: "state_refreshed",
-      delivery_outcome: "outcome_progress",
+      delivery_outcome: options.writebackOutcome ?? "outcome_progress",
       goal_id: goalId,
       agent_id: agentId,
       todo_id: todoId,
       turn_instance_id: turnId,
       settlement_identity: identity,
+      ...(options.progressObservation
+        ? { progress_observation: options.progressObservation }
+        : {}),
     });
   }
   if (options.spend) {
@@ -190,6 +195,45 @@ test("keeps partial settlement fail-closed without losing durable facts", async 
   assert.equal(result.monitor_phase, "settlement_pending");
   assert.equal(result.replay_phase, "open");
   assert.equal((result.writeback_run as any).delivery_outcome, "outcome_progress");
+});
+
+test("accepts only an attributable typed blocker as an outcome-gap writeback", async () => {
+  const qualifiedRuntime = await fixture({
+    writeback: true,
+    writebackOutcome: "outcome_gap",
+    progressObservation: {
+      schema_version: "typed_progress_observation_v0",
+      result_class: "blocked",
+      work_item_id: todoId,
+      blocker_id: "blocker-runtime-boundary",
+      evidence_ids: ["evidence-runtime-boundary"],
+    },
+  });
+  const qualified = await readQuotaSettlement(request(qualifiedRuntime));
+  assert.equal((qualified.writeback as any).payload.ok, true);
+  assert.equal((qualified.writeback_run as any).delivery_outcome, "outcome_gap");
+
+  const bareRuntime = await fixture({
+    writeback: true,
+    writebackOutcome: "outcome_gap",
+  });
+  const bare = await readQuotaSettlement(request(bareRuntime));
+  assert.equal((bare.writeback as any).payload.ok, false);
+  assert.equal((bare.writeback as any).result.failure.kind, "writeback_missing");
+
+  const mismatchedRuntime = await fixture({
+    writeback: true,
+    writebackOutcome: "outcome_gap",
+    progressObservation: {
+      schema_version: "typed_progress_observation_v0",
+      result_class: "blocked",
+      work_item_id: "todo_other",
+      blocker_id: "blocker-runtime-boundary",
+      evidence_ids: ["evidence-runtime-boundary"],
+    },
+  });
+  const mismatched = await readQuotaSettlement(request(mismatchedRuntime));
+  assert.equal((mismatched.writeback as any).payload.ok, false);
 });
 
 test("rejects a guard bound to another Todo", async () => {


### PR DESCRIPTION
## Summary

- allow one exact Turn to settle with `outcome_gap` only when the same writeback carries a typed blocked observation bound to the exact Todo, a stable blocker id, and stable evidence
- keep `outcome_gap` outside progress outcomes, so blocker settlement cannot be counted as delivery progress
- preserve fail-closed rejection for bare outcome gaps, surface-only outcomes, malformed evidence, and identity mismatches across Python accounting and TypeScript readback
- centralize the public-safe stable identifier rule so progress normalization and blocker settlement cannot drift

## Why

A truthful blocked result should not be rewritten as `outcome_progress` merely to finish the Turn receipt chain. The control plane now separates delivery progress from accountable Turn settlement while retaining exact identity and evidence requirements.

This is deliberately narrow: a blocked observation may close and spend the exact Turn, but it still does not advance the delivery outcome.

## Validation

- focused Python progress, settlement, slot-accounting, and CLI tests: 94 passed
- TypeScript control-plane tests: 244 passed
- TypeScript control-plane typecheck: passed
- Ruff and changed-file Python compile: passed
- standard premerge canary from the exact worktree head: 18 selected checks passed, 0 failures, 0 manual holds; `self_merge_allowed: true`
- public/private boundary scan: clean for all 12 changed files

## Scope

This changes Turn settlement and quota readback only. It does not classify `outcome_gap` as progress and does not change scoring, task semantics, permissions, or external delivery authority.

The future-facing refactor was kept bounded: shared stable-id validation moved to the existing work-item result boundary; no new framework or speculative provider surface was introduced.
