### PR TITLE
feat(benchmark): add bounded continuation decisions

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -50,6 +50,36 @@ consuming the result or starting a verifier, because the solver may exit while
 leaving detached descendants behind. A runner without that lifecycle must fail
 closed before invoking `agent-phase`.
 
+### Bounded continuation decision
+
+When a benchmark treatment deliberately adds LoopX-governed continuation, keep
+process launch and progress observation in the runner and ask LoopX only for the
+next disposition:
+
+```bash
+loopx benchmark continuation-decision \
+  --progress-json .local/private-run/public-progress.json \
+  --expected-first-prompt-sha256 "$EXPECTED_PROMPT_SHA256" \
+  --observed-first-prompt-sha256 "$OBSERVED_PROMPT_SHA256" \
+  --expected-total-unit-count 5 \
+  --previous-completed-unit-count 2 \
+  --completed-segment-count 1 \
+  --max-agent-segments 2 \
+  --elapsed-ms 300000 \
+  --total-budget-ms 7200000 \
+  --format json
+```
+
+The command is read-only. It accepts only aggregate public progress counts and
+returns `continue`, `stop_complete`, `stop_prompt_mismatch`,
+`stop_task_shape_mismatch`, `stop_round_limit`, or `stop_time_budget`, plus a
+fair-share timeout for the next segment. The runner must give the first solver
+segment the complete original task prompt, freeze the initial unit count, and supply
+matching independently calculated digests. Later prompts may add
+only public progress; they must not disclose verifier output or hidden evaluation.
+The runner remains responsible for invoking the next agent segment, measuring the
+shared total budget, preserving containment, and collecting evidence.
+
 ## Source revision admission
 
 A long-running campaign can keep launching from an old installed checkout after

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -72,8 +72,9 @@ loopx benchmark continuation-decision \
 
 The command is read-only. It accepts only aggregate public progress counts and
 returns `continue`, `stop_complete`, `stop_prompt_mismatch`,
-`stop_task_shape_mismatch`, `stop_round_limit`, or `stop_time_budget`, plus a
-fair-share timeout for the next segment. The runner must give the first solver
+`stop_progress_regression`, `stop_task_shape_mismatch`, `stop_round_limit`, or
+`stop_time_budget`, plus a fair-share timeout for the next segment. The runner
+must give the first solver
 segment the complete original task prompt, freeze the initial unit count, and supply
 matching independently calculated digests. Later prompts may add
 only public progress; they must not disclose verifier output or hidden evaluation.

--- a/loopx/capabilities/benchmark_toolkit/__init__.py
+++ b/loopx/capabilities/benchmark_toolkit/__init__.py
@@ -55,6 +55,13 @@ from .experiment_board import (
     render_benchmark_experiment_board_markdown,
     upsert_benchmark_experiment_board_row,
 )
+from .external_agent import (
+    BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION,
+    BENCHMARK_PUBLIC_PROGRESS_SCHEMA_VERSION,
+    BenchmarkContinuationDecision,
+    build_benchmark_continuation_decision,
+    normalize_benchmark_public_progress,
+)
 from .factorial_contrast import (
     BENCHMARK_FACTORIAL_CONTRAST_SCHEMA_VERSION,
     build_benchmark_factorial_contrasts,
@@ -178,6 +185,7 @@ __all__ = [
     "BENCHMARK_CONCURRENCY_ENVELOPE_FILENAME",
     "BENCHMARK_CONCURRENCY_ENVELOPE_SCHEMA_VERSION",
     "BENCHMARK_CONCURRENCY_FEEDBACK_SCHEMA_VERSION",
+    "BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION",
     "BENCHMARK_EXACT_CONTAINER_BINDING_SCHEMA_VERSION",
     "BENCHMARK_EXPERIMENT_BOARD_LEDGER_FILENAME",
     "BENCHMARK_EXPERIMENT_BOARD_ROW_SCHEMA_VERSION",
@@ -191,6 +199,7 @@ __all__ = [
     "BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION",
     "BENCHMARK_INTEGRITY_QUALIFICATION_SCHEMA_VERSION",
     "BENCHMARK_RESOURCE_HEADROOM_RECEIPT_SCHEMA_VERSION",
+    "BENCHMARK_PUBLIC_PROGRESS_SCHEMA_VERSION",
     "BENCHMARK_RESTRICTED_ACCESS_ADJUDICATION_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_CONTINUITY_SCHEMA_VERSION",
     "BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION",
@@ -209,6 +218,7 @@ __all__ = [
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
     "BenchmarkEventWindowState",
+    "BenchmarkContinuationDecision",
     "BenchmarkJobReceiptState",
     "BenchmarkRunnerOwnerState",
     "BenchmarkRuntimeClassification",
@@ -246,6 +256,7 @@ __all__ = [
     "build_benchmark_candidate_source_boundary",
     "build_benchmark_concurrency_config",
     "build_benchmark_concurrency_status",
+    "build_benchmark_continuation_decision",
     "build_benchmark_experiment_board",
     "build_benchmark_factorial_contrasts",
     "build_benchmark_four_arm_contract",
@@ -279,6 +290,7 @@ __all__ = [
     "normalize_benchmark_concurrency_config",
     "normalize_benchmark_concurrency_envelope",
     "normalize_benchmark_concurrency_feedback",
+    "normalize_benchmark_public_progress",
     "normalize_benchmark_experiment_board_row",
     "normalize_benchmark_resource_headroom_receipt",
     "observe_native_goal_event",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -78,6 +78,26 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": (
+                "loopx benchmark continuation-decision "
+                "--progress-json <public-progress.json> "
+                "--expected-first-prompt-sha256 <sha256> "
+                "--observed-first-prompt-sha256 <sha256> "
+                "--expected-total-unit-count <n> "
+                "--previous-completed-unit-count <n> "
+                "--completed-segment-count <n> --max-agent-segments <n> "
+                "--elapsed-ms <ms> --total-budget-ms <ms> --format json"
+            ),
+            "purpose": (
+                "Choose a bounded next agent segment from public progress while "
+                "preserving first-prompt parity and the total time budget."
+            ),
+            "write_boundary": (
+                "read-only decision; caller owns progress observation, process "
+                "lifecycle, continuation prompt construction, and evidence capture"
+            ),
+        },
+        {
+            "command": (
                 "loopx benchmark experiment-board-show --goal-id <goal-id> "
                 "[--four-arm-contract-json <compact-contract.json>] --format json"
             ),
@@ -594,6 +614,20 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         },
     },
     "implemented_protocols": [
+        {
+            "schema_version": "benchmark_public_progress_v0",
+            "purpose": (
+                "Carry aggregate completed and total unit counts without unit ids, "
+                "paths, task text, or verifier output."
+            ),
+        },
+        {
+            "schema_version": "benchmark_continuation_decision_v0",
+            "purpose": (
+                "Choose a bounded continue or stop disposition without invoking "
+                "the host, writing state, or owning benchmark lifecycle."
+            ),
+        },
         {
             "schema_version": "benchmark_four_arm_contract_v0",
             "module": "loopx.capabilities.benchmark_toolkit.four_arm_contract",

--- a/loopx/capabilities/benchmark_toolkit/external_agent.py
+++ b/loopx/capabilities/benchmark_toolkit/external_agent.py
@@ -59,6 +59,7 @@ _SOLVER_ENVIRONMENT_ALLOWLIST = (
 class BenchmarkContinuationDecision(str, Enum):
     CONTINUE = "continue"
     STOP_COMPLETE = "stop_complete"
+    STOP_PROGRESS_REGRESSION = "stop_progress_regression"
     STOP_PROMPT_MISMATCH = "stop_prompt_mismatch"
     STOP_ROUND_LIMIT = "stop_round_limit"
     STOP_TASK_SHAPE_MISMATCH = "stop_task_shape_mismatch"
@@ -258,6 +259,9 @@ def build_benchmark_continuation_decision(
     elif not task_shape_matches:
         decision = BenchmarkContinuationDecision.STOP_TASK_SHAPE_MISMATCH
         reason = "total_unit_count_mismatch"
+    elif completed < previous:
+        decision = BenchmarkContinuationDecision.STOP_PROGRESS_REGRESSION
+        reason = "public_progress_regressed"
     elif completed == total:
         decision = BenchmarkContinuationDecision.STOP_COMPLETE
         reason = "all_units_complete"
@@ -270,13 +274,9 @@ def build_benchmark_continuation_decision(
     else:
         decision = BenchmarkContinuationDecision.CONTINUE
         reason = (
-            "public_progress_regressed"
-            if completed < previous
-            else (
-                "requirements_remain_after_progress"
-                if completed > previous
-                else "requirements_remain_without_progress"
-            )
+            "requirements_remain_after_progress"
+            if completed > previous
+            else "requirements_remain_without_progress"
         )
 
     next_timeout_ms = (

--- a/loopx/capabilities/benchmark_toolkit/external_agent.py
+++ b/loopx/capabilities/benchmark_toolkit/external_agent.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import time
 from collections.abc import Mapping, Sequence
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,8 @@ EXTERNAL_AGENT_CONTAINMENT_VERIFICATION_SCHEMA_VERSION = (
 LOOPX_EXTERNAL_AGENT_PHASE_RECEIPT_SCHEMA_VERSION = (
     "loopx_external_agent_phase_receipt_v1"
 )
+BENCHMARK_PUBLIC_PROGRESS_SCHEMA_VERSION = "benchmark_public_progress_v0"
+BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION = "benchmark_continuation_decision_v0"
 _MAX_TIMEOUT_SECONDS = 86_400.0
 _RESULT_STATUSES = {"succeeded", "failed"}
 _CONTAINMENT_KINDS = {
@@ -51,6 +54,15 @@ _SOLVER_ENVIRONMENT_ALLOWLIST = (
     "TMPDIR",
     "WINDIR",
 )
+
+
+class BenchmarkContinuationDecision(str, Enum):
+    CONTINUE = "continue"
+    STOP_COMPLETE = "stop_complete"
+    STOP_PROMPT_MISMATCH = "stop_prompt_mismatch"
+    STOP_ROUND_LIMIT = "stop_round_limit"
+    STOP_TASK_SHAPE_MISMATCH = "stop_task_shape_mismatch"
+    STOP_TIME_BUDGET = "stop_time_budget"
 
 
 def _sha256(value: str) -> str:
@@ -149,6 +161,155 @@ def _validate_solver_command(value: Sequence[str]) -> list[str]:
     if len(command) != len(value) or not command:
         raise ValueError("external_agent_solver_command_invalid")
     return command
+
+
+def _positive_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{field} must be a positive integer")
+    return int(value)
+
+
+def _non_negative_int(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return int(value)
+
+
+def _sha256_digest(value: Any, *, field: str) -> str:
+    text = str(value or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", text):
+        raise ValueError(f"{field} must be a lowercase SHA-256 digest")
+    return text
+
+
+def normalize_benchmark_public_progress(
+    value: Mapping[str, Any],
+) -> dict[str, int | str]:
+    """Validate one content-free progress observation from the benchmark runner."""
+
+    if set(value) != {
+        "schema_version",
+        "total_unit_count",
+        "completed_unit_count",
+    }:
+        raise ValueError("benchmark_public_progress_fields_invalid")
+    if value.get("schema_version") != BENCHMARK_PUBLIC_PROGRESS_SCHEMA_VERSION:
+        raise ValueError("benchmark_public_progress_schema_unsupported")
+    total = _positive_int(value.get("total_unit_count"), field="total_unit_count")
+    completed = _non_negative_int(
+        value.get("completed_unit_count"), field="completed_unit_count"
+    )
+    if completed > total:
+        raise ValueError("completed_unit_count exceeds total_unit_count")
+    return {
+        "schema_version": BENCHMARK_PUBLIC_PROGRESS_SCHEMA_VERSION,
+        "total_unit_count": total,
+        "completed_unit_count": completed,
+    }
+
+
+def build_benchmark_continuation_decision(
+    progress: Mapping[str, Any],
+    *,
+    expected_first_prompt_sha256: str,
+    observed_first_prompt_sha256: str,
+    expected_total_unit_count: int,
+    previous_completed_unit_count: int,
+    completed_segment_count: int,
+    max_agent_segments: int,
+    elapsed_ms: int,
+    total_budget_ms: int,
+) -> dict[str, Any]:
+    """Decide whether another solver segment fits the frozen run envelope."""
+
+    normalized = normalize_benchmark_public_progress(progress)
+    expected_prompt = _sha256_digest(
+        expected_first_prompt_sha256, field="expected_first_prompt_sha256"
+    )
+    observed_prompt = _sha256_digest(
+        observed_first_prompt_sha256, field="observed_first_prompt_sha256"
+    )
+    prompt_matches = expected_prompt == observed_prompt
+    expected_total = _positive_int(
+        expected_total_unit_count, field="expected_total_unit_count"
+    )
+    previous = _non_negative_int(
+        previous_completed_unit_count, field="previous_completed_unit_count"
+    )
+    completed_segments = _positive_int(
+        completed_segment_count, field="completed_segment_count"
+    )
+    max_segments = _positive_int(max_agent_segments, field="max_agent_segments")
+    if completed_segments > max_segments:
+        raise ValueError("completed_segment_count exceeds max_agent_segments")
+    elapsed = _non_negative_int(elapsed_ms, field="elapsed_ms")
+    budget = _positive_int(total_budget_ms, field="total_budget_ms")
+    completed = int(normalized["completed_unit_count"])
+    total = int(normalized["total_unit_count"])
+    if previous > total:
+        raise ValueError("previous_completed_unit_count exceeds total_unit_count")
+    remaining_budget = max(0, budget - elapsed)
+    remaining_segments = max_segments - completed_segments
+    task_shape_matches = total == expected_total
+
+    if not prompt_matches:
+        decision = BenchmarkContinuationDecision.STOP_PROMPT_MISMATCH
+        reason = "first_prompt_digest_mismatch"
+    elif not task_shape_matches:
+        decision = BenchmarkContinuationDecision.STOP_TASK_SHAPE_MISMATCH
+        reason = "total_unit_count_mismatch"
+    elif completed == total:
+        decision = BenchmarkContinuationDecision.STOP_COMPLETE
+        reason = "all_units_complete"
+    elif remaining_budget == 0:
+        decision = BenchmarkContinuationDecision.STOP_TIME_BUDGET
+        reason = "total_agent_budget_exhausted"
+    elif remaining_segments == 0:
+        decision = BenchmarkContinuationDecision.STOP_ROUND_LIMIT
+        reason = "agent_segment_limit_reached"
+    else:
+        decision = BenchmarkContinuationDecision.CONTINUE
+        reason = (
+            "public_progress_regressed"
+            if completed < previous
+            else (
+                "requirements_remain_after_progress"
+                if completed > previous
+                else "requirements_remain_without_progress"
+            )
+        )
+
+    next_timeout_ms = (
+        max(1, remaining_budget // remaining_segments)
+        if decision is BenchmarkContinuationDecision.CONTINUE
+        else 0
+    )
+    return {
+        "ok": True,
+        "schema_version": BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION,
+        "decision": decision.value,
+        "reason_code": reason,
+        "continuation_allowed": decision is BenchmarkContinuationDecision.CONTINUE,
+        "total_unit_count": total,
+        "expected_total_unit_count": expected_total,
+        "task_shape_matches": task_shape_matches,
+        "completed_unit_count": completed,
+        "progress_delta": completed - previous,
+        "completed_segment_count": completed_segments,
+        "max_agent_segments": max_segments,
+        "remaining_budget_ms": remaining_budget,
+        "next_segment_timeout_ms": next_timeout_ms,
+        "first_prompt_matches": prompt_matches,
+        "first_prompt_digest_recorded": False,
+        "continuation_prompt_policy": "original_task_plus_public_progress",
+        "public_progress_only": True,
+        "raw_task_recorded": False,
+        "unit_ids_recorded": False,
+        "path_recorded": False,
+        "read_only": True,
+        "host_invoked": False,
+        "state_written": False,
+    }
 
 
 def _solver_environment(environment: Mapping[str, str]) -> dict[str, str]:

--- a/loopx/cli_commands/benchmark_external_agent.py
+++ b/loopx/cli_commands/benchmark_external_agent.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
 from ..capabilities.benchmark_toolkit.external_agent import (
+    BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION,
+    build_benchmark_continuation_decision,
     execute_external_agent_request,
 )
 
-BENCHMARK_EXTERNAL_AGENT_COMMANDS = {"agent-phase"}
+BENCHMARK_EXTERNAL_AGENT_COMMANDS = {"agent-phase", "continuation-decision"}
 
 PrintPayload = Callable[..., None]
 OutputFormat = Callable[..., str]
@@ -27,6 +30,49 @@ def _render_external_agent_result(payload: dict[str, object]) -> str:
         f"- Classification: `{receipt_mapping.get('classification')}`\n"
         f"- Exit code: `{payload.get('exit_code')}`\n"
     )
+
+
+def _render_continuation_decision(payload: dict[str, object]) -> str:
+    return (
+        "# Benchmark Continuation Decision\n\n"
+        f"- Decision: `{payload.get('decision')}`\n"
+        f"- Reason: `{payload.get('reason_code')}`\n"
+        f"- Continue: `{payload.get('continuation_allowed')}`\n"
+        f"- Next segment timeout: `{payload.get('next_segment_timeout_ms')}` ms\n"
+    )
+
+
+def _read_json_object(path_text: str) -> dict[str, object]:
+    raw = (
+        sys.stdin.read()
+        if path_text == "-"
+        else Path(path_text).expanduser().read_text(encoding="utf-8")
+    )
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise TypeError("progress JSON must contain an object")
+    return value
+
+
+def _invalid_continuation_decision() -> dict[str, object]:
+    return {
+        "ok": False,
+        "schema_version": BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION,
+        "decision": "input_invalid",
+        "reason_code": "continuation_input_invalid",
+        "continuation_allowed": False,
+        "next_segment_timeout_ms": 0,
+        "first_prompt_matches": False,
+        "task_shape_matches": False,
+        "first_prompt_digest_recorded": False,
+        "public_progress_only": True,
+        "raw_task_recorded": False,
+        "unit_ids_recorded": False,
+        "path_recorded": False,
+        "read_only": True,
+        "host_invoked": False,
+        "state_written": False,
+    }
 
 
 def register_benchmark_external_agent_commands(
@@ -66,6 +112,30 @@ def register_benchmark_external_agent_commands(
     )
     parser.set_defaults(benchmark_external_agent_parser=parser)
 
+    continuation_parser = benchmark_subparsers.add_parser(
+        "continuation-decision",
+        help="Decide whether another benchmark agent segment fits a frozen envelope.",
+    )
+    add_subcommand_format(continuation_parser)
+    continuation_parser.add_argument("--progress-json", required=True)
+    continuation_parser.add_argument("--expected-first-prompt-sha256", required=True)
+    continuation_parser.add_argument("--observed-first-prompt-sha256", required=True)
+    continuation_parser.add_argument(
+        "--expected-total-unit-count", required=True, type=int
+    )
+    continuation_parser.add_argument(
+        "--previous-completed-unit-count", required=True, type=int
+    )
+    continuation_parser.add_argument(
+        "--completed-segment-count", required=True, type=int
+    )
+    continuation_parser.add_argument("--max-agent-segments", required=True, type=int)
+    continuation_parser.add_argument("--elapsed-ms", required=True, type=int)
+    continuation_parser.add_argument("--total-budget-ms", required=True, type=int)
+    continuation_parser.set_defaults(
+        benchmark_external_agent_parser=continuation_parser
+    )
+
 
 def handle_benchmark_external_agent_command(
     args: argparse.Namespace,
@@ -76,6 +146,24 @@ def handle_benchmark_external_agent_command(
     if args.benchmark_command not in BENCHMARK_EXTERNAL_AGENT_COMMANDS:
         return None
     parser: argparse.ArgumentParser = args.benchmark_external_agent_parser
+    if args.benchmark_command == "continuation-decision":
+        try:
+            payload = build_benchmark_continuation_decision(
+                _read_json_object(args.progress_json),
+                expected_first_prompt_sha256=args.expected_first_prompt_sha256,
+                observed_first_prompt_sha256=args.observed_first_prompt_sha256,
+                expected_total_unit_count=args.expected_total_unit_count,
+                previous_completed_unit_count=args.previous_completed_unit_count,
+                completed_segment_count=args.completed_segment_count,
+                max_agent_segments=args.max_agent_segments,
+                elapsed_ms=args.elapsed_ms,
+                total_budget_ms=args.total_budget_ms,
+            )
+        except (OSError, UnicodeError, TypeError, ValueError):
+            payload = _invalid_continuation_decision()
+        print_payload(payload, output_format(args), _render_continuation_decision)
+        return 0 if payload.get("ok") else 1
+
     if not args.request or not args.result or not args.solver_command_json:
         parser.error(
             "agent-phase requires --request, --result, and --solver-command-json "

--- a/tests/capabilities/test_benchmark_external_agent.py
+++ b/tests/capabilities/test_benchmark_external_agent.py
@@ -8,8 +8,10 @@ from pathlib import Path
 import pytest
 
 from loopx.capabilities.benchmark_toolkit.external_agent import (
+    BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION,
     EXTERNAL_AGENT_REQUEST_SCHEMA_VERSION,
     EXTERNAL_AGENT_RESULT_SCHEMA_VERSION,
+    build_benchmark_continuation_decision,
     execute_external_agent_request,
 )
 import loopx.capabilities.benchmark_toolkit.external_agent as external_agent
@@ -35,6 +37,211 @@ def _request(workspace: Path) -> dict[str, object]:
             },
         },
     }
+
+
+def _progress(completed: int, total: int = 5) -> dict[str, object]:
+    return {
+        "schema_version": "benchmark_public_progress_v0",
+        "total_unit_count": total,
+        "completed_unit_count": completed,
+    }
+
+
+def test_benchmark_continuation_decision_continues_with_bounded_budget() -> None:
+    decision = build_benchmark_continuation_decision(
+        _progress(2),
+        expected_first_prompt_sha256="a" * 64,
+        observed_first_prompt_sha256="a" * 64,
+        expected_total_unit_count=5,
+        previous_completed_unit_count=1,
+        completed_segment_count=1,
+        max_agent_segments=3,
+        elapsed_ms=400,
+        total_budget_ms=1000,
+    )
+
+    assert decision["schema_version"] == BENCHMARK_CONTINUATION_DECISION_SCHEMA_VERSION
+    assert decision["decision"] == "continue"
+    assert decision["reason_code"] == "requirements_remain_after_progress"
+    assert decision["next_segment_timeout_ms"] == 300
+    assert decision["first_prompt_matches"] is True
+    assert decision["first_prompt_digest_recorded"] is False
+    assert decision["raw_task_recorded"] is False
+    assert decision["read_only"] is True
+    assert decision["host_invoked"] is False
+    assert decision["state_written"] is False
+
+
+@pytest.mark.parametrize(
+    ("progress", "overrides", "decision", "reason"),
+    [
+        (_progress(5), {}, "stop_complete", "all_units_complete"),
+        (
+            _progress(2),
+            {"observed_first_prompt_sha256": "b" * 64},
+            "stop_prompt_mismatch",
+            "first_prompt_digest_mismatch",
+        ),
+        (
+            _progress(2),
+            {"expected_total_unit_count": 6},
+            "stop_task_shape_mismatch",
+            "total_unit_count_mismatch",
+        ),
+        (
+            _progress(2),
+            {"elapsed_ms": 1000},
+            "stop_time_budget",
+            "total_agent_budget_exhausted",
+        ),
+        (
+            _progress(2),
+            {"completed_segment_count": 3},
+            "stop_round_limit",
+            "agent_segment_limit_reached",
+        ),
+    ],
+)
+def test_benchmark_continuation_decision_stops_at_frozen_boundaries(
+    progress: dict[str, object],
+    overrides: dict[str, object],
+    decision: str,
+    reason: str,
+) -> None:
+    arguments: dict[str, object] = {
+        "expected_first_prompt_sha256": "a" * 64,
+        "observed_first_prompt_sha256": "a" * 64,
+        "expected_total_unit_count": 5,
+        "previous_completed_unit_count": 1,
+        "completed_segment_count": 1,
+        "max_agent_segments": 3,
+        "elapsed_ms": 400,
+        "total_budget_ms": 1000,
+    }
+    arguments.update(overrides)
+
+    result = build_benchmark_continuation_decision(
+        progress,
+        expected_first_prompt_sha256=str(arguments["expected_first_prompt_sha256"]),
+        observed_first_prompt_sha256=str(arguments["observed_first_prompt_sha256"]),
+        expected_total_unit_count=int(arguments["expected_total_unit_count"]),
+        previous_completed_unit_count=int(arguments["previous_completed_unit_count"]),
+        completed_segment_count=int(arguments["completed_segment_count"]),
+        max_agent_segments=int(arguments["max_agent_segments"]),
+        elapsed_ms=int(arguments["elapsed_ms"]),
+        total_budget_ms=int(arguments["total_budget_ms"]),
+    )
+
+    assert result["decision"] == decision
+    assert result["reason_code"] == reason
+    assert result["continuation_allowed"] is False
+    assert result["next_segment_timeout_ms"] == 0
+
+
+def test_benchmark_continuation_decision_rejects_invalid_public_progress() -> None:
+    with pytest.raises(ValueError, match="completed_unit_count exceeds"):
+        build_benchmark_continuation_decision(
+            _progress(6),
+            expected_first_prompt_sha256="a" * 64,
+            observed_first_prompt_sha256="a" * 64,
+            expected_total_unit_count=5,
+            previous_completed_unit_count=1,
+            completed_segment_count=1,
+            max_agent_segments=3,
+            elapsed_ms=400,
+            total_budget_ms=1000,
+        )
+
+
+def test_benchmark_continuation_decision_cli_is_read_only_and_content_free(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    private_path = tmp_path / "private-progress.json"
+    private_path.write_text(json.dumps(_progress(2)), encoding="utf-8")
+    digest = "a" * 64
+
+    exit_code = main(
+        [
+            "--format",
+            "json",
+            "benchmark",
+            "continuation-decision",
+            "--progress-json",
+            str(private_path),
+            "--expected-first-prompt-sha256",
+            digest,
+            "--observed-first-prompt-sha256",
+            digest,
+            "--expected-total-unit-count",
+            "5",
+            "--previous-completed-unit-count",
+            "1",
+            "--completed-segment-count",
+            "1",
+            "--max-agent-segments",
+            "2",
+            "--elapsed-ms",
+            "400",
+            "--total-budget-ms",
+            "1000",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert exit_code == 0
+    assert payload["decision"] == "continue"
+    assert digest not in output
+    assert str(tmp_path) not in output
+    assert payload["first_prompt_digest_recorded"] is False
+    assert payload["path_recorded"] is False
+    assert payload["read_only"] is True
+    assert payload["host_invoked"] is False
+    assert payload["state_written"] is False
+
+
+def test_benchmark_continuation_decision_cli_fails_closed_without_leaking_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    private_path = tmp_path / "private-progress.json"
+    private_path.write_text("not-json", encoding="utf-8")
+    digest = "b" * 64
+
+    exit_code = main(
+        [
+            "--format",
+            "json",
+            "benchmark",
+            "continuation-decision",
+            "--progress-json",
+            str(private_path),
+            "--expected-first-prompt-sha256",
+            digest,
+            "--observed-first-prompt-sha256",
+            digest,
+            "--expected-total-unit-count",
+            "5",
+            "--previous-completed-unit-count",
+            "1",
+            "--completed-segment-count",
+            "1",
+            "--max-agent-segments",
+            "2",
+            "--elapsed-ms",
+            "400",
+            "--total-budget-ms",
+            "1000",
+        ]
+    )
+
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert exit_code == 1
+    assert payload["decision"] == "input_invalid"
+    assert digest not in output
+    assert str(tmp_path) not in output
 
 
 def test_external_agent_phase_runs_solver_with_request_reference(

--- a/tests/capabilities/test_benchmark_external_agent.py
+++ b/tests/capabilities/test_benchmark_external_agent.py
@@ -77,6 +77,12 @@ def test_benchmark_continuation_decision_continues_with_bounded_budget() -> None
     [
         (_progress(5), {}, "stop_complete", "all_units_complete"),
         (
+            _progress(0),
+            {},
+            "stop_progress_regression",
+            "public_progress_regressed",
+        ),
+        (
             _progress(2),
             {"observed_first_prompt_sha256": "b" * 64},
             "stop_prompt_mismatch",

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -63,6 +63,18 @@ def test_benchmark_toolkit_catalog_exposes_integrity_boundary() -> None:
         for command in capability["commands"]
     )
     assert any(
+        "continuation-decision" in command["command"]
+        for command in capability["commands"]
+    )
+    assert any(
+        protocol["schema_version"] == "benchmark_public_progress_v0"
+        for protocol in capability["implemented_protocols"]
+    )
+    assert any(
+        protocol["schema_version"] == "benchmark_continuation_decision_v0"
+        for protocol in capability["implemented_protocols"]
+    )
+    assert any(
         protocol["schema_version"] == "benchmark_integrity_qualification_v0"
         for protocol in capability["implemented_protocols"]
     )


### PR DESCRIPTION
## Summary
- add a provider-neutral, read-only continuation decision for benchmark agent segments
- fail closed on first-prompt digest drift, task-shape drift, total-budget exhaustion, and configured segment limits
- allocate the remaining total agent budget across remaining segments without launching a process or reading verifier evidence
- expose the contract as `loopx benchmark continuation-decision` and document runner-owned boundaries

## Why this slice
The prior LoopsBench smoke only wrapped one TraeX invocation, so it did not exercise a meaningful LoopX loop. This PR adds the smallest reusable decision table needed by a later runner adapter. It intentionally does not add a scheduler, process loop, LoopsBench-specific adapter, or scoring behavior.

## Validation
- changed-file Ruff: passed
- strict isolated mypy for the decision and CLI modules: passed
- focused benchmark tests: 135 passed
- real CLI read-only decision probe: passed
- public/private boundary scan: clean
- premerge canary: 17/18 selected checks passed; the sole failure is `examples/cli-project-lifecycle-command-modularization-smoke.py` (`delivery_postcondition` marker), reproduced unchanged on clean `origin/main`

## Boundaries
- input contains only aggregate completed/total unit counts plus caller-owned prompt digests and budgets
- output records no prompt digest, task text, unit ids, paths, verifier output, or credentials
- host invocation, progress observation, continuation prompt construction, containment, and evidence capture remain runner-owned
- benchmark-sensitive maintainer review remains required; this PR is not self-merged

## Future-facing pass
Reused the existing `benchmark-toolkit` external-agent owner. A full continuation scheduler adapter is deferred until this pure transition contract is reviewed and has a real runner call site.