### PR TITLE
fix(control-plane): repair remaining public smoke boundaries

### DIFF
--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 from collections.abc import Callable, Mapping, Sequence
-from importlib import import_module
 from pathlib import Path
 
 from ..capabilities.explore.activation import (
@@ -34,10 +33,6 @@ from ..control_plane.work_items.semantic_replan_writeback import (
 from ..extensions.lark.goal_channel_lifecycle import (
     goal_channel_gate_sync_failure,
     sync_human_gate_after_refresh,
-)
-from ..extensions.runtime import (
-    default_extension_state_file,
-    resolve_extension_activation,
 )
 from ..feedback import (
     LESSON_KINDS,
@@ -70,6 +65,10 @@ from .post_writeback import (
     PostWritebackProjectionBuilder,
     dispatch_committed_cli_post_writeback_hooks,
 )
+from .project_lifecycle_sinks import (
+    apply_external_sink_postcondition,
+    lark_explore_graph_syncer,
+)
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -94,66 +93,6 @@ INLINE_VISION_FIELDS = {
     "vision_dreaming_policy": "dreaming_policy",
     "vision_last_patch": "last_patch_summary",
 }
-
-
-def _lark_explore_graph_syncer(
-    runtime_root_arg: str | None,
-    *,
-    registry_path: Path,
-) -> Callable[..., Mapping[str, object]]:
-    extension_runtime_root = resolve_runtime_root(
-        load_registry(registry_path), runtime_root_arg
-    )
-
-    def sync(**kwargs: object) -> Mapping[str, object]:
-        implementation = import_module(
-            "loopx.extensions.lark.presentation.explore_results"
-        )
-        preview_kwargs = dict(kwargs)
-        preview_kwargs["execute"] = False
-        preview = dict(
-            implementation.sync_issue_fix_explore_on_material_change(
-                **preview_kwargs
-            )
-        )
-        if preview.get("status") in {"not_applicable", "not_configured"}:
-            return preview
-
-        provider = import_module("loopx.extensions.lark")
-        activation = resolve_extension_activation(
-            str(provider.LARK_EXTENSION_ID),
-            state_file=default_extension_state_file(extension_runtime_root),
-            required_permissions=(str(provider.LARK_PROJECTION_SINK_PERMISSION),),
-        )
-        result = (
-            dict(implementation.sync_issue_fix_explore_on_material_change(**kwargs))
-            if kwargs.get("execute")
-            else preview
-        )
-        result["extension_activation"] = activation
-        return result
-
-    return sync
-
-
-def _apply_external_sink_postcondition(
-    payload: dict[str, object],
-    *,
-    sink_result: Mapping[str, object],
-    warning: str,
-    error: str,
-) -> None:
-    postcondition = (
-        sink_result.get("delivery_postcondition")
-        if isinstance(sink_result.get("delivery_postcondition"), Mapping)
-        else {}
-    )
-    if not sink_result.get("enabled") or postcondition.get("satisfied"):
-        return
-    payload.setdefault("warnings", []).append(warning)
-    if postcondition.get("blocks_delivery"):
-        payload["ok"] = False
-        payload["error"] = error
 
 
 def _inline_agent_vision_packet(args: argparse.Namespace) -> dict[str, object] | None:
@@ -915,13 +854,13 @@ def handle_project_lifecycle_command(
                 external_sink_delivery_authorized=not bool(
                     args.suppress_external_sinks
                 ),
-                syncer=_lark_explore_graph_syncer(
+                syncer=lark_explore_graph_syncer(
                     args.runtime_root,
                     registry_path=registry_path,
                 ),
             )
             payload["explore_graph_sync"] = graph_sync
-            _apply_external_sink_postcondition(
+            apply_external_sink_postcondition(
                 payload,
                 sink_result=graph_sync,
                 warning=(
@@ -949,7 +888,7 @@ def handle_project_lifecycle_command(
                     goal_id=args.goal_id,
                 )
             payload["goal_channel_gate_sync"] = gate_sync
-            _apply_external_sink_postcondition(
+            apply_external_sink_postcondition(
                 payload,
                 sink_result=gate_sync,
                 warning=(

--- a/loopx/cli_commands/project_lifecycle_sinks.py
+++ b/loopx/cli_commands/project_lifecycle_sinks.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from importlib import import_module
+from pathlib import Path
+
+from ..extensions.runtime import (
+    default_extension_state_file,
+    resolve_extension_activation,
+)
+from ..history import load_registry
+from ..paths import resolve_runtime_root
+
+
+def lark_explore_graph_syncer(
+    runtime_root_arg: str | None,
+    *,
+    registry_path: Path,
+) -> Callable[..., Mapping[str, object]]:
+    extension_runtime_root = resolve_runtime_root(
+        load_registry(registry_path), runtime_root_arg
+    )
+
+    def sync(**kwargs: object) -> Mapping[str, object]:
+        implementation = import_module(
+            "loopx.extensions.lark.presentation.explore_results"
+        )
+        preview_kwargs = dict(kwargs)
+        preview_kwargs["execute"] = False
+        preview = dict(
+            implementation.sync_issue_fix_explore_on_material_change(
+                **preview_kwargs
+            )
+        )
+        if preview.get("status") in {"not_applicable", "not_configured"}:
+            return preview
+
+        provider = import_module("loopx.extensions.lark")
+        activation = resolve_extension_activation(
+            str(provider.LARK_EXTENSION_ID),
+            state_file=default_extension_state_file(extension_runtime_root),
+            required_permissions=(str(provider.LARK_PROJECTION_SINK_PERMISSION),),
+        )
+        result = (
+            dict(implementation.sync_issue_fix_explore_on_material_change(**kwargs))
+            if kwargs.get("execute")
+            else preview
+        )
+        result["extension_activation"] = activation
+        return result
+
+    return sync
+
+
+def apply_external_sink_postcondition(
+    payload: dict[str, object],
+    *,
+    sink_result: Mapping[str, object],
+    warning: str,
+    error: str,
+) -> None:
+    postcondition = (
+        sink_result.get("delivery_postcondition")
+        if isinstance(sink_result.get("delivery_postcondition"), Mapping)
+        else {}
+    )
+    if not sink_result.get("enabled") or postcondition.get("satisfied"):
+        return
+    payload.setdefault("warnings", []).append(warning)
+    if postcondition.get("blocks_delivery"):
+        payload["ok"] = False
+        payload["error"] = error

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -35,13 +35,11 @@ from ..control_plane.scheduler.execution_context import (
 )
 from ..control_plane.turn_driver import (
     LOOPX_TURN_EXECUTION_SCHEMA_VERSION,
-    LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
     LOOPX_TURN_SESSION_BINDING_SCHEMA_VERSION,
     TurnRecoveryBlockedError,
     build_loopx_turn_command_validator,
     build_loopx_turn_plan,
     codex_cli_session_binding,
-    inspect_loopx_turn_journal,
     load_loopx_turn_plan_from_journal,
     run_codex_cli_host,
     run_loopx_turn_once,
@@ -56,11 +54,12 @@ from .lark_inbox import (
     dispatch_goal_lark_turn_start_hooks,
 )
 from .turn_registration import register_turn_commands as register_turn_commands
+from .turn_inspection import handle_turn_journal_inspection
 from .turn_rendering import (
     render_loopx_turn_execution_markdown as _render_loopx_turn_execution_markdown,
-    render_loopx_turn_journal_inspection_markdown as _render_loopx_turn_journal_inspection_markdown,
     render_loopx_turn_plan_markdown as _render_loopx_turn_plan_markdown,
 )
+from .turn_selection import turn_controller_advisory_primary
 
 EXACT_SETTLEMENT_READBACK_NOT_FOUND = (
     "exact settlement readback unexpectedly returned not-found"
@@ -73,44 +72,6 @@ PrintPayload = Callable[
 FormatSelector = Callable[..., str]
 
 
-def _turn_controller_advisory_primary(
-    decision: Mapping[str, Any],
-) -> tuple[str, dict[str, Any]] | None:
-    """Resolve the default for Turn's model-free outer-controller phase."""
-
-    interaction = decision.get("interaction_contract")
-    cli_channel = (
-        interaction.get("cli_channel")
-        if isinstance(interaction, Mapping)
-        else None
-    )
-    if not isinstance(cli_channel, Mapping) or (
-        cli_channel.get("selection_required") is not True
-    ):
-        return None
-    portfolio = decision.get("action_portfolio")
-    if not isinstance(portfolio, Mapping) or (
-        portfolio.get("schema_version") != "quota_action_portfolio_v2"
-    ):
-        raise ValueError(
-            "Turn action selection requires a typed advisory action portfolio"
-        )
-    policy = portfolio.get("selection_policy")
-    primary = portfolio.get("primary")
-    todo_id = (
-        str(primary.get("todo_id") or "").strip()
-        if isinstance(primary, Mapping)
-        else ""
-    )
-    if (
-        not isinstance(policy, Mapping)
-        or policy.get("requires_explicit_turn_binding") is not True
-        or not todo_id
-    ):
-        raise ValueError("Turn advisory action portfolio has no bindable primary")
-    return todo_id, dict(portfolio)
-
-
 def handle_turn_command(
     args: argparse.Namespace,
     *,
@@ -121,38 +82,15 @@ def handle_turn_command(
 ) -> int | None:
     if args.command != "turn":
         return None
-    if args.turn_command == "inspect-journal":
-        try:
-            runtime_root = resolve_status_projection_cache_runtime_root(
-                registry_path=registry_path,
-                runtime_root_override=runtime_root_arg,
-            )
-            payload = inspect_loopx_turn_journal(
-                runtime_root,
-                goal_id=args.goal_id,
-                agent_id=args.agent_id,
-                turn_key=args.turn_key,
-                retry_failed=bool(args.retry_failed_turn),
-                session_binding_resolver=(
-                    lambda turn_envelope: codex_cli_session_binding(
-                        runtime_root,
-                        turn_envelope,
-                    )
-                ),
-            )
-        except Exception as exc:  # noqa: BLE001 - typed CLI failure boundary
-            payload = {
-                "ok": False,
-                "schema_version": LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
-                "error": str(exc),
-                "effects": [],
-            }
-        print_payload(
-            payload,
-            output_format(args),
-            _render_loopx_turn_journal_inspection_markdown,
-        )
-        return 0 if payload.get("ok") else 1
+    inspection_result = handle_turn_journal_inspection(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if inspection_result is not None:
+        return inspection_result
     try:
         scan_roots = [Path(item).expanduser() for item in args.scan_path]
         if not scan_roots:
@@ -205,7 +143,7 @@ def handle_turn_command(
             )
 
         decision = build_turn_decision()
-        controller_default = _turn_controller_advisory_primary(decision)
+        controller_default = turn_controller_advisory_primary(decision)
         if controller_default is not None:
             primary_todo_id, advisory_portfolio = controller_default
             decision = build_turn_decision(

--- a/loopx/cli_commands/turn_inspection.py
+++ b/loopx/cli_commands/turn_inspection.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..control_plane.runtime.status_projection_cache import (
+    resolve_status_projection_cache_runtime_root,
+)
+from ..control_plane.turn_driver import (
+    LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
+    codex_cli_session_binding,
+    inspect_loopx_turn_journal,
+)
+from .turn_rendering import render_loopx_turn_journal_inspection_markdown
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def handle_turn_journal_inspection(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.turn_command != "inspect-journal":
+        return None
+    try:
+        runtime_root = resolve_status_projection_cache_runtime_root(
+            registry_path=registry_path,
+            runtime_root_override=runtime_root_arg,
+        )
+        payload = inspect_loopx_turn_journal(
+            runtime_root,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            turn_key=args.turn_key,
+            retry_failed=bool(args.retry_failed_turn),
+            session_binding_resolver=(
+                lambda turn_envelope: codex_cli_session_binding(
+                    runtime_root,
+                    turn_envelope,
+                )
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 - typed CLI failure boundary
+        payload = {
+            "ok": False,
+            "schema_version": LOOPX_TURN_JOURNAL_INSPECTION_SCHEMA_VERSION,
+            "error": str(exc),
+            "effects": [],
+        }
+    print_payload(
+        payload,
+        output_format(args),
+        render_loopx_turn_journal_inspection_markdown,
+    )
+    return 0 if payload.get("ok") else 1

--- a/loopx/cli_commands/turn_selection.py
+++ b/loopx/cli_commands/turn_selection.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def turn_controller_advisory_primary(
+    decision: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    """Resolve the default for Turn's model-free outer-controller phase."""
+
+    interaction = decision.get("interaction_contract")
+    cli_channel = (
+        interaction.get("cli_channel")
+        if isinstance(interaction, Mapping)
+        else None
+    )
+    if not isinstance(cli_channel, Mapping) or (
+        cli_channel.get("selection_required") is not True
+    ):
+        return None
+    portfolio = decision.get("action_portfolio")
+    if not isinstance(portfolio, Mapping) or (
+        portfolio.get("schema_version") != "quota_action_portfolio_v2"
+    ):
+        raise ValueError(
+            "Turn action selection requires a typed advisory action portfolio"
+        )
+    policy = portfolio.get("selection_policy")
+    primary = portfolio.get("primary")
+    todo_id = (
+        str(primary.get("todo_id") or "").strip()
+        if isinstance(primary, Mapping)
+        else ""
+    )
+    if (
+        not isinstance(policy, Mapping)
+        or policy.get("requires_explicit_turn_binding") is not True
+        or not todo_id
+    ):
+        raise ValueError("Turn advisory action portfolio has no bindable primary")
+    return todo_id, dict(portfolio)

--- a/loopx/control_plane/work_items/task_lease_acquire_adapter.py
+++ b/loopx/control_plane/work_items/task_lease_acquire_adapter.py
@@ -8,6 +8,10 @@ from typing import Any
 
 from ...history import load_registry
 from ...paths import resolve_runtime_root
+from ..goals.active_state_event_projection import (
+    state_event_log_candidates as _state_event_log_candidates,
+)
+from ..goals.path_resolution import resolve_goal_local_path
 from ..todos.contract import normalize_todo_id
 from ..todos.handoff_mode import HANDOFF_MODE_LEGACY
 from .local_lease_record import TASK_LEASE_SCHEMA_VERSION, TaskLeaseError
@@ -56,8 +60,6 @@ def _task_lease_authority_source_paths(
 ) -> tuple[dict[str, Any] | None, Path | None, list[tuple[str, Path]]]:
     from ...rollout_event_log import rollout_event_log_path
     from ...state_refresh import resolve_goal_state
-    from ...status import state_event_log_candidates
-
     sources: list[tuple[str, Path]] = [("registry", registry_path)]
     goal = _registry_goal(registry, goal_id)
     if goal is None:
@@ -73,7 +75,11 @@ def _task_lease_authority_source_paths(
         return goal, None, sources
     sources.append(("active_state", state_file))
     for index, path in enumerate(
-        state_event_log_candidates(goal, state_path=state_file)
+        _state_event_log_candidates(
+            goal,
+            state_path=state_file,
+            resolve_goal_local_path=resolve_goal_local_path,
+        )
     ):
         sources.append((f"state_event_{index}", path))
     projection_runtime_root = resolve_runtime_root(

--- a/tests/cli_commands/test_project_lifecycle_explore_graph.py
+++ b/tests/cli_commands/test_project_lifecycle_explore_graph.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from loopx.cli_commands import project_lifecycle
+from loopx.cli_commands import project_lifecycle_sinks
 
 
 @pytest.mark.parametrize("status", ["not_applicable", "not_configured"])
@@ -23,27 +23,27 @@ def test_local_only_explore_projection_does_not_require_optional_extension(
 
     implementation = SimpleNamespace(sync_issue_fix_explore_on_material_change=project)
     monkeypatch.setattr(
-        project_lifecycle,
+        project_lifecycle_sinks,
         "import_module",
         lambda name: implementation,
     )
     monkeypatch.setattr(
-        project_lifecycle,
+        project_lifecycle_sinks,
         "resolve_runtime_root",
         lambda registry, runtime_root_arg: tmp_path,
     )
-    monkeypatch.setattr(project_lifecycle, "load_registry", lambda path: {})
+    monkeypatch.setattr(project_lifecycle_sinks, "load_registry", lambda path: {})
 
     def unexpected_activation(*args: Any, **kwargs: Any) -> dict[str, Any]:
         raise AssertionError("local-only projection must not activate a sink provider")
 
     monkeypatch.setattr(
-        project_lifecycle,
+        project_lifecycle_sinks,
         "resolve_extension_activation",
         unexpected_activation,
     )
 
-    sync = project_lifecycle._lark_explore_graph_syncer(
+    sync = project_lifecycle_sinks.lark_explore_graph_syncer(
         None,
         registry_path=tmp_path / "registry.json",
     )
@@ -80,25 +80,25 @@ def test_external_explore_projection_activates_provider_before_write(
             return provider
         raise AssertionError(name)
 
-    monkeypatch.setattr(project_lifecycle, "import_module", import_fake)
+    monkeypatch.setattr(project_lifecycle_sinks, "import_module", import_fake)
     monkeypatch.setattr(
-        project_lifecycle,
+        project_lifecycle_sinks,
         "resolve_runtime_root",
         lambda registry, runtime_root_arg: tmp_path,
     )
-    monkeypatch.setattr(project_lifecycle, "load_registry", lambda path: {})
+    monkeypatch.setattr(project_lifecycle_sinks, "load_registry", lambda path: {})
 
     def activate(*args: Any, **kwargs: Any) -> dict[str, Any]:
         events.append("activate")
         return {"status": "active"}
 
     monkeypatch.setattr(
-        project_lifecycle,
+        project_lifecycle_sinks,
         "resolve_extension_activation",
         activate,
     )
 
-    sync = project_lifecycle._lark_explore_graph_syncer(
+    sync = project_lifecycle_sinks.lark_explore_graph_syncer(
         None,
         registry_path=tmp_path / "registry.json",
     )

--- a/tests/test_loopx_turn_journal_inspection.py
+++ b/tests/test_loopx_turn_journal_inspection.py
@@ -10,6 +10,7 @@ import pytest
 
 from loopx.cli import main as cli_main
 from loopx.cli_commands import turn as turn_command
+from loopx.cli_commands import turn_rendering
 from loopx.control_plane.turn_driver import executor
 from loopx.control_plane.turn_driver import turn_journal_runtime
 
@@ -122,7 +123,7 @@ def test_existing_run_once_markdown_renderer_remains_intact() -> None:
 
 
 def test_inspection_markdown_distinguishes_current_plan_from_last_result() -> None:
-    rendered = turn_command._render_loopx_turn_journal_inspection_markdown(
+    rendered = turn_rendering.render_loopx_turn_journal_inspection_markdown(
         {
             "ok": True,
             "decision": "replay_legal",


### PR DESCRIPTION
## Summary

- remove the task-lease authority adapter's reverse import from the top-level status facade by reusing goal-owned event-log/path helpers
- extract project lifecycle sink transport from the oversized lifecycle command module
- extract Turn journal inspection and advisory selection from the oversized Turn command module
- migrate the affected tests to the new owning modules instead of restoring private compatibility wrappers

This repairs the remaining public-smoke ownership boundaries while preserving behavior. The original required pytest failure was caused by four tests still patching/importing the pre-extraction private owners; the refined head updates those seams directly.

## Value

The change reduces reverse dependencies and shrinks two overloaded Python CLI facades. Lifecycle sink effects, Turn journal inspection, and advisory selection now have narrower change reasons and clearer owners, which lowers maintenance cost and makes later TypeScript migration more local. It does not add speculative architecture or a second state authority.

## Validation

- focused pytest owner migration: 21 passed
- `npm run typecheck:control-plane`
- `npm run test:control-plane` (290 passed on the final base)
- repository-configured strict `mypy`
- changed-path Ruff and `py_compile`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` from this exact worktree: 17/17 passed, 0 failures, 0 manual holds
- change-quality receipt `cqr_b4d45e0f0c782cb2b6ef`, fingerprint `b4d45e0f0c782cb2b6ef74177c1b8c788c6f0b68ef97236ae097d37a3c1a0047`, valid

## Future-facing pass

Applied and bounded: CLI behavior is localized under cohesive sink, journal-inspection, and advisory-selection owners; task-lease path authority stays in its bounded context. No production wrapper or broad TypeScript migration was added solely for old private test seams.

## Boundary

Only public product code and durable tests are included. No local state, raw logs, credentials, generated evidence, or private paths are committed.
