### PR TITLE
fix(dashboard): retain startup error context

### DIFF
--- a/scripts/dashboard-dev.sh
+++ b/scripts/dashboard-dev.sh
@@ -62,16 +62,25 @@ fi
 wait_for_service() {
   local service_name="$1"
   local service_url="$2"
-  "${PYTHON_BIN}" - "${service_name}" "${service_url}" <<'PY'
+  local service_pid="$3"
+  local probe_status=0
+  local service_status=0
+  "${PYTHON_BIN}" - "${service_name}" "${service_url}" "${service_pid}" <<'PY'
+import os
 import sys
 import time
 import urllib.error
 import urllib.request
 
-name, url = sys.argv[1:]
+name, url, pid_text = sys.argv[1:]
+pid = int(pid_text)
 deadline = time.monotonic() + 15
 last_error = "service did not respond"
 while time.monotonic() < deadline:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        raise SystemExit(2)
     try:
         with urllib.request.urlopen(url, timeout=1) as response:
             if response.status == 200:
@@ -83,6 +92,15 @@ while time.monotonic() < deadline:
 print(f"LoopX {name} service failed to start: {last_error}", file=sys.stderr)
 raise SystemExit(1)
 PY
+  probe_status=$?
+  if [ "${probe_status}" -eq 2 ]; then
+    wait "${service_pid}"
+    service_status=$?
+    echo "LoopX ${service_name} service exited before it became ready (exit status ${service_status})." >&2
+    echo "The original service error output is shown above." >&2
+    return 1
+  fi
+  return "${probe_status}"
 }
 
 cleanup() {
@@ -188,9 +206,8 @@ resolve_lark_cli_binary() {
 
 CODEX_BIN="$(resolve_agent_binary codex)"
 CLAUDE_BIN="$(resolve_agent_binary claude)"
-LARK_CLI_ARGS=()  # Initialize as empty array
 if LARK_CLI_BIN="$(resolve_lark_cli_binary)"; then
-  LARK_CLI_ARGS=(--lark-cli-bin "${LARK_CLI_BIN}")  # Set to lark-cli arg if found
+  LARK_CLI_ARGS=(--lark-cli-bin "${LARK_CLI_BIN}")
 fi
 echo "LoopX Agent executables: Codex=${CODEX_BIN}; Claude Code=${CLAUDE_BIN}"
 if [ -n "${LARK_CLI_BIN}" ]; then
@@ -217,10 +234,10 @@ STATUS_PID=$!
   --no-open &
 CHAT_PID=$!
 
-if ! wait_for_service "status" "http://127.0.0.1:8766/healthz"; then
+if ! wait_for_service "status" "http://127.0.0.1:8766/healthz" "${STATUS_PID}"; then
   exit 1
 fi
-if ! wait_for_service "Chat" "http://127.0.0.1:8767/api/chat/capabilities"; then
+if ! wait_for_service "Chat" "http://127.0.0.1:8767/api/chat/capabilities" "${CHAT_PID}"; then
   exit 1
 fi
 

--- a/tests/test_dashboard_command.py
+++ b/tests/test_dashboard_command.py
@@ -5,7 +5,9 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
@@ -411,6 +413,53 @@ def test_dashboard_launcher_honors_configured_python_runtime(
     commands = python_log.read_text(encoding="utf-8")
     assert "-m loopx.cli serve-status" in commands
     assert "-m loopx.cli chat" in commands
+
+
+def test_dashboard_launcher_preserves_early_service_error_context(
+    tmp_path: Path,
+) -> None:
+    release_root, dashboard_script, fake_bin = _prepare_dashboard_runtime_fixture(
+        tmp_path
+    )
+    python_wrapper = tmp_path / "python-wrapper"
+    python_wrapper.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [[ "$1" == "-m" && "$*" == *"serve-status"* ]]; then\n'
+        '  echo "distinct status startup failure" >&2\n'
+        "  exit 42\n"
+        "fi\n"
+        'if [[ "$1" == "-m" && "$*" == *" chat "* ]]; then\n'
+        "  while true; do sleep 1; done\n"
+        "fi\n"
+        f'exec "{sys.executable}" "$@"\n',
+        encoding="utf-8",
+    )
+    python_wrapper.chmod(0o755)
+
+    started_at = time.monotonic()
+    completed = subprocess.run(
+        ["bash", str(dashboard_script)],
+        cwd=release_root,
+        env={
+            **os.environ,
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "LOOPX_PYTHON": str(python_wrapper),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=5,
+    )
+    elapsed = time.monotonic() - started_at
+
+    assert completed.returncode == 1
+    assert elapsed < 5
+    assert "distinct status startup failure" in completed.stderr
+    assert (
+        "LoopX status service exited before it became ready (exit status 42)."
+        in completed.stderr
+    )
+    assert "The original service error output is shown above." in completed.stderr
 
 
 def test_dashboard_launcher_selects_a_compatible_nvm_node(


### PR DESCRIPTION
## Summary

- detect when a dashboard status or Chat child exits before readiness
- keep the child's original stderr on the inherited terminal stream, then add service name and exit-status context
- fail immediately instead of waiting for the 15-second HTTP readiness timeout
- remove the duplicate Lark CLI argument initialization left adjacent to #3738

## Product and architecture judgment

PR #3738 fixed the immediate unbound-variable crash, but it also exposed a supervision gap: an early child failure printed its raw error without a durable connection to the launcher's later generic timeout. This follow-up keeps lifecycle authority in the existing `wait_for_service` boundary and reuses inherited stderr rather than adding log storage or a second error transport. The operator now sees the original failure plus the service identity and exit status together. No API, permission, persistence, or UI behavior changes.

The adjacent future-facing boundary was reviewed. Passing the existing child PID into the current readiness owner is sufficient; a new process supervisor or logging abstraction would be disproportionate here.

## Validation

- `uv run --project . --extra test pytest tests/test_dashboard_command.py -q` — 26 passed
- `uv run --project . --extra test ruff check tests/test_dashboard_command.py` — passed
- `bash -n scripts/dashboard-dev.sh` — passed
- `git diff --check` — passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed; 3 selected canaries, no failures or manual holds; self-merge allowed
- change-quality receipt `cqr_f5ee6b39882fb8035694` — valid for the exact committed diff
- ShellCheck was unavailable in the current environment

## Boundary review

The two changed public paths contain no credentials, private state, local absolute paths, raw logs, or internal links. Original service output remains transient on the user's existing terminal stream and is not copied or persisted.
