### PR TITLE
fix(dsh): make plugin release-installable

### DIFF
--- a/examples/canary/dsh-loopx-plugin-validation.py
+++ b/examples/canary/dsh-loopx-plugin-validation.py
@@ -13,7 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PACKAGE_ROOT = REPO_ROOT / "packages" / "dsh-loopx-plugin"
 PHASE_SCRIPTS = {
-    "quality": ("typecheck", "test"),
+    "quality": ("typecheck", "test", "smoke:peer-range"),
     "package": ("build", "smoke:artifact", "smoke:profile"),
     "runtime": ("smoke:runtime",),
 }

--- a/packages/dsh-loopx-plugin/README.md
+++ b/packages/dsh-loopx-plugin/README.md
@@ -48,10 +48,11 @@ environment. This works with externally managed Python distributions that
 enforce PEP 668; the plugin does not use `--break-system-packages`.
 The published plugin requires LoopX 0.5.3 or newer because that is the first
 release contract whose wheel carries the packaged workflow skills.
-Install the published package into the web profile:
+Install the prebuilt release into the web profile:
 
 ```bash
-dsh plugin --profile web add dsh-loopx-plugin
+dsh plugin --profile web add \
+  "https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.3/dsh-loopx-plugin-0.1.1-beta.3.tgz"
 ```
 
 For a source checkout, the equivalent build-and-install path is:

--- a/packages/dsh-loopx-plugin/package.json
+++ b/packages/dsh-loopx-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-loopx-plugin",
-  "version": "0.1.1-beta.2",
+  "version": "0.1.1-beta.3",
   "description": "One-step LoopX bootstrap, same-session driver, and local GoalBar for DeepSeek Harness",
   "type": "module",
   "main": "./lib/index.js",
@@ -42,6 +42,7 @@
     "test": "vitest run",
     "prepack": "pnpm build",
     "smoke:artifact": "node smoke/dsh-client-artifact-smoke.mjs",
+    "smoke:peer-range": "node smoke/dsh-peer-range-smoke.mjs",
     "smoke:profile": "node smoke/dsh-profile-smoke.mjs",
     "smoke:runtime": "node smoke/dsh-goalbar-runtime-smoke.mjs",
     "smoke:docker": "bash smoke/dsh-clean-docker-smoke.sh"
@@ -62,13 +63,13 @@
   },
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh": ">=0.1.0-rc.7 <0.2.0",
-    "@deepseek-ai/dsh-client-connection": ">=0.1.0-rc.7 <0.2.0",
-    "@deepseek-ai/dsh-client-locale": ">=0.1.0-rc.7 <0.2.0",
-    "@deepseek-ai/dsh-client-runtime": ">=0.1.0-rc.7 <0.2.0",
-    "@deepseek-ai/dsh-client-ui-conversation": ">=0.1.0-rc.7 <0.2.0",
-    "@deepseek-ai/dsh-client-ui-primitives": ">=0.1.0-rc.7 <0.2.0",
-    "@deepseek-ai/dsh-client-ui-slots": ">=0.1.0-rc.7 <0.2.0",
+    "@deepseek-ai/dsh": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
+    "@deepseek-ai/dsh-client-connection": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
+    "@deepseek-ai/dsh-client-locale": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
+    "@deepseek-ai/dsh-client-runtime": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
+    "@deepseek-ai/dsh-client-ui-conversation": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
+    "@deepseek-ai/dsh-client-ui-primitives": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
+    "@deepseek-ai/dsh-client-ui-slots": ">=0.1.0-rc.7 <0.1.1 || >=0.1.1-rc.1 <0.2.0-0",
     "react": "^18.2.0"
   },
   "peerDependenciesMeta": {

--- a/packages/dsh-loopx-plugin/pnpm-workspace.yaml
+++ b/packages/dsh-loopx-plugin/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@deepseek-ai/dsh-subprocess-local': false
+  '@google/genai': false
+  koffi: false
+  node-pty: false
+  protobufjs: false

--- a/packages/dsh-loopx-plugin/smoke/dsh-peer-range-smoke.mjs
+++ b/packages/dsh-loopx-plugin/smoke/dsh-peer-range-smoke.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)))
+const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'))
+
+function versionTuple(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u.exec(value)
+  assert(match, `unsupported version ${value}`)
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ?? null,
+  }
+}
+
+function supportsPrerelease(range, version) {
+  const tuple = versionTuple(version)
+  if (tuple.prerelease === null) return true
+  const tuplePrefix = `${tuple.major}.${tuple.minor}.${tuple.patch}-`
+  return range.split('||').some(branch => branch.includes(tuplePrefix))
+}
+
+for (const [name, range] of Object.entries(manifest.peerDependencies ?? {})) {
+  if (!name.startsWith('@deepseek-ai/')) continue
+  const testedVersion = manifest.devDependencies?.[name]
+  assert(testedVersion, `missing tested version for official peer ${name}`)
+  assert(
+    supportsPrerelease(range, testedVersion),
+    `${name} tested version ${testedVersion} is excluded by peer range ${range}`,
+  )
+}
+
+process.stdout.write('dsh-loopx peer range smoke passed\n')


### PR DESCRIPTION
## Summary

- Publish DSH LoopX plugin version `0.1.1-beta.3` with a pinned GitHub Release install path.
- Make official DSH prerelease compatibility explicit for the tested `0.1.1-rc.*` tuple instead of relying on a range that node-semver excludes.
- Add the peer-range regression smoke to the existing DSH risk-profile canary.
- Make pnpm 11 dependency build-script decisions explicit and reproducible; the plugin does not require these install scripts for its validated paths.

## Root cause

The prior peer range `>=0.1.0-rc.7 <0.2.0` appears broad but node-semver excludes prereleases from a different version tuple, including the tested `0.1.1-rc.2` packages. Marketplace installs could therefore warn or reject a host version that the plugin's own tests use. Separately, pnpm 11 treats undecided dependency build scripts as a hard install error, so a clean validator needed an explicit policy.

## Validation

- TypeScript host/client/test typechecks passed.
- Full Vitest suite: 9 files, 170 tests passed.
- Production build and client artifact smoke passed.
- Peer prerelease compatibility smoke passed.
- Real isolated DSH profile add, config readback, plugin load, and remove passed for the packed tarball.
- Real packed GoalBar runtime passed boot graph, client materialization, loopback fence, Start/Pause, and cleanup paths.
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 17 selected checks passed, no manual holds.
- Exact change-quality receipt `cqr_5957ad548bf98c898bff` is valid.
- Public/private boundary and diff hygiene passed.

## Product and architecture judgment

This removes a release/install contradiction without changing plugin runtime behavior. Compatibility remains manifest-owned, and the existing risk-profile runner owns the semantic regression. The pnpm policy is package-local and fail-explicit. Main risk is host-version compatibility; it is covered by the exact official prerelease versions used by the full suite plus real packed installs.

Future-facing pass: applied. The semantic check is now part of the standard DSH canary rather than a one-off release probe. No broader version framework or new dependency is warranted.

## Boundary

No credentials, private state, local paths, generated logs, lockfile churn, permission changes, scoring changes, or unrelated runtime behavior are included.
