### PR TITLE
feat(lark): verify structured outbound mentions

### DIFF
--- a/examples/issue-fix-reviewer-notification-sink-smoke.py
+++ b/examples/issue-fix-reviewer-notification-sink-smoke.py
@@ -9,21 +9,21 @@ import sys
 from pathlib import Path
 from typing import Any
 
-
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from loopx.capabilities.issue_fix.reviewer_notification import (  # noqa: E402
-    ISSUE_FIX_REVIEWER_NOTIFICATION_SINKS_INPUT_SCHEMA_VERSION,
-    ISSUE_FIX_REVIEWER_NOTIFICATION_SINKS_RESULT_SCHEMA_VERSION,
-    build_issue_fix_reviewer_notification_sinks_result as build_core_result,
-    with_reviewer_notification_state,
-)
-from examples.issue_fix_reviewer_notification_test_support import (  # noqa: E402
+from examples.issue_fix_reviewer_notification_test_support import (
     build_issue_fix_reviewer_notification_sinks_result,
 )
-
+from loopx.capabilities.issue_fix.reviewer_notification import (
+    ISSUE_FIX_REVIEWER_NOTIFICATION_SINKS_INPUT_SCHEMA_VERSION,
+    ISSUE_FIX_REVIEWER_NOTIFICATION_SINKS_RESULT_SCHEMA_VERSION,
+    with_reviewer_notification_state,
+)
+from loopx.capabilities.issue_fix.reviewer_notification import (
+    build_issue_fix_reviewer_notification_sinks_result as build_core_result,
+)
 
 PRIVATE_PATTERNS = (
     re.compile(r"oc_[A-Za-z0-9_-]+"),
@@ -47,6 +47,8 @@ class FakeSinkRunner:
         member_id: str = "ou_private_member",
         search_returncode: int = 0,
         search_hit: bool = False,
+        preview_matches: bool = True,
+        readback_member_id: str | None = None,
     ) -> None:
         self.send_returncode = send_returncode
         self.verify_returncode = verify_returncode
@@ -57,6 +59,8 @@ class FakeSinkRunner:
         self.member_id = member_id
         self.search_returncode = search_returncode
         self.search_hit = search_hit
+        self.preview_matches = preview_matches
+        self.readback_member_id = readback_member_id
         self.calls: list[list[str]] = []
 
     def __call__(self, args: list[str]) -> dict[str, Any]:
@@ -126,12 +130,22 @@ class FakeSinkRunner:
                     else ""
                 ),
                 "stderr": (
-                    "missing scope search:message"
-                    if self.search_returncode
-                    else ""
+                    "missing scope search:message" if self.search_returncode else ""
                 ),
             }
         if "+messages-send" in command:
+            if "--dry-run" in command:
+                content = command[command.index("--content") + 1]
+                preview_content = (
+                    content if self.preview_matches else '{"text":"wrong"}'
+                )
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {"api": [{"body": {"content": preview_content}}]}
+                    ),
+                    "stderr": "",
+                }
             return {
                 "returncode": self.send_returncode,
                 "stdout": (
@@ -146,9 +160,20 @@ class FakeSinkRunner:
                 ),
             }
         if "+messages-mget" in command:
-            send_call = next(call for call in self.calls if "+messages-send" in call)
+            send_call = next(
+                call
+                for call in self.calls
+                if "+messages-send" in call and "--dry-run" not in call
+            )
             content = send_call[send_call.index("--content") + 1]
-            text = content if self.include_message_content else "missing"
+            content_payload = json.loads(content)
+            text = (
+                content_payload["text"] if self.include_message_content else "missing"
+            )
+            rendered_text = text.replace(
+                '<at open_id="ou_private_member">Service Owner</at>',
+                "@_user_1",
+            )
             return {
                 "returncode": self.verify_returncode,
                 "stdout": json.dumps(
@@ -156,7 +181,22 @@ class FakeSinkRunner:
                         "items": [
                             {
                                 "message_id": "om_fixture_message",
-                                "body": {"content": text},
+                                "body": {
+                                    "content": json.dumps(
+                                        {"text": rendered_text},
+                                        ensure_ascii=False,
+                                    )
+                                },
+                                "mentions": [
+                                    {
+                                        "key": "@_user_1",
+                                        "name": "Service Owner",
+                                        "id": {
+                                            "open_id": self.readback_member_id
+                                            or "ou_private_member"
+                                        },
+                                    }
+                                ],
                             }
                         ]
                     }
@@ -202,12 +242,18 @@ def fixture(
     }
 
 
+def assert_one_verified_send(calls: list[list[str]]) -> None:
+    send_calls = [call for call in calls if "+messages-send" in call]
+    assert len(send_calls) == 2, calls
+    assert sum("--dry-run" in call for call in send_calls) == 1, calls
+    assert sum("--dry-run" not in call for call in send_calls) == 1, calls
+    assert sum("+messages-mget" in call for call in calls) == 1, calls
+
+
 def reviewer_artifact_application() -> dict[str, Any]:
     return {
         "ok": True,
-        "schema_version": (
-            "issue_fix_reviewer_artifact_reward_memory_application_v0"
-        ),
+        "schema_version": ("issue_fix_reviewer_artifact_reward_memory_application_v0"),
         "surface_id": "reviewer_artifact.summary",
         "reviewer_artifact": {
             "schema_version": "issue_fix_reviewer_artifact_v0",
@@ -264,18 +310,14 @@ def reviewer_notification_policy_application() -> dict[str, Any]:
             "status": "applied",
             "receipt": {
                 "schema_version": "reward_memory_application_receipt_v0",
-                "application_id": (
-                    "issue-fix:reviewer-notification:owner/repo:42"
-                ),
+                "application_id": ("issue-fix:reviewer-notification:owner/repo:42"),
                 "artifact_ref": "github:owner/repo#pr-42",
                 "corpus_id": "reviewer_notification_delivery_policy",
                 "surface_id": "reviewer_notification.before_send",
                 "mode": "function_boundary",
                 "outcome": "applied",
                 "memory_ref_digests": ["0123456789abcdef"],
-                "reasoning_summary": (
-                    "Applied the active reviewer delivery policy."
-                ),
+                "reasoning_summary": ("Applied the active reviewer delivery policy."),
                 "current_artifact_verified": True,
                 "result_readback_verified": True,
                 "model_reasoning_preserved": True,
@@ -334,8 +376,7 @@ def main() -> int:
     )
     assert core_without_provider["ok"] is False, core_without_provider
     assert (
-        core_without_provider["blocker"]
-        == "reviewer_notification_sink_unsupported"
+        core_without_provider["blocker"] == "reviewer_notification_sink_unsupported"
     ), core_without_provider
 
     provider_neutral = build_issue_fix_reviewer_notification_sinks_result(
@@ -391,9 +432,7 @@ def main() -> int:
         runner=missing_memory_runner,
     )
     assert missing_memory["ok"] is False
-    assert missing_memory["blocker"] == (
-        "reward_memory_reviewer_artifact_unverified"
-    )
+    assert missing_memory["blocker"] == ("reward_memory_reviewer_artifact_unverified")
     assert missing_memory["external_writes_performed"] is False
     assert missing_memory_runner.calls == []
 
@@ -484,9 +523,7 @@ def main() -> int:
     assert queued["status"] == "queued_until_window"
     assert queued["external_writes_performed"] is False
     assert queued["notification_verified"] is False
-    assert queued["queued_receipts"][0]["not_before"] == (
-        "2026-07-11T01:00:00Z"
-    )
+    assert queued["queued_receipts"][0]["not_before"] == ("2026-07-11T01:00:00Z")
     assert outside_window_runner.calls == []
     assert_public_safe(queued)
 
@@ -543,7 +580,7 @@ def main() -> int:
         runner=inside_window_runner,
     )
     assert inside_window["status"] == "sent_verified", inside_window
-    assert len(inside_window_runner.calls) == 3
+    assert_one_verified_send(inside_window_runner.calls)
 
     overnight_config = fixture()
     overnight_config["delivery_policy"] = {
@@ -564,7 +601,7 @@ def main() -> int:
         runner=overnight_runner,
     )
     assert overnight["status"] == "sent_verified", overnight
-    assert len(overnight_runner.calls) == 3
+    assert_one_verified_send(overnight_runner.calls)
 
     invalid_window_config = fixture()
     invalid_window_config["delivery_policy"] = {
@@ -608,8 +645,12 @@ def main() -> int:
     assert sent["status"] == "sent_verified"
     assert sent["external_writes_performed"] is True
     assert sent["notification_verified"] is True
-    assert len(runner.calls) == 3
-    send = runner.calls[1]
+    assert_one_verified_send(runner.calls)
+    send = next(
+        call
+        for call in runner.calls
+        if "+messages-send" in call and "--dry-run" not in call
+    )
     assert send[:3] == ["lark-cli", "--profile", "cli-private-profile"]
     assert send[send.index("--as") + 1] == "bot"
     assert send[send.index("--chat-id") + 1] == "oc_private_destination"
@@ -617,10 +658,9 @@ def main() -> int:
     assert provider_key.startswith("loopx-")
     assert len(provider_key) <= 50
     content = send[send.index("--content") + 1]
-    assert "ou_private_member" in content
-    assert (
-        "https://github.com/owner/repo/pull/42" in content
-    )
+    assert '<at open_id=\\"ou_private_member\\">' in content
+    assert "user_id" not in content
+    assert "https://github.com/owner/repo/pull/42" in content
     assert "请帮忙 review PR #42（修复 #40）" in content
     assert "reject file URI for consistency check" in content
     assert "loopx-reviewer-notification" not in content
@@ -642,7 +682,7 @@ def main() -> int:
     )
     assert explicit["ok"] is True, explicit
     assert explicit["results"][0]["reader_identity_verified"] is True
-    assert len(explicit_runner.calls) == 7, explicit_runner.calls
+    assert_one_verified_send(explicit_runner.calls)
     assert explicit["results"][0]["semantic_dedupe_status"] == (
         "configured_chat_no_match"
     )
@@ -654,9 +694,7 @@ def main() -> int:
         "--profile",
         "fixture-sender-profile",
     ]
-    member_read = next(
-        call for call in explicit_runner.calls if "chat.members" in call
-    )
+    member_read = next(call for call in explicit_runner.calls if "chat.members" in call)
     assert member_read[:3] == [
         "lark-cli",
         "--profile",
@@ -713,9 +751,7 @@ def main() -> int:
     assert remote_duplicate["results"][0]["semantic_dedupe_status"] == (
         "configured_chat_match"
     )
-    assert not any(
-        "+messages-send" in call for call in remote_duplicate_runner.calls
-    )
+    assert not any("+messages-send" in call for call in remote_duplicate_runner.calls)
 
     permission_fallback_runner = FakeSinkRunner(search_returncode=1)
     permission_fallback = build_issue_fix_reviewer_notification_sinks_result(
@@ -732,9 +768,7 @@ def main() -> int:
     assert permission_fallback["results"][0]["semantic_dedupe_status"] == (
         "permission_fallback"
     )
-    assert any(
-        "+messages-send" in call for call in permission_fallback_runner.calls
-    )
+    assert any("+messages-send" in call for call in permission_fallback_runner.calls)
 
     inbox_history = fixture(explicit_profiles=True)
     inbox_history["_semantic_history_pr_refs"] = [
@@ -784,9 +818,7 @@ def main() -> int:
         runner=FakeSinkRunner(member_id="ou_private_member_suffix"),
     )
     assert substring_member["ok"] is False, substring_member
-    assert substring_member["blocker"] == (
-        "reviewer_notification_identity_unresolved"
-    )
+    assert substring_member["blocker"] == ("reviewer_notification_identity_unresolved")
     assert substring_member["external_writes_performed"] is False
     assert_public_safe(substring_member)
 
@@ -884,6 +916,36 @@ def main() -> int:
     assert permission["blocker"] == "lark_bot_group_access_required"
     assert permission["external_writes_performed"] is False
     assert_public_safe(permission)
+
+    preview_mismatch = build_issue_fix_reviewer_notification_sinks_result(
+        repo="owner/repo",
+        pr_number=42,
+        pr_url="https://github.com/owner/repo/pull/42",
+        author_handle="@current-author",
+        reviewer_handles=["@service-owner"],
+        sinks_input=fixture(),
+        execute=True,
+        runner=FakeSinkRunner(preview_matches=False),
+    )
+    assert preview_mismatch["ok"] is False
+    assert preview_mismatch["blocker"] == (
+        "lark_notification_provider_preview_mismatch"
+    )
+    assert preview_mismatch["external_writes_performed"] is False
+
+    wrong_mention_readback = build_issue_fix_reviewer_notification_sinks_result(
+        repo="owner/repo",
+        pr_number=42,
+        pr_url="https://github.com/owner/repo/pull/42",
+        author_handle="@current-author",
+        reviewer_handles=["@service-owner"],
+        sinks_input=fixture(),
+        execute=True,
+        runner=FakeSinkRunner(readback_member_id="ou_wrong_member"),
+    )
+    assert wrong_mention_readback["ok"] is False
+    assert wrong_mention_readback["blocker"] == "lark_notification_not_verified"
+    assert wrong_mention_readback["external_writes_performed"] is True
 
     not_verified = build_issue_fix_reviewer_notification_sinks_result(
         repo="owner/repo",

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -37,7 +37,10 @@ from ..extensions.lark.inbox_reactions import (
     complete_lark_event_inbox_reactions,
     mark_lark_event_inbox_processing,
 )
-from ..extensions.lark.inbox_reply import reply_lark_event_inbox
+from ..extensions.lark.inbox_reply import (
+    reply_lark_event_inbox,
+    send_lark_inbox_message,
+)
 from ..extensions.lark.reviewer_notification import (
     lark_reviewer_notification_sink,
 )
@@ -47,6 +50,7 @@ from ..extensions.lark.routed_inbox import (
     inspect_routed_lark_event_inbox,
     project_routed_lark_event_inbox_urgency,
     resolve_routed_lark_inbox_config,
+    resolve_routed_lark_inbox_route,
     settle_routed_lark_event_inbox_material_review,
 )
 from ..extensions.lark.turn_start_sync import sync_lark_turn_start_inbox
@@ -165,6 +169,26 @@ def register_lark_inbox_commands(
         help="Run identity, membership, and provider dry-run checks without sending.",
     )
     reply.add_argument("--execute", action="store_true")
+    send = sub.add_parser(
+        "send",
+        help=(
+            "Send one verified chat-root message with the inbox-configured bot; "
+            "structured mentions must match provider readback exactly."
+        ),
+    )
+    add_subcommand_format(send)
+    send.add_argument("--project")
+    send.add_argument("--config")
+    send.add_argument("--goal-id")
+    send.add_argument("--agent-id")
+    send.add_argument("--route-key")
+    send.add_argument("--text", required=True)
+    send.add_argument(
+        "--provider-preflight",
+        action="store_true",
+        help="Run identity, membership, mention, and provider dry-run checks.",
+    )
+    send.add_argument("--execute", action="store_true")
     processing = sub.add_parser(
         "processing",
         help=(
@@ -274,7 +298,7 @@ def _required_extension_permissions(command: str) -> tuple[str, ...]:
         return (LARK_INBOX_WRITE_PERMISSION,)
     if command == "history-catch-up":
         return (LARK_COLLECTOR_PERMISSION, LARK_INBOX_WRITE_PERMISSION)
-    if command in {"reply", "processing", "reaction-complete"}:
+    if command in {"reply", "send", "processing", "reaction-complete"}:
         return (LARK_REPLY_PERMISSION,)
     return (LARK_COLLECTOR_PERMISSION,)
 
@@ -484,6 +508,7 @@ def handle_lark_inbox_command(
             "ack",
             "material-review",
             "reply",
+            "send",
             "processing",
             "reaction-complete",
             "ingest",
@@ -543,6 +568,19 @@ def handle_lark_inbox_command(
                 project=project,
                 config_path=routed_config,
                 message_id=args.message_id,
+                text=args.text,
+                execute=args.execute,
+                provider_preflight=args.provider_preflight,
+            )
+        elif args.lark_inbox_command == "send":
+            routed_config = resolve_routed_lark_inbox_route(
+                project=project,
+                config_path=config_path,
+                route_key=args.route_key,
+            )
+            payload = send_lark_inbox_message(
+                project=project,
+                config_path=routed_config,
                 text=args.text,
                 execute=args.execute,
                 provider_preflight=args.provider_preflight,

--- a/loopx/extensions/lark/README.md
+++ b/loopx/extensions/lark/README.md
@@ -16,6 +16,43 @@ evidence, or recovery authority.
 | `lark-periodic-report-announcement` | Deliver a periodic report while mentioning only recipients selected by its typed audience plan | [`presentation/periodic_report.py`](presentation/periodic_report.py) |
 | `lark-miaoda-html-report` | Publish an already-rendered periodic report to an operator-selected existing Miaoda app | [`presentation/periodic_report.py`](presentation/periodic_report.py) |
 
+Mention-bearing text delivery is owned by the extension's shared outbound
+contract in [`outbound.py`](outbound.py). Inbox replies and reviewer
+notifications use the same structured `<at ...>` construction, provider
+dry-run, and exact readback rule. A visible literal `@Name`, successful message
+creation, or matching display text is not mention-delivery evidence. The
+provider readback must expose exactly the identities requested at send time in
+`mentions[]`; missing, extra, ambiguous, or different identities fail closed.
+Callers that need notification semantics must use these extension surfaces
+instead of invoking a raw `lark-cli` send command.
+
+For an inbox-configured Bot, preview and verify one proactive top-level message
+with the same contract used by replies. A multi-chat collector requires its
+public-safe `route_key`; a single inbox accepts the default route:
+
+```bash
+loopx lark-inbox send \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --route-key project-feedback \
+  --text '<at open_id="ou_example">Example Reviewer</at> please review' \
+  --provider-preflight
+
+loopx lark-inbox send \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --route-key project-feedback \
+  --text '<at open_id="ou_example">Example Reviewer</at> please review' \
+  --execute
+```
+
+The command uses only the owner-local profile and chat already bound to the
+selected inbox route. It resolves every structured identity against exact chat
+membership, performs a provider dry-run, sends idempotently, and reads the
+created message back. It returns no profile, chat id, message body, or raw
+provider payload. Installation and the command itself grant no new Lark scope
+or external-write authority.
+
 The [event inbox guide](docs/lark-event-inbox.md) documents the complete
 collector, processing, reply, reaction, and acknowledgement lifecycle. The
 [Lark Kanban integration guide](../../../docs/integrations/lark-kanban-control-plane-adapter.md)

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -528,6 +528,36 @@ metadata. Verification therefore compares the normalized visible-text template
 and requires every mention to resolve to the identity requested at send time.
 A missing, extra, ambiguous, or differently resolved mention remains
 `sent_unverified`; display-name or raw-markup similarity alone is not accepted.
+Notification-style literal `@Name` text is rejected before any provider call;
+resolve the exact chat member and supply a structured `<at ...>` node. The same
+outbound verifier is used by top-level reviewer notifications, so reply and
+proactive-send paths cannot disagree about what constitutes a delivered
+mention. Both paths perform a provider dry-run before sending and verify the
+created message rather than treating its message id as delivery proof.
+
+Use the configured proactive-send surface instead of a raw provider command:
+
+```bash
+loopx lark-inbox send \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --route-key project-feedback \
+  --text '<at open_id="ou_example">Example Reviewer</at> please review' \
+  --provider-preflight
+
+loopx lark-inbox send \
+  --goal-id <goal-id> \
+  --agent-id <agent-id> \
+  --route-key project-feedback \
+  --text '<at open_id="ou_example">Example Reviewer</at> please review' \
+  --execute
+```
+
+`route_key` selects one isolated requirement/chat binding under a multi-chat
+collector and fails closed when missing or unknown. The top-level send neither
+requires nor fabricates a source message, so its verified placement is always
+`chat_root`; source-message replies continue to preserve source-context
+placement and reaction cleanup.
 
 ## Bounded history reconciliation
 

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
@@ -14,16 +13,15 @@ from .event_inbox import (
     load_lark_event_inbox_config,
 )
 from .inbox_reactions import complete_lark_event_inbox_reactions
+from .outbound import (
+    expected_lark_mention_identities,
+    lark_member_identities,
+    lark_provider_preview_matches_outbound,
+    lark_readback_matches_outbound,
+    normalize_lark_outbound_text,
+)
 
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
-
-AT_MENTION_PATTERN = re.compile(
-    r'<at\s+(?P<kind>user_id|open_id|union_id)="(?P<identity>[^"<>]+)">'
-    r"(?P<name>.*?)</at>",
-    re.IGNORECASE,
-)
-MENTION_ID_KEYS = ("open_id", "user_id", "union_id")
-FENCED_CODE_PATTERN = re.compile(r"```.*?```", re.DOTALL)
 
 
 def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
@@ -93,164 +91,6 @@ def _message(value: Any, message_id: str) -> Mapping[str, Any] | None:
     return None
 
 
-def _content_text(value: Any) -> str:
-    if isinstance(value, Mapping):
-        text = value.get("text")
-        if isinstance(text, str):
-            return text
-        content = value.get("content")
-        if content is not None:
-            return _content_text(content)
-        return ""
-    if not isinstance(value, str):
-        return ""
-    try:
-        decoded = json.loads(value)
-    except json.JSONDecodeError:
-        return value
-    return _content_text(decoded) if isinstance(decoded, Mapping) else value
-
-
-def _message_text(message: Mapping[str, Any]) -> str:
-    body = message.get("body")
-    if isinstance(body, Mapping):
-        text = _content_text(body)
-        if text:
-            return text
-    return _content_text(message.get("content"))
-
-
-def _mention_identities(mention: Mapping[str, Any]) -> set[str]:
-    identities = {
-        str(mention.get(key) or "").strip()
-        for key in MENTION_ID_KEYS
-        if str(mention.get(key) or "").strip()
-    }
-    mention_id = mention.get("id")
-    if isinstance(mention_id, Mapping):
-        identities.update(
-            str(mention_id.get(key) or "").strip()
-            for key in MENTION_ID_KEYS
-            if str(mention_id.get(key) or "").strip()
-        )
-    elif isinstance(mention_id, str) and mention_id.strip():
-        identities.add(mention_id.strip())
-    return identities
-
-
-def _canonical_expected_text(text: str) -> tuple[str, dict[str, str]]:
-    identity_tokens: dict[str, str] = {}
-
-    def replace(match: re.Match[str]) -> str:
-        identity = match.group("identity").strip()
-        token = identity_tokens.setdefault(
-            identity, f"\x00mention:{len(identity_tokens)}\x00"
-        )
-        return token
-
-    replaced = AT_MENTION_PATTERN.sub(replace, text)
-    return _normalized_lines(replaced), identity_tokens
-
-
-def _normalized_lines(value: Any) -> str:
-    lines = [" ".join(line.split()) for line in str(value or "").splitlines()]
-    while lines and not lines[0]:
-        lines.pop(0)
-    while lines and not lines[-1]:
-        lines.pop()
-    return "\n".join(lines)
-
-
-def _readback_matches_reply(*, reply_text: str, message: Mapping[str, Any]) -> bool:
-    expected_text, identity_tokens = _canonical_expected_text(reply_text)
-    actual_text = _message_text(message)
-    if not actual_text:
-        return False
-    if not identity_tokens:
-        return _normalized_lines(actual_text) == expected_text
-
-    mentions = message.get("mentions")
-    if not isinstance(mentions, list):
-        return False
-    matched_identities: set[str] = set()
-    keys_by_identity: dict[str, set[str]] = {}
-    display_text_by_identity: dict[str, set[str]] = {}
-    key_owners: dict[str, set[str]] = {}
-    display_text_owners: dict[str, set[str]] = {}
-    for mention in mentions:
-        if not isinstance(mention, Mapping):
-            return False
-        key = str(mention.get("key") or "")
-        matches = _mention_identities(mention).intersection(identity_tokens)
-        if not key or len(matches) != 1:
-            return False
-        identity = next(iter(matches))
-        matched_identities.add(identity)
-        keys_by_identity.setdefault(identity, set()).add(key)
-        key_owners.setdefault(key, set()).add(identity)
-        display_name = str(mention.get("name") or "").strip()
-        if display_name:
-            display_text = f"@{display_name}"
-            display_text_by_identity.setdefault(identity, set()).add(display_text)
-            display_text_owners.setdefault(display_text, set()).add(identity)
-    if matched_identities != set(identity_tokens):
-        return False
-    if any(len(owners) != 1 for owners in key_owners.values()):
-        return False
-
-    for identity, token in identity_tokens.items():
-        expected_count = expected_text.count(token)
-        for key in sorted(keys_by_identity.get(identity, ()), key=len, reverse=True):
-            actual_text = actual_text.replace(key, token)
-        remaining_count = expected_count - actual_text.count(token)
-        if remaining_count < 0:
-            return False
-        if remaining_count == 0:
-            continue
-        rendered_candidates = [
-            display_text
-            for display_text in display_text_by_identity.get(identity, ())
-            if display_text_owners.get(display_text) == {identity}
-            and actual_text.count(display_text) == remaining_count
-        ]
-        if len(rendered_candidates) != 1:
-            return False
-        actual_text = actual_text.replace(rendered_candidates[0], token)
-    return _normalized_lines(actual_text) == expected_text
-
-
-def _normalized_reply_text(value: Any) -> str:
-    text = str(value or "").replace("\r\n", "\n").replace("\r", "\n")
-    outside_code = FENCED_CODE_PATTERN.sub("", text)
-    if r"\n" in outside_code:
-        raise ValueError(
-            "lark inbox reply contains a literal backslash-n outside fenced code; "
-            "pass real newlines"
-        )
-    return _normalized_lines(text)[:1200]
-
-
-def _provider_preview_matches_reply(
-    *, reply_text: str, payload: Mapping[str, Any]
-) -> bool:
-    data = payload.get("data")
-    api_calls = payload.get("api")
-    if not isinstance(api_calls, list) and isinstance(data, Mapping):
-        api_calls = data.get("api")
-    if not isinstance(api_calls, list):
-        return False
-    for call in api_calls:
-        if not isinstance(call, Mapping):
-            continue
-        body = call.get("body")
-        if not isinstance(body, Mapping):
-            continue
-        preview_text = _content_text(body)
-        if preview_text and _normalized_lines(preview_text) == reply_text:
-            return True
-    return False
-
-
 def _result(
     *,
     status: str,
@@ -298,40 +138,44 @@ def _result(
     return packet
 
 
-def reply_lark_event_inbox(
+def _deliver_lark_inbox_outbound(
     *,
     project: str | Path,
     config_path: str | Path,
-    message_id: str,
+    message_id: str | None,
     text: str,
     execute: bool = False,
     provider_preflight: bool = False,
     runner: CommandRunner = _default_runner,
 ) -> dict[str, Any]:
-    """Reply with the explicit inbox-configured bot and placement policy."""
+    """Deliver through one inbox-configured bot with exact provider readback."""
 
     config = load_lark_event_inbox_config(project=project, config_path=config_path)
     if not config["enabled"]:
         raise ValueError("lark event inbox is not enabled")
     source_message_id = str(message_id or "").strip()
-    if not MESSAGE_ID_PATTERN.fullmatch(source_message_id):
+    if source_message_id and not MESSAGE_ID_PATTERN.fullmatch(source_message_id):
         raise ValueError("lark inbox reply requires a valid message id")
     inbox = config["inbox_path"]
-    source_event = next(
-        (
-            event
-            for path in (inbox.glob("*.json") if inbox.is_dir() else [])
-            if path.name != "processed.json"
-            if (event := _event_from_file(path)) is not None
-            if event.get("message_id") == source_message_id
-        ),
-        None,
+    source_event = (
+        next(
+            (
+                event
+                for path in (inbox.glob("*.json") if inbox.is_dir() else [])
+                if path.name != "processed.json"
+                if (event := _event_from_file(path)) is not None
+                if event.get("message_id") == source_message_id
+            ),
+            None,
+        )
+        if source_message_id
+        else None
     )
-    if source_event is None:
+    if source_message_id and source_event is None:
         raise ValueError(
             "lark inbox reply source message is not captured by this inbox"
         )
-    reply_text = _normalized_reply_text(text)
+    reply_text = normalize_lark_outbound_text(text)
     if not reply_text:
         raise ValueError("lark inbox reply requires non-empty text")
 
@@ -348,12 +192,15 @@ def reply_lark_event_inbox(
     profile = str(reply_config["sender_profile"])
     chat_id = str(reply_config["chat_id"])
     source_is_threaded = bool(
-        source_event.get("parent_id") or source_event.get("root_id")
+        source_event and (source_event.get("parent_id") or source_event.get("root_id"))
     )
     placement = (
         "chat_root"
-        if reply_config["placement_policy"] == "source_context"
-        and not source_is_threaded
+        if source_event is None
+        or (
+            reply_config["placement_policy"] == "source_context"
+            and not source_is_threaded
+        )
         else "source_thread"
     )
     digest = hashlib.sha256(
@@ -426,6 +273,51 @@ def reply_lark_event_inbox(
             format_preflight_passed=True,
         )
 
+    expected_mentions = expected_lark_mention_identities(reply_text)
+    if expected_mentions:
+        member_identity_sets: dict[str, set[str]] = {}
+        membership_failed = False
+        for identity_kind in sorted(set(expected_mentions.values())):
+            members = _call(
+                runner,
+                base
+                + [
+                    "im",
+                    "chat.members",
+                    "get",
+                    "--chat-id",
+                    chat_id,
+                    "--member-id-type",
+                    identity_kind,
+                    "--page-all",
+                    "--as",
+                    "bot",
+                    "--format",
+                    "json",
+                ],
+            )
+            if members.get("returncode") != 0:
+                membership_failed = True
+                break
+            member_identity_sets[identity_kind] = lark_member_identities(
+                _json_object(members.get("stdout"))
+            )
+        if membership_failed or any(
+            identity not in member_identity_sets.get(identity_kind, set())
+            for identity, identity_kind in expected_mentions.items()
+        ):
+            return _result(
+                status="gate_required",
+                ok=False,
+                execute=execute,
+                receipt=receipt,
+                identity_verified=True,
+                membership_verified=True,
+                placement=placement,
+                blocker="lark_inbox_reply_mention_identity_unresolved",
+                format_preflight_passed=True,
+            )
+
     destination = (
         [
             "im",
@@ -461,8 +353,8 @@ def reply_lark_event_inbox(
     preview = _call(runner, provider_args + ["--dry-run"])
     provider_preview_verified = bool(
         preview.get("returncode") == 0
-        and _provider_preview_matches_reply(
-            reply_text=reply_text,
+        and lark_provider_preview_matches_outbound(
+            outbound_text=reply_text,
             payload=_json_object(preview.get("stdout")),
         )
     )
@@ -548,8 +440,8 @@ def reply_lark_event_inbox(
     verified = bool(
         readback.get("returncode") == 0
         and readback_message is not None
-        and _readback_matches_reply(
-            reply_text=reply_text,
+        and lark_readback_matches_outbound(
+            outbound_text=reply_text,
             message=readback_message,
         )
     )
@@ -561,6 +453,8 @@ def reply_lark_event_inbox(
             execute=True,
             runner=runner,
         )
+        if verified and source_message_id
+        else {"ok": True}
         if verified
         else None
     )
@@ -597,3 +491,55 @@ def reply_lark_event_inbox(
         provider_preview_performed=True,
         provider_preview_verified=True,
     )
+
+
+def reply_lark_event_inbox(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    message_id: str,
+    text: str,
+    execute: bool = False,
+    provider_preflight: bool = False,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    """Reply with the explicit inbox-configured bot and placement policy."""
+
+    return _deliver_lark_inbox_outbound(
+        project=project,
+        config_path=config_path,
+        message_id=message_id,
+        text=text,
+        execute=execute,
+        provider_preflight=provider_preflight,
+        runner=runner,
+    )
+
+
+def send_lark_inbox_message(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    text: str,
+    execute: bool = False,
+    provider_preflight: bool = False,
+    runner: CommandRunner = _default_runner,
+) -> dict[str, Any]:
+    """Send one verified chat-root message through the configured inbox bot."""
+
+    result = _deliver_lark_inbox_outbound(
+        project=project,
+        config_path=config_path,
+        message_id=None,
+        text=text,
+        execute=execute,
+        provider_preflight=provider_preflight,
+        runner=runner,
+    )
+    result["schema_version"] = "lark_outbound_message_v0"
+    blocker = result.get("blocker")
+    if isinstance(blocker, str):
+        result["blocker"] = blocker.replace(
+            "lark_inbox_reply_", "lark_outbound_message_"
+        )
+    return result

--- a/loopx/extensions/lark/outbound.py
+++ b/loopx/extensions/lark/outbound.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import html
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+MentionIdentityKind = Literal["user_id", "open_id", "union_id"]
+
+AT_MENTION_PATTERN = re.compile(
+    r'<at\s+(?P<kind>user_id|open_id|union_id)="(?P<identity>[^"<>]+)">'
+    r"(?P<name>.*?)</at>",
+    re.IGNORECASE,
+)
+MENTION_ID_KEYS = ("open_id", "user_id", "union_id")
+FENCED_CODE_PATTERN = re.compile(r"```.*?```", re.DOTALL)
+LITERAL_MENTION_PATTERN = re.compile(r"(?<![\w@])@[^\s@<>]+")
+
+
+@dataclass(frozen=True)
+class LarkMention:
+    identity_kind: MentionIdentityKind
+    identity: str
+    display_name: str
+
+    def markup(self) -> str:
+        identity = self.identity.strip()
+        display_name = self.display_name.strip()
+        if self.identity_kind not in MENTION_ID_KEYS:
+            raise ValueError("unsupported Lark mention identity kind")
+        if not identity or any(character in identity for character in '"<>'):
+            raise ValueError("Lark mention identity is invalid")
+        if not display_name:
+            raise ValueError("Lark mention display name is required")
+        return f'<at {self.identity_kind}="{identity}">{html.escape(display_name)}</at>'
+
+
+def build_lark_mention_prefix(mentions: Sequence[LarkMention]) -> str:
+    if not mentions:
+        return ""
+    identities = [mention.identity.strip() for mention in mentions]
+    if len(set(identities)) != len(identities):
+        raise ValueError("Lark mention identities must be unique")
+    return " ".join(mention.markup() for mention in mentions)
+
+
+def expected_lark_mention_identities(text: str) -> dict[str, str]:
+    expected: dict[str, str] = {}
+    for match in AT_MENTION_PATTERN.finditer(text):
+        identity = match.group("identity").strip()
+        identity_kind = match.group("kind").lower()
+        existing = expected.get(identity)
+        if existing is not None and existing != identity_kind:
+            raise ValueError("Lark mention identity kind is ambiguous")
+        expected[identity] = identity_kind
+    return expected
+
+
+def lark_member_identities(value: Any) -> set[str]:
+    identities: set[str] = set()
+
+    def visit(node: Any) -> None:
+        if isinstance(node, Mapping):
+            for key, child in node.items():
+                if key in {"member_id", *MENTION_ID_KEYS} and isinstance(child, str):
+                    identity = child.strip()
+                    if identity:
+                        identities.add(identity)
+                else:
+                    visit(child)
+        elif isinstance(node, list):
+            for child in node:
+                visit(child)
+
+    visit(value)
+    return identities
+
+
+def _content_text(value: Any) -> str:
+    if isinstance(value, Mapping):
+        text = value.get("text")
+        if isinstance(text, str):
+            return text
+        content = value.get("content")
+        if content is not None:
+            return _content_text(content)
+        return ""
+    if not isinstance(value, str):
+        return ""
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return value
+    return _content_text(decoded) if isinstance(decoded, Mapping) else value
+
+
+def _message_text(message: Mapping[str, Any]) -> str:
+    body = message.get("body")
+    if isinstance(body, Mapping):
+        text = _content_text(body)
+        if text:
+            return text
+    return _content_text(message.get("content"))
+
+
+def _mention_identities(mention: Mapping[str, Any]) -> set[str]:
+    identities = {
+        str(mention.get(key) or "").strip()
+        for key in MENTION_ID_KEYS
+        if str(mention.get(key) or "").strip()
+    }
+    mention_id = mention.get("id")
+    if isinstance(mention_id, Mapping):
+        identities.update(
+            str(mention_id.get(key) or "").strip()
+            for key in MENTION_ID_KEYS
+            if str(mention_id.get(key) or "").strip()
+        )
+    elif isinstance(mention_id, str) and mention_id.strip():
+        identities.add(mention_id.strip())
+    return identities
+
+
+def _canonical_expected_text(text: str) -> tuple[str, dict[str, str]]:
+    identity_tokens: dict[str, str] = {}
+
+    def replace(match: re.Match[str]) -> str:
+        identity = match.group("identity").strip()
+        token = identity_tokens.setdefault(
+            identity, f"\x00mention:{len(identity_tokens)}\x00"
+        )
+        return token
+
+    replaced = AT_MENTION_PATTERN.sub(replace, text)
+    return normalized_lark_lines(replaced), identity_tokens
+
+
+def normalized_lark_lines(value: Any) -> str:
+    lines = [" ".join(line.split()) for line in str(value or "").splitlines()]
+    while lines and not lines[0]:
+        lines.pop(0)
+    while lines and not lines[-1]:
+        lines.pop()
+    return "\n".join(lines)
+
+
+def normalize_lark_outbound_text(value: Any, *, limit: int = 1200) -> str:
+    text = str(value or "").replace("\r\n", "\n").replace("\r", "\n")
+    outside_code = FENCED_CODE_PATTERN.sub("", text)
+    if r"\n" in outside_code:
+        raise ValueError(
+            "Lark outbound text contains a literal backslash-n outside fenced code; "
+            "pass real newlines"
+        )
+    without_structured_mentions = AT_MENTION_PATTERN.sub("", outside_code)
+    if "<at" in without_structured_mentions.lower() or "</at>" in (
+        without_structured_mentions.lower()
+    ):
+        raise ValueError(
+            "Lark outbound text contains a malformed or unsupported <at> node"
+        )
+    if LITERAL_MENTION_PATTERN.search(without_structured_mentions):
+        raise ValueError(
+            "Lark outbound notification contains a literal @ mention; resolve the "
+            "member identity and use a structured <at ...> node"
+        )
+    normalized = normalized_lark_lines(text)
+    if len(normalized) > limit:
+        raise ValueError(
+            f"Lark outbound text exceeds the {limit}-character delivery limit"
+        )
+    return normalized
+
+
+def lark_provider_preview_matches_outbound(
+    *, outbound_text: str, payload: Mapping[str, Any]
+) -> bool:
+    data = payload.get("data")
+    api_calls = payload.get("api")
+    if not isinstance(api_calls, list) and isinstance(data, Mapping):
+        api_calls = data.get("api")
+    if not isinstance(api_calls, list):
+        return False
+    for call in api_calls:
+        if not isinstance(call, Mapping):
+            continue
+        body = call.get("body")
+        if not isinstance(body, Mapping):
+            continue
+        preview_text = _content_text(body)
+        if preview_text and normalized_lark_lines(
+            preview_text
+        ) == normalized_lark_lines(outbound_text):
+            return True
+    return False
+
+
+def lark_readback_matches_outbound(
+    *, outbound_text: str, message: Mapping[str, Any]
+) -> bool:
+    expected_text, identity_tokens = _canonical_expected_text(outbound_text)
+    actual_text = _message_text(message)
+    if not actual_text:
+        return False
+
+    mentions = message.get("mentions")
+    if not identity_tokens:
+        return (mentions is None or mentions == []) and normalized_lark_lines(
+            actual_text
+        ) == expected_text
+    if not isinstance(mentions, list):
+        return False
+
+    matched_identities: set[str] = set()
+    keys_by_identity: dict[str, set[str]] = {}
+    display_text_by_identity: dict[str, set[str]] = {}
+    key_owners: dict[str, set[str]] = {}
+    display_text_owners: dict[str, set[str]] = {}
+    for mention in mentions:
+        if not isinstance(mention, Mapping):
+            return False
+        key = str(mention.get("key") or "")
+        matches = _mention_identities(mention).intersection(identity_tokens)
+        if not key or len(matches) != 1:
+            return False
+        identity = next(iter(matches))
+        matched_identities.add(identity)
+        keys_by_identity.setdefault(identity, set()).add(key)
+        key_owners.setdefault(key, set()).add(identity)
+        display_name = str(mention.get("name") or "").strip()
+        if display_name:
+            display_text = f"@{display_name}"
+            display_text_by_identity.setdefault(identity, set()).add(display_text)
+            display_text_owners.setdefault(display_text, set()).add(identity)
+    if matched_identities != set(identity_tokens):
+        return False
+    if any(len(owners) != 1 for owners in key_owners.values()):
+        return False
+
+    for identity, token in identity_tokens.items():
+        expected_count = expected_text.count(token)
+        for key in sorted(keys_by_identity.get(identity, ()), key=len, reverse=True):
+            actual_text = actual_text.replace(key, token)
+        remaining_count = expected_count - actual_text.count(token)
+        if remaining_count < 0:
+            return False
+        if remaining_count == 0:
+            continue
+        rendered_candidates = [
+            display_text
+            for display_text in display_text_by_identity.get(identity, ())
+            if display_text_owners.get(display_text) == {identity}
+            and actual_text.count(display_text) == remaining_count
+        ]
+        if len(rendered_candidates) != 1:
+            return False
+        actual_text = actual_text.replace(rendered_candidates[0], token)
+    return normalized_lark_lines(actual_text) == expected_text

--- a/loopx/extensions/lark/provider.py
+++ b/loopx/extensions/lark/provider.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import argparse
-from importlib import import_module
 import sys
 from collections.abc import Sequence
-
+from importlib import import_module
 
 REQUIRED_EXPORTS = {
     "loopx.extensions.lark.event_collector": (
@@ -19,14 +18,15 @@ REQUIRED_EXPORTS = {
         "inspect_lark_event_inbox",
         "project_lark_event_inbox_urgency",
     ),
-    "loopx.extensions.lark.inbox_reply": ("reply_lark_event_inbox",),
+    "loopx.extensions.lark.inbox_reply": (
+        "reply_lark_event_inbox",
+        "send_lark_inbox_message",
+    ),
     "loopx.extensions.lark.inbox_reactions": (
         "complete_lark_event_inbox_reactions",
         "mark_lark_event_inbox_processing",
     ),
-    "loopx.extensions.lark.reviewer_notification": (
-        "lark_reviewer_notification_sink",
-    ),
+    "loopx.extensions.lark.reviewer_notification": ("lark_reviewer_notification_sink",),
     "loopx.extensions.lark.goal_channel": (
         "doctor_lark_goal_channel",
         "notify_lark_goal_channel_gate",
@@ -77,7 +77,9 @@ def run(argv: Sequence[str] | None = None) -> int:
 def main() -> int:
     try:
         return run()
-    except Exception as exc:
+    # The provider executable is a process boundary: redact every implementation
+    # failure to its public exception type instead of leaking payload details.
+    except Exception as exc:  # noqa: BLE001
         print(f"LoopX Lark provider failed: {type(exc).__name__}", file=sys.stderr)
         return 2
 

--- a/loopx/extensions/lark/reviewer_notification.py
+++ b/loopx/extensions/lark/reviewer_notification.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import html
 import json
 import re
 import subprocess
@@ -8,13 +7,19 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ...capabilities.issue_fix.reviewer_notification import (
-    CommandRunner,
     SAFE_LOCAL_KEY_PATTERN,
+    CommandRunner,
     build_reviewer_notification_sink_result,
     reviewer_notification_idempotency_key,
 )
 from ...control_plane.runtime.public_safety import public_safe_compact_text
-
+from .outbound import (
+    LarkMention,
+    build_lark_mention_prefix,
+    lark_provider_preview_matches_outbound,
+    lark_readback_matches_outbound,
+    normalize_lark_outbound_text,
+)
 
 LARK_PERMISSION_PATTERN = re.compile(
     r"(?:missing\s+scope|permission|not\s+in\s+(?:the\s+)?chat|"
@@ -48,6 +53,22 @@ def _find_message_id(value: Any) -> str | None:
         for nested in value:
             found = _find_message_id(nested)
             if found:
+                return found
+    return None
+
+
+def _find_message(value: Any, message_id: str) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        if str(value.get("message_id") or "") == message_id:
+            return value
+        for nested in value.values():
+            found = _find_message(nested, message_id)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for nested in value:
+            found = _find_message(nested, message_id)
+            if found is not None:
                 return found
     return None
 
@@ -88,6 +109,7 @@ def _lark_member_ids(value: Any) -> set[str]:
 
     visit(value)
     return member_ids
+
 
 def lark_reviewer_notification_sink(
     *,
@@ -474,18 +496,25 @@ def lark_reviewer_notification_sink(
             )
 
     provider_idempotency_key = f"loopx-{key.partition(':')[2][:32]}"
-    mentions = " ".join(
-        f'<at user_id="{member_id}">{html.escape(display_name)}</at>'
-        for _, member_id, display_name in resolved
+    mentions = build_lark_mention_prefix(
+        [
+            LarkMention(
+                identity_kind="open_id",
+                identity=member_id,
+                display_name=display_name,
+            )
+            for _, member_id, display_name in resolved
+        ]
     )
     issue_clause = (
         f"（修复 {', '.join(linked_issue_refs)}）" if linked_issue_refs else ""
     )
     summary = f"：{pr_title}" if pr_title else ""
+    notification_text = normalize_lark_outbound_text(
+        f"{mentions} 请帮忙 review PR #{pr_number}{issue_clause}{summary}。{pr_url}"
+    )
     content = json.dumps(
-        {
-            "text": f"{mentions} 请帮忙 review PR #{pr_number}{issue_clause}{summary}。{pr_url}"
-        },
+        {"text": notification_text},
         ensure_ascii=False,
         separators=(",", ":"),
     )
@@ -508,6 +537,30 @@ def lark_reviewer_notification_sink(
         "--format",
         "json",
     ]
+    try:
+        preview = runner(send_args + ["--dry-run"])
+    except (OSError, subprocess.SubprocessError):
+        preview = {"returncode": 1}
+    preview_payload = _parse_json_object(preview.get("stdout"))
+    if not (
+        preview.get("returncode") == 0
+        and preview_payload is not None
+        and lark_provider_preview_matches_outbound(
+            outbound_text=notification_text,
+            payload=preview_payload,
+        )
+    ):
+        return build_reviewer_notification_sink_result(
+            sink_kind=sink_kind,
+            reviewer_handles=reviewer_handles,
+            idempotency_key=key,
+            status="gate_required",
+            ok=False,
+            external_write_authority_asserted=True,
+            blocker="lark_notification_provider_preview_mismatch",
+            bot_identity_verified=True,
+            reader_identity_verified=reader_verified,
+        )
     try:
         send = runner(send_args)
     except (OSError, subprocess.SubprocessError):
@@ -577,15 +630,18 @@ def lark_reviewer_notification_sink(
     except (OSError, subprocess.SubprocessError):
         readback = {"returncode": 1}
     readback_payload = _parse_json_object(readback.get("stdout"))
-    readback_text = (
-        json.dumps(readback_payload, ensure_ascii=False, sort_keys=True)
+    readback_message = (
+        _find_message(readback_payload, message_id)
         if readback_payload is not None
-        else ""
+        else None
     )
     verified = bool(
         readback.get("returncode") == 0
-        and message_id in readback_text
-        and pr_url in readback_text
+        and readback_message is not None
+        and lark_readback_matches_outbound(
+            outbound_text=notification_text,
+            message=readback_message,
+        )
     )
     return build_reviewer_notification_sink_result(
         sink_kind=sink_kind,

--- a/loopx/extensions/lark/routed_inbox.py
+++ b/loopx/extensions/lark/routed_inbox.py
@@ -193,8 +193,7 @@ def project_routed_lark_event_inbox_urgency(
             projection.get("reply_due") is True for projection in projections
         ),
         "material_review_due": any(
-            projection.get("material_review_due") is True
-            for projection in projections
+            projection.get("material_review_due") is True for projection in projections
         ),
         "material_review_drain_limit": min(
             (
@@ -270,6 +269,33 @@ def resolve_routed_lark_inbox_config(
     if len(matches) != 1:
         raise ValueError(
             "message id must resolve to exactly one configured Lark inbox route"
+        )
+    return matches[0]
+
+
+def resolve_routed_lark_inbox_route(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    route_key: str | None,
+) -> str:
+    """Resolve one explicit top-level outbound route without exposing its target."""
+
+    kind = lark_inbox_config_kind(project=project, config_path=config_path)
+    requested = str(route_key or "").strip()
+    if kind == "inbox":
+        if requested not in {"", "default"}:
+            raise ValueError("single Lark inbox accepts only the default route")
+        return str(config_path)
+    _, routes = _collector_routes(project=project, config_path=config_path)
+    matches = [
+        str(route["event_inbox_config_ref"])
+        for route in routes
+        if str(route["route_key"]) == requested
+    ]
+    if not requested or len(matches) != 1:
+        raise ValueError(
+            "routed Lark outbound send requires exactly one configured route_key"
         )
     return matches[0]
 

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -25,6 +25,7 @@ from loopx.extensions.lark.routed_inbox import (
     inspect_routed_lark_event_inbox,
     project_routed_lark_event_inbox_urgency,
     resolve_routed_lark_inbox_config,
+    resolve_routed_lark_inbox_route,
 )
 
 
@@ -158,6 +159,32 @@ def test_v1_plan_binds_one_profile_to_isolated_multi_chat_routes(
     assert second_chat not in serialized
     assert "shared-context-bot" not in serialized
     assert str(project) not in serialized
+
+
+def test_top_level_outbound_route_requires_one_explicit_route_key(
+    tmp_path: Path,
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+
+    resolved = resolve_routed_lark_inbox_route(
+        project=project,
+        config_path=collector,
+        route_key="requirements-beta",
+    )
+
+    assert resolved.endswith("requirements-beta.json")
+    with pytest.raises(ValueError, match="exactly one configured route_key"):
+        resolve_routed_lark_inbox_route(
+            project=project,
+            config_path=collector,
+            route_key=None,
+        )
+    with pytest.raises(ValueError, match="exactly one configured route_key"):
+        resolve_routed_lark_inbox_route(
+            project=project,
+            config_path=collector,
+            route_key="missing-route",
+        )
 
 
 def test_v0_config_is_normalized_to_one_route(tmp_path: Path) -> None:
@@ -321,6 +348,59 @@ def test_cli_drain_accepts_routed_collector_config(
         "requirements-alpha",
         "requirements-beta",
     ]
+    assert rendered[0]["extension_activation"] == {"enabled": True}
+
+
+def test_cli_send_resolves_route_and_forwards_safe_delivery_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+    monkeypatch.setattr(
+        lark_inbox,
+        "_resolve_lark_activation",
+        lambda *_args, **_kwargs: {"enabled": True},
+    )
+    calls: list[dict[str, object]] = []
+
+    def fake_send(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {
+            "ok": True,
+            "schema_version": "lark_outbound_message_v0",
+            "status": "preview_ready",
+            "external_write_performed": False,
+        }
+
+    monkeypatch.setattr(lark_inbox, "send_lark_inbox_message", fake_send)
+    rendered: list[dict[str, object]] = []
+    args = argparse.Namespace(
+        command="lark-inbox",
+        lark_inbox_command="send",
+        project=str(project),
+        config=str(collector),
+        goal_id=None,
+        agent_id=None,
+        route_key="requirements-beta",
+        text='<at open_id="ou_fixture">Fixture Reviewer</at> please review',
+        provider_preflight=True,
+        execute=False,
+    )
+
+    code = lark_inbox.handle_lark_inbox_command(
+        args,
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        output_format=lambda _args: "json",
+        print_payload=lambda payload, *_args: rendered.append(payload),
+    )
+
+    assert code == 0
+    assert len(calls) == 1
+    assert str(calls[0]["config_path"]).endswith("requirements-beta.json")
+    assert calls[0]["provider_preflight"] is True
+    assert calls[0]["execute"] is False
+    assert rendered[0]["status"] == "preview_ready"
     assert rendered[0]["extension_activation"] == {"enabled": True}
 
 

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -10,8 +10,8 @@ from typing import Any
 
 import pytest
 
-from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
 from loopx.extensions.lark import inbox_reactions as inbox_reactions_module
+from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
 from loopx.extensions.lark.inbox_reactions import (
     complete_lark_event_inbox_reactions,
     ensure_lark_event_inbox_received_reaction,
@@ -19,7 +19,10 @@ from loopx.extensions.lark.inbox_reactions import (
     mark_lark_event_inbox_processing,
     record_lark_inbox_reaction,
 )
-from loopx.extensions.lark.inbox_reply import reply_lark_event_inbox
+from loopx.extensions.lark.inbox_reply import (
+    reply_lark_event_inbox,
+    send_lark_inbox_message,
+)
 
 
 def _fixture(tmp_path: Path, *, lifecycle: bool = True) -> tuple[Path, Path, Path]:
@@ -321,12 +324,14 @@ class ReplyRunner:
         fail_reaction_delete: bool = False,
         readback_text: str | None = None,
         readback_mentions: list[dict[str, Any]] | None = None,
+        include_mentioned_member: bool = True,
     ) -> None:
         self.calls: list[list[str]] = []
         self.matching_readback = matching_readback
         self.fail_reaction_delete = fail_reaction_delete
         self.readback_text = readback_text
         self.readback_mentions = readback_mentions
+        self.include_mentioned_member = include_mentioned_member
 
     def __call__(self, args: Sequence[str]) -> dict[str, Any]:
         call = list(args)
@@ -349,6 +354,24 @@ class ReplyRunner:
             }
         if call[3:6] == ["im", "chats", "get"]:
             return {"returncode": 0, "stdout": "{}", "stderr": ""}
+        if "chat.members" in call and "get" in call:
+            return {
+                "returncode": 0,
+                "stdout": json.dumps(
+                    {
+                        "items": [
+                            {
+                                "member_id": (
+                                    "ou_public_reviewer"
+                                    if self.include_mentioned_member
+                                    else "ou_someone_else"
+                                )
+                            }
+                        ]
+                    }
+                ),
+                "stderr": "",
+            }
         if "+messages-reply" in call or "+messages-send" in call:
             if "--dry-run" in call:
                 reply_text = call[call.index("--text") + 1]
@@ -753,6 +776,30 @@ def test_reply_rejects_literal_backslash_n_before_provider(tmp_path: Path) -> No
     assert runner.calls == []
 
 
+def test_reply_rejects_literal_notification_mention_before_provider(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner()
+
+    try:
+        reply_lark_event_inbox(
+            project=project,
+            config_path=config,
+            message_id="om_reaction_fixture",
+            text="@PublicReviewer please review",
+            execute=False,
+            runner=runner,
+        )
+    except ValueError as exc:
+        assert "structured <at ...> node" in str(exc)
+    else:
+        raise AssertionError(
+            "literal notification mention must fail before provider calls"
+        )
+    assert runner.calls == []
+
+
 def test_multiline_readback_must_preserve_line_structure(tmp_path: Path) -> None:
     config, _, project = _fixture(tmp_path, lifecycle=False)
     runner = ReplyRunner(readback_text="line one line two")
@@ -834,6 +881,184 @@ def test_rendered_mention_name_does_not_override_identity_mismatch(
     assert result["ok"] is False
     assert result["status"] == "sent_unverified"
     assert result["reply_verified"] is False
+
+
+def test_structured_mention_requires_exact_chat_member_before_send(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(include_mentioned_member=False)
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text='<at open_id="ou_public_reviewer">Public Reviewer</at> please review',
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "gate_required"
+    assert result["blocker"] == "lark_inbox_reply_mention_identity_unresolved"
+    assert not any(
+        "+messages-send" in call or "+messages-reply" in call for call in runner.calls
+    )
+
+
+def test_structured_mention_queries_the_declared_member_identity_kind(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        readback_text="@_user_1 please review",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Public Reviewer",
+                "id": {"open_id": "ou_public_reviewer"},
+            }
+        ],
+    )
+
+    result = send_lark_inbox_message(
+        project=project,
+        config_path=config,
+        text='<at open_id="ou_public_reviewer">Public Reviewer</at> please review',
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    member_call = next(call for call in runner.calls if "chat.members" in call)
+    assert member_call[member_call.index("--member-id-type") + 1] == "open_id"
+
+
+def test_plain_reply_rejects_unexpected_provider_mention(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        readback_text="please review",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Unexpected Reviewer",
+                "id": {"open_id": "ou_unexpected_reviewer"},
+            }
+        ],
+    )
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="please review",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "sent_unverified"
+    assert result["reply_verified"] is False
+
+
+def test_top_level_send_uses_same_mention_safe_delivery_contract(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        readback_text="@_user_1 please review",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Public Reviewer",
+                "id": {"open_id": "ou_public_reviewer"},
+            }
+        ],
+    )
+
+    result = send_lark_inbox_message(
+        project=project,
+        config_path=config,
+        text='<at open_id="ou_public_reviewer">Public Reviewer</at> please review',
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["schema_version"] == "lark_outbound_message_v0"
+    assert result["status"] == "sent_verified"
+    assert result["placement"] == "chat_root"
+    assert any(
+        "+messages-send" in call and "--dry-run" not in call for call in runner.calls
+    )
+    assert not any("+messages-reply" in call for call in runner.calls)
+
+
+def test_top_level_send_rejects_literal_mention_before_provider(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner()
+
+    with pytest.raises(ValueError, match="structured <at"):
+        send_lark_inbox_message(
+            project=project,
+            config_path=config,
+            text="@PublicReviewer please review",
+            execute=True,
+            runner=runner,
+        )
+
+    assert runner.calls == []
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<at email="reviewer@example.com">Public Reviewer</at> please review',
+        '<at open_id="ou_public_reviewer">Public Reviewer',
+        "Public Reviewer</at> please review",
+    ],
+)
+def test_top_level_send_rejects_malformed_or_unsupported_mention_nodes(
+    tmp_path: Path,
+    text: str,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner()
+
+    with pytest.raises(ValueError, match="malformed or unsupported <at> node"):
+        send_lark_inbox_message(
+            project=project,
+            config_path=config,
+            text=text,
+            execute=True,
+            runner=runner,
+        )
+
+    assert runner.calls == []
+
+
+def test_top_level_send_rejects_overlong_text_instead_of_truncating_mention(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner()
+    text = (
+        "x" * 1160
+        + '<at open_id="ou_public_reviewer">Public Reviewer</at> please review'
+    )
+
+    with pytest.raises(ValueError, match="exceeds the 1200-character"):
+        send_lark_inbox_message(
+            project=project,
+            config_path=config,
+            text=text,
+            execute=True,
+            runner=runner,
+        )
+
+    assert runner.calls == []
 
 
 def test_unverified_reply_preserves_processing_reaction(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary

- Share one structured Lark outbound contract across inbox replies and reviewer notifications.
- Add a route-keyed top-level lark-inbox send path with member resolution, provider preview, idempotent send, and exact message/mention readback.
- Reject literal @ mentions and mismatched mention identities before delivery; align ou_* reviewer identities with open_id markup.
- Use synthetic public-safe fixtures only.

Validation

- 542 Lark extension tests passed.
- Python mypy, Ruff check, and Ruff format passed.
- Reviewer notification smoke passed.
- 272 control-plane TypeScript tests passed.
- LoopX standard premerge: 18/18 selected checks passed, 0 failures, 0 manual holds.
- Public-boundary scan: 11 files, 0 hits.
- Local TypeScript typecheck was not runnable because tsc is not installed; required CI remains authoritative.