### PR TITLE
fix(dashboard): avoid unbound variable error when lark-cli not found

### DIFF
--- a/scripts/dashboard-dev.sh
+++ b/scripts/dashboard-dev.sh
@@ -188,8 +188,9 @@ resolve_lark_cli_binary() {
 
 CODEX_BIN="$(resolve_agent_binary codex)"
 CLAUDE_BIN="$(resolve_agent_binary claude)"
+LARK_CLI_ARGS=()  # Initialize as empty array
 if LARK_CLI_BIN="$(resolve_lark_cli_binary)"; then
-  LARK_CLI_ARGS=(--lark-cli-bin "${LARK_CLI_BIN}")
+  LARK_CLI_ARGS=(--lark-cli-bin "${LARK_CLI_BIN}")  # Set to lark-cli arg if found
 fi
 echo "LoopX Agent executables: Codex=${CODEX_BIN}; Claude Code=${CLAUDE_BIN}"
 if [ -n "${LARK_CLI_BIN}" ]; then
@@ -212,7 +213,7 @@ STATUS_PID=$!
   --port 8767 \
   --codex-bin "${CODEX_BIN}" \
   --claude-bin "${CLAUDE_BIN}" \
-  "${LARK_CLI_ARGS[@]}" \
+  ${LARK_CLI_ARGS[@]+"${LARK_CLI_ARGS[@]}"} \
   --no-open &
 CHAT_PID=$!
 


### PR DESCRIPTION
## Summary

Fixes the 'unbound variable' error when starting LoopX dashboard via `npm run dev` when `lark-cli` is not installed.

## Root Cause

The `scripts/dashboard-dev.sh` script uses `set -u` (strict mode) which treats unset variables as errors. When `lark-cli` is not found, `LARK_CLI_ARGS` array was referenced but never initialized, causing:

```
../../../scripts/dashboard-dev.sh: line 210: LARK_CLI_ARGS[@]: unbound variable
```

## Fix

1. Explicitly initialize `LARK_CLI_ARGS=()` as empty array before the conditional assignment
2. Use bash parameter expansion `${LARK_CLI_ARGS[@]+"${LARK_CLI_ARGS[@]}"}` which only expands when the variable is set and non-empty

## Testing

```bash
cd apps/presentation/dashboard && npm run dev
```

Now starts all three services successfully:
- Status service: http://127.0.0.1:8766/status.json
- Chat service: http://127.0.0.1:8767/chat/
- Vite dev server: http://127.0.0.1:5173/
