### PR TITLE
fix(periodic-report): normalize delivery binding refs

### DIFF
--- a/loopx/capabilities/periodic_report/pending_intent.py
+++ b/loopx/capabilities/periodic_report/pending_intent.py
@@ -77,6 +77,13 @@ def _intent_key(intent: Mapping[str, Any]) -> str:
     ).hexdigest()[:24]
 
 
+def _periodic_report_delivery_binding_ref(generation_id: object) -> str:
+    digest_suffix = str(generation_id).split("_")[-1][:16]
+    # Todo capability binding refs require the namespaced value to start with
+    # a letter. Generation digests are hexadecimal and may start with a digit.
+    return f"periodic-report:g{digest_suffix}"
+
+
 def _attempt_dir(
     runtime_root: Path,
     goal_id: str,
@@ -1003,7 +1010,9 @@ def consume_pending_periodic_report_intent(
         task_class="advancement_task",
         action_kind="deliver_periodic_report_goal_channel",
         task_domain="provider_delivery",
-        capability_binding_ref=f"periodic-report:{digest_suffix}",
+        capability_binding_ref=_periodic_report_delivery_binding_ref(
+            generation["generation_id"]
+        ),
         required_write_scopes=["goal_channel/lark/messages"],
         required_capabilities=["network", "lark_bot_message_write"],
         target_capabilities=["periodic_report", "goal_channel"],

--- a/tests/capabilities/test_periodic_report_pending_intent.py
+++ b/tests/capabilities/test_periodic_report_pending_intent.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from loopx.capabilities.periodic_report.pending_intent import (
+    _periodic_report_delivery_binding_ref,
     consume_pending_periodic_report_intent,
     pending_periodic_report_intents,
     periodic_report_pending_intent_interaction_hook,
@@ -24,6 +25,12 @@ from loopx.control_plane.quota.live_decision import (
 
 GOAL_ID = "report-goal"
 AGENT_ID = "report-agent"
+
+
+def test_delivery_binding_ref_is_valid_when_generation_digest_starts_with_digit() -> None:
+    assert _periodic_report_delivery_binding_ref(
+        "report_generation_53429b77872cbe1130a3e2f3"
+    ) == "periodic-report:g53429b77872cbe11"
 
 
 def _intent() -> dict[str, object]:
@@ -403,6 +410,7 @@ def test_consumption_is_local_and_exact_replay_does_not_duplicate_gate(
     )
     assert delivery["status"] == "blocked"
     assert delivery["action_kind"] == "deliver_periodic_report_goal_channel"
+    assert delivery["capability_binding_ref"].startswith("periodic-report:g")
     assert delivery["required_decision_scopes"][0]["scope_key"].startswith(
         "periodic_report_"
     )


### PR DESCRIPTION
## Summary

- make periodic-report delivery Todo binding refs valid for every hexadecimal generation digest
- prefix the digest segment with `g` so the namespaced value always begins with a letter
- add focused regression coverage for a real digit-leading generation id

## Motivation and architecture

The periodic-report consumer creates a blocked delivery Todo before its approval gate. Generation digests can begin with a digit, while Todo capability binding refs require the value after the namespace to begin with a letter. A digit-leading report therefore generated local artifacts and then failed before durable gate/successor settlement. The fix stays inside the existing periodic-report capability owner and preserves the public Todo contract instead of weakening its validator.

## Validation

- `python -m pytest tests/capabilities/test_periodic_report_pending_intent.py -q` — 13 passed
- `python -m ruff check` on both changed files — passed
- `git diff --check` — passed
- `loopx canary premerge --from-git-diff --goal-id ark-4-0-goal` — passed; maintainability ratchet and changed-file compile passed

## Risk

Low and localized. Existing binding refs gain a stable `g` prefix only for newly generated delivery Todos; approval scope and frozen artifact identity are unchanged.

## Future-facing pass

No broader refactor was needed. A small helper centralizes the binding rule at the owning call site and keeps the Todo validator authoritative.
