### PR TITLE
docs(dashboard): clarify installed single-process launch

### DIFF
--- a/apps/presentation/dashboard/README.md
+++ b/apps/presentation/dashboard/README.md
@@ -126,9 +126,18 @@ From any directory after installing LoopX:
 loopx dashboard
 ```
 
-This command installs the dashboard's npm dependencies on first run, then
-starts the Vite UI together with the loopback status and Chat services. Open
-`http://127.0.0.1:5173/` after the readiness messages appear.
+This one command serves the packaged Personal Workspace, status projection, and
+Agent Chat from the same process. It opens the browser by default. For a
+headless launch, run `loopx dashboard --no-open` and open the URL printed by the
+command; the default is `http://127.0.0.1:8767/chat/`. Installed use does not
+require a separate `loopx serve-status` process or npm dependency installation.
+
+The packaged UI and status projection can be read back from that same process:
+
+```bash
+curl -fsS http://127.0.0.1:8767/chat/ >/dev/null
+curl -fsS http://127.0.0.1:8767/status.json
+```
 
 If a LoopX Chat service is already running on the default port (for example
 started by the Tauri desktop shell), `loopx dashboard` detects it by its exact
@@ -137,8 +146,7 @@ URL and opens the browser/PWA route, then exits without starting a second
 server. The desktop shell reuses the same services in the opposite order, so
 the browser/PWA and native entry points can be started in either order.
 
-The equivalent source-checkout command remains available for dashboard
-development:
+Source-checkout development is a separate mode:
 
 ```bash
 npm ci

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -907,23 +907,27 @@ Dashboard status is an experimental operator preview. The CLI and
 `loopx status` remain the canonical daily workflow; the React dashboard
 is useful for demos, public-safe fixtures, and local inspection.
 
-Serve status JSON:
-
-```bash
-loopx serve-status --port 8765
-```
-
-Run the dashboard:
+Start the installed Personal Workspace with one command:
 
 ```bash
 loopx dashboard
 ```
 
-On first run, LoopX installs the dashboard's npm dependencies. The command then
-starts the UI, global status service, and Agent Chat service together. Open
-`http://127.0.0.1:5173/` after the readiness messages appear.
+The installed command serves the packaged UI, status projection, and Agent Chat
+from one process. It opens the browser by default; pass `--no-open` for a
+headless launch and use the URL printed by the command. With the default port,
+the workspace URL is `http://127.0.0.1:8767/chat/`. A separate
+`loopx serve-status` process is not required.
 
-For the shared multi-project view:
+For a minimum readback after starting with `--no-open`:
+
+```bash
+curl -fsS http://127.0.0.1:8767/chat/ >/dev/null
+curl -fsS http://127.0.0.1:8767/status.json
+```
+
+`serve-status` remains available when another client needs a standalone status
+feed, independently of the installed Personal Workspace:
 
 ```bash
 loopx serve-status --global-registry --port 8766 --limit 80

--- a/docs/guides/personal-workspace-user-guide.md
+++ b/docs/guides/personal-workspace-user-guide.md
@@ -24,13 +24,23 @@ LoopX 控制台是为工程师与 Agent 深度协作打造的统一本地工作�
 loopx dashboard
 ```
 
-默认访问地址为：`http://127.0.0.1:5179/?statusUrl=%2Fstatus.json`。
+安装版会在同一个进程中启动打包后的工作区、状态投影和 Agent Chat，不需要另开
+终端运行 `loopx serve-status`。命令默认自动打开浏览器；无界面启动可使用
+`loopx dashboard --no-open`，并访问命令实际打印的 URL。默认地址为
+`http://127.0.0.1:8767/chat/`。
+
+可用下面两条命令验证页面和状态投影都来自同一个进程：
+
+```bash
+curl -fsS http://127.0.0.1:8767/chat/ >/dev/null
+curl -fsS http://127.0.0.1:8767/status.json
+```
 
 > 💡 **两种入口可共存**：`loopx dashboard`（浏览器 / PWA）与 Tauri 原生桌面壳
-> 共享 `8766/8767` 两个本地服务，且都会复用已经在运行的 LoopX 服务。先开
-> dashboard 再开桌面壳，或先开桌面壳再执行 `loopx dashboard`，两种顺序都可以；
-> 当桌面壳已经启动时，也可以直接访问 `http://127.0.0.1:8767/chat/` 使用浏览器 /
-> PWA，无需再启动一套服务。
+> 都会复用已经在运行且版本匹配的 LoopX Chat 服务。先开 dashboard 再开桌面壳，
+> 或先开桌面壳再执行 `loopx dashboard`，两种顺序都可以；当桌面壳已经启动时，
+> 也可以直接访问 `http://127.0.0.1:8767/chat/` 使用浏览器 / PWA，无需再启动一套
+> 服务。
 
 ---
 

--- a/examples/dashboard-installed-quickstart-doc-smoke.py
+++ b/examples/dashboard-installed-quickstart-doc-smoke.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Keep installed Dashboard quick starts on the single-process contract."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_WORKSPACE_URL = "http://127.0.0.1:8767/chat/"
+DEFAULT_STATUS_URL = "http://127.0.0.1:8767/status.json"
+
+
+def read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    documents = {
+        "getting started": read("docs/guides/getting-started.md"),
+        "dashboard README": read("apps/presentation/dashboard/README.md"),
+        "workspace guide": read("docs/guides/personal-workspace-user-guide.md"),
+    }
+
+    for label, content in documents.items():
+        normalized = compact(content)
+        assert "loopx dashboard" in normalized, label
+        assert "--no-open" in normalized, label
+        assert DEFAULT_WORKSPACE_URL in normalized, label
+        assert DEFAULT_STATUS_URL in normalized, label
+
+    installed_run = compact(
+        documents["dashboard README"].split("## Run", 1)[1].split(
+            "Source-checkout development is a separate mode:", 1
+        )[0]
+    )
+    assert "does not require a separate `loopx serve-status` process" in installed_run
+    assert "127.0.0.1:5173" not in installed_run
+    assert "installs the dashboard's npm dependencies" not in installed_run
+
+    print("dashboard-installed-quickstart-doc-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- make the installed Dashboard quick start one command and one process
- document the authoritative printed URL, default `/chat/` route, and `--no-open`
- separate standalone `serve-status` and source Vite development from installed use
- add same-process `/chat/` and `/status.json` readbacks plus a focused docs regression smoke

Closes #3760.

## Product judgment

Installed LoopX already serves the packaged Personal Workspace, status projection, and Agent Chat from `loopx dashboard`. The old copy described a source-development Vite topology and made a successful installed launch look broken. This PR changes only public guidance and a thin durable smoke; it does not change runtime behavior or authority.

## Validation

- `python3 examples/dashboard-installed-quickstart-doc-smoke.py`
- `python3 examples/dashboard-local-status-gitignore-smoke.py`
- `python3 examples/docs-asset-integrity-smoke.py`
- installed `loopx dashboard --no-open --port 18768 --global-registry`, then HTTP 200 readback of `/chat/` as HTML and `/status.json` as JSON with `ok=true`
- `loopx check` on all four changed paths
- `python3 -m py_compile examples/dashboard-installed-quickstart-doc-smoke.py`
- `git diff --check origin/main...HEAD`
- change-quality receipt `cqr_9bff91f91372fe1c5e69`, exact fingerprint `9bff91f91372fe1c5e698ba2d5b87e664e498df084523ff5db0034d0ff0b7dfe`
- quick premerge gate with Python 3.12 and a 180-second per-check budget: 4/4 passed, zero failures, zero manual holds, self-merge allowed

The standard gate also ran. Its install smoke crossed the default 120-second limit, then passed independently in 138 seconds with the supported Python 3.12 runtime. The unrelated `cli-project-lifecycle-command-modularization-smoke.py` baseline assertion (`delivery_postcondition`) fails identically on the unchanged checkout; it is outside this docs-only diff.

## Future-facing pass

Applied: the three installed quick starts now share one explicit contract and the smoke is insensitive to Markdown line wrapping. No broader documentation migration is needed for this issue.
