### PR TITLE
fix(chat): recover from legacy Codex model catalogs

### DIFF
--- a/examples/loopx-chat-agent-smoke.py
+++ b/examples/loopx-chat-agent-smoke.py
@@ -4,12 +4,14 @@
 from __future__ import annotations
 
 import json
+import os
 import queue
 import stat
 import sys
 import tempfile
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -25,8 +27,26 @@ from loopx.chat_agent import (  # noqa: E402
 
 FAKE_CODEX = r'''#!/usr/bin/env python3
 import json
+import os
 import sys
 import time
+from pathlib import Path
+
+if sys.argv[1:3] == ["debug", "models"]:
+    marker = os.environ.get("LOOPX_FAKE_DEBUG_MODELS_MARKER")
+    if marker:
+        Path(marker).write_text("invoked", encoding="utf-8")
+    if os.environ.get("LOOPX_FAKE_DEBUG_MODELS_FAIL") == "1":
+        raise SystemExit(2)
+    print(json.dumps({"models": [{"slug": "fake-current", "base_instructions": "Current built-in instructions."}]}))
+    raise SystemExit(0)
+
+catalog_override = None
+for index, value in enumerate(sys.argv):
+    if value == "-c" and index + 1 < len(sys.argv):
+        key, separator, encoded = sys.argv[index + 1].partition("=")
+        if separator and key == "model_catalog_json":
+            catalog_override = Path(json.loads(encoded))
 
 turn_count = 0
 assert "goals" not in sys.argv, sys.argv
@@ -40,6 +60,29 @@ for line in sys.stdin:
         result = {"serverInfo": {"name": "fake-codex"}}
     elif method in {"thread/start", "thread/resume"}:
         params = message.get("params", {})
+        if os.environ.get("LOOPX_FAKE_OTHER_THREAD_ERROR") == "1":
+            print(json.dumps({
+                "id": request_id,
+                "error": {"code": -32602, "message": "unrelated thread configuration error"},
+            }), flush=True)
+            continue
+        if os.environ.get("LOOPX_FAKE_LEGACY_MODEL_CATALOG") == "1" and catalog_override is None:
+            print(json.dumps({
+                "id": request_id,
+                "error": {
+                    "code": -32600,
+                    "message": "failed to parse model_catalog_json: missing field `base_instructions`",
+                },
+            }), flush=True)
+            continue
+        if catalog_override is not None:
+            catalog = json.loads(catalog_override.read_text(encoding="utf-8"))
+            if not catalog.get("models") or not all(model.get("base_instructions") for model in catalog["models"]):
+                print(json.dumps({
+                    "id": request_id,
+                    "error": {"code": -32600, "message": "compatibility catalog is incomplete"},
+                }), flush=True)
+                continue
         if params.get("sandbox") not in {"read-only", "workspace-write"} or params.get("approvalPolicy") != "never":
             print(json.dumps({
                 "id": request_id,
@@ -320,6 +363,65 @@ def main() -> None:
         finally:
             execution_session.close()
         assert execution_result["message"] == "Reviewed [project].", execution_result
+
+        with patch.dict(os.environ, {"LOOPX_FAKE_LEGACY_MODEL_CATALOG": "1"}):
+            compatibility_session = CodexChatAgentSession.start(
+                codex_bin=str(fake_codex),
+                work_dir=root,
+                goal_id="loopx-chat-smoke",
+                objective="Keep the review loop bounded.",
+                response_timeout_sec=3.0,
+            )
+            try:
+                compatibility_result = compatibility_session.send("user message after catalog repair")
+            finally:
+                compatibility_session.close()
+        assert compatibility_session.model_catalog_compatibility_applied is True
+        assert compatibility_result["message"] == "Reviewed [project].", compatibility_result
+
+        debug_models_marker = root / "debug-models-invoked"
+        with patch.dict(
+            os.environ,
+            {
+                "LOOPX_FAKE_DEBUG_MODELS_MARKER": str(debug_models_marker),
+                "LOOPX_FAKE_OTHER_THREAD_ERROR": "1",
+            },
+        ):
+            try:
+                CodexChatAgentSession.start(
+                    codex_bin=str(fake_codex),
+                    work_dir=root,
+                    goal_id="loopx-chat-smoke",
+                    objective="Keep the review loop bounded.",
+                    response_timeout_sec=3.0,
+                )
+            except CodexChatAgentError as exc:
+                assert "rejected thread/start" in str(exc), exc
+            else:
+                raise AssertionError("unrelated thread errors must fail without a catalog retry")
+        assert not debug_models_marker.exists(), debug_models_marker
+
+        with patch.dict(
+            os.environ,
+            {
+                "LOOPX_FAKE_DEBUG_MODELS_FAIL": "1",
+                "LOOPX_FAKE_LEGACY_MODEL_CATALOG": "1",
+            },
+        ):
+            try:
+                CodexChatAgentSession.start(
+                    codex_bin=str(fake_codex),
+                    work_dir=root,
+                    goal_id="loopx-chat-smoke",
+                    objective="Keep the review loop bounded.",
+                    response_timeout_sec=3.0,
+                )
+            except CodexChatAgentError as exc:
+                assert exc.gate["kind"] == "host_tool_gate", exc.gate
+                assert "compatible model catalog" in exc.gate["summary"], exc.gate
+                assert "legacy override" in exc.gate["next_action"], exc.gate
+            else:
+                raise AssertionError("catalog generation failures must surface a host-tool gate")
 
         active_session = CodexChatAgentSession.start(
             codex_bin=str(fake_codex),

--- a/loopx/chat_agent.py
+++ b/loopx/chat_agent.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+import os
 import queue
 import shutil
 import subprocess
+import tempfile
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Iterator
 
 from .chat import (
     CHAT_AGENT_RESPONSE_SCHEMA_VERSION,
@@ -30,6 +33,10 @@ class CodexChatTimeoutError(CodexChatAgentError):
     pass
 
 
+class _LegacyModelCatalogSchemaError(RuntimeError):
+    pass
+
+
 def _host_tool_gate(summary: str, next_action: str) -> dict[str, str]:
     return {
         "kind": "host_tool_gate",
@@ -44,6 +51,71 @@ def _approval_gate(summary: str) -> dict[str, str]:
         "summary": summary,
         "next_action": "Review the request in the active host before continuing.",
     }
+
+
+def _is_legacy_model_catalog_error(value: Any) -> bool:
+    # App-server currently reports catalog schema failures only as JSON-RPC
+    # prose. Keep this compatibility classifier bound to its three stable
+    # schema tokens until the host exposes a typed configuration error code.
+    if not isinstance(value, dict):
+        return False
+    message = str(value.get("message") or "").lower()
+    return (
+        "model_catalog_json" in message
+        and "missing field" in message
+        and "base_instructions" in message
+    )
+
+
+def _model_catalog_compatibility_error() -> CodexChatAgentError:
+    return CodexChatAgentError(
+        "Codex app-server model catalog compatibility retry failed",
+        gate=_host_tool_gate(
+            "Codex app-server could not load a compatible model catalog for LoopX Chat.",
+            "Update the Codex CLI model catalog or remove its legacy override, then retry the session.",
+        ),
+    )
+
+
+@contextmanager
+def _current_builtin_model_catalog(codex_bin: str) -> Iterator[Path]:
+    """Materialize the selected Codex binary's current built-in catalog only."""
+
+    with tempfile.TemporaryDirectory(prefix="loopx-chat-codex-home-") as codex_home:
+        env = os.environ.copy()
+        env["CODEX_HOME"] = codex_home
+        try:
+            result = subprocess.run(
+                [codex_bin, "debug", "models"],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            payload = json.loads(result.stdout) if result.returncode == 0 else None
+        except (OSError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            raise _model_catalog_compatibility_error() from exc
+        models = payload.get("models") if isinstance(payload, dict) else None
+        if not isinstance(models, list) or not models or any(
+            not isinstance(model, dict) or not str(model.get("base_instructions") or "").strip()
+            for model in models
+        ):
+            raise _model_catalog_compatibility_error()
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            prefix="loopx-chat-model-catalog-",
+            suffix=".json",
+            delete=False,
+        ) as handle:
+            json.dump(payload, handle, ensure_ascii=False)
+            catalog_path = Path(handle.name)
+        try:
+            yield catalog_path
+        finally:
+            catalog_path.unlink(missing_ok=True)
 
 
 def _reader(stream: Any, messages: "queue.Queue[dict[str, Any] | Exception]") -> None:
@@ -184,6 +256,7 @@ class CodexChatAgentSession:
     hard_timeout_sec: float = 900.0
     next_request_id: int = 5
     current_turn_id: str = ""
+    model_catalog_compatibility_applied: bool = False
     _pending_events: "queue.Queue[dict[str, Any]]" = field(default_factory=queue.Queue, repr=False)
     _response_waiters: dict[int, "queue.Queue[dict[str, Any]]"] = field(
         default_factory=dict,
@@ -207,6 +280,7 @@ class CodexChatAgentSession:
         hard_timeout_sec: float = 900.0,
         resume_thread_id: str | None = None,
         execution_mode: bool = False,
+        _compatibility_catalog_path: Path | None = None,
     ) -> "CodexChatAgentSession":
         resolved = shutil.which(codex_bin)
         if not resolved:
@@ -218,9 +292,18 @@ class CodexChatAgentSession:
                 ),
             )
         root = work_dir.resolve()
+        command = [resolved, "app-server"]
+        if _compatibility_catalog_path is not None:
+            command.extend(
+                [
+                    "-c",
+                    f"model_catalog_json={json.dumps(str(_compatibility_catalog_path))}",
+                ]
+            )
+        command.extend(["--listen", "stdio://"])
         try:
             process = subprocess.Popen(
-                [resolved, "app-server", "--listen", "stdio://"],
+                command,
                 cwd=str(root),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
@@ -251,6 +334,7 @@ class CodexChatAgentSession:
             idle_timeout_sec=idle_timeout_sec,
             hard_timeout_sec=hard_timeout_sec,
             execution_mode=execution_mode,
+            model_catalog_compatibility_applied=_compatibility_catalog_path is not None,
         )
         try:
             session._request(
@@ -287,6 +371,23 @@ class CodexChatAgentSession:
             # to be treated as continuation ticks instead of the current user task.
             session.next_request_id = 3
             return session
+        except _LegacyModelCatalogSchemaError as exc:
+            session.close()
+            if _compatibility_catalog_path is not None:
+                raise _model_catalog_compatibility_error() from exc
+            with _current_builtin_model_catalog(resolved) as catalog_path:
+                return cls.start(
+                    codex_bin=resolved,
+                    work_dir=root,
+                    goal_id=goal_id,
+                    objective=objective,
+                    response_timeout_sec=response_timeout_sec,
+                    idle_timeout_sec=idle_timeout_sec,
+                    hard_timeout_sec=hard_timeout_sec,
+                    resume_thread_id=resume_thread_id,
+                    execution_mode=execution_mode,
+                    _compatibility_catalog_path=catalog_path,
+                )
         except Exception:
             session.close()
             raise
@@ -410,6 +511,10 @@ class CodexChatAgentSession:
                                 continue
                 if message.get("id") == request_id:
                     if message.get("error"):
+                        if method in {"thread/start", "thread/resume"} and _is_legacy_model_catalog_error(
+                            message.get("error")
+                        ):
+                            raise _LegacyModelCatalogSchemaError
                         raise self._runtime_error(f"Codex app-server rejected {method}.")
                     result = message.get("result")
                     return result if isinstance(result, dict) else {}


### PR DESCRIPTION
## Summary

- recognize only the Codex app-server bootstrap error for a legacy `model_catalog_json` missing `base_instructions`
- regenerate the selected Codex binary's current built-in catalog inside an isolated temporary `CODEX_HOME`, then retry only the LoopX Chat child process
- expose whether compatibility was applied and keep unrelated configuration failures fail-closed
- cover successful recovery, unrelated-error non-retry, and catalog-generation failure

LoopX never reads, copies, edits, or persists the user's configured catalog. The temporary override is scoped to one Chat app-server process and is removed after bootstrap.

## Product and architecture judgment

The failure happens before the model turn, so intent routing cannot repair it. The compatibility owner belongs in the existing Chat app-server bootstrap boundary. Reusing the same Codex binary's built-in catalog avoids creating a second schema authority in LoopX, while the exact error classifier and one-retry limit keep the fallback narrow.

## Validation

- `python examples/loopx-chat-agent-smoke.py`
- focused pytest: 22 Chat session, attached-session broker, and CORS tests
- focused Ruff and `py_compile`
- real Codex app-server/model turn: returned the exact requested reply with `compatibility_applied=true`, no protected action, and no gate
- `loopx check` public/private scan: clean for both changed files
- exact-scope change-quality receipt `cqr_8117a4282cd955e73a11`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: passed, no manual holds
- full pytest sampling reached 298 passes before a manual interruption; required remote checks remain authoritative for the full matrix

Future-facing pass: no broader refactor was needed; the adjacent session lifecycle remains the single runtime owner.

Closes #3767
