### PR TITLE
fix(chat): keep retryable Codex turns active

### DIFF
--- a/examples/loopx-chat-agent-smoke.py
+++ b/examples/loopx-chat-agent-smoke.py
@@ -104,6 +104,16 @@ for line in sys.stdin:
                     "method": "item/started",
                     "params": {"threadId": "thread-loopx-chat", "turnId": turn_id, "item": {"id": f"work-{index}"}},
                 }), flush=True)
+        if "recover after retryable error" in prompt:
+            print(json.dumps({
+                "method": "error",
+                "params": {
+                    "threadId": "thread-loopx-chat",
+                    "turnId": turn_id,
+                    "willRetry": True,
+                    "error": {"message": "synthetic transient failure"},
+                },
+            }), flush=True)
         visible_answer = "Reviewed " + params.get("cwd", "") + ".\n"
         response = (
             visible_answer + '<loopx-review-json>'
@@ -213,6 +223,11 @@ def main() -> None:
                 "inspect attached image",
                 attachments=[{"data_url": "data:image/png;base64,aW1hZ2U="}],
             )
+            retry_events = []
+            retry_result = session.send(
+                "recover after retryable error",
+                on_event=lambda kind, payload: retry_events.append((kind, payload)),
+            )
         finally:
             session.close()
 
@@ -227,6 +242,14 @@ def main() -> None:
         ], result
         assert result["gate"] is None, result
         assert image_result["message"] == "Reviewed [project].", image_result
+        assert retry_result["message"] == "Reviewed [project].", retry_result
+        assert any(
+            kind == "agent.phase"
+            and payload.get("method") == "error"
+            and payload.get("label") == "Codex 正在重试"
+            for kind, payload in retry_events
+        ), retry_events
+        assert not any(kind == "turn.failed" for kind, _ in retry_events), retry_events
         assert str(root) not in json.dumps(result), result
         visible = "".join(
             str(payload.get("text") or "")

--- a/examples/loopx-chat-agent-smoke.py
+++ b/examples/loopx-chat-agent-smoke.py
@@ -104,7 +104,7 @@ for line in sys.stdin:
                     "method": "item/started",
                     "params": {"threadId": "thread-loopx-chat", "turnId": turn_id, "item": {"id": f"work-{index}"}},
                 }), flush=True)
-        if "recover after retryable error" in prompt:
+        if "retryable error" in prompt:
             print(json.dumps({
                 "method": "error",
                 "params": {
@@ -114,6 +114,15 @@ for line in sys.stdin:
                     "error": {"message": "synthetic transient failure"},
                 },
             }), flush=True)
+        if "ends in terminal failure" in prompt:
+            print(json.dumps({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-loopx-chat",
+                    "turn": {"id": turn_id, "status": "failed"},
+                },
+            }), flush=True)
+            continue
         visible_answer = "Reviewed " + params.get("cwd", "") + ".\n"
         response = (
             visible_answer + '<loopx-review-json>'
@@ -228,6 +237,12 @@ def main() -> None:
                 "recover after retryable error",
                 on_event=lambda kind, payload: retry_events.append((kind, payload)),
             )
+            try:
+                session.send("retryable error ends in terminal failure")
+            except CodexChatAgentError as exc:
+                assert str(exc) == "Codex app-server reported a terminal turn failure.", exc
+            else:
+                raise AssertionError("terminal failed status should fail the Chat turn")
         finally:
             session.close()
 

--- a/loopx/chat_agent.py
+++ b/loopx/chat_agent.py
@@ -16,7 +16,6 @@ from .chat import (
     CHAT_REVIEW_OPEN_TAG,
     VisibleResponseStreamFilter,
     parse_agent_response,
-    redact_local_paths,
 )
 
 
@@ -84,16 +83,6 @@ def _event_turn_id(message: dict[str, Any]) -> str:
 def _event_thread_id(message: dict[str, Any]) -> str:
     params = message.get("params")
     return str(params.get("threadId") or "") if isinstance(params, dict) else ""
-
-
-def _error_message(payload: Any, *, protected_paths: list[Path]) -> str:
-    if not isinstance(payload, dict):
-        return ""
-    value = payload.get("message")
-    if not isinstance(value, str):
-        return ""
-    compact = " ".join(value.split())
-    return redact_local_paths(compact, protected_paths=protected_paths)[:500].strip()
 
 
 def _agent_item_text(message: dict[str, Any]) -> str:
@@ -289,15 +278,7 @@ class CodexChatAgentSession:
             session.close()
             raise
 
-    def _runtime_error(
-        self,
-        summary: str,
-        *,
-        detail_payload: Any = None,
-    ) -> CodexChatAgentError:
-        detail = _error_message(detail_payload, protected_paths=[self.work_dir])
-        if detail:
-            summary = f"{summary} {detail}"
+    def _runtime_error(self, summary: str) -> CodexChatAgentError:
         return CodexChatAgentError(
             summary,
             gate=_host_tool_gate(
@@ -416,10 +397,7 @@ class CodexChatAgentSession:
                                 continue
                 if message.get("id") == request_id:
                     if message.get("error"):
-                        raise self._runtime_error(
-                            f"Codex app-server rejected {method}.",
-                            detail_payload=message.get("error"),
-                        )
+                        raise self._runtime_error(f"Codex app-server rejected {method}.")
                     result = message.get("result")
                     return result if isinstance(result, dict) else {}
                 raise self._runtime_error("Codex app-server returned an unexpected response.")
@@ -581,10 +559,7 @@ class CodexChatAgentSession:
                 turn = params.get("turn") if isinstance(params, dict) else None
                 turn_status = str(turn.get("status") or "") if isinstance(turn, dict) else ""
                 if turn_status == "failed":
-                    raise self._runtime_error(
-                        "Codex app-server reported a terminal turn failure.",
-                        detail_payload=turn.get("error") if isinstance(turn, dict) else None,
-                    )
+                    raise self._runtime_error("Codex app-server reported a terminal turn failure.")
                 if turn_status == "interrupted":
                     raise CodexChatAgentError(
                         "Codex app-server reported an interrupted turn.",
@@ -603,10 +578,7 @@ class CodexChatAgentSession:
                             {"label": "Codex 正在重试", "method": method},
                         )
                     continue
-                raise self._runtime_error(
-                    "Codex app-server reported a turn error.",
-                    detail_payload=params.get("error") if isinstance(params, dict) else None,
-                )
+                raise self._runtime_error("Codex app-server reported a turn error.")
         visible_tail = display_filter.finish()
         if visible_tail and on_event:
             visible_delta_count += 1

--- a/loopx/chat_agent.py
+++ b/loopx/chat_agent.py
@@ -16,6 +16,7 @@ from .chat import (
     CHAT_REVIEW_OPEN_TAG,
     VisibleResponseStreamFilter,
     parse_agent_response,
+    redact_local_paths,
 )
 
 
@@ -83,6 +84,16 @@ def _event_turn_id(message: dict[str, Any]) -> str:
 def _event_thread_id(message: dict[str, Any]) -> str:
     params = message.get("params")
     return str(params.get("threadId") or "") if isinstance(params, dict) else ""
+
+
+def _error_message(payload: Any, *, protected_paths: list[Path]) -> str:
+    if not isinstance(payload, dict):
+        return ""
+    value = payload.get("message")
+    if not isinstance(value, str):
+        return ""
+    compact = " ".join(value.split())
+    return redact_local_paths(compact, protected_paths=protected_paths)[:500].strip()
 
 
 def _agent_item_text(message: dict[str, Any]) -> str:
@@ -278,7 +289,15 @@ class CodexChatAgentSession:
             session.close()
             raise
 
-    def _runtime_error(self, summary: str) -> CodexChatAgentError:
+    def _runtime_error(
+        self,
+        summary: str,
+        *,
+        detail_payload: Any = None,
+    ) -> CodexChatAgentError:
+        detail = _error_message(detail_payload, protected_paths=[self.work_dir])
+        if detail:
+            summary = f"{summary} {detail}"
         return CodexChatAgentError(
             summary,
             gate=_host_tool_gate(
@@ -397,7 +416,10 @@ class CodexChatAgentSession:
                                 continue
                 if message.get("id") == request_id:
                     if message.get("error"):
-                        raise self._runtime_error(f"Codex app-server rejected {method}.")
+                        raise self._runtime_error(
+                            f"Codex app-server rejected {method}.",
+                            detail_payload=message.get("error"),
+                        )
                     result = message.get("result")
                     return result if isinstance(result, dict) else {}
                 raise self._runtime_error("Codex app-server returned an unexpected response.")
@@ -556,9 +578,35 @@ class CodexChatAgentSession:
                         visible_delta_count += 1
                         on_event("answer.delta", {"text": visible})
             elif method == "turn/completed":
+                turn = params.get("turn") if isinstance(params, dict) else None
+                turn_status = str(turn.get("status") or "") if isinstance(turn, dict) else ""
+                if turn_status == "failed":
+                    raise self._runtime_error(
+                        "Codex app-server reported a terminal turn failure.",
+                        detail_payload=turn.get("error") if isinstance(turn, dict) else None,
+                    )
+                if turn_status == "interrupted":
+                    raise CodexChatAgentError(
+                        "Codex app-server reported an interrupted turn.",
+                        error_code="interrupted",
+                        gate=_host_tool_gate(
+                            "The Codex Chat turn was interrupted.",
+                            "Send a new message to continue in the same session.",
+                        ),
+                    )
                 break
             elif method == "error":
-                raise self._runtime_error("Codex app-server reported a turn error.")
+                if isinstance(params, dict) and params.get("willRetry") is True:
+                    if on_event:
+                        on_event(
+                            "agent.phase",
+                            {"label": "Codex 正在重试", "method": method},
+                        )
+                    continue
+                raise self._runtime_error(
+                    "Codex app-server reported a turn error.",
+                    detail_payload=params.get("error") if isinstance(params, dict) else None,
+                )
         visible_tail = display_filter.finish()
         if visible_tail and on_event:
             visible_delta_count += 1


### PR DESCRIPTION
Closes #3758

## Summary

- keep a Codex app-server Turn active when an `error` notification declares `willRetry: true`
- use `turn/completed.turn.status` as the terminal failure/interruption boundary
- keep terminal error messages generic so arbitrary upstream detail cannot cross the public Dashboard boundary
- extend the durable Chat agent smoke with retryable-error-then-success and retryable-error-then-terminal-failure sequences

## Validation

- `ruff check loopx/chat_agent.py examples/loopx-chat-agent-smoke.py`
- `python examples/loopx-chat-agent-smoke.py`
- `python examples/loopx-chat-runtime-smoke.py`
- `python examples/loopx-chat-server-smoke.py`
- ego-lite end-to-end Dashboard Chat: typed a user message, submitted it through the real HTTP/SSE and authenticated Codex app-server path, and observed the exact Codex reply in the UI
- `loopx check --scan-path loopx/chat_agent.py --scan-path examples/loopx-chat-agent-smoke.py`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`

Change-quality receipt: `cqr_237dc56ee30107bce22d` (valid for the exact final two-file diff at `6855d1d8c`).

Future-facing pass: applied a bounded error-boundary simplification by deleting optional raw app-server detail forwarding and keeping lifecycle authority in the existing event loop; no broader transport refactor was needed.
