### PR TITLE
fix(todos): make monitor advancement authoring discoverable

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -250,6 +250,8 @@ next-action selection should prefer that repair-mode candidate over ordinary
 runnable work in the same claim/priority bucket so capability-building todos do
 not require fragile active-state reordering.
 
+### Machine-readable resume conditions
+
 Deferred todos may carry a machine-readable resume condition with
 `resume_when=<token>`. Supported conditions are:
 
@@ -270,6 +272,18 @@ Deferred todos may carry a machine-readable resume condition with
   material-change generation. The transition binds the monitor's current
   generation as a baseline, so unchanged polls, note edits, and replay of the
   same material result do not wake the todo.
+
+The monitor and the delivery it discovers are separate work items. A
+`continuous_monitor` is observe-only; it never becomes the runnable delivery.
+On a material observation, use `quota monitor-poll --material-change
+--next-agent-todo ... --next-action-kind ...` to emit an independent open
+`advancement_task`. A waiting advancement Todo stays `status=open` and pairs
+`resume_when=monitor_changed:<monitor_todo_id>` with that independent Todo via
+`--successor-todo-id`. The resume condition—not `status=blocked`—keeps the
+waiting Todo out of runnable selection until the monitor generation advances.
+Relevant command results expose the compact
+`monitor_advancement_authoring_v0` contract so an Agent can recover this
+sequence without parsing documentation prose.
 
 Open todos may also carry `resume_when` when they are visible but not yet
 executable. Until the parsed `resume_condition.satisfied` value is true, status

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -523,7 +523,11 @@ When a poll sees a material transition, add `--material-change` and optionally
 follow-up instead of staying as an opaque watch. A user follow-up must declare
 `--next-user-task-class user_gate|user_action` explicitly: use `user_gate` for
 a blocking owner decision and `user_action` for a visible reminder that must
-not block the bound agent lane. Omitting the task class fails before writeback:
+not block the bound agent lane. Omitting the task class fails before writeback.
+The monitor remains an observe-only `continuous_monitor`; `--next-agent-todo`
+creates a separate runnable `advancement_task`. For the corresponding
+generation-fenced waiting-Todo recipe, see
+[Project Agent Todo Contract](project-agent-todo-contract.md#machine-readable-resume-conditions):
 
 ```bash
 loopx quota monitor-poll --goal-id <GOAL_ID> \

--- a/loopx/cli_commands/quota_request.py
+++ b/loopx/cli_commands/quota_request.py
@@ -35,7 +35,13 @@ def register_quota_monitor_poll_request_arguments(
     quota_parser.add_argument("--material-change", action="store_true", help="Mark a monitor poll as a material transition instead of unchanged evidence.")
     quota_parser.add_argument("--cadence", help="Monitor cadence used to compute the next due timestamp, e.g. 30m, 2h, or 1d.")
     quota_parser.add_argument("--next-due-at", help="Explicit ISO timestamp for the next monitor poll.")
-    quota_parser.add_argument("--next-agent-todo", help="Agent follow-up todo to add when `--material-change` is set.")
+    quota_parser.add_argument(
+        "--next-agent-todo",
+        help=(
+            "Independent runnable advancement_task emitted when a monitor poll "
+            "uses --material-change; the continuous_monitor remains observe-only."
+        ),
+    )
     quota_parser.add_argument(
         "--next-action-kind",
         help="Explicit action kind for a material monitor's --next-agent-todo successor.",

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -18,6 +18,9 @@ from ..control_plane.quota.settlement import (
     settlement_result_payload,
 )
 from ..control_plane.todos.handoff_mode import HandoffModeError
+from ..control_plane.todos.external_wait_contract import (
+    TodoExternalWaitAuthoringError,
+)
 from ..control_plane.todos.markdown import render_todo_markdown
 from ..control_plane.work_items.task_lease import TaskLeaseError
 from ..file_lock import lock_timeout_error_fields
@@ -1025,6 +1028,10 @@ def handle_todo_command(
         if isinstance(exc, (TaskLeaseError, HandoffModeError)):
             payload["error_code"] = exc.code
             payload.update(exc.payload)
+        elif isinstance(exc, TodoExternalWaitAuthoringError):
+            payload["error_code"] = exc.code
+            if exc.authoring_contract is not None:
+                payload["authoring_contract"] = exc.authoring_contract
     append_todo_rollout_event(
         payload,
         args=args,

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -165,7 +165,9 @@ def register_todo_linkage_arguments(
             "condition such as todo_done:todo_ab12cd34ef56, "
             "monitor_changed:todo_monitor123, pr_merged:#532, or "
             "capacity_available:short_pool. monitor_changed binds the monitor's "
-            "current material-change generation and resumes only after it advances."
+            "current material-change generation and resumes only after it advances; "
+            "the waiting advancement todo must remain status=open and pair with an "
+            "independent runnable --successor-todo-id."
         ),
     )
     todo_parser.add_argument(

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -34,6 +34,9 @@ from ..todos.contract import (
     normalize_todo_id,
     resolve_next_user_task_class,
 )
+from ..todos.external_wait_contract import (
+    build_monitor_advancement_authoring_contract,
+)
 from ..work_items.delivery_outcome import DeliveryOutcome
 
 
@@ -452,6 +455,24 @@ def _capability_declaration_retry(before: dict[str, Any]) -> dict[str, Any] | No
     }
 
 
+def _monitor_advancement_authoring_fields(
+    *,
+    material_change: bool,
+    monitor_todo_id: Any,
+    successor_todo_ids: list[str],
+) -> dict[str, Any]:
+    """Attach the optional cross-command recipe outside the hot-path reducer."""
+
+    if not material_change:
+        return {}
+    return {
+        "authoring_contract": build_monitor_advancement_authoring_contract(
+            monitor_todo_id=str(monitor_todo_id or "") or None,
+            successor_todo_ids=successor_todo_ids,
+        )
+    }
+
+
 def record_quota_monitor_poll_for_decision(
     before: dict[str, Any],
     status_payload: dict[str, Any],
@@ -606,6 +627,11 @@ def record_quota_monitor_poll_for_decision(
                     "todo_id": existing.get("todo_id"),
                     "target_key": existing.get("target_key"),
                     "material_change": bool(existing.get("material_change")),
+                    **_monitor_advancement_authoring_fields(
+                        material_change=bool(existing.get("material_change")),
+                        monitor_todo_id=existing.get("todo_id"),
+                        successor_todo_ids=replay_successor_ids,
+                    ),
                     "turn_instance_id": normalized_turn_instance_id,
                     "monitor_event": monitor_event,
                     "todo_writeback": None,
@@ -810,6 +836,11 @@ def record_quota_monitor_poll_for_decision(
         "todo_id": record["monitor_event"].get("todo_id"),
         "target_key": record["monitor_event"].get("target_key"),
         "material_change": record["monitor_event"].get("material_change"),
+        **_monitor_advancement_authoring_fields(
+            material_change=material_change,
+            monitor_todo_id=record["monitor_event"].get("todo_id"),
+            successor_todo_ids=successor_todo_ids,
+        ),
         "monitor_event": record["monitor_event"],
         "todo_writeback": todo_writeback,
         "successor_todo_ids": successor_todo_ids,

--- a/loopx/control_plane/todos/external_wait_contract.py
+++ b/loopx/control_plane/todos/external_wait_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+MONITOR_ADVANCEMENT_AUTHORING_SCHEMA_VERSION = (
+    "monitor_advancement_authoring_v0"
+)
+
+
+def build_monitor_advancement_authoring_contract(
+    *,
+    monitor_todo_id: str | None = None,
+    successor_todo_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    """Project the cross-command monitor-to-advancement authoring contract."""
+
+    monitor_ref = str(monitor_todo_id or "<monitor_todo_id>").strip()
+    successors = [
+        str(item).strip()
+        for item in (successor_todo_ids or [])
+        if str(item).strip()
+    ]
+    return {
+        "schema_version": MONITOR_ADVANCEMENT_AUTHORING_SCHEMA_VERSION,
+        "monitor": {
+            "task_class": "continuous_monitor",
+            "execution": "observe_only",
+        },
+        "material_change": {
+            "command": "loopx quota monitor-poll",
+            "required_args": [
+                "--material-change",
+                "--next-agent-todo",
+                "--next-action-kind",
+            ],
+            "next_agent_todo_effect": "emit_independent_open_advancement_task",
+        },
+        "waiting_todo": {
+            "status": "open",
+            "task_class": "advancement_task",
+            "resume_when": f"monitor_changed:{monitor_ref}",
+            "successor_todo_ids": successors,
+            "successor_requirement": "independent_runnable_advancement_task",
+            "runnable_state": "excluded_until_resume_condition_satisfied",
+        },
+    }
+
+
+class TodoExternalWaitAuthoringError(ValueError):
+    """Typed public diagnostic for an invalid external-wait transition."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        monitor_todo_id: str | None = None,
+        successor_todo_ids: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.authoring_contract = (
+            build_monitor_advancement_authoring_contract(
+                monitor_todo_id=monitor_todo_id,
+                successor_todo_ids=successor_todo_ids,
+            )
+            if monitor_todo_id
+            else None
+        )

--- a/loopx/control_plane/todos/external_wait_writeback.py
+++ b/loopx/control_plane/todos/external_wait_writeback.py
@@ -10,6 +10,7 @@ from .contract import (
     normalize_todo_id,
     normalize_todo_id_list,
 )
+from .external_wait_contract import build_monitor_advancement_authoring_contract
 from .resume_condition import plan_todo_external_wait_transition
 
 
@@ -20,7 +21,11 @@ def _transition_items(lines: list[str]) -> list[dict[str, Any]]:
     archive_bounds = archive_section_bounds(lines)
     if archive_bounds:
         collected.extend(
-            todo_blocks(
+            {
+                **item,
+                "role": "agent",
+            }
+            for item in todo_blocks(
                 lines,
                 archive_bounds[0],
                 archive_bounds[1],
@@ -32,7 +37,11 @@ def _transition_items(lines: list[str]) -> list[dict[str, Any]]:
         bounds = section_bounds(lines, role)
         if bounds:
             collected.extend(
-                todo_blocks(
+                {
+                    **item,
+                    "role": role,
+                }
+                for item in todo_blocks(
                     lines,
                     bounds[0],
                     bounds[1],
@@ -60,24 +69,27 @@ def plan_todo_external_wait_update(
         ("todo_done:", "monitor_changed:")
     ):
         return None, None
-    eligible = (
+    uses_open_external_wait = (
         role == "agent"
         and status == TODO_STATUS_OPEN
         and task_class == TODO_TASK_CLASS_ADVANCEMENT
     )
-    if not eligible:
-        if resume_when.startswith("monitor_changed:"):
-            raise ValueError(
-                "monitor_changed requires todo update on an open agent "
-                "advancement_task with at least one --successor-todo-id"
-            )
+    # todo_done is also valid for ordinary deferred authoring. monitor_changed,
+    # however, always uses the typed open-wait protocol so invalid role/status/
+    # task-class combinations receive the exact TS-owned diagnostic.
+    if resume_when.startswith("todo_done:") and not uses_open_external_wait:
         return None, None
 
     items = _transition_items(lines)
     normalized_id = normalize_todo_id(todo_id)
     for index, item in enumerate(items):
         if normalize_todo_id(item.get("todo_id")) == normalized_id:
-            items[index] = {**item, "status": status, "task_class": task_class}
+            items[index] = {
+                **item,
+                "role": role,
+                "status": status,
+                "task_class": task_class,
+            }
     transition = plan_todo_external_wait_transition(
         todo_id=todo_id,
         resume_when=resume_when,
@@ -88,6 +100,13 @@ def plan_todo_external_wait_update(
         ),
         items=items,
     )
+    if resume_when.startswith("monitor_changed:"):
+        transition["authoring_contract"] = (
+            build_monitor_advancement_authoring_contract(
+                monitor_todo_id=resume_when.partition(":")[2],
+                successor_todo_ids=list(transition.get("successor_todo_ids") or []),
+            )
+        )
     updates = transition.get("metadata_updates")
     baseline = updates.get("resume_monitor_generation") if isinstance(updates, Mapping) else None
     return transition, int(baseline) if baseline is not None else None

--- a/loopx/control_plane/todos/resume_condition.py
+++ b/loopx/control_plane/todos/resume_condition.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from ..effect_runtime import EffectRuntimeRejected, effect_runtime_result
+from .external_wait_contract import TodoExternalWaitAuthoringError
 
 
 TODO_RESUME_NORMALIZE_REQUEST_SCHEMA_VERSION = "todo_resume_normalize_request_v0"
@@ -35,6 +36,7 @@ _RESUME_PR_MERGED_PATTERN = re.compile(
 
 _RESUME_ITEM_FIELDS = (
     "todo_id",
+    "role",
     "status",
     "task_class",
     "archive_state",
@@ -201,7 +203,15 @@ def plan_todo_external_wait_transition(
             },
         )
     except EffectRuntimeRejected as exc:
-        raise ValueError(str(exc)) from None
+        resume_kind, _, target_todo_id = resume_when.partition(":")
+        raise TodoExternalWaitAuthoringError(
+            str(exc),
+            code=exc.diagnostic_code,
+            monitor_todo_id=(
+                target_todo_id if resume_kind == TODO_RESUME_KIND_MONITOR_CHANGED else None
+            ),
+            successor_todo_ids=successor_todo_ids,
+        ) from None
     if not isinstance(result, Mapping) or (
         result.get("schema_version") != TODO_EXTERNAL_WAIT_TRANSITION_SCHEMA_VERSION
     ):

--- a/loopx/control_plane/todos/resume_condition.ts
+++ b/loopx/control_plane/todos/resume_condition.ts
@@ -53,6 +53,7 @@ interface ResumeSpec {
 
 interface TodoItem extends JsonObject {
   todo_id: string;
+  role?: string;
   status?: string;
   task_class?: string;
   resume_when?: string;
@@ -89,6 +90,7 @@ function todoItem(value: unknown, label: string): TodoItem {
   const raw = requireJsonObject(value, label);
   const item: TodoItem = { todo_id: todoId(raw.todo_id, `${label}.todo_id`) };
   for (const field of [
+    "role",
     "status",
     "task_class",
     "archive_state",
@@ -467,11 +469,25 @@ function externalWaitTodo(
   if (!todo) {
     throw new EffectRuntimeRequestError(
       "external-wait Todo is absent from current state",
+      "external_wait_todo_absent",
     );
   }
-  if (todo.status !== "open" || todo.task_class !== "advancement_task") {
+  if (todo.role !== "agent") {
     throw new EffectRuntimeRequestError(
-      "external-wait transition requires an open advancement_task",
+      "external-wait Todo must have role=agent",
+      "external_wait_todo_role_invalid",
+    );
+  }
+  if (todo.status !== "open") {
+    throw new EffectRuntimeRequestError(
+      "external-wait Todo must remain status=open; resume_when excludes it from runnable selection until the condition is satisfied",
+      "external_wait_todo_status_must_remain_open",
+    );
+  }
+  if (todo.task_class !== "advancement_task") {
+    throw new EffectRuntimeRequestError(
+      "external-wait Todo must have task_class=advancement_task",
+      "external_wait_todo_task_class_invalid",
     );
   }
   return { todoId: requestedId, todo };
@@ -486,27 +502,32 @@ function externalWaitDependency(
     throw new EffectRuntimeRequestError(
       "external-wait transition supports todo_done or monitor_changed; use ordinary " +
         "resume_when authoring for PR and capacity conditions",
+      "external_wait_resume_kind_invalid",
     );
   }
   if (spec.target === waitingTodoId) {
     throw new EffectRuntimeRequestError(
       "external-wait Todo cannot resume from itself",
+      "external_wait_dependency_self_reference",
     );
   }
   const dependency = byId.get(spec.target);
   if (!dependency) {
     throw new EffectRuntimeRequestError(
       "external-wait dependency is absent from current state",
+      "external_wait_dependency_absent",
     );
   }
   if (spec.kind === "todo_done" && dependency.task_class === "continuous_monitor") {
     throw new EffectRuntimeRequestError(
       "todo_done cannot wait on a continuous_monitor; use monitor_changed:<todo_id>",
+      "external_wait_monitor_condition_required",
     );
   }
   if (spec.kind === "todo_done" && dependency.status === "done") {
     throw new EffectRuntimeRequestError(
       "todo_done dependency is already complete",
+      "external_wait_dependency_already_complete",
     );
   }
   if (
@@ -515,6 +536,7 @@ function externalWaitDependency(
   ) {
     throw new EffectRuntimeRequestError(
       "monitor_changed requires an open continuous_monitor target",
+      "external_wait_monitor_target_invalid",
     );
   }
   return dependency;
@@ -533,6 +555,7 @@ function externalWaitSuccessors(
   if (successors.length === 0) {
     throw new EffectRuntimeRequestError(
       "external-wait transition requires at least one independent runnable successor",
+      "external_wait_successor_required",
     );
   }
   for (const successorId of successors) {
@@ -540,16 +563,19 @@ function externalWaitSuccessors(
     if (!successor || successorId === waitingTodoId) {
       throw new EffectRuntimeRequestError(
         "external-wait successor is absent or self-referential",
+        "external_wait_successor_absent_or_self",
       );
     }
     if (successor.status !== "open" || successor.task_class !== "advancement_task") {
       throw new EffectRuntimeRequestError(
         "external-wait successor must be an open advancement_task",
+        "external_wait_successor_not_open_advancement",
       );
     }
     if (successor.resume_when && successor.resume_ready !== true) {
       throw new EffectRuntimeRequestError(
         "external-wait successor must be runnable, not resume-gated",
+        "external_wait_successor_resume_gated",
       );
     }
   }
@@ -572,6 +598,7 @@ function externalWaitMetadata(
   if (sameCondition && currentCondition.satisfied === true) {
     throw new EffectRuntimeRequestError(
       "clear the satisfied resume_when before re-arming the same monitor wait",
+      "external_wait_satisfied_condition_requires_clear",
     );
   }
   const baselineGeneration =

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -350,6 +350,16 @@ def test_material_poll_reloads_status_and_projects_declared_successor(
     assert successor["target_key"] == "release-head:huangruiteng/loopx#42@merged-42"
     assert result["successor_todo_ids"] == [successor["todo_id"]]
     assert result["after"]["selected_todo"]["todo_id"] == successor["todo_id"]
+    authoring = result["authoring_contract"]
+    assert authoring["schema_version"] == "monitor_advancement_authoring_v0"
+    assert authoring["monitor"] == {
+        "task_class": "continuous_monitor",
+        "execution": "observe_only",
+    }
+    assert authoring["waiting_todo"]["successor_todo_ids"] == [
+        successor["todo_id"]
+    ]
+    assert authoring["waiting_todo"]["status"] == "open"
     # This contract owns material writeback and successor selection. Whether
     # the current CLI turn can spend quota is evaluated by should-run tests.
     assert "Validate the exact merged release head." in state.read_text(encoding="utf-8")

--- a/tests/control_plane/test_todo_external_wait.py
+++ b/tests/control_plane/test_todo_external_wait.py
@@ -9,8 +9,14 @@ import pytest
 from loopx.control_plane.scheduler.monitor_poll_writeback import (
     write_monitor_poll_todo_state,
 )
-from loopx.control_plane.testing.canary_harness import write_fixture_registry
+from loopx.control_plane.testing.canary_harness import (
+    run_json_cli_result,
+    write_fixture_registry,
+)
 from loopx.control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from loopx.control_plane.todos.external_wait_contract import (
+    TodoExternalWaitAuthoringError,
+)
 from loopx.todos import complete_goal_todo, update_goal_todo
 
 
@@ -93,6 +99,7 @@ def test_monitor_change_wait_binds_generation_and_resumes_only_after_increment(
     receipt = transition["external_wait_transition"]
     assert receipt["baseline_generation"] == 2
     assert receipt["successor_todo_ids"] == [FALLBACK_ID]
+    assert receipt["authoring_contract"]["waiting_todo"]["status"] == "open"
     waiting = _todos(state_file)[WAITING_ID]
     assert waiting["resume_monitor_generation"] == 2
     assert waiting["resume_ready"] is False
@@ -152,6 +159,82 @@ def test_monitor_change_wait_binds_generation_and_resumes_only_after_increment(
             successor_todo_ids=[FALLBACK_ID],
             agent_id=AGENT_ID,
         )
+
+
+def test_monitor_wait_diagnoses_status_and_successor_faults_separately(
+    tmp_path: Path,
+) -> None:
+    registry, _ = _write_fixture(tmp_path)
+
+    with pytest.raises(TodoExternalWaitAuthoringError) as status_error:
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=WAITING_ID,
+            status="blocked",
+            resume_when=f"monitor_changed:{MONITOR_ID}",
+            successor_todo_ids=[FALLBACK_ID],
+            agent_id=AGENT_ID,
+            dry_run=True,
+        )
+    assert status_error.value.code == "external_wait_todo_status_must_remain_open"
+    assert "must remain status=open" in str(status_error.value)
+    assert "successor" not in str(status_error.value)
+    assert status_error.value.authoring_contract["waiting_todo"] == {
+        "status": "open",
+        "task_class": "advancement_task",
+        "resume_when": f"monitor_changed:{MONITOR_ID}",
+        "successor_todo_ids": [FALLBACK_ID],
+        "successor_requirement": "independent_runnable_advancement_task",
+        "runnable_state": "excluded_until_resume_condition_satisfied",
+    }
+
+    with pytest.raises(TodoExternalWaitAuthoringError) as successor_error:
+        update_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            todo_id=WAITING_ID,
+            resume_when=f"monitor_changed:{MONITOR_ID}",
+            successor_todo_ids=[],
+            agent_id=AGENT_ID,
+            dry_run=True,
+        )
+    assert successor_error.value.code == "external_wait_successor_required"
+
+
+def test_todo_cli_projects_external_wait_repair_contract(tmp_path: Path) -> None:
+    registry, _ = _write_fixture(tmp_path)
+
+    returncode, payload = run_json_cli_result(
+        "todo",
+        "update",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--todo-id",
+        WAITING_ID,
+        "--status",
+        "blocked",
+        "--resume-when",
+        f"monitor_changed:{MONITOR_ID}",
+        "--successor-todo-id",
+        FALLBACK_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--dry-run",
+        registry_path=registry,
+    )
+
+    assert returncode == 1
+    assert payload["error_code"] == "external_wait_todo_status_must_remain_open"
+    assert "successor" not in payload["error"]
+    contract = payload["authoring_contract"]
+    assert contract["schema_version"] == "monitor_advancement_authoring_v0"
+    assert contract["monitor"]["execution"] == "observe_only"
+    assert contract["material_change"]["next_agent_todo_effect"] == (
+        "emit_independent_open_advancement_task"
+    )
 
 
 def test_overlapping_material_polls_recompute_generation_after_wait_baseline(

--- a/tests/control_plane_ts/todo_resume_condition.test.ts
+++ b/tests/control_plane_ts/todo_resume_condition.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { EffectRuntimeRequestError } from "../../loopx/control_plane/effect_runtime_errors.ts";
 import {
   TODO_EXTERNAL_WAIT_REQUEST_SCHEMA_VERSION,
   TODO_RESUME_EVALUATION_REQUEST_SCHEMA_VERSION,
@@ -16,7 +17,13 @@ function todo(
   taskClass = "advancement_task",
   extra: Record<string, unknown> = {},
 ) {
-  return { todo_id: todoId, status, task_class: taskClass, ...extra };
+  return {
+    todo_id: todoId,
+    role: "agent",
+    status,
+    task_class: taskClass,
+    ...extra,
+  };
 }
 
 test("resume syntax is normalized by the typed Todo boundary", () => {
@@ -158,6 +165,42 @@ test("external wait rejects monitor completion and non-runnable fallbacks", () =
     successor_todo_ids: ["todo_fallback001"],
     items,
   }), /successor must be an open advancement_task/);
+});
+
+test("external wait rejection codes identify status and successor faults", () => {
+  const commonItems = [
+    todo("todo_waiting001", "blocked"),
+    todo("todo_watch001", "open", "continuous_monitor"),
+    todo("todo_fallback001", "open"),
+  ];
+  assert.throws(
+    () => planTodoExternalWaitTransition({
+      schema_version: TODO_EXTERNAL_WAIT_REQUEST_SCHEMA_VERSION,
+      todo_id: "todo_waiting001",
+      resume_when: "monitor_changed:todo_watch001",
+      successor_todo_ids: ["todo_fallback001"],
+      items: commonItems,
+    }),
+    (error: unknown) =>
+      error instanceof EffectRuntimeRequestError &&
+      error.code === "external_wait_todo_status_must_remain_open" &&
+      /must remain status=open/.test(error.message),
+  );
+  assert.throws(
+    () => planTodoExternalWaitTransition({
+      schema_version: TODO_EXTERNAL_WAIT_REQUEST_SCHEMA_VERSION,
+      todo_id: "todo_waiting001",
+      resume_when: "monitor_changed:todo_watch001",
+      successor_todo_ids: [],
+      items: [
+        todo("todo_waiting001", "open"),
+        todo("todo_watch001", "open", "continuous_monitor"),
+      ],
+    }),
+    (error: unknown) =>
+      error instanceof EffectRuntimeRequestError &&
+      error.code === "external_wait_successor_required",
+  );
 });
 
 test("a satisfied monitor fence must be cleared before it can be re-armed", () => {


### PR DESCRIPTION
## Summary

Closes #3778.

- remove the Python-side combined `role/status/task_class` rejection for `monitor_changed` and validate the proposed Todo state in the TypeScript Todo-domain owner
- return stable, concern-specific diagnostic codes such as `external_wait_todo_status_must_remain_open` and `external_wait_successor_required`
- project a compact `monitor_advancement_authoring_v0` contract from failed/successful external-wait updates and material `quota monitor-poll` receipts, including idempotent replay
- clarify CLI help and canonical docs: a `continuous_monitor` observes, material change emits an independent open `advancement_task`, and an open waiting Todo is excluded by `resume_when` rather than `status=blocked`

## Architecture and compatibility

The TypeScript reducer remains the authority for external-wait transition legality. Python now supplies the candidate role from the Todo lane/target update, bridges the typed runtime rejection, and renders the cross-command authoring projection. Ordinary deferred `todo_done` authoring keeps its existing path.

This changes diagnostics and adds an optional authoring field only when the monitor-advancement contract is relevant. It does not change monitor generation fences, runnable selection, quota spend, permissions, provider behavior, or benchmark semantics.

The bounded future-facing refactor was applied at the touched owner boundary: duplicate Python validation was removed, stable TS diagnostic codes were added, and optional monitor-poll projection was extracted from the already-large decision function so the maintainability ratchet stays clean. A broader Todo/monitor framework was intentionally not introduced.

## Validation

- `npm run test:control-plane` — 295 passed
- `npm run typecheck:control-plane` — passed
- `pytest -q tests/control_plane/test_todo_external_wait.py tests/test_cli_argument_diagnostics.py tests/control_plane/test_monitor_followthrough_contract.py::test_material_poll_reloads_status_and_projects_declared_successor` — 95 passed
- focused post-refactor regression — 7 passed
- `ruff check` on changed Python/test paths — passed
- `loopx canary premerge --from-git-diff` — passed, 18 selected checks, 0 failures, 0 manual holds
- public/private boundary scan — passed
- `git diff --check origin/main...HEAD` — passed

Local repository-wide `mypy` was not used as a success signal because the current checkout reports the existing broad baseline under the local Python 3.13 environment; no changed-line failure was identified, and the TypeScript owner passed its full typecheck.
