### PR TITLE
fix(periodic-report): accept normalized card readback

### DIFF
--- a/loopx/extensions/lark/periodic_report_delivery.py
+++ b/loopx/extensions/lark/periodic_report_delivery.py
@@ -190,6 +190,50 @@ def _message_card(value: Mapping[str, Any]) -> Mapping[str, Any] | None:
     return parsed if isinstance(parsed, Mapping) else None
 
 
+def _normalized_card_text(card: Mapping[str, Any]) -> str | None:
+    """Match the lossless interactive-card projection returned by new CLIs."""
+
+    header = card.get("header")
+    elements = card.get("elements")
+    if not isinstance(header, Mapping) or not isinstance(elements, list):
+        return None
+    title = header.get("title")
+    title = title.get("content") if isinstance(title, Mapping) else None
+    if not isinstance(title, str) or not elements:
+        return None
+    first = elements[0]
+    first = first if isinstance(first, Mapping) else {}
+    text = first.get("text")
+    markdown = text.get("content") if isinstance(text, Mapping) else None
+    if not isinstance(markdown, str):
+        return None
+    footer = None
+    if len(elements) == 3 and elements[1] == {"tag": "hr"}:
+        note = elements[2]
+        note_elements = note.get("elements") if isinstance(note, Mapping) else None
+        if isinstance(note_elements, list) and len(note_elements) == 1:
+            note_text = note_elements[0]
+            footer = (
+                note_text.get("content") if isinstance(note_text, Mapping) else None
+            )
+    lines = [f'<card title="{title}">', markdown]
+    if isinstance(footer, str) and footer:
+        lines.extend(["---", f"📝 {footer}"])
+    lines.append("</card>")
+    return "\n".join(lines)
+
+
+def _message_card_matches(
+    value: Mapping[str, Any], expected: Mapping[str, Any] | None
+) -> bool:
+    if expected is None:
+        return False
+    if _message_card(value) == expected:
+        return True
+    content = value.get("content")
+    return isinstance(content, str) and content == _normalized_card_text(expected)
+
+
 def _message_sender(value: Mapping[str, Any]) -> tuple[str, str]:
     sender = value.get("sender")
     sender = sender if isinstance(sender, Mapping) else {}
@@ -412,7 +456,7 @@ class _GoalChannelDeliverySession:
             result.get("returncode") == 0
             and message is not None
             and contains_exact_field(message, "chat_id", str(self.route["chat_id"]))
-            and _message_card(message) == expected_card
+            and _message_card_matches(message, expected_card)
             and sender_type == "app"
             and sender_app_id == self.route["bot_app_id"]
             and auth_verified(

--- a/tests/extensions/test_periodic_report_goal_channel_delivery.py
+++ b/tests/extensions/test_periodic_report_goal_channel_delivery.py
@@ -124,7 +124,7 @@ def _write_binding(
     )
 
 
-def _runner(calls: list[list[str]]):
+def _runner(calls: list[list[str]], *, normalized_readback: bool = False):
     sent_cards: dict[str, dict[str, Any]] = {}
 
     def run(
@@ -159,6 +159,15 @@ def _runner(calls: list[list[str]]):
             payload = {"ok": True, "data": {"message_id": message_id}}
         elif "+messages-mget" in args:
             message_id = args[args.index("--message-ids") + 1]
+            card = sent_cards[message_id]
+            if normalized_readback:
+                title = card["header"]["title"]["content"]
+                markdown = card["elements"][0]["text"]["content"]
+                footer = card["elements"][2]["elements"][0]["content"]
+                message_content = (
+                    f'<card title="{title}">\n{markdown}\n---\n'
+                    f"📝 {footer}\n</card>"
+                )
             payload = {
                 "ok": True,
                 "data": {
@@ -171,7 +180,15 @@ def _runner(calls: list[list[str]]):
                                 "id": APP_ID,
                             },
                             "msg_type": "interactive",
-                            "body": {"content": json.dumps(sent_cards[message_id])},
+                            **(
+                                {"content": message_content}
+                                if normalized_readback
+                                else {
+                                    "body": {
+                                        "content": json.dumps(sent_cards[message_id])
+                                    }
+                                }
+                            ),
                         }
                     ]
                 },
@@ -185,6 +202,32 @@ def _runner(calls: list[list[str]]):
         }
 
     return run
+
+
+def test_goal_channel_delivery_accepts_normalized_cli_card_readback(
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    runtime_root = tmp_path / "runtime"
+    registry_path.parent.mkdir()
+    registry_path.write_text("{}", encoding="utf-8")
+    _write_binding(registry_path)
+    calls: list[list[str]] = []
+
+    result = deliver_periodic_report_to_goal_channel(
+        _request(),
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        extension_activation=_extension_activation(),
+        execute=True,
+        runner=_runner(calls, normalized_readback=True),
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "satisfied"
+    assert result["sink_result"]["readback_verified"] is True
+    assert len(result["sink_result"]["message_results"]) == 2
 
 
 def test_goal_channel_delivery_uses_only_the_bound_project_bot(


### PR DESCRIPTION
## Summary

- accept both the legacy raw `body.content` JSON card and the lossless normalized interactive-card text returned by newer Lark CLI versions
- preserve exact card, chat, and native Bot App identity verification
- add focused coverage for the normalized readback shape across both ordered periodic-report messages

## Product and architecture judgment

The Goal Channel delivery contract already owns exact provider readback. The operator problem was a representation mismatch: successful messages from the bound project Bot were marked unknown because a newer provider CLI normalized cards into top-level text. This change keeps authority in the existing Lark delivery boundary and compares two lossless projections of the same expected card; it does not weaken sender, destination, ordering, or idempotency checks. A broader provider-wide normalization layer was considered but deferred because only this exact-card delivery contract currently requires structural equality.

## Validation

- `uv run pytest tests/extensions/test_periodic_report_goal_channel_delivery.py -q` — 8 passed
- `uv run ruff check loopx/extensions/lark/periodic_report_delivery.py tests/extensions/test_periodic_report_goal_channel_delivery.py` — passed
- `git diff --check` — passed
- `loopx canary premerge --from-git-diff --format json` — direct checks, maintainability canary, and 7/8 extension-runtime smokes passed; `examples/lark-event-inbox-smoke.py` failed on an unrelated existing mock gap for `chat.members get`, reproduced unchanged from `origin/main`

## Boundary

No credentials, private state, local paths, provider ids, internal links, generated logs, or the local `uv.lock` were committed.
