### PR TITLE
fix(chat): restore ready state after healthy resume

### DIFF
--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -487,19 +487,19 @@ class ChatRuntimeController:
             ) from exc
         with self.lock:
             self.adapters[session_id] = adapter
-        self.store.update_session(
-            session_id,
-            status="ready",
-            active_turn_id=None,
-            upstream_thread_id=adapter.upstream_thread_id,
-            upstream_mode=(
-                "chat"
-                if session.get("agent_id") == "codex"
-                else str(session.get("upstream_mode") or "default")
-            ),
-            last_activity_at=utc_now(),
-            last_error_code=None,
-        )
+        try:
+            self.store.restore_managed_session_if_idle(
+                session_id,
+                upstream_thread_id=adapter.upstream_thread_id,
+            )
+        except KeyError:
+            with self.lock:
+                owns_adapter = self.adapters.get(session_id) is adapter
+                if owns_adapter:
+                    self.adapters.pop(session_id, None)
+            if owns_adapter:
+                adapter.close_session()
+            raise
         return adapter
 
     def submit_turn(

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -1017,11 +1017,11 @@ class ChatRuntimeController:
             active_turn_id=None,
             last_error_code=None,
         )
-        self._ensure_adapter(session, work_dir=work_dir, objective=objective)
-        restored = self.store.load_session(session_id)
-        if restored is None:
-            raise KeyError("chat session was not found")
-        return restored
+        adapter = self._ensure_adapter(session, work_dir=work_dir, objective=objective)
+        return self.store.restore_managed_session_if_idle(
+            session_id,
+            upstream_thread_id=adapter.upstream_thread_id,
+        )
 
     def close(self) -> None:
         self.closed.set()

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -1018,10 +1018,19 @@ class ChatRuntimeController:
             last_error_code=None,
         )
         adapter = self._ensure_adapter(session, work_dir=work_dir, objective=objective)
-        return self.store.restore_managed_session_if_idle(
-            session_id,
-            upstream_thread_id=adapter.upstream_thread_id,
-        )
+        try:
+            return self.store.restore_managed_session_if_idle(
+                session_id,
+                upstream_thread_id=adapter.upstream_thread_id,
+            )
+        except KeyError:
+            with self.lock:
+                owns_adapter = self.adapters.get(session_id) is adapter
+                if owns_adapter:
+                    self.adapters.pop(session_id, None)
+            if owns_adapter:
+                adapter.close_session()
+            raise
 
     def close(self) -> None:
         self.closed.set()

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -277,6 +277,14 @@ class ChatRuntimeController:
         ]
         return [*builtins, *(endpoint.public_summary() for endpoint in self.endpoint_registry.list())]
 
+    @staticmethod
+    def _managed_upstream_mode(session: dict[str, Any]) -> str:
+        return (
+            "chat"
+            if session.get("agent_id") == "codex"
+            else str(session.get("upstream_mode") or "default")
+        )
+
     def _start_adapter(
         self,
         *,
@@ -491,6 +499,7 @@ class ChatRuntimeController:
             self.store.restore_managed_session_if_idle(
                 session_id,
                 upstream_thread_id=adapter.upstream_thread_id,
+                upstream_mode=self._managed_upstream_mode(session),
             )
         except KeyError:
             with self.lock:
@@ -1025,6 +1034,7 @@ class ChatRuntimeController:
             return self.store.restore_managed_session_if_idle(
                 session_id,
                 upstream_thread_id=adapter.upstream_thread_id,
+                upstream_mode=self._managed_upstream_mode(session),
             )
         except KeyError:
             with self.lock:

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -1011,12 +1011,15 @@ class ChatRuntimeController:
                 last_error_code=None,
             )
             return restored
-        self.store.update_session(
+        with self.lock:
+            current = self.adapters.get(session_id)
+            adapter_healthy = current is not None and current.healthcheck()
+        session, active_turn_preserved = self.store.prepare_managed_session_resume(
             session_id,
-            status="stale",
-            active_turn_id=None,
-            last_error_code=None,
+            preserve_active_turn=adapter_healthy,
         )
+        if active_turn_preserved:
+            return session
         adapter = self._ensure_adapter(session, work_dir=work_dir, objective=objective)
         try:
             return self.store.restore_managed_session_if_idle(

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -346,20 +346,28 @@ class ChatSessionStore:
                     raise ValueError("the selected Session is an attached host session")
                 if payload.get("status") == "closed":
                     raise KeyError("chat session was not found")
-                if payload.get("active_turn_id"):
-                    return payload
-                changes: dict[str, Any] = {
-                    "status": "ready",
-                    "last_error_code": None,
-                    "last_activity_at": utc_now(),
-                }
+                identity_changes: dict[str, Any] = {}
                 if upstream_thread_id is not None:
-                    changes["upstream_thread_id"] = _upstream_id(upstream_thread_id)
+                    identity_changes["upstream_thread_id"] = _upstream_id(
+                        upstream_thread_id
+                    )
                 if upstream_mode is not None:
-                    changes["upstream_mode"] = _opaque_id(
+                    identity_changes["upstream_mode"] = _opaque_id(
                         upstream_mode,
                         field="upstream_mode",
                     )
+                if payload.get("active_turn_id"):
+                    if identity_changes:
+                        payload.update(identity_changes)
+                        payload["updated_at"] = utc_now()
+                        _atomic_write_json(path, payload, preserve_mode=True)
+                    return payload
+                changes = {
+                    "status": "ready",
+                    "last_error_code": None,
+                    "last_activity_at": utc_now(),
+                    **identity_changes,
+                }
                 payload.update(changes)
                 payload["updated_at"] = utc_now()
                 _atomic_write_json(path, payload, preserve_mode=True)

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -300,6 +300,8 @@ class ChatSessionStore:
                     raise KeyError("chat session was not found")
                 if payload.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
                     raise ValueError("the selected Session is an attached host session")
+                if payload.get("status") == "closed":
+                    raise KeyError("chat session was not found")
                 if payload.get("active_turn_id"):
                     return payload
                 changes: dict[str, Any] = {

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -328,6 +328,7 @@ class ChatSessionStore:
         session_id: str,
         *,
         upstream_thread_id: str | None = None,
+        upstream_mode: str | None = None,
     ) -> dict[str, Any]:
         """Restore a managed Session only while it has no active Turn."""
 
@@ -354,6 +355,11 @@ class ChatSessionStore:
                 }
                 if upstream_thread_id is not None:
                     changes["upstream_thread_id"] = _upstream_id(upstream_thread_id)
+                if upstream_mode is not None:
+                    changes["upstream_mode"] = _opaque_id(
+                        upstream_mode,
+                        field="upstream_mode",
+                    )
                 payload.update(changes)
                 payload["updated_at"] = utc_now()
                 _atomic_write_json(path, payload, preserve_mode=True)

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -280,6 +280,49 @@ class ChatSessionStore:
                 _atomic_write_json(path, payload, preserve_mode=True)
                 return payload
 
+    def prepare_managed_session_resume(
+        self,
+        session_id: str,
+        *,
+        preserve_active_turn: bool,
+    ) -> tuple[dict[str, Any], bool]:
+        """Begin managed resume without taking ownership from an active Turn."""
+
+        path = self._session_path(session_id)
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                path,
+                agent_id="loopx-chat",
+                operation="prepare_managed_chat_resume",
+            ):
+                payload = self.load_session(session_id)
+                if payload is None or payload.get("status") == "closed":
+                    raise KeyError("chat session was not found")
+                active_turn_id = str(payload.get("active_turn_id") or "")
+                active_turn = (
+                    self.load_turn(session_id, active_turn_id)
+                    if active_turn_id
+                    else None
+                )
+                if (
+                    preserve_active_turn
+                    and active_turn is not None
+                    and active_turn.get("status")
+                    in {"queued", "starting", "running", "interrupting"}
+                ):
+                    return payload, True
+                resume_snapshot = dict(payload)
+                payload.update(
+                    {
+                        "status": "stale",
+                        "active_turn_id": None,
+                        "last_error_code": None,
+                        "updated_at": utc_now(),
+                    }
+                )
+                _atomic_write_json(path, payload, preserve_mode=True)
+                return resume_snapshot, False
+
     def restore_managed_session_if_idle(
         self,
         session_id: str,

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -280,6 +280,40 @@ class ChatSessionStore:
                 _atomic_write_json(path, payload, preserve_mode=True)
                 return payload
 
+    def restore_managed_session_if_idle(
+        self,
+        session_id: str,
+        *,
+        upstream_thread_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Restore a managed Session only while it has no active Turn."""
+
+        path = self._session_path(session_id)
+        with self._session_lock(session_id):
+            with exclusive_file_lock(
+                path,
+                agent_id="loopx-chat",
+                operation="restore_managed_chat_session",
+            ):
+                payload = self.load_session(session_id)
+                if payload is None:
+                    raise KeyError("chat session was not found")
+                if payload.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+                    raise ValueError("the selected Session is an attached host session")
+                if payload.get("active_turn_id"):
+                    return payload
+                changes: dict[str, Any] = {
+                    "status": "ready",
+                    "last_error_code": None,
+                    "last_activity_at": utc_now(),
+                }
+                if upstream_thread_id is not None:
+                    changes["upstream_thread_id"] = _upstream_id(upstream_thread_id)
+                payload.update(changes)
+                payload["updated_at"] = utc_now()
+                _atomic_write_json(path, payload, preserve_mode=True)
+                return payload
+
     def release_active_turn(
         self,
         session_id: str,

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -476,6 +476,60 @@ def test_resume_cannot_reopen_a_session_closed_during_restore(
     assert adapter.closed is True
 
 
+def test_close_wins_during_adapter_start_without_reopening_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    adapter = _HealthyChatAdapter()
+    start_entered = threading.Event()
+    release_start = threading.Event()
+
+    def start_adapter(*_args: object, **_kwargs: object) -> _HealthyChatAdapter:
+        start_entered.set()
+        release_start.wait(timeout=2)
+        return adapter
+
+    monkeypatch.setattr(runtime, "_start_adapter", start_adapter)
+    resume_error: list[BaseException] = []
+
+    def resume() -> None:
+        try:
+            runtime.resume_session(
+                session_id=session_id,
+                work_dir=tmp_path,
+                objective="resume this session",
+            )
+        except BaseException as exc:  # pragma: no cover - assertion captures it.
+            resume_error.append(exc)
+
+    worker = threading.Thread(target=resume)
+    worker.start()
+    assert start_entered.wait(timeout=2)
+    assert runtime.close_session(session_id) is True
+    release_start.set()
+    worker.join(timeout=2)
+
+    assert len(resume_error) == 1
+    assert isinstance(resume_error[0], KeyError)
+    assert str(resume_error[0]) == "'chat session was not found'"
+    persisted = store.load_session(session_id)
+    assert persisted is not None
+    assert persisted["status"] == "closed"
+    assert session_id not in runtime.adapters
+    assert adapter.closed is True
+
+
 def test_restore_ready_does_not_clear_a_new_active_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -46,8 +46,14 @@ class _BlockingChatAdapter:
 class _HealthyChatAdapter:
     upstream_thread_id = "thread-one"
 
+    def __init__(self) -> None:
+        self.closed = False
+
     def healthcheck(self) -> bool:
         return True
+
+    def close_session(self) -> None:
+        self.closed = True
 
 
 def _slow_new_turn_writes(monkeypatch) -> set[str]:
@@ -375,7 +381,8 @@ def test_resume_with_healthy_adapter_restores_persisted_ready_state(
     )
     session_id = str(session["session_id"])
     runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
-    runtime.adapters[session_id] = _HealthyChatAdapter()  # type: ignore[assignment]
+    adapter = _HealthyChatAdapter()
+    runtime.adapters[session_id] = adapter  # type: ignore[assignment]
 
     restored = runtime.resume_session(
         session_id=session_id,
@@ -388,6 +395,45 @@ def test_resume_with_healthy_adapter_restores_persisted_ready_state(
     assert persisted is not None
     assert persisted["status"] == "ready"
     assert persisted["active_turn_id"] is None
+
+
+def test_resume_cannot_reopen_a_session_closed_during_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    adapter = _HealthyChatAdapter()
+
+    def close_before_restore(*_args: object, **_kwargs: object) -> object:
+        store.update_session(session_id, status="closed", active_turn_id=None)
+        runtime.adapters[session_id] = adapter  # type: ignore[assignment]
+        return adapter
+
+    monkeypatch.setattr(runtime, "_ensure_adapter", close_before_restore)
+
+    with pytest.raises(KeyError, match="chat session was not found"):
+        runtime.resume_session(
+            session_id=session_id,
+            work_dir=tmp_path,
+            objective="resume this session",
+        )
+
+    persisted = store.load_session(session_id)
+    assert persisted is not None
+    assert persisted["status"] == "closed"
+    assert persisted["active_turn_id"] is None
+    assert session_id not in runtime.adapters
+    assert adapter.closed is True
 
 
 def test_restore_ready_does_not_clear_a_new_active_turn(

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -442,6 +442,75 @@ def test_legacy_codex_resume_persists_chat_mode_after_one_time_migration(
     assert len(start_calls) == 1
 
 
+def test_legacy_codex_resume_commits_identity_when_new_turn_wins(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="legacy-thread",
+        upstream_mode="default",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    adapter = _HealthyChatAdapter()
+    start_calls: list[dict[str, object]] = []
+    winning_turn: dict[str, object] = {}
+
+    def start_adapter(**kwargs: object) -> _HealthyChatAdapter:
+        start_calls.append(kwargs)
+        turn, _created = store.create_turn(
+            session_id,
+            client_turn_id="identity-race-turn",
+            message="new turn wins before restore",
+        )
+        winning_turn.update(turn)
+        store.update_turn(session_id, str(turn["turn_id"]), status="running")
+        return adapter
+
+    monkeypatch.setattr(runtime, "_start_adapter", start_adapter)
+
+    restored = runtime.resume_session(
+        session_id=session_id,
+        work_dir=tmp_path,
+        objective="resume this session",
+    )
+
+    assert restored["status"] == "busy"
+    assert restored["active_turn_id"] == winning_turn["turn_id"]
+    persisted = store.load_session(session_id)
+    assert persisted is not None
+    assert persisted["upstream_thread_id"] == "thread-one"
+    assert persisted["upstream_mode"] == "chat"
+    assert start_calls[0]["resume_thread_id"] is None
+
+    store.update_turn(
+        session_id,
+        str(winning_turn["turn_id"]),
+        status="completed",
+        completed_at="2026-09-01T00:00:00Z",
+    )
+    assert store.release_active_turn(
+        session_id,
+        str(winning_turn["turn_id"]),
+        last_activity_at="2026-09-01T00:00:01Z",
+        last_error_code=None,
+    )
+    runtime.adapters.pop(session_id)
+    runtime.resume_session(
+        session_id=session_id,
+        work_dir=tmp_path,
+        objective="resume this session",
+    )
+
+    assert start_calls[1]["resume_thread_id"] == "thread-one"
+    assert start_calls[1]["history"] is None
+
+
 def test_resume_does_not_clear_a_healthy_active_turn(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -397,6 +397,46 @@ def test_resume_with_healthy_adapter_restores_persisted_ready_state(
     assert persisted["active_turn_id"] is None
 
 
+def test_resume_does_not_clear_a_healthy_active_turn(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    turn, _created = store.create_turn(
+        session_id,
+        client_turn_id="active-resume-turn",
+        message="keep this active",
+    )
+    store.update_turn(session_id, str(turn["turn_id"]), status="running")
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    runtime.adapters[session_id] = _HealthyChatAdapter()  # type: ignore[assignment]
+
+    restored = runtime.resume_session(
+        session_id=session_id,
+        work_dir=tmp_path,
+        objective="resume this session",
+    )
+
+    assert restored["status"] == "busy"
+    assert restored["active_turn_id"] == turn["turn_id"]
+    with pytest.raises(RuntimeError, match=str(turn["turn_id"])):
+        runtime.submit_turn(
+            session_id=session_id,
+            client_turn_id="blocked-during-active-resume",
+            message="must wait",
+            work_dir=tmp_path,
+            objective="resume this session",
+        )
+
+
 def test_resume_cannot_reopen_a_session_closed_during_restore(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -43,6 +43,13 @@ class _BlockingChatAdapter:
         return True
 
 
+class _HealthyChatAdapter:
+    upstream_thread_id = "thread-one"
+
+    def healthcheck(self) -> bool:
+        return True
+
+
 def _slow_new_turn_writes(monkeypatch) -> set[str]:
     original_atomic_write = chat_store._atomic_write_json
     turn_write_threads: set[str] = set()
@@ -352,6 +359,64 @@ def test_managed_close_rejects_active_turn_before_closing_adapter(
         timeout_sec=2,
     )["status"] == "completed"
     assert runtime.close_session(session_id) is True
+
+
+def test_resume_with_healthy_adapter_restores_persisted_ready_state(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    runtime.adapters[session_id] = _HealthyChatAdapter()  # type: ignore[assignment]
+
+    restored = runtime.resume_session(
+        session_id=session_id,
+        work_dir=tmp_path,
+        objective="resume this session",
+    )
+
+    assert restored["status"] == "ready"
+    persisted = store.load_session(session_id)
+    assert persisted is not None
+    assert persisted["status"] == "ready"
+    assert persisted["active_turn_id"] is None
+
+
+def test_restore_ready_does_not_clear_a_new_active_turn(
+    tmp_path: Path,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="thread-one",
+        upstream_mode="chat",
+    )
+    session_id = str(session["session_id"])
+    store.update_session(session_id, status="stale")
+    turn, _created = store.create_turn(
+        session_id,
+        client_turn_id="resume-race-turn",
+        message="new turn wins",
+    )
+
+    restored = store.restore_managed_session_if_idle(
+        session_id,
+        upstream_thread_id="thread-one",
+    )
+
+    assert restored["status"] == "busy"
+    assert restored["active_turn_id"] == turn["turn_id"]
 
 
 def test_managed_close_rejects_pending_queue_without_stranding_it(

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -397,6 +397,51 @@ def test_resume_with_healthy_adapter_restores_persisted_ready_state(
     assert persisted["active_turn_id"] is None
 
 
+def test_legacy_codex_resume_persists_chat_mode_after_one_time_migration(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="goal-one",
+        agent_id="codex",
+        executor_endpoint_id="codex",
+        adapter_kind="codex_app_server",
+        upstream_thread_id="legacy-thread",
+        upstream_mode="default",
+    )
+    session_id = str(session["session_id"])
+    runtime = ChatRuntimeController(store=store, codex_bin="missing-codex")
+    adapter = _HealthyChatAdapter()
+    start_calls: list[dict[str, object]] = []
+
+    def start_adapter(**kwargs: object) -> _HealthyChatAdapter:
+        start_calls.append(kwargs)
+        return adapter
+
+    monkeypatch.setattr(runtime, "_start_adapter", start_adapter)
+
+    restored = runtime.resume_session(
+        session_id=session_id,
+        work_dir=tmp_path,
+        objective="resume this session",
+    )
+
+    assert restored["status"] == "ready"
+    persisted = store.load_session(session_id)
+    assert persisted is not None
+    assert persisted["upstream_thread_id"] == "thread-one"
+    assert persisted["upstream_mode"] == "chat"
+    assert start_calls[0]["resume_thread_id"] is None
+
+    runtime.resume_session(
+        session_id=session_id,
+        work_dir=tmp_path,
+        objective="resume this session",
+    )
+    assert len(start_calls) == 1
+
+
 def test_resume_does_not_clear_a_healthy_active_turn(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

`resume_session()` marks a managed Chat session as `stale` before restoring its adapter. When the adapter is already healthy, `_ensure_adapter()` returns early and the persisted session never returns to `ready`.

That leaves the API reporting a successful resume while the durable session projection remains stale, which can mislead the UI and queue/controller paths.

This patch:

- adds an atomic `restore_managed_session_if_idle` store transition;
- restores `ready` only when no newer active Turn has claimed the session;
- preserves `busy` and its active Turn if a new Turn wins the resume race;
- keeps the existing attached-session and normal close behavior unchanged.

## Validation

- Chat and attached-session tests: 25 passed
- Chat runtime smoke: passed
- Ruff: passed
- `loopx canary premerge --from-git-diff`: passed
- `git diff --check`: passed
