### PR TITLE
fix(chat): prevent closing sessions with pending turns

### DIFF
--- a/loopx/attached_session_api.py
+++ b/loopx/attached_session_api.py
@@ -89,6 +89,12 @@ class AttachedSessionRequestMixin:
                 "attached_session_queue_pending": (
                     "complete queued attached Agent turns before closing the session"
                 ),
+                "managed_session_turn_active": (
+                    "interrupt the active Agent turn before closing the session"
+                ),
+                "managed_session_queue_pending": (
+                    "complete queued Agent turns before closing the session"
+                ),
             }
             if error_code not in messages:
                 raise

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -13,14 +13,16 @@ from typing import Any, Callable, Protocol
 from .chat_acp import ACPStdioAdapter
 from .chat_agent import CodexChatAgentError, CodexChatAgentSession, CodexChatTimeoutError
 from .chat_endpoints import AgentEndpointRegistry
-from .chat_store import CHAT_SESSION_MODE_ATTACHED, ChatSessionStore, utc_now
+from .chat_store import (
+    CHAT_SESSION_MODE_ATTACHED,
+    TERMINAL_TURN_STATES,
+    ChatSessionStore,
+    utc_now,
+)
 from .chat_providers import ClaudeCodeAdapter, direct_model_from_environment
 
 
 EventSink = Callable[[str, dict[str, Any]], None]
-TERMINAL_TURN_STATES = {"completed", "interrupted", "timed_out", "failed"}
-
-
 class ChatRuntimeAdapter(Protocol):
     @property
     def upstream_thread_id(self) -> str: ...

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -979,6 +979,9 @@ class ChatRuntimeController:
             return False
         if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
             return self.store.close_attached_session(session_id)
+        closed = self.store.close_managed_session(session_id)
+        if not closed:
+            return False
         with self.lock:
             adapter = self.adapters.pop(session_id, None)
             event_buffers = [
@@ -990,7 +993,6 @@ class ChatRuntimeController:
             event_buffer.close()
         if adapter is not None:
             adapter.close_session()
-        self.store.update_session(session_id, status="closed", active_turn_id=None)
         return True
 
     def resume_session(self, *, session_id: str, work_dir: Path, objective: str) -> dict[str, Any]:

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -23,6 +23,7 @@ CHAT_INGRESS_SCHEMA_VERSION = "loopx_chat_ingress_receipt_v1"
 CHAT_SESSION_MODE_MANAGED = "managed_runtime"
 CHAT_SESSION_MODE_ATTACHED = "attached_host"
 RESUMABLE_SESSION_STATES = {"ready", "busy", "stale", "resuming"}
+TERMINAL_TURN_STATES = {"completed", "interrupted", "timed_out", "failed"}
 SESSION_QUEUE_MAX_PENDING = 20
 SESSION_QUEUE_TTL_SECONDS = 3600
 
@@ -921,12 +922,7 @@ class ChatSessionStore:
                 active_turn_id = str(session.get("active_turn_id") or "")
                 if active_turn_id:
                     active_turn = self.load_turn(session_id, active_turn_id)
-                    if active_turn and active_turn.get("status") not in {
-                        "completed",
-                        "interrupted",
-                        "timed_out",
-                        "failed",
-                    }:
+                    if active_turn and active_turn.get("status") not in TERMINAL_TURN_STATES:
                         raise RuntimeError("attached_session_turn_active")
                 live_queued_turns = self._settle_expired_queued_turns(
                     session_id,
@@ -963,8 +959,11 @@ class ChatSessionStore:
                     raise ValueError("the selected Session is an attached host session")
                 if session.get("status") == "closed":
                     return True
-                if session.get("active_turn_id"):
-                    raise RuntimeError("managed_session_turn_active")
+                active_turn_id = str(session.get("active_turn_id") or "")
+                if active_turn_id:
+                    active_turn = self.load_turn(session_id, active_turn_id)
+                    if active_turn is None or active_turn.get("status") not in TERMINAL_TURN_STATES:
+                        raise RuntimeError("managed_session_turn_active")
                 if self._settle_expired_queued_turns(
                     session_id,
                     now=datetime.now(timezone.utc),

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -946,6 +946,42 @@ class ChatSessionStore:
                 _atomic_write_json(session_path, session, preserve_mode=True)
                 return True
 
+    def close_managed_session(self, session_id: str) -> bool:
+        """Close an idle managed Session without stranding background work."""
+
+        session_path = self._session_path(session_id)
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                session_path,
+                agent_id="loopx-chat",
+                operation="close_managed_chat_session",
+            ):
+                session = self.load_session(session_id)
+                if session is None:
+                    return False
+                if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+                    raise ValueError("the selected Session is an attached host session")
+                if session.get("status") == "closed":
+                    return True
+                if session.get("active_turn_id"):
+                    raise RuntimeError("managed_session_turn_active")
+                if self._settle_expired_queued_turns(
+                    session_id,
+                    now=datetime.now(timezone.utc),
+                ):
+                    raise RuntimeError("managed_session_queue_pending")
+                now = utc_now()
+                session.update(
+                    {
+                        "status": "closed",
+                        "active_turn_id": None,
+                        "last_activity_at": now,
+                        "updated_at": now,
+                    }
+                )
+                _atomic_write_json(session_path, session, preserve_mode=True)
+                return True
+
     def _event_rows_locked(self, session_id: str, turn_id: str) -> list[dict[str, Any]]:
         key = (session_id, turn_id)
         path = self._event_path(session_id, turn_id)

--- a/tests/test_attached_session_broker.py
+++ b/tests/test_attached_session_broker.py
@@ -612,6 +612,74 @@ def test_attached_close_settles_expired_queue_before_closing(tmp_path: Path) -> 
     assert events[-1]["payload"] == {"error_code": "session_queue_expired"}
 
 
+def test_managed_close_reports_active_turn_instead_of_stranding_it(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        adapter_kind="managed-test",
+        upstream_thread_id="managed-thread",
+    )
+    turn, _created = store.create_turn(
+        str(session["session_id"]),
+        client_turn_id="managed-active-close",
+        message="active managed turn",
+    )
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+
+    responses = _delete_session(runtime, str(session["session_id"]))
+
+    assert responses == [
+        {
+            "ok": False,
+            "error": "interrupt the active Agent turn before closing the session",
+            "status": 409,
+            "error_code": "managed_session_turn_active",
+        }
+    ]
+    current = store.load_session(str(session["session_id"]))
+    assert current is not None
+    assert current["status"] == "busy"
+    assert current["active_turn_id"] == turn["turn_id"]
+
+
+def test_managed_close_reports_pending_queue_instead_of_stranding_it(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        adapter_kind="managed-test",
+        upstream_thread_id="managed-thread",
+    )
+    queued, _created = store.create_queued_turn(
+        str(session["session_id"]),
+        client_turn_id="managed-queued-close",
+        message="queued managed turn",
+    )
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+
+    responses = _delete_session(runtime, str(session["session_id"]))
+
+    assert responses == [
+        {
+            "ok": False,
+            "error": "complete queued Agent turns before closing the session",
+            "status": 409,
+            "error_code": "managed_session_queue_pending",
+        }
+    ]
+    current = store.load_session(str(session["session_id"]))
+    assert current is not None
+    assert current["status"] == "ready"
+    assert store.load_turn(
+        str(session["session_id"]), str(queued["turn_id"])
+    )["status"] == "queued"  # type: ignore[index]
+
+
 def test_attached_live_steering_fails_closed_with_durable_receipt(tmp_path: Path) -> None:
     store = ChatSessionStore(tmp_path)
     session_id = str(_bind(store)["session"]["session_id"])

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -7,7 +7,11 @@ import pytest
 
 import loopx.chat_store as chat_store
 from loopx.chat_runtime import ChatRuntimeController
-from loopx.chat_store import ChatSessionStore, SESSION_QUEUE_MAX_PENDING
+from loopx.chat_store import (
+    SESSION_QUEUE_MAX_PENDING,
+    TERMINAL_TURN_STATES,
+    ChatSessionStore,
+)
 
 
 class _BlockingChatAdapter:
@@ -379,3 +383,38 @@ def test_managed_close_rejects_pending_queue_without_stranding_it(
     assert current["status"] == "ready"
     assert current["active_turn_id"] is None
     assert store.load_turn(session_id, str(queued["turn_id"]))["status"] == "queued"  # type: ignore[index]
+
+
+@pytest.mark.parametrize("terminal_status", sorted(TERMINAL_TURN_STATES))
+def test_managed_close_clears_terminal_active_turn_left_by_crash(
+    tmp_path: Path,
+    terminal_status: str,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    turn, created = store.create_turn(
+        session_id,
+        client_turn_id=f"managed-close-{terminal_status}",
+        message="terminal state persisted before owner release",
+    )
+    assert created is True
+    store.update_turn(session_id, str(turn["turn_id"]), status=terminal_status)
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    adapter = _BlockingChatAdapter()
+    runtime.adapters[session_id] = adapter  # type: ignore[assignment]
+
+    assert runtime.close_session(session_id) is True
+
+    current = store.load_session(session_id)
+    assert current is not None
+    assert current["status"] == "closed"
+    assert current["active_turn_id"] is None
+    assert adapter.closed is True

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -3,8 +3,40 @@ from pathlib import Path
 import threading
 import time
 
+import pytest
+
 import loopx.chat_store as chat_store
+from loopx.chat_runtime import ChatRuntimeController
 from loopx.chat_store import ChatSessionStore, SESSION_QUEUE_MAX_PENDING
+
+
+class _BlockingChatAdapter:
+    upstream_thread_id = "fake-upstream"
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+        self.closed = False
+
+    def capabilities(self) -> dict[str, object]:
+        return {}
+
+    def start_turn(self, message: str, event_sink) -> dict[str, object]:
+        del message, event_sink
+        self.started.set()
+        self.release.wait(timeout=2)
+        return {"message": "late response"}
+
+    def interrupt_turn(self, turn_id: str | None = None) -> None:
+        del turn_id
+        self.release.set()
+
+    def close_session(self) -> None:
+        self.closed = True
+        self.release.set()
+
+    def healthcheck(self) -> bool:
+        return True
 
 
 def _slow_new_turn_writes(monkeypatch) -> set[str]:
@@ -272,3 +304,78 @@ def test_queued_turn_rejects_closed_session(tmp_path: Path) -> None:
         assert str(exc) == "'chat session was not found'"
     else:  # pragma: no cover - safety net for unexpected passes.
         raise AssertionError("closed session should not accept queued turns")
+
+
+def test_managed_close_rejects_active_turn_before_closing_adapter(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    adapter = _BlockingChatAdapter()
+    runtime.adapters[session_id] = adapter  # type: ignore[assignment]
+    turn, created = runtime.submit_turn(
+        session_id=session_id,
+        client_turn_id="managed-close-active",
+        message="keep running",
+        work_dir=tmp_path,
+        objective="sample objective",
+    )
+
+    assert created is True
+    assert adapter.started.wait(timeout=2)
+    with pytest.raises(RuntimeError, match="managed_session_turn_active"):
+        runtime.close_session(session_id)
+
+    current = store.load_session(session_id)
+    assert current is not None
+    assert current["status"] == "busy"
+    assert current["active_turn_id"] == turn["turn_id"]
+    assert adapter.closed is False
+
+    adapter.release.set()
+    assert runtime.wait_for_turn(
+        session_id=session_id,
+        turn_id=str(turn["turn_id"]),
+        timeout_sec=2,
+    )["status"] == "completed"
+    assert runtime.close_session(session_id) is True
+
+
+def test_managed_close_rejects_pending_queue_without_stranding_it(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    queued, created = store.create_queued_turn(
+        session_id,
+        client_turn_id="managed-close-queued",
+        message="do not strand me",
+    )
+
+    assert created is True
+    with pytest.raises(RuntimeError, match="managed_session_queue_pending"):
+        runtime.close_session(session_id)
+
+    current = store.load_session(session_id)
+    assert current is not None
+    assert current["status"] == "ready"
+    assert current["active_turn_id"] is None
+    assert store.load_turn(session_id, str(queued["turn_id"]))["status"] == "queued"  # type: ignore[index]


### PR DESCRIPTION
## Summary

Closing a managed Chat session while a Turn is active or queued currently marks the session closed immediately. The background Turn can still write a completed response, while queued Turns remain stranded forever.

This patch aligns managed-session close behavior with the existing attached-session contract:

- reject close while an active managed Turn exists;
- reject close while live queued managed Turns exist;
- perform the check under the durable session lock;
- only close the adapter after the session has been durably closed;
- return actionable 409 error codes from the loopback API.

## Validation

- Chat and attached-session regression tests: 27 passed
- Chat runtime smoke: passed
- Ruff: passed
- loopx canary premerge --from-git-diff: passed
- git diff --check: passed

The full local pytest run also exposed three unrelated baseline/environment failures in provider-gateway networking, quota settlement hook expectations, and the external scheduler short-timeout test; none touched the changed close-session path.
