### PR TITLE
fix(periodic-report): freeze stage progress snapshots

### DIFF
--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -126,9 +126,10 @@ composition boundary:
 After a committed `refresh-state` writeback with complete
 Goal/Agent/Todo/Turn/effect identity, core dispatches the TypeScript-validated
 `post_writeback` hook outside the primary transaction. The capability receives
-only a bounded stage-completion projection and may propose one idempotent
-`periodic_report.trigger_evaluation` intent. Core checkpoints that proposal in
-a replay-safe sidecar. A transient failure is durably recorded as
+only a bounded stage-completion projection and its public-safe progress
+snapshot, both captured at the writeback boundary. It may propose one
+idempotent `periodic_report.trigger_evaluation` intent. Core checkpoints that
+proposal in a replay-safe sidecar. A transient failure is durably recorded as
 `retryable_failure`; the next exact replay advances its attempt and may replace
 it with `intent_recorded` or `not_applicable`, while terminal replay returns the
 original receipt without invoking the provider again. Disabled profiles,

--- a/loopx/capabilities/periodic_report/pending_intent.py
+++ b/loopx/capabilities/periodic_report/pending_intent.py
@@ -31,6 +31,7 @@ from .post_writeback_hook import (
     PERIODIC_REPORT_TRIGGER_EVALUATION_INTENT,
     evaluate_periodic_report_trigger_evaluation_intent,
 )
+from .project_progress_snapshot import build_project_progress_snapshot
 
 
 PENDING_INTENT_SCHEMA = "pending_capability_intent_projection_v0"
@@ -49,11 +50,6 @@ _ANALYSIS_SECTION_CONTRACT = (
     ("coverage_and_actions", "版本覆盖与处置"),
     ("next_actions", "下一步"),
 )
-_META_ACTION_KINDS = {
-    "consume_periodic_report_intent",
-    "repair_periodic_report_intent_consumption",
-    "repair_periodic_report_editorial",
-}
 _SECTION_CONTENT_KINDS = {
     "overview": "decision",
     "problem_map": "risk",
@@ -409,96 +405,87 @@ def periodic_report_pending_intent_interaction_hook(
 def _progress_facts(
     *, registry_path: Path, goal_id: str, agent_id: str, completed_at: str
 ) -> list[dict[str, Any]]:
-    registry = read_json(registry_path)
-    goal = find_registry_goal(registry, goal_id)
-    if not isinstance(goal, Mapping):
-        raise ValueError("periodic-report Goal is not registered")
-    repo = Path(str(goal.get("repo") or "")).expanduser()
-    state_path = resolve_state_file(repo, str(goal.get("state_file") or ""))
-    if state_path is None or not state_path.is_file():
-        raise ValueError("periodic-report active state is unavailable")
-    parsed = parse_active_state_todos(
-        state_path.read_text(encoding="utf-8"),
-        goal=dict(goal),
-        state_path=state_path,
-        item_limit=None,
+    snapshot = build_project_progress_snapshot(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        completed_at=completed_at,
     )
-    agent_summary = parsed.get("agent_todos")
-    items = agent_summary.get("items") if isinstance(agent_summary, Mapping) else []
-    stage_time = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+    if not isinstance(snapshot, Mapping):
+        raise ValueError("periodic-report has no public-safe progress items")
+    return _progress_facts_from_snapshot(
+        snapshot,
+        goal_id=goal_id,
+        completed_at=completed_at,
+    )
 
-    def not_after_stage(item: Mapping[str, Any]) -> bool:
-        raw = str(item.get("completed_at") or item.get("updated_at") or "").strip()
-        if not raw:
-            return False
-        try:
-            return datetime.fromisoformat(raw.replace("Z", "+00:00")) <= stage_time
-        except ValueError:
-            return False
 
-    done = [
-        dict(item)
-        for item in items or []
-        if isinstance(item, Mapping)
-        and item.get("status") == "done"
-        and str(item.get("claimed_by") or "") == agent_id
-        and not_after_stage(item)
-    ]
-    done.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+def _progress_facts_from_snapshot(
+    snapshot: Mapping[str, Any], *, goal_id: str, completed_at: str
+) -> list[dict[str, Any]]:
+    if (
+        snapshot.get("schema_version")
+        != "periodic_report_project_progress_projection_v0"
+        or snapshot.get("goal_id") != goal_id
+        or snapshot.get("observed_at") != completed_at
+    ):
+        raise ValueError("periodic-report progress snapshot identity is invalid")
+    raw_items = snapshot.get("items")
+    if not isinstance(raw_items, list):
+        raise ValueError("periodic-report progress snapshot items are invalid")
     facts: list[dict[str, Any]] = []
-    reportable_done = [
-        item
-        for item in done
-        if str(item.get("action_kind") or "") not in _META_ACTION_KINDS
-    ]
-    for index, item in enumerate(reportable_done[:12]):
-        summary = " ".join(
-            str(
-                item.get("evidence")
-                or item.get("note")
-                or item.get("text")
-                or ""
-            ).split()
-        )
-        title = " ".join(
-            str(item.get("text") or "Completed project work").split()
-        )
-        facts.append(
-            {
-                "fact_id": f"completed_{index + 1}",
-                "title": title[:500],
-                "summary": summary[:1000]
-                or "Validated completion is durably recorded.",
-                "status": "done",
-                "completed_at": str(
-                    item.get("completed_at") or item.get("updated_at") or ""
-                ),
-                "source_ref": f"todo:{item.get('todo_id')}",
-            }
-        )
-    open_items = [
-        dict(item)
-        for item in items or []
-        if isinstance(item, Mapping)
-        and item.get("status") == "open"
-        and str(item.get("claimed_by") or "") == agent_id
-        and item.get("task_class") != "continuous_monitor"
-        and str(item.get("action_kind") or "") not in _META_ACTION_KINDS
-    ]
-    if open_items:
-        next_item = open_items[0]
-        facts.append(
-            {
-                "fact_id": "next_action",
-                "title": "Open successor",
-                "summary": " ".join(str(next_item.get("text") or "").split())[:1000],
-                "status": "open",
-                "source_ref": f"todo:{next_item.get('todo_id')}",
-            }
-        )
+    seen_source_refs: set[str] = set()
+    for index, raw_item in enumerate(raw_items):
+        if not isinstance(raw_item, Mapping):
+            raise ValueError(f"periodic-report progress snapshot item {index} is invalid")
+        item_id = str(raw_item.get("item_id") or "").strip()
+        title = " ".join(str(raw_item.get("title") or "").split())
+        summary = " ".join(str(raw_item.get("summary") or "").split())
+        source_ref = str(raw_item.get("source_ref") or "").strip()
+        content_kind = str(raw_item.get("content_kind") or "").strip()
+        if not item_id or not title or not summary or not source_ref:
+            raise ValueError("periodic-report progress snapshot item is incomplete")
+        if source_ref in seen_source_refs:
+            raise ValueError("periodic-report progress snapshot source is duplicated")
+        raw_completed_at = str(raw_item.get("completed_at") or "").strip()
+        if content_kind == "outcome":
+            status = "done"
+            completed = _validated_snapshot_timestamp(
+                raw_completed_at,
+                observed_at=completed_at,
+            )
+        elif content_kind == "next_action":
+            status = "open"
+            completed = None
+        else:
+            raise ValueError("periodic-report progress snapshot item kind is invalid")
+        fact: dict[str, Any] = {
+            "fact_id": item_id,
+            "title": title[:500],
+            "summary": summary[:1000],
+            "status": status,
+            "source_ref": source_ref,
+        }
+        if completed is not None:
+            fact["completed_at"] = completed
+        facts.append(fact)
+        seen_source_refs.add(source_ref)
     if not facts:
         raise ValueError("periodic-report has no public-safe progress items")
     return facts
+
+
+def _validated_snapshot_timestamp(value: str, *, observed_at: str) -> str:
+    try:
+        timestamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        boundary = datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            "periodic-report progress snapshot timestamp is invalid"
+        ) from exc
+    if timestamp.tzinfo is None or boundary.tzinfo is None or timestamp > boundary:
+        raise ValueError("periodic-report progress snapshot timestamp is invalid")
+    return value
 
 
 def _build_editorial_request(
@@ -843,11 +830,20 @@ def consume_pending_periodic_report_intent(
     payload = intent["payload"]
     stage = payload["stage_completion"]
     completed_at = str(stage["completed_at"])
-    facts = _progress_facts(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        agent_id=agent_id,
-        completed_at=completed_at,
+    project_progress = payload.get("project_progress")
+    facts = (
+        _progress_facts_from_snapshot(
+            project_progress,
+            goal_id=goal_id,
+            completed_at=completed_at,
+        )
+        if isinstance(project_progress, Mapping)
+        else _progress_facts(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            completed_at=completed_at,
+        )
     )
     actionable, rejection_revision = _next_attempt_revision(
         registry_path=registry_path,

--- a/loopx/capabilities/periodic_report/post_writeback_hook.py
+++ b/loopx/capabilities/periodic_report/post_writeback_hook.py
@@ -20,6 +20,7 @@ from ...registry import registry_goals
 from .stage_completion import STAGE_COMPLETION_RECEIPT_SCHEMA
 from .stage_completion import derive_periodic_report_stage_completion_from_runs
 from .presets import build_periodic_report_preset_activation
+from .project_progress_snapshot import build_project_progress_snapshot_from_state
 from .triggers import build_periodic_report_trigger_decision
 
 
@@ -166,8 +167,9 @@ def build_periodic_report_post_writeback_projection(
         ),
         {},
     )
+    state_text = state_path.read_text(encoding="utf-8")
     projection, _user_summary, _agent_summary = _frontier_projection(
-        state_text=state_path.read_text(encoding="utf-8"),
+        state_text=state_text,
         goal=goal,
         state_path=state_path,
         goal_id=goal_id,
@@ -231,7 +233,20 @@ def build_periodic_report_post_writeback_projection(
         settled_replan_obligation=settled_obligation,
         settled_replan_ack=settled_ack,
     )
-    return {"stage_completion": receipt} if receipt is not None else {}
+    if receipt is None:
+        return {}
+    result: dict[str, object] = {"stage_completion": receipt}
+    project_progress = build_project_progress_snapshot_from_state(
+        state_text=state_text,
+        goal=goal,
+        state_path=state_path,
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+        completed_at=str(receipt["completed_at"]),
+    )
+    if project_progress is not None:
+        result["project_progress"] = project_progress
+    return result
 
 
 def periodic_report_post_writeback_hook(
@@ -261,6 +276,21 @@ def periodic_report_post_writeback_hook(
             return _result(status="not_applicable", intent=None)
         receipt_id = str(receipt.get("event_id") or "")
         stage_identity = str(stage["stage_identity"])
+        project_progress = (
+            projection.get("project_progress")
+            if isinstance(projection, Mapping)
+            else None
+        )
+        intent_payload: dict[str, Any] = {
+            "schema_version": "periodic_report_trigger_evaluation_intent_v0",
+            "stage_completion": dict(stage),
+            "profile_ref": dict(profile_ref or {}),
+            "trigger_policy": dict(trigger_policy or {}),
+            "generation_authorized": False,
+            "external_delivery_authorized": False,
+        }
+        if isinstance(project_progress, Mapping):
+            intent_payload["project_progress"] = dict(project_progress)
         return _result(
             status="intent",
             intent={
@@ -268,14 +298,7 @@ def periodic_report_post_writeback_hook(
                 "intent_kind": PERIODIC_REPORT_TRIGGER_EVALUATION_INTENT,
                 "idempotency_key": f"periodic-report:{stage_identity}",
                 "source_receipt_id": receipt_id,
-                "payload": {
-                    "schema_version": "periodic_report_trigger_evaluation_intent_v0",
-                    "stage_completion": dict(stage),
-                    "profile_ref": dict(profile_ref or {}),
-                    "trigger_policy": dict(trigger_policy or {}),
-                    "generation_authorized": False,
-                    "external_delivery_authorized": False,
-                },
+                "payload": intent_payload,
                 "requested_write_scope": [],
             },
         )
@@ -285,7 +308,7 @@ def periodic_report_post_writeback_hook(
         capability_id="periodic-report",
         event_kinds=("refresh_state", "todo_complete"),
         intent_kinds=(PERIODIC_REPORT_TRIGGER_EVALUATION_INTENT,),
-        requested_read_scope=("stage_completion",),
+        requested_read_scope=("stage_completion", "project_progress"),
         producer=producer,
         policy_version=policy_version,
     )

--- a/loopx/capabilities/periodic_report/project_progress_snapshot.py
+++ b/loopx/capabilities/periodic_report/project_progress_snapshot.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from ...registry import find_registry_goal, read_json, resolve_state_file
+
+
+def build_project_progress_snapshot(
+    *, registry_path: Path, goal_id: str, agent_id: str, completed_at: str
+) -> dict[str, Any] | None:
+    """Build a bounded public-safe progress snapshot at a stage boundary."""
+
+    registry = read_json(registry_path)
+    goal = find_registry_goal(registry, goal_id)
+    if not isinstance(goal, Mapping):
+        raise ValueError("periodic-report Goal is not registered")
+    repo = Path(str(goal.get("repo") or "")).expanduser()
+    state_path = resolve_state_file(repo, str(goal.get("state_file") or ""))
+    if state_path is None or not state_path.is_file():
+        raise ValueError("periodic-report active state is unavailable")
+    return build_project_progress_snapshot_from_state(
+        state_text=state_path.read_text(encoding="utf-8"),
+        goal=dict(goal),
+        state_path=state_path,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        completed_at=completed_at,
+    )
+
+
+def build_project_progress_snapshot_from_state(
+    *,
+    state_text: str,
+    goal: Mapping[str, Any],
+    state_path: Path,
+    goal_id: str,
+    agent_id: str,
+    completed_at: str,
+) -> dict[str, Any] | None:
+    """Build a progress snapshot from one already-read authoritative state."""
+
+    parsed = parse_active_state_todos(
+        state_text,
+        goal=dict(goal),
+        state_path=state_path,
+        item_limit=None,
+    )
+    agent_summary = parsed.get("agent_todos")
+    items = agent_summary.get("items") if isinstance(agent_summary, Mapping) else []
+    stage_time = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+
+    def not_after_stage(item: Mapping[str, Any]) -> bool:
+        raw = str(item.get("updated_at") or item.get("completed_at") or "").strip()
+        if not raw:
+            return True
+        try:
+            return datetime.fromisoformat(raw.replace("Z", "+00:00")) <= stage_time
+        except ValueError:
+            return False
+
+    done = [
+        dict(item)
+        for item in items or []
+        if isinstance(item, Mapping)
+        and item.get("status") == "done"
+        and str(item.get("claimed_by") or "") == agent_id
+        and not_after_stage(item)
+    ]
+    done.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
+    progress_items: list[dict[str, Any]] = []
+    for index, item in enumerate(done[:6]):
+        summary = " ".join(
+            str(
+                item.get("evidence") or item.get("note") or item.get("text") or ""
+            ).split()
+        )
+        title = " ".join(str(item.get("text") or "Completed project work").split())
+        progress_items.append(
+            {
+                "item_id": f"completed_{index + 1}",
+                "title": title[:240],
+                "summary": summary[:360] or "Validated completion is durably recorded.",
+                "content_kind": "outcome",
+                "value_rank": 10 + index,
+                "source_ref": f"todo:{item.get('todo_id')}",
+                "completed_at": str(
+                    item.get("completed_at") or item.get("updated_at") or ""
+                ),
+            }
+        )
+    open_items = [
+        dict(item)
+        for item in items or []
+        if isinstance(item, Mapping)
+        and item.get("status") == "open"
+        and str(item.get("claimed_by") or "") == agent_id
+        and not_after_stage(item)
+        and item.get("task_class") != "continuous_monitor"
+        and item.get("action_kind")
+        not in {
+            "consume_periodic_report_intent",
+            "repair_periodic_report_intent_consumption",
+        }
+    ]
+    if open_items:
+        next_item = open_items[0]
+        progress_items.append(
+            {
+                "item_id": "next_action",
+                "title": "Next action",
+                "summary": " ".join(str(next_item.get("text") or "").split())[:360],
+                "content_kind": "next_action",
+                "value_rank": 90,
+                "source_ref": f"todo:{next_item.get('todo_id')}",
+            }
+        )
+    if not progress_items:
+        return None
+    return {
+        "schema_version": "periodic_report_project_progress_projection_v0",
+        "goal_id": goal_id,
+        "observed_at": completed_at,
+        "language": "zh-CN",
+        "items": progress_items,
+    }
+
+
+__all__ = [
+    "build_project_progress_snapshot",
+    "build_project_progress_snapshot_from_state",
+]

--- a/loopx/capabilities/periodic_report/project_progress_snapshot.py
+++ b/loopx/capabilities/periodic_report/project_progress_snapshot.py
@@ -9,6 +9,15 @@ from ...control_plane.todos.active_state_todo_parser import parse_active_state_t
 from ...registry import find_registry_goal, read_json, resolve_state_file
 
 
+_META_ACTION_KINDS = frozenset(
+    {
+        "consume_periodic_report_intent",
+        "repair_periodic_report_intent_consumption",
+        "repair_periodic_report_editorial",
+    }
+)
+
+
 def build_project_progress_snapshot(
     *, registry_path: Path, goal_id: str, agent_id: str, completed_at: str
 ) -> dict[str, Any] | None:
@@ -69,6 +78,7 @@ def build_project_progress_snapshot_from_state(
         and item.get("status") == "done"
         and str(item.get("claimed_by") or "") == agent_id
         and not_after_stage(item)
+        and str(item.get("action_kind") or "") not in _META_ACTION_KINDS
     ]
     done.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
     progress_items: list[dict[str, Any]] = []

--- a/tests/capabilities/test_periodic_report_pending_intent.py
+++ b/tests/capabilities/test_periodic_report_pending_intent.py
@@ -425,10 +425,54 @@ def test_consumption_uses_the_stage_progress_snapshot(tmp_path: Path) -> None:
     facts = request["facts"]
 
     assert any("Finish the bounded analysis" in fact["title"] for fact in facts)
+    completed_fact = next(
+        fact for fact in facts if "Finish the bounded analysis" in fact["title"]
+    )
+    assert completed_fact["completed_at"] == "2026-08-30T09:00:00Z"
+    assert request["actual_work_window"]["period_label"] == (
+        "2026-08-30 17:00（北京时间）"
+    )
     assert not any(
         "Follow-up work added after stage completion" in fact["title"]
         for fact in facts
     )
+
+
+def test_consumption_rejects_snapshot_outcome_after_stage_completion(
+    tmp_path: Path,
+) -> None:
+    registry, runtime = _fixture(tmp_path)
+    sidecar = next(
+        (runtime / "goals" / GOAL_ID / "post_writeback_hooks").glob("*.json")
+    )
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["intent"]["payload"]["project_progress"] = {
+        "schema_version": "periodic_report_project_progress_projection_v0",
+        "goal_id": GOAL_ID,
+        "observed_at": "2026-08-30T09:00:00Z",
+        "language": "zh-CN",
+        "items": [
+            {
+                "item_id": "completed_1",
+                "title": "Future outcome",
+                "summary": "This timestamp is outside the frozen stage.",
+                "content_kind": "outcome",
+                "value_rank": 10,
+                "source_ref": "todo:future",
+                "completed_at": "2026-08-30T09:00:01Z",
+            }
+        ],
+    }
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="snapshot timestamp is invalid"):
+        consume_pending_periodic_report_intent(
+            registry_path=registry,
+            runtime_root=runtime,
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            execute=True,
+        )
 
 
 def test_consumption_recovers_when_gate_precedes_receipt_write(tmp_path: Path) -> None:

--- a/tests/capabilities/test_periodic_report_pending_intent.py
+++ b/tests/capabilities/test_periodic_report_pending_intent.py
@@ -10,6 +10,10 @@ from loopx.capabilities.periodic_report.pending_intent import (
     pending_periodic_report_intents,
     periodic_report_pending_intent_interaction_hook,
 )
+from loopx.capabilities.periodic_report.project_progress_snapshot import (
+    build_project_progress_snapshot,
+)
+from loopx.todos import add_goal_todo
 from loopx.control_plane.capability_hooks import dispatch_interaction_projection_hooks
 from loopx.control_plane.quota.live_decision import (
     _apply_pending_capability_intent_precedence,
@@ -382,6 +386,49 @@ def test_consumption_is_local_and_exact_replay_does_not_duplicate_gate(
     state = (registry.parent / "ACTIVE_GOAL_STATE.md").read_text(encoding="utf-8")
     assert state.count("approve_periodic_report_payload") == 1
     assert "批准前不得发布妙搭或发送群消息" in state
+
+
+def test_consumption_uses_the_stage_progress_snapshot(tmp_path: Path) -> None:
+    registry, runtime = _fixture(tmp_path)
+    sidecar = next(
+        (runtime / "goals" / GOAL_ID / "post_writeback_hooks").glob("*.json")
+    )
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["intent"]["payload"]["project_progress"] = build_project_progress_snapshot(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-30T09:00:00Z",
+    )
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    add_goal_todo(
+        registry_path=registry,
+        goal_id=GOAL_ID,
+        role="agent",
+        text="Follow-up work added after stage completion",
+        claimed_by=AGENT_ID,
+        agent_id=AGENT_ID,
+    )
+
+    result = consume_pending_periodic_report_intent(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        execute=True,
+    )
+    assert result["status"] == "editorial_required"
+    request = json.loads(
+        Path(result["editorial_request_path"]).read_text(encoding="utf-8")
+    )
+    facts = request["facts"]
+
+    assert any("Finish the bounded analysis" in fact["title"] for fact in facts)
+    assert not any(
+        "Follow-up work added after stage completion" in fact["title"]
+        for fact in facts
+    )
 
 
 def test_consumption_recovers_when_gate_precedes_receipt_write(tmp_path: Path) -> None:

--- a/tests/cli_commands/test_project_lifecycle_goal_channel.py
+++ b/tests/cli_commands/test_project_lifecycle_goal_channel.py
@@ -398,11 +398,16 @@ def test_refresh_state_dispatches_and_replays_post_writeback_sidecar(
         "sync_human_gate_after_refresh",
         lambda **kwargs: {"enabled": False},
     )
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+        encoding="utf-8",
+    )
 
     for _ in range(2):
         result = project_lifecycle.handle_project_lifecycle_command(
             args,
-            registry_path=tmp_path / "registry.json",
+            registry_path=registry_path,
             print_payload=lambda payload, fmt, renderer: captured.update(payload),
             output_format=lambda args: "json",
             append_cli_rollout_event=lambda *args, **kwargs: {},

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -139,9 +139,29 @@ def test_post_writeback_dispatch_rejects_non_durable_input_before_provider() -> 
 
 
 def test_periodic_report_hook_emits_only_an_approval_neutral_trigger_intent() -> None:
+    hook_input = _input()
+    hook_input["projection"] = {
+        **hook_input["projection"],  # type: ignore[dict-item]
+        "project_progress": {
+            "schema_version": "periodic_report_project_progress_projection_v0",
+            "goal_id": "goal-1",
+            "observed_at": "2026-08-30T09:00:00Z",
+            "language": "zh-CN",
+            "items": [
+                {
+                    "item_id": "completed_1",
+                    "title": "Frozen stage outcome",
+                    "summary": "The stage snapshot is captured at writeback.",
+                    "content_kind": "outcome",
+                    "value_rank": 10,
+                    "source_ref": "todo:todo-1",
+                }
+            ],
+        },
+    }
     dispatch = dispatch_post_writeback_hooks(
         [periodic_report_post_writeback_hook()],
-        hook_input=_input(),
+        hook_input=hook_input,
     )
 
     intent = dispatch["intents"][0]
@@ -149,6 +169,9 @@ def test_periodic_report_hook_emits_only_an_approval_neutral_trigger_intent() ->
     assert intent["requested_write_scope"] == []
     assert intent["payload"]["generation_authorized"] is False
     assert intent["payload"]["external_delivery_authorized"] is False
+    assert intent["payload"]["project_progress"]["items"][0]["title"] == (
+        "Frozen stage outcome"
+    )
 
 
 def test_periodic_report_hook_accepts_durable_todo_completion() -> None:
@@ -444,6 +467,7 @@ def test_periodic_report_projection_reduces_durable_successor_transition(
     receipt = projection["stage_completion"]
     assert receipt["transition"] == "successor_frontier_settled"
     assert receipt["frontier_identity"] == "frontier-2"
+    assert projection["project_progress"]["observed_at"] == receipt["completed_at"]
 
 
 def test_periodic_report_projection_reduces_terminal_after_todo_completion(


### PR DESCRIPTION
## Summary

- Freeze the public-safe project progress used by automatic periodic-report intents at the committed writeback boundary.
- Reuse the frozen snapshot during delayed/editorial consumption instead of rebuilding facts from live Todo state.
- Reject state-file drift by the committed digest and keep legacy intents on a bounded fallback path.
- Keep the post-writeback intent effect-free; generation and external delivery remain separately authorized.

## Validation

- Focused periodic-report, post-writeback, and lifecycle tests: 33 passed
- `npm run typecheck:control-plane`
- `npm run test:control-plane` (288 passed)
- `loopx canary premerge --from-git-diff` (14 selected checks passed)
- Ruff, Python compilation, and strict mypy for the new snapshot module passed
- Full pytest run: 4845 passed, 12 skipped; two intermittent full-suite failures passed on isolated reruns

## Review note

The snapshot logic stays within the periodic-report bounded context. No new dependency or external write authority is introduced.

我按这个边界把快照和消费链路收了一遍，麻烦您看看；如果还有需要调整的地方，您可以直接基于这个提交继续改。