### PR TITLE
feat(extension): add Luna and bounded account ring

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -39,4 +39,7 @@ image history. Luna has no heterogeneous fallback tail.
 
 Codex App settings use the same evidence rule. A selector label is not proof
 that a running turn adopted the new model. Qualification requires a durable
-settings revision and a turn receipt that matches it.
+settings revision and a turn receipt that matches it. The content-free runtime
+snapshot must also report each resilient route's entry point, ordered
+candidates, terminal tail and maximum cycle count; catalog compilation alone
+cannot qualify a deployment.

--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -17,17 +17,25 @@ permission. A qualification result is evidence, not permission to edit a
 Codex home, install CPA, change a model, start a turn, rotate a credential or
 merge an upstream PR.
 
-Auto routes apply two admission filters before priority and affinity:
+The catalog defines one bounded account ring, not one ring per visible route.
+Auto and Luna enter the same ring through affinity (or its first member for a
+cold task); Prefer A and Prefer B select different entry points. The ring is
+traversed at most once. A route may then append a terminal fallback tail, but
+the tail is not a ring member and is never revisited. Explicit Ark remains a
+manual hard pin.
+
+Resilient routes apply two admission filters before ring traversal and
+affinity:
 
 1. every candidate must support all modalities required by the complete
    request history;
 2. when Fast is selected, every candidate must support the requested service
    tier.
 
-Affinity can reorder only the remaining eligible candidates. If none remain,
+Affinity can reorder only the remaining eligible ring members. If none remain,
 the route fails closed before the first visible output or tool call. A
 text-only fallback can therefore serve text Auto requests but cannot receive
-image history.
+image history. Luna has no heterogeneous fallback tail.
 
 Codex App settings use the same evidence rule. A selector label is not proof
 that a running turn adopted the new model. Qualification requires a durable

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -36,7 +36,8 @@ qualification.
 `qualify_snapshot`
 : Checks the content-free App/CPA readback: visible and hidden routes, input
   modalities, Fast projection with default-off semantics, loopback binding,
-  modality-aware affinity, durable settings revision and commit barrier.
+  modality-aware affinity, typed route traversal, durable settings revision
+  and commit barrier.
 
 `upgrade_plan`
 : Produces a bounded upgrade/rollback checklist from public current and target

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -26,10 +26,12 @@ qualification.
 
 `compile_catalog`
 : Compiles secret-free logical profiles and routes into
-  `codex_provider_routing_catalog_v1`. Auto affinity is only a hint and must be
-  revalidated against required input modalities and service tier on every
-  attempt. With a text-only fallback, image traffic remains eligible only for
-  image-capable profiles and fails closed when none remain.
+  `codex_provider_routing_catalog_v1`. One bounded account ring can back Auto,
+  Prefer A, Prefer B and Luna without presenting separate rings to the user.
+  Route affinity is only a hint and must be revalidated against required input
+  modalities and service tier on every attempt. A terminal text-only fallback
+  can serve compatible Sol requests but cannot receive image history; Luna has
+  no heterogeneous fallback tail.
 
 `qualify_snapshot`
 : Checks the content-free App/CPA readback: visible and hidden routes, input

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -8,7 +8,7 @@ ports, accounts or private receipts.
 
 | Prototype responsibility | Disposition | Public owner |
 | --- | --- | --- |
-| Compile secret-free profiles and logical model routes | Migrated and strengthened | `contract.py::compile_catalog`; modality and Fast eligibility are explicit |
+| Compile secret-free profiles, one-pass account rings and logical model routes | Migrated and strengthened | `contract.py::compile_catalog`; preferred entry points, terminal fallback tails, modality and Fast eligibility are explicit |
 | Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
 | Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
 | Snapshot App/selector configuration, validate hashes and roll back selected files | Planning contract migrated | `upgrade_plan` owns order, matrix and rollback trigger; filesystem effects need a future request-bound execution envelope |
@@ -24,7 +24,7 @@ ports, accounts or private receipts.
 The package keeps three credential-free examples:
 
 - [`examples/request.json`](examples/request.json): logical profiles and model
-  routes for `compile_catalog`;
+  routes backed by one bounded account ring for `compile_catalog`;
 - [`examples/qualification-snapshot.json`](examples/qualification-snapshot.json):
   content-free App/CPA readback for `qualify_snapshot`;
 - [`examples/upgrade-request.json`](examples/upgrade-request.json): exact public

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -166,6 +166,7 @@ flowchart LR
 | `auto/gpt-5.6-sol` | Codex A → B；两个订阅都不可用且尚未提交输出时，文本请求可转 Ark | `text, image`；图片只由 A/B 承担 | 可选，默认关闭 |
 | `codex-a/gpt-5.6-sol` | 手动固定到订阅 A | `text, image` | 可选，默认关闭 |
 | `codex-b/gpt-5.6-sol` | 手动固定到订阅 B | `text, image` | 可选，默认关闭 |
+| [`gpt-5.6-luna`](https://developers.openai.com/codex/models) | Luna；只在 Codex A/B 间路由，不异构降级到 Ark | `text, image`；推理档位为 `low` 至 `max`，不声明 `ultra` | 可选，默认关闭 |
 | `codex-c/gpt-5.6-sol` | 预留；只有第三个订阅真实接入并通过矩阵后才暴露 | 由真实 credential 决定 | 不预声明 |
 | `ark/deepseek-v4-flash` | 手动固定到 Ark DeepSeek V4 Flash | `text` | 不支持 |
 | `gpt-5.6-sol` | 隐藏 compatibility alias；处理 App / host 继承裸 model metadata 的旧 task，实际行为与 Auto 一致 | `text, image` | 可选，默认关闭 |

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -46,7 +46,7 @@ LoopX 只记录目标、门禁、证据和回滚状态。它不保存 OAuth toke
 
 ### Public PR lineage
 
-以下是截至 2026-08-28 与这套能力直接相关的完整公共 PR 索引。LoopX PR 记录 runbook 与
+以下是截至 2026-08-29 与这套能力直接相关的完整公共 PR 索引。LoopX PR 记录 runbook 与
 SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 
 | Repository | PR | 状态 | 沉淀内容 |
@@ -61,9 +61,11 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | LoopX | [#3576](https://github.com/huangruiteng/loopx/pull/3576) | merged | 记录 CPA upstream qualification |
 | LoopX | [#3585](https://github.com/huangruiteng/loopx/pull/3585) | merged | 固化 pinned CPA self-use routing 与回滚边界 |
 | LoopX | [#3665](https://github.com/huangruiteng/loopx/pull/3665) | merged | 沉淀 CPA + Codex App 分层重试与延迟门禁 |
-| LoopX | [#3711](https://github.com/huangruiteng/loopx/pull/3711) | open | 将 runbook、脚本迁移清单、无密配置和资格 contract 升级为独立 extension |
+| LoopX | [#3711](https://github.com/huangruiteng/loopx/pull/3711) | merged | 将 runbook、脚本迁移清单、无密配置和资格 contract 升级为独立 extension |
+| LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | open | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
 | CLIProxyAPI | [#5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | open / review required | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer |
 | CLIProxyAPI | [#5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | open / review required | ChatGPT uTLS HTTP/2 连接池、TLS session resumption 与异常重建 |
+| CLIProxyAPI | [#5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) | open / review required | per-route credential priority；同一 A/B 账号环支持 Prefer A 与 Prefer B 两个入口 |
 
 这个索引只收录直接改变本能力契约、运行面或上游实现的 PR，不扩张成作者的全部 PR 列表。
 新 PR 创建后要在同一 PR 内登记；merge 后把状态和锁定 head/merge commit 一起刷新。
@@ -118,13 +120,13 @@ merge commit，并重新运行本文矩阵。
 | A → B credential failover | loopback 与 live 均通过 | `fill-first`、priority、session affinity 与 commit 前 stream failover 已验证；live auto 请求在 A 建连失败后由 B 完成 |
 | Provider-bound history normalization | candidate、stale-task 与 `additional_tools` 回归通过 | 同 provider 的 A → B 也视为 scope 变化；跨 scope 时移除异源 identity / opaque state，保留可移植 summary、namespace/tool schema 与 tool call/result 因果链；unsupported item 仍返回 typed `409` |
 | Ark Responses SSE lifecycle normalizer | candidate 与真实 endpoint 通过 | 只对显式 `is-compat: true` 的模型启用；原生 Codex stream 保持原字节路径；真实 Ark HTTP/SSE 返回完整 lifecycle |
-| A → B → Ark 组合路径 | loopback 与分层 live 证据通过 | 合成 quota 链 5/5 通过；live A → B 在同一请求完成；隔离禁用 A/B 后 auto 由 Ark 完成并恢复 auth 状态 |
-| Codex App selector projection | 本机与 SSH App Server 通过 | `model/list` 暴露 Auto、A、B、Ark 四个可见 route，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
-| 图片能力投影 | 正向 E2E 通过，Auto 负向路径有已复现缺口 | Auto、A、B 声明 `text + image`，Ark 保持 `text`；健康 A/B 下图片到达 Codex。A/B 失败后，当前 Auto affinity 可能错误粘到 Ark，尚未做到 modality-aware fail closed |
+| A/B 环 → Ark 组合路径 | loopback 与分层 live 证据通过 | 合成 quota 链 5/5 通过；live A → B 在同一请求完成；隔离禁用 A/B 后 auto 由 Ark 完成并恢复 auth 状态；Prefer B → A 依赖 CPA PR #5336 |
+| Codex App selector projection | contract 已更新；live readback 待 CPA #5336 | 目标 `model/list` 暴露 Auto、Prefer A、Prefer B、Luna、Ark 五个可见 route，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
+| 图片能力投影 | 正向 E2E 通过，Auto 负向路径有已复现缺口 | Auto、Prefer A、Prefer B、Luna 声明 `text + image`，Ark 保持 `text`；健康 A/B 下图片到达 Codex。A/B 失败后，当前 Auto affinity 可能错误粘到 Ark，尚未做到 modality-aware fail closed |
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
-| Fast tier 投影 | 本机 App Server readback 通过 | Auto、A、B 声明 `fast → priority`；Ark 不声明 Fast。`features.fast_mode = true` 只显示按钮，`service_tier = "default"` 保证默认关闭 |
+| Fast tier 投影 | A/B 既有 readback 通过；Luna/Prefer 显示待统一重验 | Auto、Prefer A、Prefer B、Luna 声明 `fast → priority`；Ark 不声明 Fast。`features.fast_mode = true` 只显示按钮，`service_tier = "default"` 保证默认关闭 |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | 两个 PR 已提交、CI 通过 | PR #5220 head `9357def`、PR #5261 head `c8e76e1`；均目标 `dev`、mergeable、等待 review |
+| CPA upstream review | 三个 PR 已提交、CI 通过 | PR #5220 head `9357def`、PR #5261 head `c8e76e1`、PR #5336 head `a8136d87`；均目标 `dev`、等待 review |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
 | 当前 Codex App | self-use 配置已安装并完成 CLI / App Server readback | 主 App 与 SSH host 都指向 loopback CPA；模型目录变化需要重启或重连对应 App Server 才能刷新 UI cache，旧 task store 不复制、不删除 |
@@ -163,10 +165,10 @@ flowchart LR
 
 | 模型 ID | 行为 | 输入能力 | Fast |
 | --- | --- | --- | --- |
-| `auto/gpt-5.6-sol` | Codex A → B；两个订阅都不可用且尚未提交输出时，文本请求可转 Ark | `text, image`；图片只由 A/B 承担 | 可选，默认关闭 |
-| `codex-a/gpt-5.6-sol` | 手动固定到订阅 A | `text, image` | 可选，默认关闭 |
-| `codex-b/gpt-5.6-sol` | 手动固定到订阅 B | `text, image` | 可选，默认关闭 |
-| [`gpt-5.6-luna`](https://developers.openai.com/codex/models) | Luna；只在 Codex A/B 间路由，不异构降级到 Ark | `text, image`；推理档位为 `low` 至 `max`，不声明 `ultra` | 可选，默认关闭 |
+| `auto/gpt-5.6-sol` | 同一 A/B 账号环；已有 task 尊重 affinity，冷启动从 A 开始；A/B 都不可用且尚未提交输出时，兼容文本请求可转 Ark | `text, image`；图片只由 A/B 承担 | 可选，默认关闭 |
+| `codex-a/gpt-5.6-sol` | Sol · Prefer A：A → B → Ark；不是 hard pin | `text, image` | 可选，默认关闭 |
+| `codex-b/gpt-5.6-sol` | Sol · Prefer B：B → A → Ark；不是 hard pin | `text, image` | 可选，默认关闭 |
+| [`gpt-5.6-luna`](https://developers.openai.com/codex/models) | Luna；复用同一个 A/B 账号环，只在 Codex A/B 间路由，不异构降级到 Ark | `text, image`；推理档位为 `low` 至 `max`，不声明 `ultra` | 可选，默认关闭 |
 | `codex-c/gpt-5.6-sol` | 预留；只有第三个订阅真实接入并通过矩阵后才暴露 | 由真实 credential 决定 | 不预声明 |
 | `ark/deepseek-v4-flash` | 手动固定到 Ark DeepSeek V4 Flash | `text` | 不支持 |
 | `gpt-5.6-sol` | 隐藏 compatibility alias；处理 App / host 继承裸 model metadata 的旧 task，实际行为与 Auto 一致 | `text, image` | 可选，默认关闭 |
@@ -174,7 +176,7 @@ flowchart LR
 模型 ID 是路由契约，不是上游真实 model slug。显示名可本地化，但 ID 一经上线应保持稳定，
 否则已有 task 的 model metadata 会产生第二种方言。
 
-当前 self-use build 已完成 Codex 多账号、prefix 固定路由和 Codex → Ark heterogeneous
+当前 self-use build 已完成 Codex 多账号、prefix 路由和 Codex → Ark heterogeneous
 failover 的分层资格验证，因此 `auto/...` 可以在该锁定 commit 上灰度。升级到其他 commit
 时不能继承这个结论，必须重跑后文矩阵。不要用第二层 AgentSwap proxy 假装补齐缺口。
 
@@ -190,8 +192,8 @@ Fast 是一次 turn 的 service tier，不是独立模型。model catalog 需要
 只有用户手动开启 Fast 后，请求才映射为 `priority`。
 
 这里的“开启自动切换开关”不是修改 CPA 的一个全局布尔值，而是让 App selector 暴露并
-允许选择 `auto/...` 虚拟模型。关闭时只暴露显式 `codex-a`、`codex-b` 和 `ark`；打开后
-CPA 才按已验收的 provider pool 执行自动路由。
+允许选择 `auto/...` 虚拟模型。A/B 也不再表示 hard pin，而是同一账号环的两个首选入口；
+只有显式 Ark 仍固定单一 provider。CPA 只按已验收的 provider pool 执行自动路由。
 
 ## CPA：唯一在线 data plane
 
@@ -247,7 +249,7 @@ auth，CPA 与 Codex provider 必须同时配置同一个由 secret store 注入
 
 首轮 qualification 使用 `request-retry / max-retry-credentials / max-retry-interval =
 0 / 0 / 0`。这不等于“完全不 failover”：round 0 仍会把每个 eligible credential 最多
-尝试一次；它只禁止 A → B → Ark 之后再开启额外 retry round，也不等待 cooldown。这样
+尝试一次；它只禁止一次 A/B 环遍历与可选 Ark tail 之后再开启额外 retry round，也不等待 cooldown。这样
 可以先证明一条有限、可解释的路由链，避免同一 credential 被重复尝试。需要额外 round
 时必须单独增加参数并重跑提交边界测试。
 
@@ -284,7 +286,7 @@ credential 遍历之后最多允许十个附加 round；`max-retry-credentials: 
 | 层 | 主要职责 | 允许恢复的边界 |
 | --- | --- | --- |
 | ChatGPT uTLS transport | 复用 HTTP/2 连接和 TLS session；连接已失效时重建 | 响应头之前；只有幂等请求，或带 idempotency key 且 body 可重建的请求，才允许一次快速重放 |
-| CPA | credential / provider 分类、A → B → Ark、首个生成事件前的 in-band 错误吸收 | HTTP 403/408/429/500/502/503/504 与明确的 quota / overload；提交后禁止切换 |
+| CPA | credential / provider 分类、A/B 单圈遍历与可选 Ark tail、首个生成事件前的 in-band 错误吸收 | HTTP 403/408/429/500/502/503/504 与明确的 quota / overload；提交后禁止切换 |
 | Codex App | CPA endpoint 的 request / stream 外层恢复 | 只消费 CPA 最终暴露的失败；不能把已可见的文本、tool call 或 tool result 当成全新请求重放 |
 | LoopX | 记录资格证据、pin、回滚与运维状态 | 不代理模型请求，也不新增第四层 retry |
 
@@ -293,7 +295,7 @@ credential 遍历之后最多允许十个附加 round；`max-retry-credentials: 
 1. DNS、TCP、TLS 或空闲 HTTP/2 连接失效：优先重用连接池；确需重拨时使用已有 TLS
    session。连接级第一次安全重拨立即执行，不先 sleep。
 2. 401：只刷新一次对应 credential；仍失败则标记该 credential 不健康并进入下一项。
-3. quota、overload、429 或可恢复 5xx：只在首个可见生成事件前按 A → B → Ark 切换。
+3. quota、overload、429 或可恢复 5xx：只在首个可见生成事件前遍历一次 A/B 环，再按 route 决定是否进入 Ark tail。
 4. schema / lifecycle 破坏、foreign compaction barrier、不可恢复 4xx：fail closed，不用高
    retry 上限掩盖协议错误。
 5. 已发送文本 delta、tool call 或 tool result：返回明确错误和恢复入口，禁止透明重放。
@@ -403,7 +405,7 @@ request_max_retries = 30
 stream_max_retries = 30
 ```
 
-受控 model catalog 同时描述 Auto、A、B、Ark 四个虚拟模型 ID；未配置的 C 不写入 catalog。
+受控 model catalog 同时描述 Auto、Prefer A、Prefer B、Luna、Ark 五个虚拟模型 ID；未配置的 C 不写入 catalog。
 App 的原生模型下拉框就是唯一手动切换入口。`30 / 30` 只保留 CPA 之外的外层恢复余量；
 credential 遍历、provider 选择和 commit barrier 仍由 CPA 独占。两层都必须遵守前文的
 提交边界和 wall-clock budget，不能无界相乘。不要再让 CC Switch 在 App 运行期间替换
@@ -411,11 +413,10 @@ credential 遍历、provider 选择和 commit barrier 仍由 CPA 独占。两层
 
 受控 catalog 至少要同时验证四类字段：
 
-1. `slug / visibility / priority`：四个可见 route 与一个隐藏 bare compatibility alias；
-2. `input_modalities`：Auto/A/B 为 `text, image`，Ark 为 `text`；
-3. `supported_reasoning_levels`：Auto 至少覆盖 `low / medium / high / xhigh / max`，A/B
-   可额外开放已经验证的更高档；
-4. `additional_speed_tiers / service_tiers`：Auto/A/B 暴露 `fast → priority`，Ark 不暴露，
+1. `slug / visibility / priority`：五个可见 route 与一个隐藏 bare compatibility alias；
+2. `input_modalities`：Auto/Prefer A/Prefer B/Luna 为 `text, image`，Ark 为 `text`；
+3. `supported_reasoning_levels`：Sol 与 Luna 都只声明已验证的 `low / medium / high / xhigh / max`；
+4. `additional_speed_tiers / service_tiers`：Auto/Prefer A/Prefer B/Luna 暴露 `fast → priority`，Ark 不暴露，
    `default_service_tier` 保持空或 default。
 
 App Server 的 `model/list` readback 是 catalog 验收面。只检查 JSON 文件内容不够，因为旧
@@ -447,7 +448,7 @@ service_tier = "default"
 fast_mode = true
 
 [model_providers.local-cpa]
-name = "CPA · Codex A → B → Ark"
+name = "CPA · Codex A/B ring → Ark"
 base_url = "http://127.0.0.1:<REMOTE_CPA_PORT>/v1"
 wire_api = "responses"
 requires_openai_auth = false
@@ -457,7 +458,7 @@ stream_max_retries = 30
 ```
 
 远端默认使用隐藏 `gpt-5.6-sol` compatibility alias，避免旧 task 或跨 host metadata 只保存
-裸 model slug 时回落到未知模型；模型下拉框仍只显示 Auto、A、B、Ark。
+裸 model slug 时回落到未知模型；模型下拉框仍只显示 Auto、Prefer A、Prefer B、Luna、Ark。
 
 SSH host 的 session 安全边界：
 
@@ -473,7 +474,7 @@ SSH host 的 session 安全边界：
 1. `ssh <host-alias>` 能正常进入，远端 login shell 可以找到 `codex`；
 2. `codex --version` 达到锁定版本；
 3. reverse tunnel 两端都只监听 loopback；
-4. App Server `model/list` 返回四个可见 route、隐藏 bare alias、正确图片能力与 Fast tier；
+4. App Server `model/list` 返回五个可见 route、隐藏 bare alias、正确图片能力与 Fast tier；
 5. Auto 发送一张公开安全的测试图片，模型实际返回成功；
 6. 打开一个已有 task，确认历史仍在，再验证 A/B 切换；
 7. 最后才在真实工作 task 上使用。
@@ -658,18 +659,19 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 | 场景 | 验收条件 |
 | --- | --- |
-| Codex A → B → 可选 C | 每次只使用一个真实账号；额度错误触发下一优先级；未配置 C 时跳过而不是创建空 profile；同一 turn 不重复输出 |
+| A/B 单账号环 | Auto/Prefer A/Luna 可走 A → B，Prefer B 可走 B → A；单次最多一圈，每个账号最多一次；同一 turn 不重复输出 |
+| Sol terminal fallback | 只有 A/B 都不可用、请求仍在 commit barrier 前且 modality/tier 兼容时才进入 Ark tail；Ark 不回跳 Codex |
 | GPT → Ark | 消息、reasoning summary、tool call/result 可继续；无 active-item / delta 生命周期警告 |
 | Ark → GPT | 异源 reasoning identity 被剥离；保留 summary；`remote_compaction_v2` 可成功重建窗口 |
 | A/B + `additional_tools` → 另一 scope | namespace 与 tool schema 保留；provider-bound id / opaque state 被剥离；不误报 `unsupported_history_item` |
 | foreign compact → 任意目标 | 明确识别 barrier 并 fork；不发送 opaque foreign blob |
-| 模型下拉框手动切换 | 选中虚拟模型后路由与显示一致，不需要 CC Switch 重启 App |
+| 模型下拉框手动切换 | Prefer A/B 表示首选入口而非 hard pin；显式 Ark 才固定 provider；切换后路由与显示一致，不需要 CC Switch 重启 App |
 | settings apply → turn start | 新 turn 的 receipt 使用已持久化的新 settings revision；并发启动不能捕获旧 Auto snapshot |
 | hidden bare alias | 旧 task 或跨 host metadata 使用 `gpt-5.6-sol` 时按 Auto 路由，不在 selector 重复显示 |
 | Auto / A / B 图片输入 | App admission 通过，图片实际到达 A/B；A/B 均不可用时明确失败，不降级为 Ark 文本请求 |
 | Auto affinity + 图片 + Codex 故障 | 每个 attempt 重算 required modalities；旧 Ark affinity 失效；A/B 无 eligible target 时首字节前返回 typed error |
 | Ark 图片输入 | App 或 provider 明确拒绝；不把 Ark catalog 伪装为 image-capable |
-| Fast tier | Auto/A/B 显示 Fast 按钮，但新 task 默认 `service_tier = "default"`；手动开启后请求才使用 `priority` |
+| Fast tier | Auto/Prefer A/Prefer B/Luna 显示 Fast 按钮，但新 task 默认 `service_tier = "default"`；手动开启后请求才使用 `priority` |
 | SSH host 重连 | 同 alias、同远端 `CODEX_HOME` 下旧 task 可继续；catalog/CLI 刷新不删除或复制 session store |
 | 首字节前 quota / overload | CPA 可重试下一 eligible auth；客户端只看到一条回答 |
 | 空闲 HTTP/2 连接断开 | 下一条安全请求自动重建连接；TLS session 恢复；不重复已提交输出 |
@@ -704,15 +706,15 @@ commit 作为升级候选并重跑 qualification。#5261 在进入 self-use pin 
 
 1. **影子验证（已完成）**：保持现有 App 不变，在隔离 home、loopback fault server 和 stale
    task 上跑完整矩阵。
-2. **单 App / 手动路由（已完成）**：App 指向固定 CPA；开放 `codex-a`、`codex-b`、
-   `ark`，未配置的 `codex-c` 不出现在 selector。
-3. **Codex pool 自动切换（已完成）**：priority + fill-first + affinity 已通过 loopback 与 live
-   A → B；安全回切发生在新 session / turn 边界。
+2. **单 App / 显式路由（已完成旧语义）**：App 指向固定 CPA；开放 A、B、Ark，未配置的
+   C 不出现在 selector；A/B 从 hard pin 升级为 Prefer 入口依赖 #5336。
+3. **Codex 账号环（A → B 已完成，B → A 待 #5336）**：priority + fill-first + affinity 已
+   通过 loopback 与 live A → B；route priority 合入并部署后补 Prefer B → A 资格验证。
 4. **跨 provider 自动切换（self-use 已启用）**：固定 build 已通过 history projection、
    `additional_tools`、Ark SSE、commit barrier、真实 Ark 与故障注入矩阵，文本请求可由
    `auto/...` 降级到 Ark；foreign compaction barrier 仍 fail closed 并走显式 fork。
-5. **本机与 SSH selector（已完成 App Server 资格验证）**：四个可见 selector、hidden bare
-   alias、图片能力和 Fast default-off contract 已进入受控 catalog；每次 catalog 更新后仍要
+5. **本机与 SSH selector（contract 已收敛，live 升级待执行）**：五个可见 selector、hidden
+   bare alias、图片能力和 Fast default-off contract 已进入受控 catalog；#5336 部署后仍要
    重启对应 App Server 并做 UI readback。
 6. **多模态 Auto 负向路径（待修复）**：健康 A/B 的图片 E2E 已通过；modality-aware
    affinity、A/B 全不可用时的 typed fail-closed，以及 settings revision / turn-start 竞态仍要

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -126,7 +126,7 @@ merge commit，并重新运行本文矩阵。
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
 | Fast tier 投影 | A/B 既有 readback 通过；Luna/Prefer 显示待统一重验 | Auto、Prefer A、Prefer B、Luna 声明 `fast → priority`；Ark 不声明 Fast。`features.fast_mode = true` 只显示按钮，`service_tier = "default"` 保证默认关闭 |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | 三个 PR 已提交、CI 通过 | PR #5220 head `9357def`、PR #5261 head `c8e76e1`、PR #5336 head `a8136d87`；均目标 `dev`、等待 review |
+| CPA upstream review | 三个 PR 已提交、CI 通过 | PR #5220 head `9357def`、PR #5261 head `c8e76e1`、PR #5336 head `3d038a27`；均目标 `dev`、等待 review |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
 | 当前 Codex App | self-use 配置已安装并完成 CLI / App Server readback | 主 App 与 SSH host 都指向 loopback CPA；模型目录变化需要重启或重连对应 App Server 才能刷新 UI cache，旧 task store 不复制、不删除 |

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -121,6 +121,7 @@ merge commit，并重新运行本文矩阵。
 | Provider-bound history normalization | candidate、stale-task 与 `additional_tools` 回归通过 | 同 provider 的 A → B 也视为 scope 变化；跨 scope 时移除异源 identity / opaque state，保留可移植 summary、namespace/tool schema 与 tool call/result 因果链；unsupported item 仍返回 typed `409` |
 | Ark Responses SSE lifecycle normalizer | candidate 与真实 endpoint 通过 | 只对显式 `is-compat: true` 的模型启用；原生 Codex stream 保持原字节路径；真实 Ark HTTP/SSE 返回完整 lifecycle |
 | A/B 环 → Ark 组合路径 | loopback 与分层 live 证据通过 | 合成 quota 链 5/5 通过；live A → B 在同一请求完成；隔离禁用 A/B 后 auto 由 Ark 完成并恢复 auth 状态；Prefer B → A 依赖 CPA PR #5336 |
+| Route traversal readback | public contract 已补齐；live 待 #5336 | qualification 必须同时读回 entrypoint、ordered candidates、terminal tail 与 `max_cycles = 1`；只看到正确 selector 标签不能通过 |
 | Codex App selector projection | contract 已更新；live readback 待 CPA #5336 | 目标 `model/list` 暴露 Auto、Prefer A、Prefer B、Luna、Ark 五个可见 route，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
 | 图片能力投影 | 正向 E2E 通过，Auto 负向路径有已复现缺口 | Auto、Prefer A、Prefer B、Luna 声明 `text + image`，Ark 保持 `text`；健康 A/B 下图片到达 Codex。A/B 失败后，当前 Auto affinity 可能错误粘到 Ark，尚未做到 modality-aware fail closed |
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |

--- a/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
+++ b/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
@@ -9,7 +9,8 @@
     "fast_models": [
       "auto/gpt-5.6-sol",
       "codex-a/gpt-5.6-sol",
-      "codex-b/gpt-5.6-sol"
+      "codex-b/gpt-5.6-sol",
+      "gpt-5.6-luna"
     ],
     "hidden_models": [
       "gpt-5.6-sol"
@@ -29,6 +30,10 @@
       "codex-b/gpt-5.6-sol": [
         "text",
         "image"
+      ],
+      "gpt-5.6-luna": [
+        "text",
+        "image"
       ]
     },
     "settings_revision_durable": true,
@@ -37,6 +42,7 @@
       "auto/gpt-5.6-sol",
       "codex-a/gpt-5.6-sol",
       "codex-b/gpt-5.6-sol",
+      "gpt-5.6-luna",
       "ark/deepseek-v4-flash"
     ]
   }

--- a/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
+++ b/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
@@ -3,6 +3,53 @@
   "schema_version": "loopx_codex_provider_routing_request_v0",
   "snapshot": {
     "affinity_policy": "hint_revalidated_per_attempt",
+    "route_traversal": {
+      "auto/gpt-5.6-sol": {
+        "entrypoint": "affinity_then_first",
+        "fallback_tail": [
+          "ark-text"
+        ],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-a",
+          "codex-b",
+          "ark-text"
+        ]
+      },
+      "codex-a/gpt-5.6-sol": {
+        "entrypoint": "codex-a",
+        "fallback_tail": [
+          "ark-text"
+        ],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-a",
+          "codex-b",
+          "ark-text"
+        ]
+      },
+      "codex-b/gpt-5.6-sol": {
+        "entrypoint": "codex-b",
+        "fallback_tail": [
+          "ark-text"
+        ],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-b",
+          "codex-a",
+          "ark-text"
+        ]
+      },
+      "gpt-5.6-luna": {
+        "entrypoint": "affinity_then_first",
+        "fallback_tail": [],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-a",
+          "codex-b"
+        ]
+      }
+    },
     "commit_barrier": "before_first_visible_output_or_tool_call",
     "default_service_tier": "default",
     "endpoint_host": "127.0.0.1",

--- a/packages/loopx-codex-provider-routing/examples/request.json
+++ b/packages/loopx-codex-provider-routing/examples/request.json
@@ -33,14 +33,23 @@
         "supports_fast": false
       }
     ],
+    "rings": [
+      {
+        "id": "codex-accounts",
+        "max_cycles": 1,
+        "members": [
+          "codex-a",
+          "codex-b"
+        ]
+      }
+    ],
     "routes": [
       {
-        "candidates": [
-          "codex-a",
-          "codex-b",
+        "display_name": "Auto · Sol (A/B → Ark)",
+        "entrypoint": "affinity_then_first",
+        "fallback_tail": [
           "ark-text"
         ],
-        "display_name": "Auto · Codex A → B → text fallback",
         "input_modalities": [
           "text",
           "image"
@@ -53,60 +62,60 @@
           "xhigh",
           "max"
         ],
+        "ring": "codex-accounts",
         "slug": "auto/gpt-5.6-sol",
         "supports_fast": true,
         "visible": true
       },
       {
-        "candidates": [
-          "codex-a"
+        "display_name": "Sol · Prefer A",
+        "entrypoint": "codex-a",
+        "fallback_tail": [
+          "ark-text"
         ],
-        "display_name": "Codex A",
         "input_modalities": [
           "text",
           "image"
         ],
-        "mode": "manual",
+        "mode": "preferred",
         "reasoning_levels": [
           "low",
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ],
+        "ring": "codex-accounts",
         "slug": "codex-a/gpt-5.6-sol",
         "supports_fast": true,
         "visible": true
       },
       {
-        "candidates": [
-          "codex-b"
+        "display_name": "Sol · Prefer B",
+        "entrypoint": "codex-b",
+        "fallback_tail": [
+          "ark-text"
         ],
-        "display_name": "Codex B",
         "input_modalities": [
           "text",
           "image"
         ],
-        "mode": "manual",
+        "mode": "preferred",
         "reasoning_levels": [
           "low",
           "medium",
           "high",
           "xhigh",
-          "max",
-          "ultra"
+          "max"
         ],
+        "ring": "codex-accounts",
         "slug": "codex-b/gpt-5.6-sol",
         "supports_fast": true,
         "visible": true
       },
       {
-        "candidates": [
-          "codex-a",
-          "codex-b"
-        ],
-        "display_name": "Luna · GPT-5.6-Luna",
+        "display_name": "Luna · A/B",
+        "entrypoint": "affinity_then_first",
         "input_modalities": [
           "text",
           "image"
@@ -119,6 +128,7 @@
           "xhigh",
           "max"
         ],
+        "ring": "codex-accounts",
         "slug": "gpt-5.6-luna",
         "supports_fast": true,
         "visible": true

--- a/packages/loopx-codex-provider-routing/examples/request.json
+++ b/packages/loopx-codex-provider-routing/examples/request.json
@@ -103,6 +103,28 @@
       },
       {
         "candidates": [
+          "codex-a",
+          "codex-b"
+        ],
+        "display_name": "Luna · GPT-5.6-Luna",
+        "input_modalities": [
+          "text",
+          "image"
+        ],
+        "mode": "auto",
+        "reasoning_levels": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "slug": "gpt-5.6-luna",
+        "supports_fast": true,
+        "visible": true
+      },
+      {
+        "candidates": [
           "ark-text"
         ],
         "display_name": "Ark text fallback",

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -76,11 +76,36 @@ def main() -> int:
     assert auto["eligible_candidates"]["text"] == ["codex-a", "codex-b", "ark-text"]
     assert auto["fast_candidates"] == ["codex-a", "codex-b"]
     assert auto["routing_policy"]["session_affinity"] == "hint_revalidated_per_attempt"
+    assert auto["ring_id"] == "codex-accounts"
+    assert auto["entrypoint"] == "affinity_then_first"
+    assert auto["routing_policy"]["max_cycles"] == 1
+    prefer_a = next(
+        route for route in catalog["routes"] if route["slug"].startswith("codex-a/")
+    )
+    prefer_b = next(
+        route for route in catalog["routes"] if route["slug"].startswith("codex-b/")
+    )
+    assert prefer_a["candidates"] == ["codex-a", "codex-b", "ark-text"]
+    assert prefer_b["candidates"] == ["codex-b", "codex-a", "ark-text"]
+    assert prefer_a["routing_mode"] == prefer_b["routing_mode"] == "preferred"
     luna = next(route for route in catalog["routes"] if route["slug"] == "gpt-5.6-luna")
     assert luna["candidates"] == ["codex-a", "codex-b"]
     assert luna["eligible_candidates"]["image"] == ["codex-a", "codex-b"]
     assert luna["reasoning_levels"] == ["low", "medium", "high", "xhigh", "max"]
     assert luna["fast_candidates"] == ["codex-a", "codex-b"]
+
+    repeated_ring = copy.deepcopy(_source())
+    repeated_ring["rings"][0]["max_cycles"] = 2
+    expect_error(
+        lambda: compile_catalog(repeated_ring), "multi-cycle fallback ring was accepted"
+    )
+
+    overlapping_tail = copy.deepcopy(_source())
+    overlapping_tail["routes"][1]["fallback_tail"] = ["codex-b"]
+    expect_error(
+        lambda: compile_catalog(overlapping_tail),
+        "fallback tail overlapping the account ring was accepted",
+    )
 
     leaked = copy.deepcopy(_source())
     leaked["profiles"][0]["access_token"] = "example-sensitive-value"

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -52,6 +52,32 @@ def _valid_snapshot() -> dict:
         "default_service_tier": "default",
         "endpoint_host": "127.0.0.1",
         "affinity_policy": "hint_revalidated_per_attempt",
+        "route_traversal": {
+            "auto/gpt-5.6-sol": {
+                "entrypoint": "affinity_then_first",
+                "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
+                "fallback_tail": ["ark-text"],
+                "max_cycles": 1,
+            },
+            "codex-a/gpt-5.6-sol": {
+                "entrypoint": "codex-a",
+                "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
+                "fallback_tail": ["ark-text"],
+                "max_cycles": 1,
+            },
+            "codex-b/gpt-5.6-sol": {
+                "entrypoint": "codex-b",
+                "ordered_candidates": ["codex-b", "codex-a", "ark-text"],
+                "fallback_tail": ["ark-text"],
+                "max_cycles": 1,
+            },
+            "gpt-5.6-luna": {
+                "entrypoint": "affinity_then_first",
+                "ordered_candidates": ["codex-a", "codex-b"],
+                "fallback_tail": [],
+                "max_cycles": 1,
+            },
+        },
         "settings_revision_durable": True,
         "turn_revision_matches": True,
         "commit_barrier": "before_first_visible_output_or_tool_call",
@@ -148,6 +174,32 @@ def main() -> int:
         "modality_aware_affinity",
         "settings_revision",
     }
+
+    wrong_prefer_b = _valid_snapshot()
+    wrong_prefer_b["route_traversal"]["codex-b/gpt-5.6-sol"]["ordered_candidates"] = [
+        "codex-a",
+        "codex-b",
+        "ark-text",
+    ]
+    failed = qualify_snapshot(wrong_prefer_b)
+    assert failed["qualified"] is False
+    assert "preferred_route_order" in {
+        item["id"] for item in failed["checks"] if not item["passed"]
+    }
+
+    luna_with_ark = _valid_snapshot()
+    luna_with_ark["route_traversal"]["gpt-5.6-luna"]["ordered_candidates"] = [
+        "codex-a",
+        "codex-b",
+        "ark-text",
+    ]
+    luna_with_ark["route_traversal"]["gpt-5.6-luna"]["fallback_tail"] = ["ark-text"]
+    failed = qualify_snapshot(luna_with_ark)
+    assert failed["qualified"] is False
+    assert {
+        "preferred_route_order",
+        "terminal_fallback_tail",
+    } <= {item["id"] for item in failed["checks"] if not item["passed"]}
 
     plan = build_upgrade_plan(
         {

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -32,6 +32,7 @@ def _valid_snapshot() -> dict:
             "auto/gpt-5.6-sol",
             "codex-a/gpt-5.6-sol",
             "codex-b/gpt-5.6-sol",
+            "gpt-5.6-luna",
             "ark/deepseek-v4-flash",
         ],
         "hidden_models": ["gpt-5.6-sol"],
@@ -39,12 +40,14 @@ def _valid_snapshot() -> dict:
             "auto/gpt-5.6-sol": ["text", "image"],
             "codex-a/gpt-5.6-sol": ["text", "image"],
             "codex-b/gpt-5.6-sol": ["text", "image"],
+            "gpt-5.6-luna": ["text", "image"],
             "ark/deepseek-v4-flash": ["text"],
         },
         "fast_models": [
             "auto/gpt-5.6-sol",
             "codex-a/gpt-5.6-sol",
             "codex-b/gpt-5.6-sol",
+            "gpt-5.6-luna",
         ],
         "default_service_tier": "default",
         "endpoint_host": "127.0.0.1",
@@ -73,6 +76,11 @@ def main() -> int:
     assert auto["eligible_candidates"]["text"] == ["codex-a", "codex-b", "ark-text"]
     assert auto["fast_candidates"] == ["codex-a", "codex-b"]
     assert auto["routing_policy"]["session_affinity"] == "hint_revalidated_per_attempt"
+    luna = next(route for route in catalog["routes"] if route["slug"] == "gpt-5.6-luna")
+    assert luna["candidates"] == ["codex-a", "codex-b"]
+    assert luna["eligible_candidates"]["image"] == ["codex-a", "codex-b"]
+    assert luna["reasoning_levels"] == ["low", "medium", "high", "xhigh", "max"]
+    assert luna["fast_candidates"] == ["codex-a", "codex-b"]
 
     leaked = copy.deepcopy(_source())
     leaked["profiles"][0]["access_token"] = "example-sensitive-value"

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -108,6 +108,46 @@ def _compile_profiles(raw_profiles: Any) -> dict[str, dict[str, Any]]:
     return profiles
 
 
+def _compile_rings(
+    raw_rings: Any, profiles: Mapping[str, Mapping[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    if raw_rings is None:
+        return {}
+    if not isinstance(raw_rings, list):
+        raise ValueError("rings must be a list")
+    rings: dict[str, dict[str, Any]] = {}
+    for index, raw in enumerate(raw_rings):
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"rings[{index}] must be an object")
+        ring_id = _non_empty_string(raw.get("id"), f"rings[{index}].id")
+        if SYMBOLIC_ID_RE.fullmatch(ring_id) is None:
+            raise ValueError(f"ring id must be a public symbolic id: {ring_id}")
+        if ring_id in rings:
+            raise ValueError(f"duplicate ring id: {ring_id}")
+        members = _string_list(raw.get("members"), f"rings[{index}].members")
+        if len(members) < 2:
+            raise ValueError(f"ring {ring_id} needs at least two members")
+        for profile_id in members:
+            if profile_id not in profiles:
+                raise ValueError(
+                    f"ring {ring_id} references unknown profile: {profile_id}"
+                )
+        max_cycles = raw.get("max_cycles")
+        if max_cycles != 1 or isinstance(max_cycles, bool):
+            raise ValueError(f"ring {ring_id} must use exactly one cycle")
+        rings[ring_id] = {
+            "id": ring_id,
+            "members": members,
+            "max_cycles": max_cycles,
+        }
+    return rings
+
+
+def _rotate_members(members: Sequence[str], entrypoint: str) -> list[str]:
+    index = members.index(entrypoint)
+    return list(members[index:]) + list(members[:index])
+
+
 def _eligible_profiles(
     candidates: Sequence[str],
     profiles: Mapping[str, Mapping[str, Any]],
@@ -129,6 +169,7 @@ def _eligible_profiles(
 def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
     reject_private_material(source)
     profiles = _compile_profiles(source.get("profiles"))
+    rings = _compile_rings(source.get("rings"), profiles)
     raw_routes = source.get("routes")
     if not isinstance(raw_routes, list) or not raw_routes:
         raise ValueError("routes must be a non-empty list")
@@ -145,7 +186,7 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
             raise ValueError(f"duplicate route slug: {slug}")
         route_ids.add(slug)
         mode = _non_empty_string(raw.get("mode"), f"routes[{index}].mode")
-        if mode not in {"auto", "manual", "alias"}:
+        if mode not in {"auto", "preferred", "manual", "alias"}:
             raise ValueError(f"route {slug} has unsupported mode: {mode}")
         visible = _boolean(raw.get("visible"), f"routes[{index}].visible", default=True)
         display_name = _non_empty_string(
@@ -165,9 +206,52 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
         if not set(reasoning) <= ALLOWED_REASONING_LEVELS:
             raise ValueError(f"route {slug} has unsupported reasoning levels")
 
-        candidates = _string_list(
-            raw.get("candidates", []), f"routes[{index}].candidates"
+        ring_id = raw.get("ring")
+        uses_ring = ring_id is not None
+        fallback_tail = _string_list(
+            raw.get("fallback_tail", []), f"routes[{index}].fallback_tail"
         )
+        entrypoint = raw.get("entrypoint")
+        if uses_ring:
+            ring_id = _non_empty_string(ring_id, f"routes[{index}].ring")
+            if ring_id not in rings:
+                raise ValueError(f"route {slug} references unknown ring: {ring_id}")
+            if mode not in {"auto", "preferred"}:
+                raise ValueError(f"route {slug} cannot use a ring in {mode} mode")
+            if "candidates" in raw:
+                raise ValueError(
+                    f"ring route must derive candidates instead of declaring them: {slug}"
+                )
+            members = rings[ring_id]["members"]
+            if entrypoint is None and mode == "auto":
+                entrypoint = "affinity_then_first"
+            else:
+                entrypoint = _non_empty_string(
+                    entrypoint, f"routes[{index}].entrypoint"
+                )
+            if entrypoint == "affinity_then_first":
+                if mode != "auto":
+                    raise ValueError(
+                        f"preferred route needs an explicit ring member: {slug}"
+                    )
+                ring_candidates = list(members)
+            elif entrypoint in members:
+                ring_candidates = _rotate_members(members, entrypoint)
+            else:
+                raise ValueError(
+                    f"route {slug} entrypoint is not a member of ring {ring_id}"
+                )
+            if set(fallback_tail) & set(members):
+                raise ValueError(f"route {slug} fallback tail overlaps its ring")
+            candidates = ring_candidates + fallback_tail
+        else:
+            if fallback_tail or entrypoint is not None:
+                raise ValueError(
+                    f"non-ring route must not declare entrypoint or fallback tail: {slug}"
+                )
+            candidates = _string_list(
+                raw.get("candidates", []), f"routes[{index}].candidates"
+            )
         for profile_id in candidates:
             if profile_id not in profiles:
                 raise ValueError(
@@ -175,8 +259,10 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
                 )
         if mode == "manual" and len(candidates) != 1:
             raise ValueError(f"manual route must pin exactly one profile: {slug}")
-        if mode == "auto" and len(candidates) < 2:
-            raise ValueError(f"auto route needs at least two candidates: {slug}")
+        if mode in {"auto", "preferred"} and len(candidates) < 2:
+            raise ValueError(f"resilient route needs at least two candidates: {slug}")
+        if mode == "preferred" and not uses_ring:
+            raise ValueError(f"preferred route must reference a ring: {slug}")
         if mode == "alias" and candidates:
             raise ValueError(f"alias route must not declare candidates: {slug}")
 
@@ -188,8 +274,12 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
 
         if mode != "alias":
             priorities = [profiles[profile_id]["priority"] for profile_id in candidates]
-            if mode == "auto" and any(
-                current <= following for current, following in pairwise(priorities)
+            if (
+                mode == "auto"
+                and not uses_ring
+                and any(
+                    current <= following for current, following in pairwise(priorities)
+                )
             ):
                 raise ValueError(f"auto route priorities must strictly descend: {slug}")
             for modality in declared_modalities:
@@ -224,6 +314,9 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
                 "visibility": "visible" if visible else "hidden",
                 "routing_mode": mode,
                 "alias_for": alias_for,
+                "ring_id": ring_id,
+                "entrypoint": entrypoint,
+                "fallback_tail": fallback_tail,
                 "input_modalities": declared_modalities,
                 "reasoning_levels": reasoning,
                 "candidates": candidates,
@@ -248,8 +341,12 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
                     "candidate_filter": "required_modalities_and_service_tier",
                     "on_no_eligible_provider": "fail_closed_before_first_output",
                     "session_affinity": "hint_revalidated_per_attempt"
-                    if mode == "auto"
+                    if mode in {"auto", "preferred"}
                     else "disabled",
+                    "traversal": "one_ring_pass_then_tail"
+                    if uses_ring
+                    else "ordered_candidates_once",
+                    "max_cycles": rings[ring_id]["max_cycles"] if uses_ring else 1,
                     "commit_barrier": "before_first_visible_output_or_tool_call",
                     "foreign_history": "normalize_or_quarantine",
                 },
@@ -278,6 +375,7 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
         "credential_free": True,
         "default_service_tier": "default",
         "profiles": list(profiles.values()),
+        "rings": list(rings.values()),
         "routes": routes,
     }
 
@@ -303,7 +401,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     check(
         "visible_routes",
         visible == expected_visible,
-        "selector exposes exactly Auto/A/B/Luna/Ark",
+        "selector exposes exactly Auto/Prefer A/Prefer B/Luna/Ark",
     )
     check(
         "hidden_alias",
@@ -324,7 +422,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
                 "gpt-5.6-luna",
             )
         ),
-        "Auto/A/B/Luna declare text and image",
+        "Auto/Prefer A/Prefer B/Luna declare text and image",
     )
     check(
         "ark_text_only",
@@ -341,7 +439,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             "codex-b/gpt-5.6-sol",
             "gpt-5.6-luna",
         },
-        "Fast is exposed only for Auto/A/B/Luna",
+        "Fast is exposed only for Auto/Prefer A/Prefer B/Luna",
     )
     check(
         "fast_default_off",

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -288,6 +288,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "auto/gpt-5.6-sol",
         "codex-a/gpt-5.6-sol",
         "codex-b/gpt-5.6-sol",
+        "gpt-5.6-luna",
         "ark/deepseek-v4-flash",
     }
     checks: list[dict[str, Any]] = []
@@ -302,7 +303,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     check(
         "visible_routes",
         visible == expected_visible,
-        "selector exposes exactly Auto/A/B/Ark",
+        "selector exposes exactly Auto/A/B/Luna/Ark",
     )
     check(
         "hidden_alias",
@@ -320,9 +321,10 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
                 "auto/gpt-5.6-sol",
                 "codex-a/gpt-5.6-sol",
                 "codex-b/gpt-5.6-sol",
+                "gpt-5.6-luna",
             )
         ),
-        "Auto/A/B declare text and image",
+        "Auto/A/B/Luna declare text and image",
     )
     check(
         "ark_text_only",
@@ -337,8 +339,9 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             "auto/gpt-5.6-sol",
             "codex-a/gpt-5.6-sol",
             "codex-b/gpt-5.6-sol",
+            "gpt-5.6-luna",
         },
-        "Fast is exposed only for Auto/A/B",
+        "Fast is exposed only for Auto/A/B/Luna",
     )
     check(
         "fast_default_off",

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -456,6 +456,68 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         snapshot.get("affinity_policy") == "hint_revalidated_per_attempt",
         "Auto affinity is revalidated against required modalities per attempt",
     )
+    route_traversal = snapshot.get("route_traversal")
+    if not isinstance(route_traversal, Mapping):
+        raise TypeError("snapshot.route_traversal must be an object")
+    expected_traversal = {
+        "auto/gpt-5.6-sol": {
+            "entrypoint": "affinity_then_first",
+            "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
+            "fallback_tail": ["ark-text"],
+        },
+        "codex-a/gpt-5.6-sol": {
+            "entrypoint": "codex-a",
+            "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
+            "fallback_tail": ["ark-text"],
+        },
+        "codex-b/gpt-5.6-sol": {
+            "entrypoint": "codex-b",
+            "ordered_candidates": ["codex-b", "codex-a", "ark-text"],
+            "fallback_tail": ["ark-text"],
+        },
+        "gpt-5.6-luna": {
+            "entrypoint": "affinity_then_first",
+            "ordered_candidates": ["codex-a", "codex-b"],
+            "fallback_tail": [],
+        },
+    }
+    traversal_rows: dict[str, Mapping[str, Any]] = {}
+    for slug in expected_traversal:
+        raw_row = route_traversal.get(slug)
+        if not isinstance(raw_row, Mapping):
+            raise TypeError(f"snapshot.route_traversal[{slug}] must be an object")
+        traversal_rows[slug] = raw_row
+        _string_list(
+            raw_row.get("ordered_candidates"),
+            f"snapshot.route_traversal[{slug}].ordered_candidates",
+        )
+        _string_list(
+            raw_row.get("fallback_tail"),
+            f"snapshot.route_traversal[{slug}].fallback_tail",
+        )
+    check(
+        "preferred_route_order",
+        all(
+            traversal_rows[slug].get("entrypoint") == expected["entrypoint"]
+            and traversal_rows[slug].get("ordered_candidates")
+            == expected["ordered_candidates"]
+            for slug, expected in expected_traversal.items()
+        ),
+        "Auto/Prefer A/Prefer B/Luna use the expected account-ring entrypoint and order",
+    )
+    check(
+        "terminal_fallback_tail",
+        all(
+            traversal_rows[slug].get("fallback_tail") == expected["fallback_tail"]
+            for slug, expected in expected_traversal.items()
+        ),
+        "Sol routes append Ark once and Luna has no heterogeneous fallback tail",
+    )
+    check(
+        "single_cycle_traversal",
+        all(row.get("max_cycles") == 1 for row in traversal_rows.values()),
+        "every resilient route traverses the account ring at most once",
+    )
     check(
         "settings_revision",
         snapshot.get("settings_revision_durable") is True


### PR DESCRIPTION
## Summary

- expose gpt-5.6-luna across the two Codex subscription profiles with text/image, low through max reasoning, and optional Fast that defaults off
- model Codex A and B as one bounded account ring shared by Auto, Prefer A, Prefer B, and Luna
- make Prefer A compile to A -> B -> Ark and Prefer B compile to B -> A -> Ark; explicit Ark remains a hard pin
- keep Ark as a terminal Sol text fallback, not a ring member; Luna never silently degrades to Ark
- reject multi-cycle traversal and ring/tail overlap in the public contract
- register CLIProxyAPI PR #5336 as the runtime owner for route-specific credential priorities

## Interaction

The selector remains Auto / Prefer A / Prefer B / Luna / Ark. These are not separate rings. Auto and Luna use affinity (or A for a cold task), the two Prefer routes choose a different entry point into the same A/B ring, and Ark is the terminal escape hatch only when modality and service tier allow it. A single request visits each eligible account at most once.

## Validation

- uv run python packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
- uv run --with pytest python -m pytest -q tests/extensions/test_colocated_extension_layout.py
- uv run --with ruff ruff check packages/loopx-codex-provider-routing/src packages/loopx-codex-provider-routing/smoke tests/extensions/test_colocated_extension_layout.py
- uv run --with ruff ruff format --check packages/loopx-codex-provider-routing/src packages/loopx-codex-provider-routing/smoke tests/extensions/test_colocated_extension_layout.py
- python3 -m py_compile on the touched Python modules
- git diff --check

## Boundary

No credentials, account identities, local paths, logs, or private runtime evidence are included. Generated uv.lock remains untracked and excluded. Live deployment and App Server readback remain gated on CPA PR #5336 and the existing qualification matrix.