### PR TITLE
fix(feedback): select latest run by UTC timestamp

### DIFF
--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .history import load_index, load_registry
+from .history import _chronology_key, load_index, load_registry
 from .paths import resolve_runtime_root
 from .registry import registry_goals, resolve_state_file
 
@@ -213,7 +213,13 @@ def select_run(runs: list[dict[str, Any]], run_generated_at: str | None) -> dict
             if str(run.get("generated_at") or "") == run_generated_at:
                 return run
         raise ValueError(f"run not found for generated_at={run_generated_at}")
-    return sorted(runs, key=lambda item: str(item.get("generated_at") or ""), reverse=True)[0]
+    return max(
+        enumerate(runs),
+        key=lambda item: (
+            *_chronology_key(item[1].get("generated_at")),
+            item[0],
+        ),
+    )[1]
 
 
 def find_registry_goal(registry: dict[str, Any], goal_id: str) -> dict[str, Any] | None:

--- a/tests/test_feedback_run_selection.py
+++ b/tests/test_feedback_run_selection.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.feedback import append_human_reward, select_run
+
+
+def _run(generated_at: str | None, classification: str) -> dict[str, object]:
+    return {
+        "generated_at": generated_at,
+        "classification": classification,
+        "json_path": f"runs/{classification}.json",
+        "markdown_path": f"runs/{classification}.md",
+    }
+
+
+def test_select_run_uses_utc_instant_for_mixed_offsets() -> None:
+    runs = [
+        _run("2026-08-31T01:00:00+08:00", "older-utc"),
+        _run("2026-08-31T00:30:00Z", "newer-utc"),
+    ]
+
+    assert select_run(runs, None)["classification"] == "newer-utc"
+
+
+def test_select_run_prefers_valid_timestamps_over_legacy_values() -> None:
+    runs = [
+        _run(None, "missing-time"),
+        _run("not-a-timestamp", "malformed-time"),
+        _run("2026-08-30T23:59:59Z", "valid-time"),
+    ]
+
+    assert select_run(runs, None)["classification"] == "valid-time"
+
+
+def test_select_run_has_deterministic_equal_instant_tie_break() -> None:
+    runs = [
+        _run("2026-08-31T01:00:00+08:00", "offset-form"),
+        _run("2026-08-30T17:00:00Z", "utc-form"),
+    ]
+
+    assert select_run(runs, None)["classification"] == "offset-form"
+
+
+def test_append_human_reward_binds_default_overlay_to_latest_utc_run(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir()
+    registry_path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime),
+                "goals": [{"id": "fixture-goal", "repo": str(project)}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    runs_dir = runtime / "goals" / "fixture-goal" / "runs"
+    runs_dir.mkdir(parents=True)
+    rows = [
+        _run("2026-08-31T01:00:00+08:00", "older-utc"),
+        _run("2026-08-31T00:30:00Z", "newer-utc"),
+    ]
+    (runs_dir / "index.jsonl").write_text(
+        "".join(json.dumps(row) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+    result = append_human_reward(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id="fixture-goal",
+        run_generated_at=None,
+        reward={
+            "recorded_at": "2026-08-31T02:00:00Z",
+            "decision": "continue",
+            "reward": "positive",
+            "reason_summary": "fixture accepted",
+        },
+    )
+
+    assert result["selected_run"]["classification"] == "newer-utc"
+    assert result["index_record"]["classification"] == "newer-utc"
+
+
+@pytest.mark.parametrize(
+    "run_generated_at",
+    ["2026-08-31T01:00:00+08:00", "2026-08-31T00:30:00Z"],
+)
+def test_select_run_keeps_explicit_timestamp_matching_exact(
+    run_generated_at: str,
+) -> None:
+    runs = [
+        _run("2026-08-31T01:00:00+08:00", "older-utc"),
+        _run("2026-08-31T00:30:00Z", "newer-utc"),
+    ]
+
+    assert select_run(runs, run_generated_at)["generated_at"] == run_generated_at


### PR DESCRIPTION
## Summary

Closes #3774.

`loopx project reward` currently selects the default run by lexicographically sorting the raw `generated_at` string. ISO-8601 values with different UTC offsets are not lexicographically chronological, so the reward overlay can be appended to the wrong run.

## Fix

- reuse the canonical `history._chronology_key()` UTC-aware ordering rule;
- keep valid timestamps ahead of malformed or missing legacy values;
- retain deterministic ordering for equal instants;
- preserve exact matching when `--run-generated-at` is supplied;
- keep the persisted schema and append behavior unchanged.

## Validation

- focused feedback tests: 26 passed
- full Python suite: 4868 passed, 12 skipped
- `loopx canary premerge --from-git-diff`: passed
- Ruff and `git diff --check`: passed

One existing pydantic warning remains in the full suite.
