### PR TITLE
feat(extension): project provider runtime identity

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -8,6 +8,8 @@ Response: `loopx_codex_provider_routing_response_v0`
 
 Catalog: `codex_provider_routing_catalog_v1`
 
+Runtime status: `codex_provider_routing_runtime_status_v0`
+
 The provider accepts exactly one public-safe operation per invocation and
 returns a deterministic JSON result. An input containing credential-shaped
 keys fails before any operation runs.
@@ -16,6 +18,19 @@ The provider has no Kernel transition authority and no external write
 permission. A qualification result is evidence, not permission to edit a
 Codex home, install CPA, change a model, start a turn, rotate a credential or
 merge an upstream PR.
+
+Runtime status deliberately has two projections. `host_identity` records only
+that the operator's ChatGPT identity is retained but is not projected by the
+custom provider; its `route_binding` is always `none`. `route_intent` and
+`execution` separately report the requested logical route and the symbolic
+provider profiles actually attempted by CPA. A direct Auto hit on B is not a
+fallback; fallback is true only after a second candidate was attempted.
+
+Account observations may contain symbolic catalog profile IDs, readiness,
+bounded success/failure counters and percentage quota windows. The provider
+derives `remaining_percent`. Email addresses, auth IDs/files, credentials,
+private paths, task IDs and request content are forbidden at the public
+boundary.
 
 The catalog defines one bounded account ring, not one ring per visible route.
 Auto and Luna enter the same ring through affinity (or its first member for a

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -39,6 +39,13 @@ qualification.
   modality-aware affinity, typed route traversal, durable settings revision
   and commit barrier.
 
+`project_runtime_status`
+: Joins a stable, route-independent host ChatGPT identity state with a
+  content-free CPA execution observation and symbolic A/B quota/activity.
+  It validates the actual attempt chain against the compiled route, derives
+  remaining quota and reports fallback only when more than one provider was
+  attempted. It never accepts account identity, auth-file names or tokens.
+
 `upgrade_plan`
 : Produces a bounded upgrade/rollback checklist from public current and target
   refs plus the changed seams. It never installs, switches or deletes a
@@ -76,7 +83,7 @@ The earlier operator scripts split into three classes:
 | Upgrade matrix, snapshot order and rollback triggers | Migrated as `upgrade_plan`; effect execution remains operator-owned |
 | CPA process launcher, OAuth login/reconcile, Ark key loading | Excluded; these are provider runtime and credential lifecycle, not LoopX state |
 | Direct App config writes, private snapshots and rollback copies | Excluded from v0; require an explicit permissioned execution envelope before productization |
-| Raw log/evidence collection | Excluded; callers may submit only content-free error classes and qualification booleans |
+| Raw log/evidence collection | Excluded; an operator adapter may submit only symbolic, content-free observations to `project_runtime_status` |
 
 The complete responsibility-by-responsibility mapping and credential-free
 configuration references are in [`REFERENCES.md`](REFERENCES.md).

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -9,6 +9,7 @@ ports, accounts or private receipts.
 | Prototype responsibility | Disposition | Public owner |
 | --- | --- | --- |
 | Compile secret-free profiles, one-pass account rings and logical model routes | Migrated and strengthened | `contract.py::compile_catalog`; preferred entry points, terminal fallback tails, modality and Fast eligibility are explicit |
+| Project host identity separately from actual A/B routing and quota | Migrated as a public-safe adapter boundary | `contract.py::project_runtime_status`; raw CPA management responses and logs remain operator-local |
 | Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
 | Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
 | Snapshot App/selector configuration, validate hashes and roll back selected files | Planning contract migrated | `upgrade_plan` owns order, matrix and rollback trigger; filesystem effects need a future request-bound execution envelope |
@@ -21,10 +22,12 @@ ports, accounts or private receipts.
 
 ## Configuration References
 
-The package keeps three credential-free examples:
+The package keeps four credential-free examples:
 
 - [`examples/request.json`](examples/request.json): logical profiles and model
   routes backed by one bounded account ring for `compile_catalog`;
+- [`examples/runtime-status.json`](examples/runtime-status.json): dual host and
+  route identity projection with symbolic quota/activity observations;
 - [`examples/qualification-snapshot.json`](examples/qualification-snapshot.json):
   content-free App/CPA readback for `qualify_snapshot`;
 - [`examples/upgrade-request.json`](examples/upgrade-request.json): exact public

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -46,7 +46,7 @@ LoopX 只记录目标、门禁、证据和回滚状态。它不保存 OAuth toke
 
 ### Public PR lineage
 
-以下是截至 2026-08-29 与这套能力直接相关的完整公共 PR 索引。LoopX PR 记录 runbook 与
+以下是截至 2026-09-01 与这套能力直接相关的完整公共 PR 索引。LoopX PR 记录 runbook 与
 SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 
 | Repository | PR | 状态 | 沉淀内容 |
@@ -62,8 +62,9 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | LoopX | [#3585](https://github.com/huangruiteng/loopx/pull/3585) | merged | 固化 pinned CPA self-use routing 与回滚边界 |
 | LoopX | [#3665](https://github.com/huangruiteng/loopx/pull/3665) | merged | 沉淀 CPA + Codex App 分层重试与延迟门禁 |
 | LoopX | [#3711](https://github.com/huangruiteng/loopx/pull/3711) | merged | 将 runbook、脚本迁移清单、无密配置和资格 contract 升级为独立 extension |
-| LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | open | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
-| CLIProxyAPI | [#5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | open / review required | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer |
+| LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | merged | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
+| CLIProxyAPI | [#5211](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | merged | 被动观测 per-auth quota header 与最近请求计数；management 原始身份字段仍须由 operator adapter 脱敏 |
+| CLIProxyAPI | [#5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | open / conflicts | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer；CI 通过但需 rebase 后再 review |
 | CLIProxyAPI | [#5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | open / review required | ChatGPT uTLS HTTP/2 连接池、TLS session resumption 与异常重建 |
 | CLIProxyAPI | [#5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) | open / review required | per-route credential priority；同一 A/B 账号环支持 Prefer A 与 Prefer B 两个入口 |
 
@@ -93,6 +94,7 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | CPA upstream release baseline | [`a7e3596b7e351d800e58ed29529fbca3d1c18737`](https://github.com/router-for-me/CLIProxyAPI/commit/a7e3596b7e351d800e58ed29529fbca3d1c18737) | `fill-first`、priority、prefix、session affinity、stream bootstrap buffering、OpenAI-compatible provider 的原始基线 |
 | CPA public candidate | [PR #5220 head `9357def40dfccc3151e4797cbfa400d4df8e1d26`](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | 当前 `dev` 上的 provider-history / SSE candidate；CI 已通过且 mergeable，仍在等待 review，不等于 upstream release |
 | ChatGPT uTLS transport candidate | [PR #5261 head `c8e76e1e76aba4cc2206cec9d2a6444c9f527998`](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | 复用 HTTP/2 transport、TLS session resumption、draining/异常连接重建；CI 已通过且 mergeable，仍在等待 review |
+| Passive quota observation | [PR #5211 merge `ca601db05d858472b25e7c56580555ab62b90e68`](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | management API 暴露 bounded quota signal 与 200 分钟 recent-request buckets；原始 auth identity 只在 operator adapter 内使用 |
 | AgentSwap | [`c9b76f4a4adae81274eb8f52d428bba925a1a7ef`](https://github.com/bojieli/agentswap/commit/c9b76f4a4adae81274eb8f52d428bba925a1a7ef) | `teleport` / `handoff`、`--dry-run`、`--compact`、`--budget` |
 | Codex protocol reference | [`40b7560169c7274147a47f9b0c75db89fe016d34`](https://github.com/openai/codex/commit/40b7560169c7274147a47f9b0c75db89fe016d34) | `ResponseItem::Reasoning`、history normalization 和 remote compaction 行为的源码参照 |
 | SSH host Codex baseline | `codex-cli 0.150.1` | Remote App Server、受控 model catalog、图片 admission 与现有 task resume 的当前验证版本 |
@@ -120,14 +122,14 @@ merge commit，并重新运行本文矩阵。
 | A → B credential failover | loopback 与 live 均通过 | `fill-first`、priority、session affinity 与 commit 前 stream failover 已验证；live auto 请求在 A 建连失败后由 B 完成 |
 | Provider-bound history normalization | candidate、stale-task 与 `additional_tools` 回归通过 | 同 provider 的 A → B 也视为 scope 变化；跨 scope 时移除异源 identity / opaque state，保留可移植 summary、namespace/tool schema 与 tool call/result 因果链；unsupported item 仍返回 typed `409` |
 | Ark Responses SSE lifecycle normalizer | candidate 与真实 endpoint 通过 | 只对显式 `is-compat: true` 的模型启用；原生 Codex stream 保持原字节路径；真实 Ark HTTP/SSE 返回完整 lifecycle |
-| A/B 环 → Ark 组合路径 | loopback 与分层 live 证据通过 | 合成 quota 链 5/5 通过；live A → B 在同一请求完成；隔离禁用 A/B 后 auto 由 Ark 完成并恢复 auth 状态；Prefer B → A 依赖 CPA PR #5336 |
-| Route traversal readback | public contract 已补齐；live 待 #5336 | qualification 必须同时读回 entrypoint、ordered candidates、terminal tail 与 `max_cycles = 1`；只看到正确 selector 标签不能通过 |
-| Codex App selector projection | contract 已更新；live readback 待 CPA #5336 | 目标 `model/list` 暴露 Auto、Prefer A、Prefer B、Luna、Ark 五个可见 route，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
+| A/B 环 → Ark 组合路径 | loopback 与分层 live 证据通过 | A → B、Prefer B → A 与隔离 A/B 后的 Ark tail 均已在 integrated self-use candidate 通过；公共分发仍依赖 CPA PR #5336 |
+| Route traversal readback | public contract 与 self-use live 均通过 | qualification 同时读回 entrypoint、ordered candidates、terminal tail 与 `max_cycles = 1`；只看到正确 selector 标签不能通过 |
+| Codex App selector projection | 本机与 SSH App Server readback 通过 | `model/list` 暴露 Auto、Prefer A、Prefer B、Luna、Ark 五个可见 route，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
 | 图片能力投影 | 正向 E2E 通过，Auto 负向路径有已复现缺口 | Auto、Prefer A、Prefer B、Luna 声明 `text + image`，Ark 保持 `text`；健康 A/B 下图片到达 Codex。A/B 失败后，当前 Auto affinity 可能错误粘到 Ark，尚未做到 modality-aware fail closed |
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
 | Fast tier 投影 | A/B 既有 readback 通过；Luna/Prefer 显示待统一重验 | Auto、Prefer A、Prefer B、Luna 声明 `fast → priority`；Ark 不声明 Fast。`features.fast_mode = true` 只显示按钮，`service_tier = "default"` 保证默认关闭 |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | 三个 PR 已提交、CI 通过 | PR #5220 head `9357def`、PR #5261 head `c8e76e1`、PR #5336 head `3d038a27`；均目标 `dev`、等待 review |
+| CPA upstream review | quota PR 已合并；三个分发 PR CI 通过 | #5211 merge `ca601db0`；#5220 head `9357def` 当前 conflicts；#5261 head `c8e76e1`、#5336 head `3d038a27` mergeable；后三者仍等待 review |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
 | 当前 Codex App | self-use 配置已安装并完成 CLI / App Server readback | 主 App 与 SSH host 都指向 loopback CPA；模型目录变化需要重启或重连对应 App Server 才能刷新 UI cache，旧 task store 不复制、不删除 |
@@ -191,6 +193,22 @@ Fast 是一次 turn 的 service tier，不是独立模型。model catalog 需要
 `additional_speed_tiers: ["fast"]` 和 `service_tiers[].id: "priority"`，App 才显示按钮。
 `features.fast_mode = true` 只开放选择入口；默认配置继续使用 `service_tier = "default"`。
 只有用户手动开启 Fast 后，请求才映射为 `priority`。
+
+## 身份与路由状态双投影
+
+Codex App Server 的 `account/read` 与 `chatgptAuthTokens` 都是单一活动身份接口；自定义
+provider 下 `requiresOpenaiAuth = false`，因此不能根据模型 route 同时伪造 A/B 两个 App 原生
+账户。运行面采用两个互不覆盖的状态：
+
+- host identity 只表示 ChatGPT 登录凭据仍由宿主保留，但当前 custom provider 不投影它，
+  且永远不绑定 A/B route；
+- route identity 来自 CPA 的实际选择观测，只用 `codex-a`、`codex-b`、`ark-text` 等符号 ID，
+  同时给出 attempt chain、最终选择、fallback 和脱敏额度窗口。
+
+`project_runtime_status` 校验 attempt chain 必须是 catalog 法定顺序的前缀。Auto 可以从账号环
+任意 affinity 入口开始，所以直接命中 B 不等于 fallback；只有发生第二次 provider attempt
+才记为 fallback。原始 management 响应、auth filename、email、请求内容和 task/session ID
+不得进入 LoopX 仓库或 extension 输入。
 
 这里的“开启自动切换开关”不是修改 CPA 的一个全局布尔值，而是让 App selector 暴露并
 允许选择 `auto/...` 虚拟模型。A/B 也不再表示 hard pin，而是同一账号环的两个首选入口；
@@ -688,7 +706,7 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 | Upstream | 计划 | 合并门槛 |
 | --- | --- | --- |
-| CPA | **公共分发 PR**：[history / SSE normalization #5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) head `9357def`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1` | 截至 2026-08-28，两个 PR 都基于 upstream `dev`、CI 通过且 mergeable，仍等待 review；self-use 可锁定 fork SHA，但不得把它表述为 upstream release |
+| CPA | **公共分发 PR**：[history / SSE normalization #5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) head `9357def`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `3d038a27` | 截至 2026-09-01，三者 CI 通过；#5220 与 `dev` 冲突，后两者 mergeable，均等待 review；self-use 可锁定 integrated fork SHA，但不得把它表述为 upstream release |
 | CPA modality-aware Auto | **待提交公共 PR**：required-modality admission、affinity invalidation、无 eligible provider 的 typed error | 先用 text-only fallback + image history 复现；验证 A/B 正常、B 网络失败、A/B 全不可用与旧 Ark affinity 四类路径；不得把图片剥离后继续文本请求 |
 | AgentSwap | **条件 PR**：只有 locked commit 的 Codex writer 不能保持 multipart tool-result 1:1，或需要 provider-neutral checkpoint export 时才提交 | round-trip test 先复现真实缺口；不增加在线 retry、模型选择或第二 data plane |
 | Codex App / App Server | **待验证上游 seam**：settings revision 持久化/readback 与 turn-start 原子顺序；compaction barrier 仍只需要 fork + navigate host hook | 新 turn 必须证明采用新 revision；旧 turn 的 retry 不得被 UI 显示伪装为新模型；hook 不获得 provider 路由、凭据或 LoopX authority |
@@ -698,8 +716,8 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 所以近期技术选型不是 CPA 或 AgentSwap 二选一，而是 **CPA online + AgentSwap offline**，
 同时保持单一在线 authority。当前自用运行锁定 operator-owned private receipt，公共候选跟踪
 #5220 head `9357def`，都不等待 upstream review 才能做本机资格验证；上游合并后再把 merge
-commit 作为升级候选并重跑 qualification。#5261 在进入 self-use pin 前也要单独完成连接
-复用、异常重建、session resumption 与安全重放矩阵。AgentSwap 只有在独立、可复现的迁移
+commit 作为升级候选并重跑 qualification。#5261 已进入 integrated self-use candidate 并完成连接
+复用、异常重建、session resumption 与安全重放矩阵；上游合并版本仍需重新资格化。AgentSwap 只有在独立、可复现的迁移
 缺口出现时才改。Codex App PR 不阻塞日常切换，只决定 barrier case 能否“一键 fork
 并跳转”。
 
@@ -707,22 +725,22 @@ commit 作为升级候选并重跑 qualification。#5261 在进入 self-use pin 
 
 1. **影子验证（已完成）**：保持现有 App 不变，在隔离 home、loopback fault server 和 stale
    task 上跑完整矩阵。
-2. **单 App / 显式路由（已完成旧语义）**：App 指向固定 CPA；开放 A、B、Ark，未配置的
-   C 不出现在 selector；A/B 从 hard pin 升级为 Prefer 入口依赖 #5336。
-3. **Codex 账号环（A → B 已完成，B → A 待 #5336）**：priority + fill-first + affinity 已
-   通过 loopback 与 live A → B；route priority 合入并部署后补 Prefer B → A 资格验证。
+2. **单 App / 显式路由（self-use 已完成）**：App 指向固定 CPA；开放 A、B、Luna、Ark，未配置的
+   C 不出现在 selector；A/B 是同一环的两个 Prefer 入口，公共分发依赖 #5336。
+3. **Codex 账号环（self-use 已完成）**：priority + fill-first + affinity 已通过 A → B 与
+   Prefer B → A；上游 #5336 合并后仍需对 exact merge commit 重跑资格验证。
 4. **跨 provider 自动切换（self-use 已启用）**：固定 build 已通过 history projection、
    `additional_tools`、Ark SSE、commit barrier、真实 Ark 与故障注入矩阵，文本请求可由
    `auto/...` 降级到 Ark；foreign compaction barrier 仍 fail closed 并走显式 fork。
-5. **本机与 SSH selector（contract 已收敛，live 升级待执行）**：五个可见 selector、hidden
-   bare alias、图片能力和 Fast default-off contract 已进入受控 catalog；#5336 部署后仍要
-   重启对应 App Server 并做 UI readback。
+5. **本机与 SSH selector（self-use 已完成）**：五个可见 selector、hidden bare alias、图片
+   能力和 Fast default-off contract 已在两端 App Server readback 通过；上游 release 升级仍要
+   重启对应 App Server 并重复 readback。
 6. **多模态 Auto 负向路径（待修复）**：健康 A/B 的图片 E2E 已通过；modality-aware
    affinity、A/B 全不可用时的 typed fail-closed，以及 settings revision / turn-start 竞态仍要
    修复并重跑矩阵。在此之前不宣称 Auto 图片 failover 已完整资格化。
-7. **连接复用升级（待上游 review / self-use qualification）**：#5261 已通过公共 CI；进入
-   self-use pin 前验证 HTTP/2 reuse、TLS resumed、draining transport close、异常重建和非幂等
-   请求不重放。
+7. **连接复用升级（self-use 已完成，上游待 review）**：#5261 已通过公共 CI 与 integrated
+   self-use matrix，覆盖 HTTP/2 reuse、TLS resumed、draining transport close、异常重建和
+   已提交输出不重放；上游合并后仍要以 merge commit 重新验证。
 
 回滚时停止新 CPA，恢复升级前的 Codex provider 配置和旧二进制 symlink。不要回滚 session
 数据库，不删除新 task，也不要把新旧 `CODEX_HOME` 合并。CC Switch 在这里提供 profile

--- a/packages/loopx-codex-provider-routing/examples/runtime-status.json
+++ b/packages/loopx-codex-provider-routing/examples/runtime-status.json
@@ -1,0 +1,123 @@
+{
+  "operation": "project_runtime_status",
+  "schema_version": "loopx_codex_provider_routing_request_v0",
+  "status": {
+    "account_observations": [
+      {
+        "profile_id": "codex-a",
+        "quota": {
+          "observed_at": "2026-09-01T08:00:00Z",
+          "windows": [
+            {
+              "id": "primary",
+              "reset_at": "2026-09-01T10:00:00Z",
+              "used_percent": 25,
+              "window_minutes": 300
+            }
+          ]
+        },
+        "recent_activity": {
+          "failed": 1,
+          "success": 3,
+          "window_minutes": 200
+        },
+        "state": "ready"
+      },
+      {
+        "profile_id": "codex-b",
+        "quota": null,
+        "recent_activity": {
+          "failed": 0,
+          "success": 2,
+          "window_minutes": 200
+        },
+        "state": "ready"
+      }
+    ],
+    "catalog_source": {
+      "profiles": [
+        {
+          "id": "codex-a",
+          "input_modalities": [
+            "text",
+            "image"
+          ],
+          "priority": 300,
+          "provider": "codex",
+          "supports_fast": true
+        },
+        {
+          "id": "codex-b",
+          "input_modalities": [
+            "text",
+            "image"
+          ],
+          "priority": 200,
+          "provider": "codex",
+          "supports_fast": true
+        },
+        {
+          "id": "ark-text",
+          "input_modalities": [
+            "text"
+          ],
+          "priority": 100,
+          "provider": "openai_compatibility",
+          "supports_fast": false
+        }
+      ],
+      "rings": [
+        {
+          "id": "codex-accounts",
+          "max_cycles": 1,
+          "members": [
+            "codex-a",
+            "codex-b"
+          ]
+        }
+      ],
+      "routes": [
+        {
+          "display_name": "Sol · Prefer B",
+          "entrypoint": "codex-b",
+          "fallback_tail": [
+            "ark-text"
+          ],
+          "input_modalities": [
+            "text",
+            "image"
+          ],
+          "mode": "preferred",
+          "reasoning_levels": [
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max"
+          ],
+          "ring": "codex-accounts",
+          "slug": "codex-b/gpt-5.6-sol",
+          "supports_fast": true,
+          "visible": true
+        }
+      ]
+    },
+    "execution_observation": {
+      "attempted_profiles": [
+        "codex-b",
+        "codex-a"
+      ],
+      "fast": false,
+      "modality": "text",
+      "observed_at": "2026-09-01T08:00:00Z",
+      "outcome": "success",
+      "route_slug": "codex-b/gpt-5.6-sol",
+      "selected_profile": "codex-a"
+    },
+    "host_identity": {
+      "projection": "not_projected",
+      "route_binding": "none",
+      "state": "retained"
+    }
+  }
+}

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.1.0"
+version = "0.2.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.1.0"
+version = "0.2.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/schemas/request.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/request.schema.json
@@ -5,9 +5,23 @@
     {
       "properties": {
         "operation": {
+          "const": "project_runtime_status"
+        },
+        "snapshot": false,
+        "source": false,
+        "upgrade": false
+      },
+      "required": [
+        "status"
+      ]
+    },
+    {
+      "properties": {
+        "operation": {
           "const": "compile_catalog"
         },
         "snapshot": false,
+        "status": false,
         "upgrade": false
       },
       "required": [
@@ -20,6 +34,7 @@
           "const": "qualify_snapshot"
         },
         "source": false,
+        "status": false,
         "upgrade": false
       },
       "required": [
@@ -32,7 +47,8 @@
           "const": "upgrade_plan"
         },
         "snapshot": false,
-        "source": false
+        "source": false,
+        "status": false
       },
       "required": [
         "upgrade"
@@ -43,6 +59,7 @@
     "operation": {
       "enum": [
         "compile_catalog",
+        "project_runtime_status",
         "qualify_snapshot",
         "upgrade_plan"
       ]
@@ -51,6 +68,9 @@
       "const": "loopx_codex_provider_routing_request_v0"
     },
     "snapshot": {
+      "type": "object"
+    },
+    "status": {
       "type": "object"
     },
     "source": {

--- a/packages/loopx-codex-provider-routing/schemas/response.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/response.schema.json
@@ -43,6 +43,7 @@
     "operation": {
       "enum": [
         "compile_catalog",
+        "project_runtime_status",
         "qualify_snapshot",
         "upgrade_plan"
       ]

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -17,6 +17,7 @@ _run_request = cli._run_request
 REQUEST_SCHEMA_VERSION = contract.REQUEST_SCHEMA_VERSION
 build_upgrade_plan = contract.build_upgrade_plan
 compile_catalog = contract.compile_catalog
+project_runtime_status = contract.project_runtime_status
 qualify_snapshot = contract.qualify_snapshot
 
 
@@ -84,6 +85,58 @@ def _valid_snapshot() -> dict:
     }
 
 
+def _runtime_status() -> dict:
+    return {
+        "catalog_source": _source(),
+        "host_identity": {
+            "state": "retained",
+            "projection": "not_projected",
+            "route_binding": "none",
+        },
+        "execution_observation": {
+            "route_slug": "auto/gpt-5.6-sol",
+            "modality": "text",
+            "fast": False,
+            "observed_at": "2026-09-01T08:00:00Z",
+            "attempted_profiles": ["codex-b"],
+            "selected_profile": "codex-b",
+            "outcome": "success",
+        },
+        "account_observations": [
+            {
+                "profile_id": "codex-a",
+                "state": "ready",
+                "quota": {
+                    "observed_at": "2026-09-01T08:00:00Z",
+                    "windows": [
+                        {
+                            "id": "primary",
+                            "used_percent": 25,
+                            "window_minutes": 300,
+                            "reset_at": "2026-09-01T10:00:00Z",
+                        }
+                    ],
+                },
+                "recent_activity": {
+                    "success": 3,
+                    "failed": 1,
+                    "window_minutes": 200,
+                },
+            },
+            {
+                "profile_id": "codex-b",
+                "state": "ready",
+                "quota": None,
+                "recent_activity": {
+                    "success": 2,
+                    "failed": 0,
+                    "window_minutes": 200,
+                },
+            },
+        ],
+    }
+
+
 def expect_error(action, message: str) -> None:
     try:
         action()
@@ -119,6 +172,88 @@ def main() -> int:
     assert luna["eligible_candidates"]["image"] == ["codex-a", "codex-b"]
     assert luna["reasoning_levels"] == ["low", "medium", "high", "xhigh", "max"]
     assert luna["fast_candidates"] == ["codex-a", "codex-b"]
+
+    runtime = project_runtime_status(_runtime_status())
+    assert runtime["credential_free"] is True
+    assert runtime["host_identity"]["route_binding"] == "none"
+    assert runtime["execution"]["selected_profile"] == "codex-b"
+    assert runtime["execution"]["fallback_used"] is False
+    assert runtime["accounts"][0]["quota"]["windows"][0]["remaining_percent"] == 75
+
+    preferred_fallback = _runtime_status()
+    preferred_fallback["execution_observation"].update(
+        {
+            "route_slug": "codex-b/gpt-5.6-sol",
+            "attempted_profiles": ["codex-b", "codex-a"],
+            "selected_profile": "codex-a",
+        }
+    )
+    runtime = project_runtime_status(preferred_fallback)
+    assert runtime["execution"]["fallback_used"] is True
+
+    fast_fallback = _runtime_status()
+    fast_fallback["execution_observation"].update(
+        {
+            "route_slug": "codex-b/gpt-5.6-sol",
+            "fast": True,
+            "attempted_profiles": ["codex-b", "codex-a"],
+            "selected_profile": "codex-a",
+        }
+    )
+    runtime = project_runtime_status(fast_fallback)
+    assert runtime["route_intent"]["legal_attempt_orders"] == [["codex-b", "codex-a"]]
+
+    image_affinity = _runtime_status()
+    image_affinity["execution_observation"]["modality"] = "image"
+    runtime = project_runtime_status(image_affinity)
+    assert runtime["route_intent"]["legal_attempt_orders"] == [
+        ["codex-a", "codex-b"],
+        ["codex-b", "codex-a"],
+    ]
+
+    host_bound_to_route = _runtime_status()
+    host_bound_to_route["host_identity"]["route_binding"] = "codex-a"
+    expect_error(
+        lambda: project_runtime_status(host_bound_to_route),
+        "host identity was allowed to bind a route",
+    )
+
+    luna_to_ark = _runtime_status()
+    luna_to_ark["execution_observation"].update(
+        {
+            "route_slug": "gpt-5.6-luna",
+            "attempted_profiles": ["codex-a", "codex-b", "ark-text"],
+            "selected_profile": "ark-text",
+        }
+    )
+    expect_error(
+        lambda: project_runtime_status(luna_to_ark),
+        "Luna was allowed to select Ark",
+    )
+
+    failed_execution = _runtime_status()
+    failed_execution["execution_observation"]["outcome"] = "failed"
+    failed_execution["execution_observation"].pop("selected_profile")
+    runtime = project_runtime_status(failed_execution)
+    assert "selected_profile" not in runtime["execution"]
+
+    failed_with_selection = _runtime_status()
+    failed_with_selection["execution_observation"].update(
+        {"outcome": "failed", "selected_profile": None}
+    )
+    expect_error(
+        lambda: project_runtime_status(failed_with_selection),
+        "failed execution declared a selected profile",
+    )
+
+    identified_runtime = _runtime_status()
+    identified_runtime["account_observations"][0]["email"] = (
+        "operator" + "@" + "example.invalid"
+    )
+    expect_error(
+        lambda: project_runtime_status(identified_runtime),
+        "account identity leaked through runtime status",
+    )
 
     repeated_ring = copy.deepcopy(_source())
     repeated_ring["rings"][0]["max_cycles"] = 2
@@ -226,6 +361,7 @@ def main() -> int:
     assert response["ok"] is True and response["result"]["qualified"] is True
     for example_name in (
         "request.json",
+        "runtime-status.json",
         "qualification-snapshot.json",
         "upgrade-request.json",
     ):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -64,6 +64,8 @@ def _run_request(request: Any) -> dict[str, Any]:
         "qualify_snapshot": "snapshot",
         "upgrade_plan": "upgrade",
     }
+    if not isinstance(operation, str):
+        raise ValueError(f"unsupported operation: {operation!r}")
     expected_field = operation_fields.get(operation)
     if expected_field is None:
         raise ValueError(f"unsupported operation: {operation!r}")

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -11,6 +11,7 @@ from .contract import (
     RESPONSE_SCHEMA_VERSION,
     build_upgrade_plan,
     compile_catalog,
+    project_runtime_status,
     qualify_snapshot,
     reject_private_material,
 )
@@ -38,7 +39,12 @@ def _doctor() -> int:
             "schema_version": RESPONSE_SCHEMA_VERSION,
             "extension_id": EXTENSION_ID,
             "doctor": "ready",
-            "operations": ["compile_catalog", "qualify_snapshot", "upgrade_plan"],
+            "operations": [
+                "compile_catalog",
+                "project_runtime_status",
+                "qualify_snapshot",
+                "upgrade_plan",
+            ],
             "effect_boundary": "read_only_public_safe",
         }
     )
@@ -54,6 +60,7 @@ def _run_request(request: Any) -> dict[str, Any]:
     operation = request.get("operation")
     operation_fields = {
         "compile_catalog": "source",
+        "project_runtime_status": "status",
         "qualify_snapshot": "snapshot",
         "upgrade_plan": "upgrade",
     }
@@ -68,6 +75,11 @@ def _run_request(request: Any) -> dict[str, Any]:
         if not isinstance(source, Mapping):
             raise ValueError("compile_catalog requires object `source`")
         result = compile_catalog(source)
+    elif operation == "project_runtime_status":
+        status = request.get("status")
+        if not isinstance(status, Mapping):
+            raise ValueError("project_runtime_status requires object `status`")
+        result = project_runtime_status(status)
     elif operation == "qualify_snapshot":
         snapshot = request.get("snapshot")
         if not isinstance(snapshot, Mapping):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -323,6 +323,7 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
             )
         ):
             raise ValueError(f"route {slug} has no fast-eligible candidate")
+        max_cycles = rings[ring_id]["max_cycles"] if isinstance(ring_id, str) else 1
 
         routes.append(
             {
@@ -363,7 +364,7 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
                     "traversal": "one_ring_pass_then_tail"
                     if uses_ring
                     else "ordered_candidates_once",
-                    "max_cycles": rings[ring_id]["max_cycles"] if uses_ring else 1,
+                    "max_cycles": max_cycles,
                     "commit_barrier": "before_first_visible_output_or_tool_call",
                     "foreign_history": "normalize_or_quarantine",
                 },

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -6,17 +6,26 @@ from itertools import pairwise
 from typing import Any
 
 CATALOG_SCHEMA_VERSION = "codex_provider_routing_catalog_v1"
+RUNTIME_STATUS_SCHEMA_VERSION = "codex_provider_routing_runtime_status_v0"
 REQUEST_SCHEMA_VERSION = "loopx_codex_provider_routing_request_v0"
 RESPONSE_SCHEMA_VERSION = "loopx_codex_provider_routing_response_v0"
 
 FORBIDDEN_KEYS = {
+    "account_id",
     "api_key",
     "access_token",
+    "auth_file",
+    "auth_index",
     "refresh_token",
     "authorization",
     "cookie",
+    "email",
+    "filename",
     "password",
+    "project_id",
     "secret",
+    "session_id",
+    "task_id",
     "token",
 }
 ALLOWED_MODALITIES = {"text", "image"}
@@ -69,6 +78,14 @@ def _boolean(value: Any, field: str, *, default: bool | None = None) -> bool:
     if not isinstance(value, bool):
         raise TypeError(f"{field} must be a boolean")
     return value
+
+
+def _reject_unexpected_keys(
+    value: Mapping[str, Any], allowed: set[str], field: str
+) -> None:
+    unexpected = sorted(set(value) - allowed)
+    if unexpected:
+        raise ValueError(f"{field} has unsupported fields: {unexpected}")
 
 
 def _compile_profiles(raw_profiles: Any) -> dict[str, dict[str, Any]]:
@@ -377,6 +394,296 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
         "profiles": list(profiles.values()),
         "rings": list(rings.values()),
         "routes": routes,
+    }
+
+
+def _timestamp(value: Any, field: str) -> str:
+    timestamp = _non_empty_string(value, field)
+    if (
+        re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z", timestamp)
+        is None
+    ):
+        raise ValueError(f"{field} must be an RFC 3339 UTC timestamp")
+    return timestamp
+
+
+def _percentage(value: Any, field: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise TypeError(f"{field} must be a number")
+    if not 0 <= value <= 100:
+        raise ValueError(f"{field} must be between 0 and 100")
+    return float(value)
+
+
+def _quota_windows(raw: Any, field: str) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise TypeError(f"{field} must be a list")
+    windows: list[dict[str, Any]] = []
+    ids: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise TypeError(f"{field}[{index}] must be an object")
+        _reject_unexpected_keys(
+            item,
+            {"id", "used_percent", "window_minutes", "reset_at"},
+            f"{field}[{index}]",
+        )
+        window_id = _non_empty_string(item.get("id"), f"{field}[{index}].id")
+        if SYMBOLIC_ID_RE.fullmatch(window_id) is None:
+            raise ValueError(f"{field}[{index}].id must be a symbolic id")
+        if window_id in ids:
+            raise ValueError(f"{field} has duplicate window id: {window_id}")
+        ids.add(window_id)
+        used = _percentage(item.get("used_percent"), f"{field}[{index}].used_percent")
+        minutes = item.get("window_minutes")
+        if not isinstance(minutes, int) or isinstance(minutes, bool) or minutes <= 0:
+            raise ValueError(f"{field}[{index}].window_minutes must be positive")
+        reset_at = item.get("reset_at")
+        if reset_at is not None:
+            reset_at = _timestamp(reset_at, f"{field}[{index}].reset_at")
+        windows.append(
+            {
+                "id": window_id,
+                "used_percent": used,
+                "remaining_percent": 100.0 - used,
+                "window_minutes": minutes,
+                "reset_at": reset_at,
+            }
+        )
+    return windows
+
+
+def _eligible_route_order(
+    route: Mapping[str, Any],
+    profiles: Mapping[str, Mapping[str, Any]],
+    *,
+    modality: str,
+    fast: bool,
+) -> list[str]:
+    return _eligible_profiles(
+        route["candidates"],
+        profiles,
+        required_modalities={modality},
+        require_fast=fast,
+    )
+
+
+def _legal_attempt_orders(
+    route: Mapping[str, Any],
+    rings: Mapping[str, Mapping[str, Any]],
+    profiles: Mapping[str, Mapping[str, Any]],
+    *,
+    modality: str,
+    fast: bool,
+) -> list[list[str]]:
+    eligible = _eligible_route_order(route, profiles, modality=modality, fast=fast)
+    if route["entrypoint"] != "affinity_then_first":
+        return [eligible]
+    ring = rings[route["ring_id"]]
+    eligible_ring = [item for item in ring["members"] if item in eligible]
+    eligible_tail = [item for item in route["fallback_tail"] if item in eligible]
+    if not eligible_ring:
+        return [eligible_tail]
+    return [
+        _rotate_members(eligible_ring, entrypoint) + eligible_tail
+        for entrypoint in eligible_ring
+    ]
+
+
+def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and project content-free host, route and account observations."""
+
+    reject_private_material(status)
+    _reject_unexpected_keys(
+        status,
+        {
+            "schema_version",
+            "credential_free",
+            "catalog_source",
+            "host_identity",
+            "execution_observation",
+            "account_observations",
+        },
+        "status",
+    )
+    source = status.get("catalog_source")
+    if not isinstance(source, Mapping):
+        raise TypeError("status.catalog_source must be an object")
+    catalog = compile_catalog(source)
+    profiles = {item["id"]: item for item in catalog["profiles"]}
+    rings = {item["id"]: item for item in catalog["rings"]}
+    routes = {
+        item["slug"]: item
+        for item in catalog["routes"]
+        if item["routing_mode"] != "alias"
+    }
+
+    host = status.get("host_identity")
+    if not isinstance(host, Mapping):
+        raise TypeError("status.host_identity must be an object")
+    expected_host = {
+        "state": "retained",
+        "projection": "not_projected",
+        "route_binding": "none",
+    }
+    if dict(host) != expected_host:
+        raise ValueError(
+            "host identity must be retained, not projected and independent of routing"
+        )
+
+    observation = status.get("execution_observation")
+    if not isinstance(observation, Mapping):
+        raise TypeError("status.execution_observation must be an object")
+    _reject_unexpected_keys(
+        observation,
+        {
+            "route_slug",
+            "modality",
+            "fast",
+            "observed_at",
+            "attempted_profiles",
+            "selected_profile",
+            "outcome",
+        },
+        "status.execution_observation",
+    )
+    route_slug = _non_empty_string(
+        observation.get("route_slug"), "status.execution_observation.route_slug"
+    )
+    route = routes.get(route_slug)
+    if route is None:
+        raise ValueError(
+            "execution observation must reference a concrete catalog route"
+        )
+    modality = _non_empty_string(
+        observation.get("modality"), "status.execution_observation.modality"
+    )
+    if modality not in route["input_modalities"]:
+        raise ValueError(f"route {route_slug} does not admit modality {modality}")
+    fast = _boolean(observation.get("fast"), "status.execution_observation.fast")
+    if fast and not route["supports_fast"]:
+        raise ValueError(f"route {route_slug} does not support Fast")
+    observed_at = _timestamp(
+        observation.get("observed_at"), "status.execution_observation.observed_at"
+    )
+    attempted = _string_list(
+        observation.get("attempted_profiles"),
+        "status.execution_observation.attempted_profiles",
+    )
+    if not attempted:
+        raise ValueError("execution observation needs at least one attempted profile")
+    legal_orders = _legal_attempt_orders(
+        route, rings, profiles, modality=modality, fast=fast
+    )
+    matching_orders = [
+        order for order in legal_orders if attempted == order[: len(attempted)]
+    ]
+    if not matching_orders:
+        raise ValueError(
+            f"attempted profiles are not a legal prefix for route {route_slug}"
+        )
+    outcome = _non_empty_string(
+        observation.get("outcome"), "status.execution_observation.outcome"
+    )
+    if outcome not in {"success", "failed"}:
+        raise ValueError("execution outcome must be success or failed")
+    selected = observation.get("selected_profile")
+    if outcome == "success":
+        selected = _non_empty_string(
+            selected, "status.execution_observation.selected_profile"
+        )
+        if selected != attempted[-1]:
+            raise ValueError(
+                "successful selection must equal the final attempted profile"
+            )
+    elif "selected_profile" in observation:
+        raise ValueError("failed execution must not declare a selected profile")
+
+    raw_accounts = status.get("account_observations")
+    if not isinstance(raw_accounts, list):
+        raise TypeError("status.account_observations must be a list")
+    accounts: list[dict[str, Any]] = []
+    account_ids: set[str] = set()
+    for index, raw in enumerate(raw_accounts):
+        field = f"status.account_observations[{index}]"
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"{field} must be an object")
+        _reject_unexpected_keys(
+            raw,
+            {"profile_id", "state", "quota", "recent_activity"},
+            field,
+        )
+        profile_id = _non_empty_string(raw.get("profile_id"), f"{field}.profile_id")
+        if profile_id in account_ids:
+            raise ValueError(f"duplicate account observation: {profile_id}")
+        if profile_id not in profiles or profiles[profile_id]["provider"] != "codex":
+            raise ValueError(
+                f"account observation must reference a Codex profile: {profile_id}"
+            )
+        account_ids.add(profile_id)
+        state = _non_empty_string(raw.get("state"), f"{field}.state")
+        if state not in {"ready", "degraded", "unavailable", "unknown"}:
+            raise ValueError(f"unsupported account state: {state}")
+        quota = raw.get("quota")
+        projected_quota = None
+        if quota is not None:
+            if not isinstance(quota, Mapping):
+                raise TypeError(f"{field}.quota must be an object")
+            _reject_unexpected_keys(quota, {"observed_at", "windows"}, f"{field}.quota")
+            projected_quota = {
+                "observed_at": _timestamp(
+                    quota.get("observed_at"), f"{field}.quota.observed_at"
+                ),
+                "windows": _quota_windows(
+                    quota.get("windows", []), f"{field}.quota.windows"
+                ),
+            }
+        activity = raw.get("recent_activity")
+        if not isinstance(activity, Mapping):
+            raise TypeError(f"{field}.recent_activity must be an object")
+        _reject_unexpected_keys(
+            activity,
+            {"success", "failed", "window_minutes"},
+            f"{field}.recent_activity",
+        )
+        projected_activity: dict[str, int] = {}
+        for key in ("success", "failed", "window_minutes"):
+            value = activity.get(key)
+            minimum = 1 if key == "window_minutes" else 0
+            if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+                raise ValueError(f"{field}.recent_activity.{key} is invalid")
+            projected_activity[key] = value
+        accounts.append(
+            {
+                "profile_id": profile_id,
+                "state": state,
+                "quota": projected_quota,
+                "recent_activity": projected_activity,
+            }
+        )
+
+    execution = {
+        "observed_at": observed_at,
+        "attempted_profiles": attempted,
+        "outcome": outcome,
+        "fallback_used": len(attempted) > 1,
+    }
+    if selected is not None:
+        execution["selected_profile"] = selected
+
+    return {
+        "schema_version": RUNTIME_STATUS_SCHEMA_VERSION,
+        "credential_free": True,
+        "host_identity": expected_host,
+        "route_intent": {
+            "route_slug": route_slug,
+            "routing_mode": route["routing_mode"],
+            "modality": modality,
+            "fast": fast,
+            "legal_attempt_orders": legal_orders,
+        },
+        "execution": execution,
+        "accounts": accounts,
     }
 
 


### PR DESCRIPTION
## Summary

- add `project_runtime_status` to keep host ChatGPT identity separate from CPA route identity
- validate route intent, affinity rotations, modality/Fast eligibility, actual attempt chains, selected profile and fallback
- project only symbolic A/B readiness, recent activity and bounded quota windows with derived remaining percentage
- update the canonical runbook and public PR lineage; bump the extension to 0.2.0

## Validation

- `ruff check` on extension source and smoke
- `codex_provider_routing_smoke.py`
- `pytest -q tests/extensions/test_colocated_extension_layout.py` (2 passed)
- extension `--doctor` includes `project_runtime_status`
- `loopx check --scan-path packages/loopx-codex-provider-routing` (0 errors; public boundary clean)
- live public-safe status projection against the local CPA observation
- local and SSH App Server readback: five selectors, Fast available/default off, custom-provider account remains unprojected

## Public/private boundary

The PR contains no operator paths, auth filenames, email/account identity, credentials, request content, task/session IDs or raw logs. The effectful CPA management-key and log adapter remains operator-local and is intentionally excluded.

## Residual risk

Quota remains unknown until an upstream response supplies bounded Codex quota headers. The native Codex lower-left account widget remains singular; this extension exposes a truthful separate status contract instead of spoofing App identity.

Signed-off-by: huangruiteng <huangrt01@163.com>