### PR TITLE
test(cli): follow extracted lifecycle sink owner

### DIFF
--- a/examples/cli-project-lifecycle-command-modularization-smoke.py
+++ b/examples/cli-project-lifecycle-command-modularization-smoke.py
@@ -187,11 +187,16 @@ def main() -> None:
         "read-only-map",
         "reward",
         "operator-gate",
-        "delivery_postcondition",
-        "blocks_delivery",
         "retry it before delivery",
     ):
         require(marker in module_source, f"project lifecycle module missing {marker}")
+    sink_source = (MODULE.parent / "project_lifecycle_sinks.py").read_text(encoding="utf-8")
+    for marker in (
+        "apply_external_sink_postcondition",
+        "delivery_postcondition",
+        "blocks_delivery",
+    ):
+        require(marker in sink_source, f"project lifecycle sink module missing {marker}")
     require("register_project_lifecycle_commands" in cli_source, "cli.py did not register project lifecycle commands")
     require("handle_project_lifecycle_command" in cli_source, "cli.py did not dispatch project lifecycle commands")
     require("register_project_lifecycle_commands" in init_source, "__init__ did not export project lifecycle registration")


### PR DESCRIPTION
## Summary

- Update the CLI modularization smoke to read sink-specific postcondition markers from the extracted `project_lifecycle_sinks.py` owner.
- Keep command registration and dispatch assertions in the existing `project_lifecycle.py` owner.

## Root cause

The sink implementation moved in #3740, but this source-ownership smoke still searched the previous module. The product code was correct; the stale assertion blocked unrelated risk-based canaries.

## Validation

- `python3 examples/cli-project-lifecycle-command-modularization-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed, no manual holds
- Change-quality receipt `cqr_21482b94252aae405371` — exact scope valid

## Product and architecture judgment

This restores the smoke's intended ownership contract without changing runtime behavior or introducing a compatibility seam. Future-facing pass: no adjacent refactor is needed because the implementation boundary is already extracted and the smoke now follows it directly.

## Boundary

No runtime behavior, credentials, private state, local paths, or generated logs are included.
