### PR TITLE
Make onboarding connection validation ownership explicit

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -101,6 +101,23 @@ safe to rerun: by default it keeps an existing state file and existing registry
 entry. If the goal only needs an additional write boundary after connection,
 prefer the incremental migration path:
 
+An integration provider that already qualified the project bridge can own the
+one-time connection check explicitly:
+
+```bash
+loopx connect \
+  --goal-id project-goal \
+  --no-onboarding-scan \
+  --onboarding-connection-validation provider-prevalidated
+```
+
+The default remains `agent`, which may create a `loopx check` onboarding Todo
+for generic adapters. `provider-prevalidated` records provider ownership in the
+registry and omits that agent Todo; it does not run validation, grant tools, or
+expand the provider's authority. Use it only when the caller has already
+validated the connection. Repository scanning and connection validation remain
+separate controls.
+
 ```bash
 loopx configure-goal \
   --goal-id project-goal \

--- a/examples/project/onboarding-no-scan-projection-smoke.py
+++ b/examples/project/onboarding-no-scan-projection-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GOAL_ID = "fresh-no-scan-projection"
+PROVIDER_GOAL_ID = "fresh-provider-prevalidated-projection"
 DOMAIN_GOAL_ID = "fresh-domain-owned-projection"
 
 
@@ -116,6 +117,66 @@ def main() -> int:
         assert broken_check["ok"] is True, broken_check
         assert broken_check["summary"]["warnings"] == 1, broken_check
         assert any("state_projection_gap" in warning for warning in broken_check["warnings"]), broken_check
+
+        provider_project, provider_readme = initialize_project(root, "provider-project")
+        provider_registry = provider_project / ".loopx" / "registry.json"
+        provider_connected = run_cli(
+            provider_registry,
+            runtime,
+            "connect",
+            "--project",
+            str(provider_project),
+            "--goal-id",
+            PROVIDER_GOAL_ID,
+            "--objective",
+            "Validate provider-owned connection onboarding.",
+            "--domain",
+            "engineering",
+            "--goal-doc",
+            str(provider_readme),
+            "--adapter-kind",
+            "read_only_project_map_v0",
+            "--adapter-status",
+            "connected-read-only",
+            "--codex-app-heartbeat",
+            "no",
+            "--no-onboarding-scan",
+            "--onboarding-connection-validation",
+            "provider-prevalidated",
+            "--no-global-sync",
+        )
+        assert provider_connected["ok"] is True, provider_connected
+        assert (
+            provider_connected["onboarding_connection_validation"]
+            == "provider-prevalidated"
+        ), provider_connected
+
+        provider_state_file = (
+            provider_project
+            / ".codex"
+            / "goals"
+            / PROVIDER_GOAL_ID
+            / "ACTIVE_GOAL_STATE.md"
+        )
+        provider_state_text = provider_state_file.read_text(encoding="utf-8")
+        assert "action_kind=onboarding_connection_validation" not in provider_state_text
+        assert "Run `loopx check` against the project registry" not in provider_state_text
+        provider_goal = json.loads(provider_registry.read_text(encoding="utf-8"))["goals"][0]
+        assert provider_goal["adapter"]["connection_validation"] == {
+            "owner": "provider",
+            "status": "prevalidated",
+            "agent_todo_required": False,
+        }, provider_goal
+
+        provider_check = run_cli(
+            provider_registry,
+            runtime,
+            "check",
+            "--scan-path",
+            str(provider_readme),
+        )
+        assert provider_check["ok"] is True, provider_check
+        assert provider_check["summary"]["warnings"] == 0, provider_check
 
         domain_project, domain_readme = initialize_project(root, "domain-project")
         domain_registry = domain_project / ".loopx" / "registry.json"

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -65,6 +65,12 @@ HEARTBEAT_OPT_IN_DECLINED_INSTRUCTION = (
     "on-demand unless the user later opts in."
 )
 CODEX_APP_HEARTBEAT_CHOICES = {"ask", "yes", "no"}
+ONBOARDING_CONNECTION_VALIDATION_AGENT = "agent"
+ONBOARDING_CONNECTION_VALIDATION_PROVIDER_PREVALIDATED = "provider-prevalidated"
+ONBOARDING_CONNECTION_VALIDATION_CHOICES = {
+    ONBOARDING_CONNECTION_VALIDATION_AGENT,
+    ONBOARDING_CONNECTION_VALIDATION_PROVIDER_PREVALIDATED,
+}
 
 
 def slugify_goal_id(value: str) -> str:
@@ -141,6 +147,16 @@ def normalize_codex_app_heartbeat(value: str | None) -> str:
     choice = (value or "ask").strip().lower()
     if choice not in CODEX_APP_HEARTBEAT_CHOICES:
         raise ValueError("codex_app_heartbeat must be one of: ask, yes, no")
+    return choice
+
+
+def normalize_onboarding_connection_validation(value: str | None) -> str:
+    choice = (value or ONBOARDING_CONNECTION_VALIDATION_AGENT).strip().lower()
+    if choice not in ONBOARDING_CONNECTION_VALIDATION_CHOICES:
+        raise ValueError(
+            "onboarding_connection_validation must be one of: "
+            "agent, provider-prevalidated"
+        )
     return choice
 
 
@@ -574,6 +590,7 @@ def build_goal_entry(
     goal_doc: Path | None,
     adapter_kind: str,
     adapter_status: str,
+    onboarding_connection_validation: str,
     next_probe: str | None,
     spawn_allowed: bool,
     max_children: int,
@@ -591,6 +608,19 @@ def build_goal_entry(
                 "role": "primary_goal_document",
             }
         )
+    adapter = {
+        "kind": adapter_kind,
+        "status": adapter_status,
+    }
+    if (
+        onboarding_connection_validation
+        == ONBOARDING_CONNECTION_VALIDATION_PROVIDER_PREVALIDATED
+    ):
+        adapter["connection_validation"] = {
+            "owner": "provider",
+            "status": "prevalidated",
+            "agent_todo_required": False,
+        }
     return {
         "id": goal_id,
         **({"display_name": display_name} if display_name else {}),
@@ -601,10 +631,7 @@ def build_goal_entry(
         "repo": str(project),
         "state_file": relative_state_file(project, state_file),
         "authority_sources": authority_sources,
-        "adapter": {
-            "kind": adapter_kind,
-            "status": adapter_status,
-        },
+        "adapter": adapter,
         "spawn_policy": {
             "mode": (
                 MULTI_SUBAGENT_ORCHESTRATION_MODE
@@ -686,6 +713,7 @@ def bootstrap_project(
     execution_outcome_must_advance: list[str] | None = None,
     execution_turn_granularity: str | None = None,
     onboarding_scan_enabled: bool = True,
+    onboarding_connection_validation: str = ONBOARDING_CONNECTION_VALIDATION_AGENT,
     accept_onboarding_agent_todos: bool = False,
     begin_autonomous_advance: bool = False,
     codex_app_heartbeat: str = "ask",
@@ -694,7 +722,6 @@ def bootstrap_project(
     onboarding_max_top_level_files: int = 24,
     preserve_todos: bool = False,
     display_name: str | None = None,
-    include_connection_validation: bool = True,
     force: bool,
     dry_run: bool,
     sync_global: bool,
@@ -702,6 +729,12 @@ def bootstrap_project(
 ) -> dict[str, Any]:
     project = project.expanduser().resolve()
     codex_app_heartbeat = normalize_codex_app_heartbeat(codex_app_heartbeat)
+    onboarding_connection_validation = normalize_onboarding_connection_validation(
+        onboarding_connection_validation
+    )
+    include_connection_validation = (
+        onboarding_connection_validation == ONBOARDING_CONNECTION_VALIDATION_AGENT
+    )
     registry_path = registry_path.expanduser()
     if not registry_path.is_absolute():
         registry_path = project / registry_path
@@ -751,6 +784,7 @@ def bootstrap_project(
         goal_doc=goal_doc,
         adapter_kind=adapter_kind,
         adapter_status=adapter_status,
+        onboarding_connection_validation=onboarding_connection_validation,
         next_probe=next_probe,
         spawn_allowed=spawn_allowed,
         max_children=max_children,
@@ -893,6 +927,7 @@ def bootstrap_project(
                 "accept_onboarding_agent_todos": accept_onboarding_agent_todos,
                 "begin_autonomous_advance": begin_autonomous_advance,
                 "codex_app_heartbeat": codex_app_heartbeat,
+                "onboarding_connection_validation": onboarding_connection_validation,
                 "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
                 "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
                 "heartbeat_opt_in_required": heartbeat_required,
@@ -972,6 +1007,7 @@ def bootstrap_project(
         "accept_onboarding_agent_todos": accept_onboarding_agent_todos,
         "begin_autonomous_advance": begin_autonomous_advance,
         "codex_app_heartbeat": codex_app_heartbeat,
+        "onboarding_connection_validation": onboarding_connection_validation,
         "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
         "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
         "heartbeat_opt_in_required": heartbeat_required,
@@ -1035,6 +1071,10 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
         f"- onboarding_acceptance_required: `{payload.get('onboarding_acceptance_required')}`",
         f"- autonomous_advance_choice_required: `{payload.get('autonomous_advance_choice_required')}`",
         f"- codex_app_heartbeat: `{payload.get('codex_app_heartbeat')}`",
+        (
+            "- onboarding_connection_validation: "
+            f"`{payload.get('onboarding_connection_validation')}`"
+        ),
         f"- heartbeat_opt_in_required: `{payload.get('heartbeat_opt_in_required')}`",
         f"- host_loop_activation_required: `{payload.get('host_loop_activation_required')}`",
         f"- onboarding_todos_written: `{payload.get('onboarding_todos_written')}`",

--- a/loopx/chat_actions.py
+++ b/loopx/chat_actions.py
@@ -863,7 +863,7 @@ class ChatActionService(
                 adapter_kind=str((source_goal.get("adapter") or {}).get("kind") or "generic_project_goal_v0"),
                 adapter_status="connected",
                 display_name=str(parameters.get("title") or "").strip() or None,
-                include_connection_validation=False,
+                onboarding_connection_validation="provider-prevalidated",
                 next_probe=None,
                 spawn_allowed=False,
                 max_children=0,

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from ..bootstrap import (
     DEFAULT_DOMAIN,
     DEFAULT_OBJECTIVE,
+    ONBOARDING_CONNECTION_VALIDATION_AGENT,
+    ONBOARDING_CONNECTION_VALIDATION_CHOICES,
     bootstrap_project,
     render_bootstrap_markdown,
 )
@@ -116,6 +118,16 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
         help="Skip the fast first-connect repository scan and todo candidate proposal.",
     )
     bootstrap_parser.add_argument(
+        "--onboarding-connection-validation",
+        choices=sorted(ONBOARDING_CONNECTION_VALIDATION_CHOICES),
+        default=ONBOARDING_CONNECTION_VALIDATION_AGENT,
+        help=(
+            "Choose who validates the project connection. The default 'agent' may create "
+            "a loopx-check Todo; 'provider-prevalidated' records provider ownership and "
+            "omits that agent Todo."
+        ),
+    )
+    bootstrap_parser.add_argument(
         "--accept-onboarding-agent-todos",
         action="store_true",
         help="Write all proposed onboarding agent todos into the initial active state.",
@@ -216,6 +228,9 @@ def handle_bootstrap_connect_command(
             execution_outcome_must_advance=args.execution_outcome_must_advance or None,
             execution_turn_granularity=("fine" if bool(args.fine_grained) else None),
             onboarding_scan_enabled=not bool(args.no_onboarding_scan),
+            onboarding_connection_validation=str(
+                args.onboarding_connection_validation
+            ),
             accept_onboarding_agent_todos=bool(args.accept_onboarding_agent_todos),
             begin_autonomous_advance=bool(args.begin_autonomous_advance),
             codex_app_heartbeat=str(args.codex_app_heartbeat),

--- a/loopx/control_plane/projects/registry.py
+++ b/loopx/control_plane/projects/registry.py
@@ -244,6 +244,7 @@ def register_project_goal(
         goal_doc=None,
         adapter_kind="read_only_project_map_v0",
         adapter_status="connected",
+        onboarding_connection_validation="agent",
         next_probe=None,
         spawn_allowed=False,
         max_children=0,


### PR DESCRIPTION
## Summary

- add `--onboarding-connection-validation {agent,provider-prevalidated}` to project connect/bootstrap
- preserve the default agent-owned `loopx check` Todo while allowing an integration provider to record prevalidated ownership and omit that Todo
- keep repository onboarding scans independent from connection validation and document the authority boundary

## Validation

- `python3 examples/project/onboarding-no-scan-projection-smoke.py`
- 86 focused pytest cases for Goal bootstrap/handoff lifecycle
- fresh-project onboarding and LoopX Chat action smokes
- source-based `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, no manual holds
- public/private boundary scan passed

The provider-prevalidated mode does not run validation, grant tools, or expand provider authority; callers may select it only after their own connection preflight.