### PR TITLE
fix(dashboard): stop goals without redundant confirmation

### DIFF
--- a/apps/presentation/dashboard/src/features/personal-workspace/goal-sidebar.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/goal-sidebar.tsx
@@ -17,6 +17,7 @@ const goalStateClass: Record<WorkspaceGoal["state"], string> = {
 export function GoalSidebar({
   attentionCount,
   goals,
+  lifecycleBusyGoalIds,
   onRequestGoalCreate,
   onOpenSettings,
   onRequestGoalLifecycle,
@@ -26,6 +27,7 @@ export function GoalSidebar({
 }: {
   attentionCount: number;
   goals: WorkspaceGoal[];
+  lifecycleBusyGoalIds?: ReadonlySet<string>;
   onRequestGoalCreate?: () => void;
   onOpenSettings?: () => void;
   onRequestGoalLifecycle?: (goal: WorkspaceGoal, operation: "stop" | "resume" | "delete") => void;
@@ -56,6 +58,7 @@ export function GoalSidebar({
           <button
             aria-label={`${stopped ? t("sidebar.resume") : t("sidebar.stop")} ${goal.title}`}
             className="personal-goal-lifecycle"
+            disabled={lifecycleBusyGoalIds?.has(goal.goalId)}
             onClick={() => onRequestGoalLifecycle(goal, stopped ? "resume" : "stop")}
             title={stopped ? t("sidebar.resumeGoal") : t("sidebar.stopGoal")}
             type="button"

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -153,6 +153,11 @@ assert.match(dashboard, /onReconcileStatus=\{\(\) => loadFromUrl\([\s\S]*\{ back
 assert.match(dashboard, /statusRequestCanCommit\(statusRequestFenceRef\.current, request\)/, "A stale background response cannot overwrite a newer optimistic transition");
 assert.match(sidebar, /Trash2/, "Stopped Goals expose a delete icon");
 assert.match(sidebar, /onRequestGoalLifecycle\(goal, "delete"\)/, "Goal deletion stays behind the lifecycle request boundary");
+assert.match(page, /\{ select: operation !== "stop" \}/, "Goal stop suppresses the confirmation drawer while other lifecycle actions retain it");
+assert.match(page, /await applyProposal\(proposal, \{ presentation: "feedback" \}\)/, "Goal stop reuses the canonical apply state machine and surfaces its receipt as feedback");
+assert.match(page, /if \(proposal\.status === "ready"\)[\s\S]*setSelection\(\{ item: proposal, kind: "proposal" \}\)/, "A stop action only bypasses review when its typed preview is ready");
+assert.match(page, /A newly discovered authority gate always deserves review/, "A direct action escalates a newly discovered authority gate to the drawer");
+assert.match(sidebar, /disabled=\{lifecycleBusyGoalIds\?\.has\(goal\.goalId\)\}/, "An in-flight Goal stop cannot be submitted twice from the sidebar");
 assert.match(page, /lifecycleOperation === "delete"/, "Goal deletion has an explicit lifecycle operation");
 assert.match(page, /callbacks\.onGoalDeleted/, "Successful Goal deletion removes the optimistic sidebar projection");
 assert.match(status, /function withoutGoal/, "Status projection can remove a deleted Goal");

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-page.tsx
@@ -663,6 +663,7 @@ export function PersonalWorkspacePage({
   const [imageAttachments, setImageAttachments] = useState<WorkspaceImageAttachment[]>([]);
   const [imageAttachmentError, setImageAttachmentError] = useState<string | null>(null);
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [lifecycleBusyGoalIds, setLifecycleBusyGoalIds] = useState<ReadonlySet<string>>(() => new Set());
   const [refreshState, setRefreshState] = useState<"idle" | "loading" | "done" | "error">("idle");
   const [sessionProposalIds, setSessionProposalIds] = useState<string[]>([]);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
@@ -679,6 +680,7 @@ export function PersonalWorkspacePage({
   const composerRef = useRef<HTMLTextAreaElement>(null);
   const channelScrollRef = useRef<HTMLDivElement>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
+  const lifecyclePendingGoalIdsRef = useRef(new Set<string>());
   const [digest, setDigest] = useState<{ attention: number; done: number; failed: number } | null>(null);
   const selectedGoalId = controlledGoalId === undefined ? localGoalId : controlledGoalId;
   const selectedAgentId = controlledAgentId ?? localAgentId;
@@ -935,7 +937,10 @@ export function PersonalWorkspacePage({
     return () => { cancelled = true; };
   }, [readOnly, selectedGoalId, t]);
 
-  async function createPreview(request: WorkspaceActionPreviewRequest) {
+  async function createPreview(
+    request: WorkspaceActionPreviewRequest,
+    options: { select?: boolean } = {},
+  ) {
     if (readOnly) throw new Error(t("source.readOnlyWriteError"));
     let local: WorkspaceActionPreview;
     try {
@@ -982,7 +987,7 @@ export function PersonalWorkspacePage({
     }
     setSessionProposalIds((current) => current.includes(local.previewId) ? current : [...current, local.previewId]);
     setProposals((current) => ({ ...current, [local.previewId]: local }));
-    setSelection({ item: local, kind: "proposal" });
+    if (options.select !== false) setSelection({ item: local, kind: "proposal" });
     return local;
   }
 
@@ -1004,7 +1009,13 @@ export function PersonalWorkspacePage({
       stop: t("proposal.summary.lifecycleStop", { title: goal.title }),
     };
     try {
-      await createPreview({
+      if (operation === "stop") {
+        if (lifecyclePendingGoalIdsRef.current.has(goal.goalId)) return;
+        lifecyclePendingGoalIdsRef.current.add(goal.goalId);
+        setLifecycleBusyGoalIds(new Set(lifecyclePendingGoalIdsRef.current));
+        setSelection(null);
+      }
+      const proposal = await createPreview({
         actionKind: "goal.lifecycle",
         context: { kind: "goal_directory", goal_id: goal.goalId },
         idempotencyKey: `workspace-goal-${operation}-${goal.goalId}-${Date.now().toString(36)}`,
@@ -1014,11 +1025,23 @@ export function PersonalWorkspacePage({
           reason: reasonByOperation[operation],
         },
         summary: summaryByOperation[operation],
-      });
+      }, { select: operation !== "stop" });
+      if (operation === "stop") {
+        if (proposal.status === "ready") {
+          await applyProposal(proposal, { presentation: "feedback" });
+        } else {
+          setSelection({ item: proposal, kind: "proposal" });
+        }
+      }
     } catch (error) {
       setActionFeedback(t("feedback.executionFailed", {
         error: error instanceof Error ? error.message : String(error),
       }));
+    } finally {
+      if (operation === "stop") {
+        lifecyclePendingGoalIdsRef.current.delete(goal.goalId);
+        setLifecycleBusyGoalIds(new Set(lifecyclePendingGoalIdsRef.current));
+      }
     }
   }
 
@@ -1074,6 +1097,117 @@ export function PersonalWorkspacePage({
     });
   }
 
+  async function applyProposal(
+    proposal: WorkspaceActionPreview,
+    options: { presentation?: "drawer" | "feedback" } = {},
+  ) {
+    const showDrawer = options.presentation !== "feedback";
+    const lifecycleChange = proposal.actionKind === "goal.lifecycle"
+      && proposal.goalId
+      && (proposal.lifecycleOperation === "stop" || proposal.lifecycleOperation === "resume")
+      ? {
+          goalId: proposal.goalId,
+          next: proposal.lifecycleOperation === "stop" ? "stopped" as const : "active" as const,
+          previous: model.goals.find((goal) => goal.goalId === proposal.goalId)?.activationState
+            ?? (proposal.lifecycleOperation === "stop" ? "active" as const : "stopped" as const),
+        }
+      : null;
+    setActionFeedback(t("feedback.applying", { title: proposal.title }));
+    const applying = { ...proposal, status: "applying" as const };
+    setProposals((current) => ({ ...current, [proposal.previewId]: applying }));
+    if (showDrawer) setSelection({ item: applying, kind: "proposal" });
+    if (lifecycleChange) {
+      callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.next);
+    }
+    try {
+      if (callbacks.onApplyProposal) {
+        await callbacks.onApplyProposal(proposal);
+        const applied = { ...proposal, status: "applied" as const };
+        setProposals((current) => ({ ...current, [proposal.previewId]: applied }));
+        if (showDrawer) setSelection({ item: applied, kind: "proposal" });
+        setActionFeedback(t("feedback.completed", { title: proposal.title }));
+        if (proposal.actionKind === "goal.lifecycle") {
+          if (proposal.lifecycleOperation === "stop" || proposal.lifecycleOperation === "delete") {
+            selectGoal(null);
+          }
+          if (proposal.lifecycleOperation === "delete" && proposal.goalId) {
+            callbacks.onGoalDeleted?.(proposal.goalId);
+          }
+          const reconcile = callbacks.onReconcileStatus ?? callbacks.onRefresh;
+          void Promise.resolve().then(() => reconcile?.()).catch(() => undefined);
+        }
+        return;
+      }
+      const result = await applyTypedAction(proposal.previewId);
+      const applied = workspaceProposal(result.proposal, t);
+      setProposals((current) => ({ ...current, [proposal.previewId]: applied }));
+      if (showDrawer) setSelection({ item: applied, kind: "proposal" });
+      if (result.proposal.status !== "applied" || result.proposal.receipt?.projection_verified !== true) {
+        if (lifecycleChange) {
+          callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.previous);
+        }
+        setActionFeedback(
+          result.proposal.status === "stale"
+            ? t("feedback.stale")
+            : t("feedback.notCompleted", { status: result.proposal.status }),
+        );
+        return;
+      }
+      setActionFeedback(t("feedback.completed", { title: applied.title }));
+      // Keep the success receipt visible for reviewed actions. Direct actions
+      // surface the same result through the persistent feedback receipt.
+      if (applied.actionKind === "todo.create") {
+        await callbacks.onRefresh?.();
+      }
+      if (applied.actionKind === "goal.lifecycle" && (applied.lifecycleOperation === "stop" || applied.lifecycleOperation === "delete")) {
+        selectGoal(null);
+      }
+      if (applied.actionKind === "goal.lifecycle" && applied.lifecycleOperation === "delete" && applied.goalId) {
+        callbacks.onGoalDeleted?.(applied.goalId);
+      }
+      if (applied.actionKind === "goal.lifecycle") {
+        const reconcile = callbacks.onReconcileStatus ?? callbacks.onRefresh;
+        void Promise.resolve().then(() => reconcile?.()).catch(() => undefined);
+      }
+    } catch (error) {
+      if (lifecycleChange) {
+        callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.previous);
+      }
+      if (error instanceof ChatApiError && error.payload.error_code === "protected_action") {
+        const rawGate = error.payload.gate;
+        const gate = rawGate && typeof rawGate === "object" ? rawGate as Record<string, unknown> : {};
+        const gated = {
+          ...proposal,
+          gate: {
+            kind: String(gate.kind ?? "protected_action"),
+            nextAction: typeof gate.next_action === "string" ? gate.next_action : undefined,
+            summary: String(gate.summary ?? error.message),
+          },
+          status: "gated" as const,
+        };
+        setProposals((current) => ({ ...current, [proposal.previewId]: gated }));
+        // A newly discovered authority gate always deserves review, including
+        // when the action started on the direct path.
+        setSelection({ item: gated, kind: "proposal" });
+        setActionFeedback(t("feedback.gateRequired", { summary: gated.gate.summary }));
+        if (proposal.actionKind === "goal.create" && proposal.goalId) {
+          callbacks.onRefresh?.();
+          selectGoal(proposal.goalId);
+        }
+        return;
+      }
+      const stale = error instanceof Error && /stale|状态.*变化|conflict/i.test(error.message);
+      const failed = {
+        ...proposal,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        status: (stale ? "stale" : "error") as "stale" | "error",
+      };
+      setProposals((current) => ({ ...current, [proposal.previewId]: failed }));
+      if (showDrawer) setSelection({ item: failed, kind: "proposal" });
+      setActionFeedback(t("feedback.executionFailed", { error: failed.errorMessage }));
+    }
+  }
+
   const drawerCallbacks: PersonalWorkspaceCallbacks = {
     ...callbacks,
     onOpenRunSession: async (run) => {
@@ -1097,109 +1231,7 @@ export function PersonalWorkspacePage({
       setSelectedGoalTab("files");
       callbacks.onOpenOutput?.(output);
     },
-    onApplyProposal: async (proposal) => {
-      const lifecycleChange = proposal.actionKind === "goal.lifecycle"
-        && proposal.goalId
-        && (proposal.lifecycleOperation === "stop" || proposal.lifecycleOperation === "resume")
-        ? {
-            goalId: proposal.goalId,
-            next: proposal.lifecycleOperation === "stop" ? "stopped" as const : "active" as const,
-            previous: model.goals.find((goal) => goal.goalId === proposal.goalId)?.activationState
-              ?? (proposal.lifecycleOperation === "stop" ? "active" as const : "stopped" as const),
-          }
-        : null;
-      setActionFeedback(t("feedback.applying", { title: proposal.title }));
-      setProposals((current) => ({ ...current, [proposal.previewId]: { ...proposal, status: "applying" } }));
-      setSelection({ item: { ...proposal, status: "applying" }, kind: "proposal" });
-      if (lifecycleChange) {
-        callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.next);
-      }
-      try {
-        if (callbacks.onApplyProposal) {
-          await callbacks.onApplyProposal(proposal);
-          const applied = { ...proposal, status: "applied" as const };
-          setProposals((current) => ({ ...current, [proposal.previewId]: applied }));
-          setSelection({ item: applied, kind: "proposal" });
-          setActionFeedback(t("feedback.completed", { title: proposal.title }));
-          if (proposal.actionKind === "goal.lifecycle") {
-            if (proposal.lifecycleOperation === "stop" || proposal.lifecycleOperation === "delete") {
-              selectGoal(null);
-            }
-            if (proposal.lifecycleOperation === "delete" && proposal.goalId) {
-              callbacks.onGoalDeleted?.(proposal.goalId);
-            }
-            const reconcile = callbacks.onReconcileStatus ?? callbacks.onRefresh;
-            void Promise.resolve().then(() => reconcile?.()).catch(() => undefined);
-          }
-          return;
-        }
-        const result = await applyTypedAction(proposal.previewId);
-        const applied = workspaceProposal(result.proposal, t);
-        setProposals((current) => ({ ...current, [proposal.previewId]: applied }));
-        setSelection({ item: applied, kind: "proposal" });
-        if (result.proposal.status !== "applied" || result.proposal.receipt?.projection_verified !== true) {
-          if (lifecycleChange) {
-            callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.previous);
-          }
-          setActionFeedback(
-            result.proposal.status === "stale"
-              ? t("feedback.stale")
-              : t("feedback.notCompleted", { status: result.proposal.status }),
-          );
-          return;
-        }
-        setActionFeedback(t("feedback.completed", { title: applied.title }));
-        // Keep the success receipt visible. Refresh and navigation happen when
-        // the user chooses the explicit "进入 Goal" action in the drawer.
-        if (applied.actionKind === "todo.create") {
-          await callbacks.onRefresh?.();
-        }
-        if (applied.actionKind === "goal.lifecycle" && (applied.lifecycleOperation === "stop" || applied.lifecycleOperation === "delete")) {
-          selectGoal(null);
-        }
-        if (applied.actionKind === "goal.lifecycle" && applied.lifecycleOperation === "delete" && applied.goalId) {
-          callbacks.onGoalDeleted?.(applied.goalId);
-        }
-        if (applied.actionKind === "goal.lifecycle") {
-          const reconcile = callbacks.onReconcileStatus ?? callbacks.onRefresh;
-          void Promise.resolve().then(() => reconcile?.()).catch(() => undefined);
-        }
-      } catch (error) {
-        if (lifecycleChange) {
-          callbacks.onGoalActivationStateChange?.(lifecycleChange.goalId, lifecycleChange.previous);
-        }
-        if (error instanceof ChatApiError && error.payload.error_code === "protected_action") {
-          const rawGate = error.payload.gate;
-          const gate = rawGate && typeof rawGate === "object" ? rawGate as Record<string, unknown> : {};
-          const gated = {
-            ...proposal,
-            gate: {
-              kind: String(gate.kind ?? "protected_action"),
-              nextAction: typeof gate.next_action === "string" ? gate.next_action : undefined,
-              summary: String(gate.summary ?? error.message),
-            },
-            status: "gated" as const,
-          };
-          setProposals((current) => ({ ...current, [proposal.previewId]: gated }));
-          setSelection({ item: gated, kind: "proposal" });
-          setActionFeedback(t("feedback.gateRequired", { summary: gated.gate.summary }));
-          if (proposal.actionKind === "goal.create" && proposal.goalId) {
-            callbacks.onRefresh?.();
-            selectGoal(proposal.goalId);
-          }
-          return;
-        }
-        const stale = error instanceof Error && /stale|状态.*变化|conflict/i.test(error.message);
-        const failed = {
-          ...proposal,
-          errorMessage: error instanceof Error ? error.message : String(error),
-          status: (stale ? "stale" : "error") as "stale" | "error",
-        };
-        setProposals((current) => ({ ...current, [proposal.previewId]: failed }));
-        setSelection({ item: failed, kind: "proposal" });
-        setActionFeedback(t("feedback.executionFailed", { error: failed.errorMessage }));
-      }
-    },
+    onApplyProposal: applyProposal,
     onCancelProposal: async (proposal) => {
       setSelection(null);
       setProposals((current) => {
@@ -1764,6 +1796,7 @@ export function PersonalWorkspacePage({
         <GoalSidebar
           attentionCount={managerNeedsYouCount}
           goals={workspaceGoals}
+          lifecycleBusyGoalIds={lifecycleBusyGoalIds}
           onRequestGoalCreate={readOnly ? undefined : requestGoalCreate}
           onRequestGoalLifecycle={readOnly ? undefined : (goal, operation) => void requestGoalLifecycle(goal, operation)}
           onOpenSettings={readOnly ? undefined : () => setSelection({ kind: "settings" })}

--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace.css
@@ -92,6 +92,7 @@
 .personal-goal-link { display: grid; grid-template-columns: 30px minmax(0, 1fr) auto; align-items: center; gap: 10px; min-height: 44px; padding: 7px 5px 7px 10px; border-radius: 11px; }
 .personal-goal-lifecycle { display: grid; place-items: center; width: 26px; height: 26px; padding: 0; border: 0; border-radius: 7px; background: transparent; color: var(--pw-faint); cursor: pointer; }
 .personal-goal-lifecycle:hover { background: #fff; color: var(--pw-text); box-shadow: 0 1px 3px rgb(30 28 20 / 12%); }
+.personal-goal-lifecycle:disabled { opacity: .45; cursor: wait; }
 .personal-goal-delete:hover { color: var(--pw-danger); }
 .personal-goal-link-copy { display: grid; min-width: 0; gap: 2px; }
 .personal-goal-link-copy strong, .personal-goal-link-copy small { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }

--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -539,20 +539,19 @@ async function main() {
     const stoppedDirectory = page.locator(".personal-stopped-goals");
     if (!(await stoppedDirectory.isVisible()) || await stoppedDirectory.getAttribute("open") !== null) throw new Error("Stopped Goals are not available in a collapsed directory section");
     const writesBeforeLifecyclePreview = api.durableWriteCount;
-    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
-    await page.getByText("确认执行", { exact: true }).waitFor({ state: "visible" });
-    const stopPreview = api.actionPreviews.findLast((preview) => preview.action_kind === "goal.lifecycle" && preview.normalized_parameters.operation === "stop");
-    if (!stopPreview || stopPreview.normalized_parameters.goal_id !== "product-release") throw new Error("Goal stop did not create the expected typed preview");
-    if (api.durableWriteCount !== writesBeforeLifecyclePreview) throw new Error("Goal stop preview wrote state before owner confirmation");
     const statusRequestsBeforeStop = api.statusRequestCount;
     api.nextLifecycleApplyDelayMs = 900;
     api.nextStatusDelayMs = 900;
-    await page.getByRole("button", { name: "停止 Goal", exact: true }).click();
+    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
     await page.waitForFunction(
       () => document.querySelectorAll(".personal-goal-list:not(.is-stopped) .personal-goal-row").length === 2,
       null,
       { timeout: 600 },
     );
+    const stopPreview = api.actionPreviews.findLast((preview) => preview.action_kind === "goal.lifecycle" && preview.normalized_parameters.operation === "stop");
+    if (!stopPreview || stopPreview.normalized_parameters.goal_id !== "product-release") throw new Error("Goal stop did not create the expected typed preview");
+    if (api.durableWriteCount !== writesBeforeLifecyclePreview) throw new Error("Goal stop wrote durable state before its typed apply completed");
+    if (await page.getByText("确认执行", { exact: true }).count()) throw new Error("Goal stop still opened a redundant confirmation drawer");
     if ((await page.locator(".personal-goal-list:not(.is-stopped) .personal-goal-row").count()) !== 2) throw new Error("Optimistic Goal stop did not update the active sidebar immediately");
     await page.waitForTimeout(2_000);
     if (api.statusRequestCount <= statusRequestsBeforeStop) throw new Error("Successful Goal stop did not start background full-status reconciliation");
@@ -569,10 +568,8 @@ async function main() {
     await page.waitForTimeout(1_100);
     if ((await page.locator(".personal-goal-list:not(.is-stopped) .personal-goal-row").count()) !== 3) throw new Error("Full-status reconciliation reverted a successful Goal resume");
 
-    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
-    await page.getByText("确认执行", { exact: true }).waitFor({ state: "visible" });
     api.nextStatusDelayMs = 1_600;
-    await page.getByRole("button", { name: "停止 Goal", exact: true }).click();
+    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
     await page.getByRole("button", { name: "恢复 Product Release", exact: true }).waitFor({ state: "attached" });
     await page.getByRole("button", { name: "恢复 Product Release", exact: true }).click();
     await page.getByText("确认执行", { exact: true }).waitFor({ state: "visible" });
@@ -581,19 +578,15 @@ async function main() {
     await page.waitForTimeout(1_800);
     if ((await page.locator(".personal-goal-list:not(.is-stopped) .personal-goal-row").count()) !== 3) throw new Error("A stale background response overwrote a newer optimistic Goal transition");
 
-    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
-    await page.getByText("确认执行", { exact: true }).waitFor({ state: "visible" });
     api.failNextLifecycleApply = true;
     api.nextLifecycleApplyDelayMs = 900;
-    await page.getByRole("button", { name: "停止 Goal", exact: true }).click();
+    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
     await page.getByRole("button", { name: "恢复 Product Release", exact: true }).waitFor({ state: "attached", timeout: 600 });
     await page.getByRole("button", { name: "停止 Product Release", exact: true }).waitFor({ state: "attached", timeout: 2_000 });
     if (api.goalActivationStates.get("product-release") !== "active") throw new Error("Rejected Goal stop mutated the durable fixture state");
-    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
-    await page.getByText("确认执行", { exact: true }).waitFor({ state: "visible" });
     api.failNextStatusRequest = true;
     api.nextStatusDelayMs = 400;
-    await page.getByRole("button", { name: "停止 Goal", exact: true }).click();
+    await page.getByRole("button", { name: "停止 Product Release", exact: true }).click();
     await page.waitForTimeout(900);
     if (await page.getByText("无法读取状态", { exact: false }).count()) throw new Error("Background lifecycle reconciliation replaced the workspace with a fatal status error");
     if ((await page.locator(".personal-goal-list:not(.is-stopped) .personal-goal-row").count()) !== 2) throw new Error("Background reconciliation failure reverted the successful optimistic Goal state");
@@ -604,7 +597,7 @@ async function main() {
     if (stoppedChevronTransition !== "0s") throw new Error(`Stopped Goals disclosure ignores reduced motion: ${stoppedChevronTransition}`);
     await page.emulateMedia({ reducedMotion: "no-preference" });
     await page.screenshot({ path: resolve(outputDir, "goal-lifecycle-directory.png"), fullPage: false, animations: "disabled" });
-    pass(1, "Goal stop/resume updates the sidebar optimistically, rolls back a rejected apply, and still reconciles the full status payload in the background.");
+    pass(1, "Goal stop applies directly without a redundant confirmation, while resume stays reviewed; both update optimistically, roll back rejected applies, and reconcile status in the background.");
     if (await page.locator(".personal-timeline-row").filter({ hasText: /纠偏/u }).count()) throw new Error("Browse rows expose repeated correction actions");
     pass(2, "Browse rows are full-row click targets and Session rows state that they open execution progress and results.");
     await page.screenshot({ path: resolve(outputDir, "desktop-first-screen.png"), fullPage: false, animations: "disabled" });


### PR DESCRIPTION
## Summary

- make the Goal sidebar stop control a single-click action
- retain the typed preview/apply, optimistic rollback, projection receipt, and background status reconciliation boundaries
- keep resume and delete review-first; escalate any newly discovered authority gate back to the review drawer
- prevent duplicate stop submissions while apply is in flight

## Behavior change

The active-Goal stop icon no longer opens the confirmation drawer. A ready typed preview is applied directly and its outcome stays visible in the persistent feedback receipt. Resume/delete and non-ready/gated stop proposals still require review.

## Validation

- `npx tsc --noEmit`
- `node src/features/personal-workspace/personal-workspace-contract.test.mjs`
- `npm run smoke:personal-workspace`
- `loopx canary premerge --from-git-diff` (standard tier; 4 selected checks passed; no failures, warnings, or manual holds)

## Future-facing pass

Applied: extracted one shared proposal-apply state machine so direct and reviewed presentation modes cannot drift in lifecycle execution, rollback, gate escalation, or reconciliation semantics.