### PR TITLE
Fix read-only autonomous replan settlement

### DIFF
--- a/loopx/control_plane/quota/settlement_readback.ts
+++ b/loopx/control_plane/quota/settlement_readback.ts
@@ -278,7 +278,7 @@ function findWriteback(
     isTurnScopedSettlementOutcome(
       run.delivery_outcome,
       run.progress_observation,
-      identity.todo_id,
+      identity.todo_id ?? identity.replan_obligation_id,
     )
   ) ?? null;
 }
@@ -396,7 +396,8 @@ function inferPersistedIdentity(
         !isTurnScopedSettlementOutcome(
           run.delivery_outcome,
           run.progress_observation,
-          normalizeTodoId(run.todo_id),
+          normalizeTodoId(run.todo_id) ??
+            normalizeReplanObligationId(run.replan_obligation_id),
         ))
     ) {
       continue;
@@ -406,7 +407,8 @@ function inferPersistedIdentity(
       !isTurnScopedSettlementOutcome(
         run.delivery_outcome,
         run.progress_observation,
-        normalizeTodoId(run.todo_id),
+        normalizeTodoId(run.todo_id) ??
+          normalizeReplanObligationId(run.replan_obligation_id),
       )
     ) {
       return null;

--- a/loopx/control_plane/quota/settlement_workspace_causality.py
+++ b/loopx/control_plane/quota/settlement_workspace_causality.py
@@ -24,6 +24,9 @@ DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION = "delivery_workspace_resolution_v0
 SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION = (
     "settlement_workspace_requirement_v0"
 )
+LEGACY_SETTLEMENT_RECEIPT_EVIDENCE_SCHEMA_VERSION = (
+    "legacy_settlement_receipt_evidence_v0"
+)
 DELIVERY_WORKSPACE_REQUIREMENTS = frozenset({"required", "not_required", "unknown"})
 
 
@@ -294,6 +297,7 @@ def resolve_settlement_workspace_requirement(
     causality: Mapping[str, Any] | None,
     *,
     settlement_binding_kind: str,
+    legacy_settlement_evidence: Mapping[str, Any] | None = None,
 ) -> dict[str, str]:
     """Resolve workspace policy from the original typed settlement binding."""
 
@@ -302,6 +306,11 @@ def resolve_settlement_workspace_requirement(
         expected_todo_id=None,
         causality=_prepared_causality(causality),
         settlement_binding_kind=settlement_binding_kind,
+        legacy_settlement_evidence=(
+            dict(legacy_settlement_evidence)
+            if isinstance(legacy_settlement_evidence, Mapping)
+            else None
+        ),
     )
     value = result.get("settlement_requirement")
     expected_keys = {

--- a/loopx/control_plane/quota/settlement_workspace_causality.py
+++ b/loopx/control_plane/quota/settlement_workspace_causality.py
@@ -21,6 +21,9 @@ DELIVERY_WORKSPACE_CAUSALITY_RESULT_SCHEMA = (
     "loopx_delivery_workspace_causality_result_v0"
 )
 DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION = "delivery_workspace_resolution_v0"
+SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION = (
+    "settlement_workspace_requirement_v0"
+)
 DELIVERY_WORKSPACE_REQUIREMENTS = frozenset({"required", "not_required", "unknown"})
 
 
@@ -285,6 +288,43 @@ def missing_delivery_workspace_resolution(
             "TypeScript delivery workspace resolution result shape mismatch"
         )
     return dict(value)
+
+
+def resolve_settlement_workspace_requirement(
+    causality: Mapping[str, Any] | None,
+    *,
+    settlement_binding_kind: str,
+) -> dict[str, str]:
+    """Resolve workspace policy from the original typed settlement binding."""
+
+    result = _runtime_result(
+        "settlement_requirement",
+        expected_todo_id=None,
+        causality=_prepared_causality(causality),
+        settlement_binding_kind=settlement_binding_kind,
+    )
+    value = result.get("settlement_requirement")
+    expected_keys = {
+        "schema_version",
+        "settlement_binding_kind",
+        "requirement",
+        "source",
+        "reason",
+    }
+    if (
+        not isinstance(value, Mapping)
+        or set(value) != expected_keys
+        or value.get("schema_version")
+        != SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION
+        or value.get("settlement_binding_kind") != settlement_binding_kind
+        or value.get("requirement") not in DELIVERY_WORKSPACE_REQUIREMENTS
+        or not str(value.get("source") or "").strip()
+        or not str(value.get("reason") or "").strip()
+    ):
+        raise RuntimeError(
+            "TypeScript settlement workspace requirement result shape mismatch"
+        )
+    return {key: str(value[key]) for key in expected_keys}
 
 
 def completed_todo_workspace_causality(

--- a/loopx/control_plane/quota/settlement_workspace_causality.ts
+++ b/loopx/control_plane/quota/settlement_workspace_causality.ts
@@ -12,6 +12,8 @@ export const DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION =
   "delivery_workspace_resolution_v0";
 export const SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION =
   "settlement_workspace_requirement_v0";
+export const LEGACY_SETTLEMENT_RECEIPT_EVIDENCE_SCHEMA_VERSION =
+  "legacy_settlement_receipt_evidence_v0";
 
 export const DELIVERY_WORKSPACE_REQUIREMENTS = [
   "required",
@@ -44,6 +46,39 @@ export interface SettlementWorkspaceRequirement extends JsonObject {
   requirement: DeliveryWorkspaceRequirement;
   source: string;
   reason: string;
+}
+
+function hasCompleteLegacySettlementReceipts(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const evidence = value as JsonObject;
+  if (
+    evidence.schema_version !== LEGACY_SETTLEMENT_RECEIPT_EVIDENCE_SCHEMA_VERSION ||
+    typeof evidence.settlement_effect_id !== "string" ||
+    !evidence.settlement_effect_id.trim() ||
+    evidence.delivery_workspace_present !== false ||
+    !Array.isArray(evidence.receipts) ||
+    evidence.receipts.length !== 2
+  ) {
+    return false;
+  }
+  const expectedKinds = new Set(["validation", "durable_writeback"]);
+  for (const value of evidence.receipts) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return false;
+    }
+    const receipt = value as JsonObject;
+    if (
+      typeof receipt.step_kind !== "string" ||
+      !expectedKinds.delete(receipt.step_kind) ||
+      receipt.status !== "committed" ||
+      receipt.effect_id !== evidence.settlement_effect_id
+    ) {
+      return false;
+    }
+  }
+  return expectedKinds.size === 0;
 }
 
 export type DeliveryWorkspaceResolution =
@@ -108,6 +143,7 @@ function operation(value: unknown): DeliveryWorkspaceCausalityOperation {
 export function resolveSettlementWorkspaceRequirement(
   value: unknown,
   settlementBindingKind: unknown,
+  legacySettlementEvidence: unknown = null,
 ): SettlementWorkspaceRequirement {
   if (
     settlementBindingKind !== "todo" &&
@@ -134,6 +170,15 @@ export function resolveSettlementWorkspaceRequirement(
       requirement: "not_required",
       source: "typed_settlement_identity",
       reason: "autonomous_replan_is_non_repository_control_plane_work",
+    };
+  }
+  if (hasCompleteLegacySettlementReceipts(legacySettlementEvidence)) {
+    return {
+      schema_version: SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION,
+      settlement_binding_kind: settlementBindingKind,
+      requirement: "not_required",
+      source: "legacy_settlement_receipts",
+      reason: "pre_causality_settlement_already_committed",
     };
   }
   return {
@@ -329,6 +374,7 @@ export function evaluateDeliveryWorkspaceCausality(value: unknown): JsonObject {
       settlement_requirement: resolveSettlementWorkspaceRequirement(
         request.causality,
         request.settlement_binding_kind,
+        request.legacy_settlement_evidence,
       ),
     });
   }

--- a/loopx/control_plane/quota/settlement_workspace_causality.ts
+++ b/loopx/control_plane/quota/settlement_workspace_causality.ts
@@ -10,6 +10,8 @@ export const DELIVERY_WORKSPACE_CAUSALITY_RESULT_SCHEMA =
   "loopx_delivery_workspace_causality_result_v0";
 export const DELIVERY_WORKSPACE_RESOLUTION_SCHEMA_VERSION =
   "delivery_workspace_resolution_v0";
+export const SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION =
+  "settlement_workspace_requirement_v0";
 
 export const DELIVERY_WORKSPACE_REQUIREMENTS = [
   "required",
@@ -33,7 +35,16 @@ type DeliveryWorkspaceCausalityOperation =
   | "normalize"
   | "event_fields"
   | "missing_workspace"
+  | "settlement_requirement"
   | "from_event";
+
+export interface SettlementWorkspaceRequirement extends JsonObject {
+  schema_version: typeof SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION;
+  settlement_binding_kind: "todo" | "autonomous_replan";
+  requirement: DeliveryWorkspaceRequirement;
+  source: string;
+  reason: string;
+}
 
 export type DeliveryWorkspaceResolution =
   | {
@@ -88,9 +99,50 @@ function operation(value: unknown): DeliveryWorkspaceCausalityOperation {
   if (
     value === "classify" || value === "normalize" ||
     value === "event_fields" || value === "missing_workspace" ||
+    value === "settlement_requirement" ||
     value === "from_event"
   ) return value;
   throw new EffectRuntimeRequestError("delivery workspace causality operation is unsupported");
+}
+
+export function resolveSettlementWorkspaceRequirement(
+  value: unknown,
+  settlementBindingKind: unknown,
+): SettlementWorkspaceRequirement {
+  if (
+    settlementBindingKind !== "todo" &&
+    settlementBindingKind !== "autonomous_replan"
+  ) {
+    throw new EffectRuntimeRequestError(
+      "settlement_binding_kind must be todo or autonomous_replan",
+    );
+  }
+  const causality = normalizeDeliveryWorkspaceCausality(value, null);
+  if (causality) {
+    return {
+      schema_version: SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION,
+      settlement_binding_kind: settlementBindingKind,
+      requirement: causality.requirement,
+      source: causality.source,
+      reason: causality.reason,
+    };
+  }
+  if (settlementBindingKind === "autonomous_replan") {
+    return {
+      schema_version: SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION,
+      settlement_binding_kind: settlementBindingKind,
+      requirement: "not_required",
+      source: "typed_settlement_identity",
+      reason: "autonomous_replan_is_non_repository_control_plane_work",
+    };
+  }
+  return {
+    schema_version: SETTLEMENT_WORKSPACE_REQUIREMENT_SCHEMA_VERSION,
+    settlement_binding_kind: settlementBindingKind,
+    requirement: "unknown",
+    source: "typed_settlement_identity",
+    reason: "todo_delivery_contract_not_available",
+  };
 }
 
 function requestObject(value: unknown): JsonObject {
@@ -270,6 +322,14 @@ export function evaluateDeliveryWorkspaceCausality(value: unknown): JsonObject {
   if (selectedOperation === "missing_workspace") {
     return result({
       resolution: resolveMissingDeliveryWorkspace(request.causality),
+    });
+  }
+  if (selectedOperation === "settlement_requirement") {
+    return result({
+      settlement_requirement: resolveSettlementWorkspaceRequirement(
+        request.causality,
+        request.settlement_binding_kind,
+      ),
     });
   }
   const nested = normalizeDeliveryWorkspaceCausality(

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -39,6 +39,7 @@ from .settlement import (
 from .settlement_workspace_causality import (
     completed_todo_workspace_causality,
     missing_delivery_workspace_resolution,
+    resolve_settlement_workspace_requirement,
 )
 from .settlement_validation import completion_validation_spend_error
 from .spend_sources import (
@@ -384,35 +385,65 @@ def _latest_unspent_turn_settlement_run(
             if isinstance(run.get("progress_observation"), dict)
             else None,
             work_item_id=normalize_todo_id(run.get("todo_id")),
+            replan_obligation_id=normalize_todo_replan_obligation_id(
+                run.get("replan_obligation_id")
+            ),
         ):
             return run
         return None
     return None
 
 
+def _settlement_workspace_requirement(
+    delivery_workspace_causality: dict[str, Any] | None,
+    settlement_identity: SettlementIdentity | None,
+) -> dict[str, str] | None:
+    if settlement_identity is None:
+        return None
+    return resolve_settlement_workspace_requirement(
+        delivery_workspace_causality,
+        settlement_binding_kind=settlement_identity.binding_kind.value,
+    )
+
+
+def _workspace_requirement_value(
+    settlement_workspace_requirement: dict[str, Any] | None,
+    delivery_workspace_causality: dict[str, Any] | None,
+) -> str:
+    return str(
+        (settlement_workspace_requirement or {}).get("requirement")
+        or (delivery_workspace_causality or {}).get("requirement")
+        or ""
+    )
+
+
 def _missing_delivery_workspace_preview(
     *,
     delivery_workspace_causality: dict[str, Any] | None,
+    settlement_workspace_requirement: dict[str, Any] | None,
     delivery_workspace: dict[str, Any] | None,
     goal_id: str,
     slots: int,
     agent_id: str | None,
     before: dict[str, Any],
 ) -> dict[str, Any] | None:
-    if not delivery_workspace_causality or delivery_workspace_identity(
-        delivery_workspace
-    ):
+    if delivery_workspace_identity(delivery_workspace):
+        return None
+    requirement = _workspace_requirement_value(
+        settlement_workspace_requirement, delivery_workspace_causality
+    )
+    if not requirement or requirement == "not_required":
         return None
     resolution = missing_delivery_workspace_resolution(
         delivery_workspace_causality
     )
-    if resolution is None or resolution["decision"] == "omit_snapshot":
+    if resolution is not None and resolution["decision"] == "omit_snapshot":
         return None
-    requirement = resolution["requirement"]
     reason = (
         "quota spend requires a valid delivery workspace snapshot for "
         f"settlement causality requirement {requirement}"
-        if resolution["decision"] == "require_snapshot"
+        if resolution is not None
+        and resolution["decision"] == "require_snapshot"
         else (
             "quota spend requires an explicit Todo delivery contract; declare "
             "repository/write requirements or mark the Todo as explicit "
@@ -431,6 +462,7 @@ def _missing_delivery_workspace_preview(
         "reason": reason,
         "delivery_workspace": delivery_workspace,
         "delivery_workspace_causality": delivery_workspace_causality,
+        "settlement_workspace_requirement": settlement_workspace_requirement,
         "delivery_workspace_resolution": resolution,
         "delivery_workspace_validated": False,
         "before": before,
@@ -579,6 +611,9 @@ def build_quota_slot_preview_for_decision(
         settlement_identity=settlement_identity,
         causality=delivery_workspace_causality,
     )
+    settlement_workspace_requirement = _settlement_workspace_requirement(
+        delivery_workspace_causality, settlement_identity
+    )
     safe_bypass_without_delivery = (
         safe_bypass_requested and delivery_completion_run is None
     )
@@ -608,6 +643,7 @@ def build_quota_slot_preview_for_decision(
     )
     missing_delivery_workspace_preview = _missing_delivery_workspace_preview(
         delivery_workspace_causality=delivery_workspace_causality,
+        settlement_workspace_requirement=settlement_workspace_requirement,
         delivery_workspace=raw_delivery_workspace,
         goal_id=safe_goal_id,
         slots=safe_slots,
@@ -616,8 +652,8 @@ def build_quota_slot_preview_for_decision(
     )
     if missing_delivery_workspace_preview:
         return missing_delivery_workspace_preview
-    workspace_requirement = str(
-        (delivery_workspace_causality or {}).get("requirement") or ""
+    workspace_requirement = _workspace_requirement_value(
+        settlement_workspace_requirement, delivery_workspace_causality
     )
     raw_delivery_workspace_identity = delivery_workspace_identity(
         raw_delivery_workspace
@@ -815,6 +851,7 @@ def build_quota_slot_preview_for_decision(
         else None,
         "delivery_workspace": delivery_workspace,
         "delivery_workspace_causality": delivery_workspace_causality,
+        "settlement_workspace_requirement": settlement_workspace_requirement,
         "delivery_workspace_validated": delivery_workspace_validated,
     }
 

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -37,6 +37,7 @@ from .settlement import (
     settlement_result_payload,
 )
 from .settlement_workspace_causality import (
+    LEGACY_SETTLEMENT_RECEIPT_EVIDENCE_SCHEMA_VERSION,
     completed_todo_workspace_causality,
     missing_delivery_workspace_resolution,
     resolve_settlement_workspace_requirement,
@@ -397,12 +398,37 @@ def _latest_unspent_turn_settlement_run(
 def _settlement_workspace_requirement(
     delivery_workspace_causality: dict[str, Any] | None,
     settlement_identity: SettlementIdentity | None,
+    settlement_result: SettlementResult[dict[str, Any]] | None,
+    delivery_completion_run: dict[str, Any] | None,
 ) -> dict[str, str] | None:
     if settlement_identity is None:
         return None
     return resolve_settlement_workspace_requirement(
         delivery_workspace_causality,
         settlement_binding_kind=settlement_identity.binding_kind.value,
+        legacy_settlement_evidence=(
+            {
+                "schema_version": (
+                    LEGACY_SETTLEMENT_RECEIPT_EVIDENCE_SCHEMA_VERSION
+                ),
+                "settlement_effect_id": settlement_identity.effect_id,
+                "delivery_workspace_present": bool(
+                    isinstance(delivery_completion_run, dict)
+                    and delivery_completion_run.get("delivery_workspace") is not None
+                ),
+                "receipts": [
+                    {
+                        "step_kind": receipt.step_kind.value,
+                        "status": receipt.status,
+                        "effect_id": receipt.effect_id,
+                    }
+                    for receipt in settlement_result.receipts
+                ],
+            }
+            if settlement_result is not None
+            and settlement_result.failure is None
+            else None
+        ),
     )
 
 
@@ -612,7 +638,10 @@ def build_quota_slot_preview_for_decision(
         causality=delivery_workspace_causality,
     )
     settlement_workspace_requirement = _settlement_workspace_requirement(
-        delivery_workspace_causality, settlement_identity
+        delivery_workspace_causality,
+        settlement_identity,
+        settlement_result,
+        delivery_completion_run,
     )
     safe_bypass_without_delivery = (
         safe_bypass_requested and delivery_completion_run is None

--- a/loopx/control_plane/work_items/delivery_outcome.py
+++ b/loopx/control_plane/work_items/delivery_outcome.py
@@ -63,12 +63,13 @@ def qualifies_turn_scoped_blocker_settlement(
     progress_observation: Mapping[str, Any] | None,
     *,
     work_item_id: str | None = None,
+    replan_obligation_id: str | None = None,
 ) -> bool:
     """Return whether an outcome gap is a typed, attributable blocker receipt.
 
     ``outcome_gap`` remains outside the progress outcomes: it can settle one
     exact Turn only when the same writeback carries a blocked observation with
-    a stable blocker, evidence, and matching work-item identity.
+    a stable blocker, evidence, and matching Todo or replan-obligation identity.
     """
 
     if (
@@ -77,11 +78,13 @@ def qualifies_turn_scoped_blocker_settlement(
         or progress_observation.get("schema_version")
         != PROGRESS_OBSERVATION_SCHEMA_VERSION
         or not isinstance(progress_observation.get("evidence_ids"), list)
-        or normalize_progress_identifier(work_item_id) is None
+        or bool(work_item_id) == bool(replan_obligation_id)
     ):
         return False
     observation = dict(progress_observation)
-    normalized_work_item_id = normalize_progress_identifier(work_item_id)
+    normalized_work_item_id = normalize_progress_identifier(
+        work_item_id or replan_obligation_id
+    )
     if (
         observation.get("result_class") != ProgressResultClass.BLOCKED.value
         or normalize_progress_identifier(observation.get("blocker_id")) is None
@@ -101,6 +104,7 @@ def qualifies_turn_scoped_settlement(
     progress_observation: Mapping[str, Any] | None,
     *,
     work_item_id: str | None = None,
+    replan_obligation_id: str | None = None,
 ) -> bool:
     """Return whether one delivery record may satisfy a Turn settlement."""
 
@@ -110,6 +114,7 @@ def qualifies_turn_scoped_settlement(
             normalized,
             progress_observation,
             work_item_id=work_item_id,
+            replan_obligation_id=replan_obligation_id,
         )
     )
 

--- a/loopx/control_plane/work_items/delivery_outcome.ts
+++ b/loopx/control_plane/work_items/delivery_outcome.ts
@@ -38,11 +38,14 @@ function stableIdentifier(value: unknown): string | null {
 export function isTurnScopedSettlementOutcome(
   deliveryOutcome: unknown,
   progressObservation: unknown,
-  expectedWorkItemId: string | null,
+  expectedSettlementBindingId: string | null,
 ): boolean {
   const normalizedOutcome = String(deliveryOutcome ?? "").trim() as DeliveryOutcome;
   if (PROGRESS_DELIVERY_OUTCOMES.has(normalizedOutcome)) return true;
-  if (normalizedOutcome !== "outcome_gap" || expectedWorkItemId === null) {
+  if (
+    normalizedOutcome !== "outcome_gap" ||
+    expectedSettlementBindingId === null
+  ) {
     return false;
   }
   const observation = jsonObject(progressObservation);
@@ -50,7 +53,7 @@ export function isTurnScopedSettlementOutcome(
     !observation ||
     observation.schema_version !== "typed_progress_observation_v0" ||
     observation.result_class !== "blocked" ||
-    stableIdentifier(observation.work_item_id) !== expectedWorkItemId ||
+    stableIdentifier(observation.work_item_id) !== expectedSettlementBindingId ||
     stableIdentifier(observation.blocker_id) === null ||
     !Array.isArray(observation.evidence_ids) ||
     observation.evidence_ids.length === 0

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -27,6 +27,7 @@ from .control_plane.quota.settlement import (
     read_heartbeat_settlement,
     settlement_result_payload,
 )
+from .control_plane.quota.settlement_workspace_causality import resolve_settlement_workspace_requirement
 from .control_plane.quota.codex_session_usage import (
     book_codex_session_usage,
     usage_booking_lock_target,
@@ -902,7 +903,7 @@ def refresh_state_run(
     normalized_progress_observation = (
         normalize_progress_observation(
             progress_observation,
-            work_item_id=todo_id,
+            work_item_id=todo_id or normalized_replan_obligation_id,
         )
         if progress_observation is not None
         else None
@@ -911,6 +912,7 @@ def refresh_state_run(
         normalized_delivery_outcome,
         normalized_progress_observation,
         work_item_id=todo_id,
+        replan_obligation_id=normalized_replan_obligation_id,
     )
     if delivery_workspace_path is not None and not turn_scoped_settlement_qualified:
         raise ValueError(
@@ -922,6 +924,7 @@ def refresh_state_run(
     settlement_identity = None
     settlement_result = None
     delivery_workspace_causality = None
+    settlement_workspace_requirement = None
     if todo_id or normalized_replan_obligation_id or turn_instance_id:
         if not turn_scoped_settlement_qualified:
             raise ValueError(
@@ -945,6 +948,9 @@ def refresh_state_run(
         if settlement_identity is None:
             raise ValueError("turn-scoped refresh-state has no settlement identity")
         delivery_workspace_causality = settlement_readback.workspace_causality
+        settlement_workspace_requirement = resolve_settlement_workspace_requirement(
+            delivery_workspace_causality, settlement_binding_kind=settlement_identity.binding_kind.value
+        )
         if not dry_run:
             prior_writeback = settlement_readback.writeback
             if prior_writeback.failure is None and prior_writeback.value is not None:
@@ -1180,7 +1186,7 @@ def refresh_state_run(
     )
     delivery_workspace = None
     workspace_requirement = str(
-        (delivery_workspace_causality or {}).get("requirement") or "unknown"
+        (settlement_workspace_requirement or {}).get("requirement") or "unknown"
     )
     if delivery_workspace_path is not None and workspace_requirement == "not_required":
         raise ValueError(
@@ -1258,6 +1264,10 @@ def refresh_state_run(
     )
     if delivery_workspace_causality:
         record["delivery_workspace_causality"] = delivery_workspace_causality
+    if settlement_workspace_requirement:
+        record["settlement_workspace_requirement"] = (
+            settlement_workspace_requirement
+        )
     if autonomous_replan_recorded:
         if "autonomous_replan_ack" not in record:
             record["autonomous_replan_ack"] = {

--- a/tests/control_plane/test_delivery_workspace_causality.py
+++ b/tests/control_plane/test_delivery_workspace_causality.py
@@ -165,3 +165,57 @@ def test_missing_todo_causality_remains_fail_closed() -> None:
 
     assert requirement["requirement"] == "unknown"
     assert requirement["reason"] == "todo_delivery_contract_not_available"
+
+
+def test_complete_legacy_todo_settlement_can_finish_quota_accounting() -> None:
+    effect_id = "goal:agent:todo_legacy:turn-1"
+    requirement = resolve_settlement_workspace_requirement(
+        None,
+        settlement_binding_kind="todo",
+        legacy_settlement_evidence={
+            "schema_version": "legacy_settlement_receipt_evidence_v0",
+            "settlement_effect_id": effect_id,
+            "delivery_workspace_present": False,
+            "receipts": [
+                {
+                    "step_kind": "validation",
+                    "status": "committed",
+                    "effect_id": effect_id,
+                },
+                {
+                    "step_kind": "durable_writeback",
+                    "status": "committed",
+                    "effect_id": effect_id,
+                },
+            ],
+        },
+    )
+
+    assert requirement == {
+        "schema_version": "settlement_workspace_requirement_v0",
+        "settlement_binding_kind": "todo",
+        "requirement": "not_required",
+        "source": "legacy_settlement_receipts",
+        "reason": "pre_causality_settlement_already_committed",
+    }
+
+
+def test_partial_legacy_todo_settlement_remains_fail_closed() -> None:
+    requirement = resolve_settlement_workspace_requirement(
+        None,
+        settlement_binding_kind="todo",
+        legacy_settlement_evidence={
+            "schema_version": "legacy_settlement_receipt_evidence_v0",
+            "settlement_effect_id": "effect-1",
+            "delivery_workspace_present": False,
+            "receipts": [
+                {
+                    "step_kind": "validation",
+                    "status": "committed",
+                    "effect_id": "effect-1",
+                }
+            ],
+        },
+    )
+
+    assert requirement["requirement"] == "unknown"

--- a/tests/control_plane/test_delivery_workspace_causality.py
+++ b/tests/control_plane/test_delivery_workspace_causality.py
@@ -7,6 +7,7 @@ from loopx.control_plane.quota.settlement_workspace_causality import (
     delivery_workspace_causality_event_fields,
     delivery_workspace_causality_from_event_details,
     missing_delivery_workspace_resolution,
+    resolve_settlement_workspace_requirement,
 )
 
 
@@ -141,3 +142,26 @@ def test_event_causality_rejects_cross_todo_replay() -> None:
         )
         is None
     )
+
+
+def test_typed_autonomous_replan_binding_is_explicit_non_repository() -> None:
+    assert resolve_settlement_workspace_requirement(
+        None,
+        settlement_binding_kind="autonomous_replan",
+    ) == {
+        "schema_version": "settlement_workspace_requirement_v0",
+        "settlement_binding_kind": "autonomous_replan",
+        "requirement": "not_required",
+        "source": "typed_settlement_identity",
+        "reason": "autonomous_replan_is_non_repository_control_plane_work",
+    }
+
+
+def test_missing_todo_causality_remains_fail_closed() -> None:
+    requirement = resolve_settlement_workspace_requirement(
+        None,
+        settlement_binding_kind="todo",
+    )
+
+    assert requirement["requirement"] == "unknown"
+    assert requirement["reason"] == "todo_delivery_contract_not_available"

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -2452,6 +2452,119 @@ def test_todoless_autonomous_replan_settles_quota_refresh_spend_chain(
     assert _spend_run_count(runtime) == 1
 
 
+def test_todoless_blocked_replan_settles_read_only_external_evidence_without_worktree(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_autonomous_replan_fixture(project, runtime, registry_path)
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["coordination"]["registered_agents"].append(
+        "codex-settlement-peer"
+    )
+    registry_path.write_text(
+        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    external_evidence_dir = tmp_path / "external-review"
+    external_evidence_dir.mkdir()
+    turn_instance_id = "turn-autonomous-replan-blocked-external-evidence"
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+
+    assert guard_rc == 0, guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    obligation_id = guard["replan_action_packet"]["obligation_id"]
+    binding = (
+        "--agent-id",
+        AGENT_ID,
+        "--replan-obligation-id",
+        obligation_id,
+        "--turn-instance-id",
+        turn_instance_id,
+    )
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--progress-scope",
+        "agent_lane",
+        "--classification",
+        "external_evidence_replan_blocked",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_gap",
+        "--progress-result-class",
+        "blocked",
+        "--progress-blocker-id",
+        "public-head-validation-failed",
+        "--progress-evidence-id",
+        "public-review-readback",
+        *binding,
+        "--no-global-sync",
+        "--suppress-external-sinks",
+        cwd=external_evidence_dir,
+    )
+
+    assert refresh_rc == 0, refresh.get("error") or refresh
+    assert refresh["delivery_outcome"] == "outcome_gap"
+    assert refresh["progress_observation"]["work_item_id"] == obligation_id
+    assert refresh["settlement_workspace_requirement"] == {
+        "schema_version": "settlement_workspace_requirement_v0",
+        "settlement_binding_kind": "autonomous_replan",
+        "requirement": "not_required",
+        "source": "typed_settlement_identity",
+        "reason": "autonomous_replan_is_non_repository_control_plane_work",
+    }
+    assert "delivery_workspace" not in refresh
+    assert refresh["settlement_result"]["ok"] is True
+
+    spend_rc, spend = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "spend-slot",
+        "--goal-id",
+        GOAL_ID,
+        "--slots",
+        "1",
+        "--source",
+        "heartbeat",
+        "--execute",
+        *binding,
+        "--scan-path",
+        str(project),
+        cwd=external_evidence_dir,
+    )
+
+    assert spend_rc == 0, spend
+    assert spend["settlement_workspace_requirement"]["requirement"] == (
+        "not_required"
+    )
+    assert spend["delivery_workspace_validated"] is False
+    assert spend["settlement_result"]["ok"] is True
+    assert [
+        receipt["step_kind"] for receipt in spend["settlement_result"]["receipts"]
+    ] == ["validation", "durable_writeback", "quota_spend"]
+    assert _spend_run_count(runtime) == 1
+
+
 def test_unbound_visible_goal_todoless_replan_reenters_through_guided_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/control_plane_ts/settlement_workspace_causality.test.ts
+++ b/tests/control_plane_ts/settlement_workspace_causality.test.ts
@@ -137,3 +137,49 @@ test("typed settlement identity distinguishes replan from unknown Todo causality
     "required",
   );
 });
+
+test("legacy Todo compatibility requires exact committed settlement receipts", () => {
+  const effectId = "goal:agent:todo_legacy:turn-1";
+  const completeEvidence = {
+    schema_version: "legacy_settlement_receipt_evidence_v0",
+    settlement_effect_id: effectId,
+    delivery_workspace_present: false,
+    receipts: [
+      { step_kind: "validation", status: "committed", effect_id: effectId },
+      { step_kind: "durable_writeback", status: "committed", effect_id: effectId },
+    ],
+  };
+  assert.deepEqual(
+    resolveSettlementWorkspaceRequirement(null, "todo", completeEvidence),
+    {
+      schema_version: "settlement_workspace_requirement_v0",
+      settlement_binding_kind: "todo",
+      requirement: "not_required",
+      source: "legacy_settlement_receipts",
+      reason: "pre_causality_settlement_already_committed",
+    },
+  );
+  assert.equal(
+    resolveSettlementWorkspaceRequirement(null, "todo", {
+      ...completeEvidence,
+      delivery_workspace_present: true,
+    }).requirement,
+    "unknown",
+  );
+  assert.equal(
+    resolveSettlementWorkspaceRequirement(null, "todo", {
+      ...completeEvidence,
+      receipts: completeEvidence.receipts.slice(0, 1),
+    }).requirement,
+    "unknown",
+  );
+  assert.equal(
+    resolveSettlementWorkspaceRequirement(null, "todo", {
+      ...completeEvidence,
+      receipts: completeEvidence.receipts.map((receipt, index) =>
+        index === 1 ? { ...receipt, effect_id: "other-effect" } : receipt
+      ),
+    }).requirement,
+    "unknown",
+  );
+});

--- a/tests/control_plane_ts/settlement_workspace_causality.test.ts
+++ b/tests/control_plane_ts/settlement_workspace_causality.test.ts
@@ -6,6 +6,7 @@ import {
   DELIVERY_WORKSPACE_CAUSALITY_REQUEST_SCHEMA,
   evaluateDeliveryWorkspaceCausality,
   resolveMissingDeliveryWorkspace,
+  resolveSettlementWorkspaceRequirement,
 } from "../../loopx/control_plane/quota/settlement_workspace_causality.ts";
 
 const fixture = JSON.parse(
@@ -102,4 +103,37 @@ test("missing workspace resolution preserves all three typed requirements", () =
       "declare_explicit_non_delivery_contract",
     ],
   });
+});
+
+test("typed settlement identity distinguishes replan from unknown Todo causality", () => {
+  assert.deepEqual(
+    resolveSettlementWorkspaceRequirement(null, "autonomous_replan"),
+    {
+      schema_version: "settlement_workspace_requirement_v0",
+      settlement_binding_kind: "autonomous_replan",
+      requirement: "not_required",
+      source: "typed_settlement_identity",
+      reason: "autonomous_replan_is_non_repository_control_plane_work",
+    },
+  );
+  assert.deepEqual(resolveSettlementWorkspaceRequirement(null, "todo"), {
+    schema_version: "settlement_workspace_requirement_v0",
+    settlement_binding_kind: "todo",
+    requirement: "unknown",
+    source: "typed_settlement_identity",
+    reason: "todo_delivery_contract_not_available",
+  });
+  assert.equal(
+    resolveSettlementWorkspaceRequirement(
+      {
+        schema_version: "delivery_workspace_causality_v0",
+        todo_id: "todo_write",
+        requirement: "required",
+        source: "selected_todo_contract",
+        reason: "declared_repository_or_write_contract",
+      },
+      "autonomous_replan",
+    ).requirement,
+    "required",
+  );
 });


### PR DESCRIPTION
## Summary

- bind typed `blocked + outcome_gap` settlement to an autonomous replan obligation when no Todo exists
- derive workspace requirements from the original typed settlement identity
- allow read-only autonomous replans to settle without a Git worktree while preserving repository/write and unknown-Todo fail-closed behavior
- preserve historical Todo settlements only through a strict typed compatibility proof: causality absent, workspace absent, exact settlement effect, and committed `validation` plus `durable_writeback` receipts
- keep explicit `unknown` causality, partial/mismatched receipts, and any existing workspace record fail closed

## Value

This closes a real control-plane deadlock: a valid read-only autonomous replan could durably write `blocked + outcome_gap` but could not settle or spend because the workspace guard incorrectly required repository causality. The refined design fixes that without weakening delivery guards and without moving state authority into Python.

The compatibility refinement also prevents the new rule from stranding pre-causality Todo settlements after successor reselection. It is identity- and receipt-bound, so it does not become a broad “missing metadata means safe” fallback.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` (290 passed)
- repository-configured strict `mypy`
- relevant Python settlement suites: 90/91 passed before the final safe fix; the sole workspace-mismatch failure and the exact compatibility/negative matrix all passed after the fix
- changed-path Ruff and `py_compile`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` from this exact worktree: 17/17 passed, 0 failures, 0 manual holds
- change-quality receipt `cqr_bedfd37dbad76bd0f3b4`, fingerprint `bedfd37dbad76bd0f3b49f2733d1190977e5907ad0eb0bdfe2f6678b83ce34e7`, valid

## Architecture and future-facing pass

The TypeScript workspace-causality module remains the only decision owner. Python serializes already validated exact settlement facts and validates the returned schema; it does not recreate the rule. The bounded companion refactor shares the typed requirement contract across refresh and spend. A broader TypeScript migration would mix unrelated scope and was intentionally deferred.

## Boundary

Runtime/API behavior and durable validation only. No benchmark scoring or task semantics, permissions, production authority, private state, credentials, raw evidence, or external jobs are involved.
