### PR TITLE
docs(benchmark): separate monitor observation from delivery

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -835,6 +835,53 @@ of the benchmark lifecycle, not an optional cleanup pass. The catalog entry is a
 guidance template rather than a scheduler: the benchmark startup provider creates
 the todo, and the registered monitor runtime owns its cadence.
 
+### Monitor-to-advancement handoff
+
+A benchmark `continuous_monitor` is an observation and control-plane lane. Do not
+put repository delivery, runner repair, experiment redesign, or PR work only in
+the monitor text and expect it to execute. When a monitor poll discovers material
+bounded work, record the transition and create an independent executable successor
+in one writeback:
+
+```bash
+loopx quota monitor-poll \
+  --goal-id <goal-id> \
+  --todo-id <monitor-todo-id> \
+  --agent-id <registered-agent> \
+  --result-hash <public-safe-hash> \
+  --material-change \
+  --next-agent-todo "<bounded public-safe work>" \
+  --next-action-kind <action-kind> \
+  --next-task-repository <git-repository> \
+  --next-required-capability <capability> \
+  --execute \
+  --format json
+```
+
+The monitor remains open, while the new `advancement_task` enters ordinary claim,
+lease, validation, and delivery lifecycle. The poll itself spends no delivery
+quota. An unchanged poll creates no successor.
+
+When the main campaign Todo must remain visible but cannot advance until a monitor
+generation changes—for example, target occupancy is full—keep that Todo `open` and
+pair the wait with an already-created independent runnable successor:
+
+```bash
+loopx todo update \
+  --goal-id <goal-id> \
+  --todo-id <waiting-advancement-todo-id> \
+  --agent-id <registered-agent> \
+  --status open \
+  --resume-when monitor_changed:<monitor-todo-id> \
+  --successor-todo-id <independent-runnable-successor-id> \
+  --reason "<public-safe external-wait rationale>" \
+  --format json
+```
+
+The resume condition removes the waiting Todo from runnable selection until the
+monitor records a newer material-change generation. Do not mark this typed external
+wait `blocked`, and do not use the monitor itself as the runnable successor.
+
 A material user update should include the current countable arm and pair coverage,
 aggregate primary metric by arm, binary outcomes when the benchmark exposes them,
 improved/flat/regressed pair counts, and the new causal insight or next probe. Derive

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -354,6 +354,45 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "submission authority."
         ),
     },
+    "campaign_monitor_handoff": {
+        "lane_boundary": (
+            "A continuous_monitor observes and records campaign transitions; "
+            "repository delivery, runner repair, experiment redesign, and other "
+            "bounded work belong in an independent advancement_task."
+        ),
+        "material_transition_command": (
+            "loopx quota monitor-poll --goal-id <goal-id> "
+            "--todo-id <monitor-todo-id> --agent-id <registered-agent> "
+            "--result-hash <public-safe-hash> --material-change "
+            '--next-agent-todo "<bounded public-safe work>" '
+            "--next-action-kind <action-kind> "
+            "--next-task-repository <git-repository> "
+            "--next-required-capability <capability> --execute --format json"
+        ),
+        "material_transition_result": {
+            "monitor_status": "open",
+            "successor_task_class": "advancement_task",
+            "successor_relationship": "independent_runnable_work",
+            "quota_spend": False,
+        },
+        "external_wait_command": (
+            "loopx todo update --goal-id <goal-id> "
+            "--todo-id <waiting-advancement-todo-id> "
+            "--agent-id <registered-agent> --status open "
+            "--resume-when monitor_changed:<monitor-todo-id> "
+            "--successor-todo-id <independent-runnable-successor-id> "
+            '--reason "<public-safe external-wait rationale>" --format json'
+        ),
+        "external_wait_result": (
+            "Keep the waiting advancement Todo visible but non-runnable until the "
+            "monitor generation advances. Do not mark it blocked, and do not use "
+            "the monitor itself as executable delivery work."
+        ),
+        "unchanged_policy": (
+            "An unchanged poll records monitor evidence only; it creates no "
+            "successor and spends no delivery quota."
+        ),
+    },
     "post_run_case_analysis": {
         "benchmark_start_hint": (
             "When starting a benchmark, add one continuous_monitor todo that "

--- a/skills/loopx-benchmark/SKILL.md
+++ b/skills/loopx-benchmark/SKILL.md
@@ -138,6 +138,16 @@ the task's normal tools instead of imposing this workflow.
   `continuous_monitor` todo. Refresh aggregate score/coverage and write
   `benchmark_case_insight_v0` on material scored-case transitions, with bounded
   periodic reviews while the campaign remains active.
+- Treat that monitor as an observation lane, not executable delivery. When a
+  material poll discovers bounded repository, runner-repair, or experiment work,
+  use `quota monitor-poll --material-change --next-agent-todo` with explicit
+  `--next-action-kind`, repository, and required capabilities so it creates an
+  independent runnable `advancement_task`. An unchanged poll creates no successor
+  and spends no delivery quota.
+- If the main campaign advancement Todo is waiting for a monitor transition, keep
+  it `open` and pair `resume_when=monitor_changed:<monitor-todo-id>` with an
+  already-created independent runnable successor. Do not mark the wait `blocked`,
+  and do not treat the monitor itself as delivery work.
 - Report only public-safe conclusions (countable baselines, countable
   treatments, matched pairs, aggregate primary metric by arm, improved/flat/
   regressed pair counts). Never copy raw private evidence into a user update.

--- a/tests/capabilities/test_capability_extension_registry.py
+++ b/tests/capabilities/test_capability_extension_registry.py
@@ -184,6 +184,33 @@ def test_benchmark_toolkit_catalog_exposes_packaged_task_triggered_skill() -> No
     }
 
 
+def test_benchmark_toolkit_separates_monitor_observation_from_delivery() -> None:
+    capability = build_capability_detail_packet("benchmark-toolkit")["capability"]
+    handoff = capability["campaign_monitor_handoff"]
+
+    assert "continuous_monitor observes" in handoff["lane_boundary"]
+    command = handoff["material_transition_command"]
+    for required_option in (
+        "--material-change",
+        "--next-agent-todo",
+        "--next-action-kind",
+        "--next-task-repository",
+        "--next-required-capability",
+    ):
+        assert required_option in command
+    assert handoff["material_transition_result"] == {
+        "monitor_status": "open",
+        "successor_task_class": "advancement_task",
+        "successor_relationship": "independent_runnable_work",
+        "quota_spend": False,
+    }
+    external_wait = handoff["external_wait_command"]
+    assert "--status open" in external_wait
+    assert "--resume-when monitor_changed:<monitor-todo-id>" in external_wait
+    assert "--successor-todo-id <independent-runnable-successor-id>" in external_wait
+    assert "Do not mark it blocked" in handoff["external_wait_result"]
+
+
 def test_change_quality_catalog_exposes_default_off_managed_workflow() -> None:
     capability = build_capability_detail_packet("change-quality-qualification")[
         "capability"


### PR DESCRIPTION
## Summary

- expose a provider-neutral monitor-to-advancement handoff in `benchmark-toolkit` capability readback
- teach the packaged `loopx-benchmark` skill that `continuous_monitor` is observational and material work needs an independent `advancement_task`
- document the typed `open` + `resume_when=monitor_changed` external-wait form for full-capacity campaigns
- add a focused catalog contract regression

## Placement and scope

The existing built-in `benchmark-toolkit` capability and `loopx-core` provider own this lifecycle guidance. This PR adds no scheduler, runner, benchmark adapter, scoring behavior, or new capability. It contains no private runner state, case data, trajectories, verifier output, credentials, local paths, or internal links.

Related to #3778; that issue tracks the broader control-plane diagnostic wording and is not closed by this benchmark-specific guidance.

## Validation

- `python examples/control_plane/monitor-poll-writeback-smoke.py`
- `python -m pytest tests/test_workflow_skill_install.py tests/capabilities/test_capability_extension_registry.py tests/control_plane/test_todo_external_wait.py -q` — 32 passed
- `python -m ruff check ...` and focused format check — passed
- source `capability show benchmark-toolkit` readback exposes the new handoff packet
- `loopx check` public-boundary scan — clean for all four changed files
- risk-based premerge canary: all 4 direct checks and 17/18 selected checks passed; the sole failing `cli-project-lifecycle-command-modularization-smoke.py` was reproduced unchanged on clean `origin/main` (`b9927f6fe`) with missing `delivery_postcondition`

## Merge decision

The premerge classifier placed a manual hold on the benchmark-sensitive surface. This PR is intentionally not self-merged; maintainer review should confirm the public workflow wording and scope.