### PR TITLE
test: repair public smoke fixtures

### DIFF
--- a/examples/control_plane/quota-spend-agent-identity-smoke.py
+++ b/examples/control_plane/quota-spend-agent-identity-smoke.py
@@ -19,7 +19,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.quota.slot_accounting import (  # noqa: E402
-    _latest_unspent_accountable_delivery_run,
+    _latest_unspent_turn_settlement_run,
 )
 from loopx.control_plane.scheduler.execution_context import (  # noqa: E402
     GENERIC_CLI_OUTER_CONTROLLER_SCHEDULER_CONTEXT,
@@ -342,7 +342,7 @@ def assert_quota_neutral_events_do_not_hide_same_agent_delivery(agent_id: str) -
             "".join(json.dumps(row) + "\n" for row in neutral_runs),
             encoding="utf-8",
         )
-        selected = _latest_unspent_accountable_delivery_run(
+        selected = _latest_unspent_turn_settlement_run(
             runtime, goal_id, agent_id=agent_id
         )
         assert selected == delivery, selected
@@ -356,7 +356,7 @@ def assert_quota_neutral_events_do_not_hide_same_agent_delivery(agent_id: str) -
         }
         with index_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(material_monitor) + "\n")
-        selected = _latest_unspent_accountable_delivery_run(
+        selected = _latest_unspent_turn_settlement_run(
             runtime, goal_id, agent_id=agent_id
         )
         assert selected == material_monitor, selected
@@ -373,7 +373,7 @@ def assert_quota_neutral_events_do_not_hide_same_agent_delivery(agent_id: str) -
                 + "\n"
             )
         assert (
-            _latest_unspent_accountable_delivery_run(
+            _latest_unspent_turn_settlement_run(
                 runtime, goal_id, agent_id=agent_id
             )
             is None

--- a/examples/state-migration-smoke.py
+++ b/examples/state-migration-smoke.py
@@ -66,7 +66,19 @@ def main() -> int:
             },
         )
         (legacy_runtime / "goals" / OLD_GOAL_ID / "rollout-event-log.jsonl").write_text(
-            json.dumps({"goal_id": OLD_GOAL_ID, "event_kind": "quota_should_run"}) + "\n",
+            json.dumps(
+                {
+                    "schema_version": "loopx_rollout_event_v0",
+                    "event_id": "legacy-quota-should-run",
+                    "event_kind": "quota_should_run",
+                    "recorded_at": "2026-01-01T00:00:00+00:00",
+                    "status": "normal_run",
+                    "summary": "legacy quota guard completed",
+                    "goal_id": OLD_GOAL_ID,
+                    "details": {},
+                }
+            )
+            + "\n",
             encoding="utf-8",
         )
         write_json(


### PR DESCRIPTION
## Summary

- update the quota identity smoke to use the current settlement-owner helper
- make the legacy migration fixture emit a valid `loopx_rollout_event_v0`

This repairs two failures from Full Public Smokes run 33256588400 without changing production behavior. The remaining failures require separate core-owned fixes or are already covered by #3716.

## Validation

- `python3 examples/control_plane/quota-spend-agent-identity-smoke.py`
- `python3 examples/state-migration-smoke.py`
- focused selection through `examples/run-smokes.py`
- `python3 -m py_compile` for both changed scripts
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (passed; 5 selected checks, 0 failures, 0 manual holds)
- change-quality receipt `cqr_6f687be30b7e7cd7ad7c` (valid)

## Future-facing pass

No companion refactor was needed: the changes reuse the existing helper and canonical event schema, with no new abstraction or compatibility seam.
