### PR TITLE
feat(extension): add explicit Fast selector rows

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -59,9 +59,11 @@ declare one `fast_selector`; the compiler emits `fast/<route>`, filters its
 candidates to Fast-capable profiles and marks its default tier as `fast`.
 `normalize_selector_request` consumes only the original selector and optional
 service tier: Fast rows resolve to the underlying route and force the wire tier
-to `priority`, while ordinary rows preserve the request. It never accepts a
-prompt or request body. A Fast selector cannot fall through to a provider that
-does not support Fast.
+to `priority`, while ordinary rows preserve the request. A preserved
+`priority` tier is nevertheless treated as effective Fast state for candidate
+admission, so both the explicit sibling row and the native Fast entry are
+limited to Fast-capable providers. It never accepts a prompt or request body.
+A Fast request cannot fall through to a provider that does not support Fast.
 
 Codex App settings use the same evidence rule. A selector label is not proof
 that a running turn adopted the new model. Qualification requires a durable

--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -25,6 +25,8 @@ custom provider; its `route_binding` is always `none`. `route_intent` and
 `execution` separately report the requested logical route and the symbolic
 provider profiles actually attempted by CPA. A direct Auto hit on B is not a
 fallback; fallback is true only after a second candidate was attempted.
+`route_intent.fast` is derived from the selected `fast/` route slug. A caller
+may include a redundant boolean only when it agrees with that slug.
 
 Account observations may contain symbolic catalog profile IDs, readiness,
 bounded success/failure counters and percentage quota windows. The provider
@@ -51,6 +53,15 @@ Affinity can reorder only the remaining eligible ring members. If none remain,
 the route fails closed before the first visible output or tool call. A
 text-only fallback can therefore serve text Auto requests but cannot receive
 image history. Luna has no heterogeneous fallback tail.
+
+Fast is modeled as a selector projection over an existing route. A route may
+declare one `fast_selector`; the compiler emits `fast/<route>`, filters its
+candidates to Fast-capable profiles and marks its default tier as `fast`.
+`normalize_selector_request` consumes only the original selector and optional
+service tier: Fast rows resolve to the underlying route and force the wire tier
+to `priority`, while ordinary rows preserve the request. It never accepts a
+prompt or request body. A Fast selector cannot fall through to a provider that
+does not support Fast.
 
 Codex App settings use the same evidence rule. A selector label is not proof
 that a running turn adopted the new model. Qualification requires a durable

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -31,13 +31,21 @@ qualification.
   Route affinity is only a hint and must be revalidated against required input
   modalities and service tier on every attempt. A terminal text-only fallback
   can serve compatible Sol requests but cannot receive image history; Luna has
-  no heterogeneous fallback tail.
+  no heterogeneous fallback tail. A route may declare one `fast_selector`;
+  the compiler then emits a `fast/<route>` sibling row whose candidates are
+  limited to Fast-capable providers and whose default tier is `fast`.
+
+`normalize_selector_request`
+: Resolves the original App model selector before provider alias mapping. A
+  `fast/` selector is stripped to its underlying route and forces the wire
+  request tier to `priority`; an ordinary selector preserves the caller's
+  service tier. The operation accepts no prompt, auth or request body.
 
 `qualify_snapshot`
 : Checks the content-free App/CPA readback: visible and hidden routes, input
-  modalities, Fast projection with default-off semantics, loopback binding,
-  modality-aware affinity, typed route traversal, durable settings revision
-  and commit barrier.
+  modalities, explicit Fast sibling rows, per-row default tiers, active request
+  normalization, loopback binding, modality-aware affinity, typed route
+  traversal, durable settings revision and commit barrier.
 
 `project_runtime_status`
 : Joins a stable, route-independent host ChatGPT identity state with a
@@ -66,6 +74,10 @@ loopx extension run loopx-codex-provider-routing \
   --input-json packages/loopx-codex-provider-routing/examples/request.json \
   --execute \
   --format json
+loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/normalize-request.json \
+  --execute \
+  --format json
 ```
 
 The extension runtime owns install/enable/disable/doctor registration. Package
@@ -79,6 +91,7 @@ The earlier operator scripts split into three classes:
 | Script responsibility | Extension ownership |
 | --- | --- |
 | Secret-free profile/catalog compiler | Migrated into `compile_catalog` and strengthened with modality/service-tier eligibility |
+| Fast selector catalog generation and request-tier normalization | Migrated into `compile_catalog` plus `normalize_selector_request`; the CPA adapter remains the online enforcement point |
 | App/CPA model readback assertions | Migrated as the content-free `qualify_snapshot` contract |
 | Upgrade matrix, snapshot order and rollback triggers | Migrated as `upgrade_plan`; effect execution remains operator-owned |
 | CPA process launcher, OAuth login/reconcile, Ark key loading | Excluded; these are provider runtime and credential lifecycle, not LoopX state |

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -39,13 +39,16 @@ qualification.
 : Resolves the original App model selector before provider alias mapping. A
   `fast/` selector is stripped to its underlying route and forces the wire
   request tier to `priority`; an ordinary selector preserves the caller's
-  service tier. The operation accepts no prompt, auth or request body.
+  service tier. If that preserved tier is `priority`, candidate admission still
+  switches to Fast-capable-only, so the native Fast entry cannot reach Ark.
+  The operation accepts no prompt, auth or request body.
 
 `qualify_snapshot`
 : Checks the content-free App/CPA readback: visible and hidden routes, input
   modalities, explicit Fast sibling rows, per-row default tiers, active request
-  normalization, loopback binding, modality-aware affinity, typed route
-  traversal, durable settings revision and commit barrier.
+  normalization including effective-priority admission, loopback binding,
+  modality-aware affinity, typed route traversal, durable settings revision and
+  commit barrier.
 
 `project_runtime_status`
 : Joins a stable, route-independent host ChatGPT identity state with a

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -9,6 +9,7 @@ ports, accounts or private receipts.
 | Prototype responsibility | Disposition | Public owner |
 | --- | --- | --- |
 | Compile secret-free profiles, one-pass account rings and logical model routes | Migrated and strengthened | `contract.py::compile_catalog`; preferred entry points, terminal fallback tails, modality and Fast eligibility are explicit |
+| Generate explicit Fast sibling rows and inject the Fast request tier | Migrated as a public-safe compiler/normalizer contract | `contract.py::compile_catalog` plus `normalize_selector_request`; the live CPA adapter/plugin enforces the same decision before alias mapping |
 | Project host identity separately from actual A/B routing and quota | Migrated as a public-safe adapter boundary | `contract.py::project_runtime_status`; raw CPA management responses and logs remain operator-local |
 | Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
 | Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
@@ -22,10 +23,12 @@ ports, accounts or private receipts.
 
 ## Configuration References
 
-The package keeps four credential-free examples:
+The package keeps five credential-free examples:
 
 - [`examples/request.json`](examples/request.json): logical profiles and model
   routes backed by one bounded account ring for `compile_catalog`;
+- [`examples/normalize-request.json`](examples/normalize-request.json): one
+  Fast selector normalization that forces `priority` without accepting a body;
 - [`examples/runtime-status.json`](examples/runtime-status.json): dual host and
   route identity projection with symbolic quota/activity observations;
 - [`examples/qualification-snapshot.json`](examples/qualification-snapshot.json):

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -64,6 +64,7 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | LoopX | [#3711](https://github.com/huangruiteng/loopx/pull/3711) | merged | 将 runbook、脚本迁移清单、无密配置和资格 contract 升级为独立 extension |
 | LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | merged | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
 | LoopX | [#3804](https://github.com/huangruiteng/loopx/pull/3804) | merged | 将宿主身份、路由选择、额度与真实 attempt chain 投影为无密运行状态 |
+| LoopX | [#3805](https://github.com/huangruiteng/loopx/pull/3805) | open | 生成显式 Fast sibling rows，固化 `fast/` request normalization、默认 tier 与 A/B-only fallback |
 | CLIProxyAPI | [#5211](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | merged | 被动观测 per-auth quota header 与最近请求计数；management 原始身份字段仍须由 operator adapter 脱敏 |
 | CLIProxyAPI | [#5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | open / conflicts | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer；CI 通过但需 rebase 后再 review |
 | CLIProxyAPI | [#5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | open / review required | ChatGPT uTLS HTTP/2 连接池、TLS session resumption 与异常重建 |

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -199,7 +199,9 @@ provider 的原生 Fast 按钮还受宿主 ChatGPT 身份投影约束，不能�
 因此从显式声明 `fast_selector` 的普通 route 生成 `fast/<route>` sibling 行：普通行使用
 `default_service_tier = "default"`，Fast 行使用 `default_service_tier = "fast"`。CPA adapter/plugin
 必须在 alias 映射前读取原始 selector；命中 `fast/` 时去掉前缀并强制请求
-`service_tier = "priority"`，普通 selector 不改 tier。
+`service_tier = "priority"`。普通 selector 不改调用方传入的 tier；若原生 Fast
+入口已经传入 `priority`，normalizer 仍会按有效 Fast 状态收窄到 A/B
+Fast-capable candidates，不能落到 Ark。
 
 Fast sibling 的候选不是复制普通 route，而是按 `supports_fast` 过滤。A/B 支持 Fast，Ark 不支持，
 所以 Fast 行只能在 A/B 环内切换；没有 Fast-capable provider 时必须在首个输出前 fail closed。
@@ -481,7 +483,9 @@ credential 遍历、provider 选择和 commit barrier 仍由 CPA 独占。两层
 2. `input_modalities`：Standard/Fast Sol 与 Luna 为 `text, image`，Ark 为 `text`；
 3. `supported_reasoning_levels`：Sol 与 Luna 都只声明已验证的 `low / medium / high / xhigh / max`；
 4. `selector_default_service_tiers`：普通行、Luna、Ark 为 `default`，三条 `fast/` 行为 `fast`；
-5. `request_normalizer`：`fast/` 在 alias mapping 前强制 `priority`，普通行保持原请求；
+5. `request_normalizer`：`fast/` 在 alias mapping 前强制 `priority`；普通行保持原请求，
+   但原请求为 `priority` 时同样启用 Fast-capable-only admission；readback 必须报告
+   `effective_priority_admission = fast_capable_only`；
 6. `route_traversal`：普通 Sol 允许一次 A/B 环后接 Ark，Fast Sol 只允许一次 A/B 环。
 
 App Server 的 `model/list` readback 是 catalog 验收面。只检查 JSON 文件内容不够，因为旧

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -63,6 +63,7 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | LoopX | [#3665](https://github.com/huangruiteng/loopx/pull/3665) | merged | 沉淀 CPA + Codex App 分层重试与延迟门禁 |
 | LoopX | [#3711](https://github.com/huangruiteng/loopx/pull/3711) | merged | 将 runbook、脚本迁移清单、无密配置和资格 contract 升级为独立 extension |
 | LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | merged | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
+| LoopX | [#3804](https://github.com/huangruiteng/loopx/pull/3804) | merged | 将宿主身份、路由选择、额度与真实 attempt chain 投影为无密运行状态 |
 | CLIProxyAPI | [#5211](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | merged | 被动观测 per-auth quota header 与最近请求计数；management 原始身份字段仍须由 operator adapter 脱敏 |
 | CLIProxyAPI | [#5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | open / conflicts | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer；CI 通过但需 rebase 后再 review |
 | CLIProxyAPI | [#5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | open / review required | ChatGPT uTLS HTTP/2 连接池、TLS session resumption 与异常重建 |
@@ -124,12 +125,12 @@ merge commit，并重新运行本文矩阵。
 | Ark Responses SSE lifecycle normalizer | candidate 与真实 endpoint 通过 | 只对显式 `is-compat: true` 的模型启用；原生 Codex stream 保持原字节路径；真实 Ark HTTP/SSE 返回完整 lifecycle |
 | A/B 环 → Ark 组合路径 | loopback 与分层 live 证据通过 | A → B、Prefer B → A 与隔离 A/B 后的 Ark tail 均已在 integrated self-use candidate 通过；公共分发仍依赖 CPA PR #5336 |
 | Route traversal readback | public contract 与 self-use live 均通过 | qualification 同时读回 entrypoint、ordered candidates、terminal tail 与 `max_cycles = 1`；只看到正确 selector 标签不能通过 |
-| Codex App selector projection | 本机与 SSH App Server readback 通过 | `model/list` 暴露 Auto、Prefer A、Prefer B、Luna、Ark 五个可见 route，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
+| Codex App selector projection | 本机与 SSH App Server readback 通过 | `model/list` 暴露三组 Standard/Fast Sol 行、Luna、Ark 共八个可见 selector，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
 | 图片能力投影 | 正向 E2E 通过，Auto 负向路径有已复现缺口 | Auto、Prefer A、Prefer B、Luna 声明 `text + image`，Ark 保持 `text`；健康 A/B 下图片到达 Codex。A/B 失败后，当前 Auto affinity 可能错误粘到 Ark，尚未做到 modality-aware fail closed |
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
-| Fast tier 投影 | A/B 既有 readback 通过；Luna/Prefer 显示待统一重验 | Auto、Prefer A、Prefer B、Luna 声明 `fast → priority`；Ark 不声明 Fast。`features.fast_mode = true` 只显示按钮，`service_tier = "default"` 保证默认关闭 |
+| Fast tier 投影 | 本机与 SSH App Server readback 通过 | Auto、Prefer A、Prefer B 各有显式 `fast/` sibling 行，默认 tier 为 `fast` 并在请求规整时强制 `priority`；普通行与 Luna 保持 `default`，Fast 行不进入 Ark |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | quota PR 已合并；三个分发 PR CI 通过 | #5211 merge `ca601db0`；#5220 head `9357def` 当前 conflicts；#5261 head `c8e76e1`、#5336 head `3d038a27` mergeable；后三者仍等待 review |
+| CPA upstream review | quota PR 已合并；三个分发 PR CI 通过 | #5211 merge `ca601db0`；#5220 head `9357def` 当前 conflicts；#5261 head `c8e76e1`、#5336 head `3d038a27` 当前 blocked pending review；后三者仍等待 maintainer review |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
 | 当前 Codex App | self-use 配置已安装并完成 CLI / App Server readback | 主 App 与 SSH host 都指向 loopback CPA；模型目录变化需要重启或重连对应 App Server 才能刷新 UI cache，旧 task store 不复制、不删除 |
@@ -168,10 +169,13 @@ flowchart LR
 
 | 模型 ID | 行为 | 输入能力 | Fast |
 | --- | --- | --- | --- |
-| `auto/gpt-5.6-sol` | 同一 A/B 账号环；已有 task 尊重 affinity，冷启动从 A 开始；A/B 都不可用且尚未提交输出时，兼容文本请求可转 Ark | `text, image`；图片只由 A/B 承担 | 可选，默认关闭 |
-| `codex-a/gpt-5.6-sol` | Sol · Prefer A：A → B → Ark；不是 hard pin | `text, image` | 可选，默认关闭 |
-| `codex-b/gpt-5.6-sol` | Sol · Prefer B：B → A → Ark；不是 hard pin | `text, image` | 可选，默认关闭 |
-| [`gpt-5.6-luna`](https://developers.openai.com/codex/models) | Luna；复用同一个 A/B 账号环，只在 Codex A/B 间路由，不异构降级到 Ark | `text, image`；推理档位为 `low` 至 `max`，不声明 `ultra` | 可选，默认关闭 |
+| `auto/gpt-5.6-sol` | 同一 A/B 账号环；已有 task 尊重 affinity，冷启动从 A 开始；A/B 都不可用且尚未提交输出时，兼容文本请求可转 Ark | `text, image`；图片只由 A/B 承担 | Standard，默认行 |
+| `fast/auto/gpt-5.6-sol` | 与 Auto 共享同一 route；只保留 A/B Fast-capable candidates | `text, image` | Fast，强制 `priority` |
+| `codex-a/gpt-5.6-sol` | Prefer A：A → B → Ark；不是 hard pin | `text, image` | Standard，默认行 |
+| `fast/codex-a/gpt-5.6-sol` | Prefer A：A → B；不落 Ark | `text, image` | Fast，强制 `priority` |
+| `codex-b/gpt-5.6-sol` | Prefer B：B → A → Ark；不是 hard pin | `text, image` | Standard，默认行 |
+| `fast/codex-b/gpt-5.6-sol` | Prefer B：B → A；不落 Ark | `text, image` | Fast，强制 `priority` |
+| [`gpt-5.6-luna`](https://developers.openai.com/codex/models) | Luna；复用同一个 A/B 账号环，只在 Codex A/B 间路由，不异构降级到 Ark | `text, image`；推理档位为 `low` 至 `max`，不声明 `ultra` | Standard；不生成重复 Fast alias |
 | `codex-c/gpt-5.6-sol` | 预留；只有第三个订阅真实接入并通过矩阵后才暴露 | 由真实 credential 决定 | 不预声明 |
 | `ark/deepseek-v4-flash` | 手动固定到 Ark DeepSeek V4 Flash | `text` | 不支持 |
 | `gpt-5.6-sol` | 隐藏 compatibility alias；处理 App / host 继承裸 model metadata 的旧 task，实际行为与 Auto 一致 | `text, image` | 可选，默认关闭 |
@@ -189,10 +193,49 @@ failover 的分层资格验证，因此 `auto/...` 可以在该锁定 commit 上
 路径已通过，但 affinity 的负向 modality recheck 尚有已复现缺口；在该修复通过前，不能把
 “Auto 支持图片”扩写成“所有 Auto failover 路径都支持图片”。
 
-Fast 是一次 turn 的 service tier，不是独立模型。model catalog 需要同时声明
-`additional_speed_tiers: ["fast"]` 和 `service_tiers[].id: "priority"`，App 才显示按钮。
-`features.fast_mode = true` 只开放选择入口；默认配置继续使用 `service_tier = "default"`。
-只有用户手动开启 Fast 后，请求才映射为 `priority`。
+Fast 在语义上仍是一次 turn 的 service tier，不是第二个上游模型；但桌面 App 对 custom
+provider 的原生 Fast 按钮还受宿主 ChatGPT 身份投影约束，不能作为唯一入口。catalog compiler
+因此从显式声明 `fast_selector` 的普通 route 生成 `fast/<route>` sibling 行：普通行使用
+`default_service_tier = "default"`，Fast 行使用 `default_service_tier = "fast"`。CPA adapter/plugin
+必须在 alias 映射前读取原始 selector；命中 `fast/` 时去掉前缀并强制请求
+`service_tier = "priority"`，普通 selector 不改 tier。
+
+Fast sibling 的候选不是复制普通 route，而是按 `supports_fast` 过滤。A/B 支持 Fast，Ark 不支持，
+所以 Fast 行只能在 A/B 环内切换；没有 Fast-capable provider 时必须在首个输出前 fail closed。
+Luna 仍保持普通行：若同一个 Luna upstream 再生成重复 alias，某些 CPA/App catalog 路径会去重
+并使普通 Luna 消失。`features.fast_mode = true` 可以保留给支持原生按钮的 host，但这套显式行
+不依赖该按钮，顶层默认仍是 `service_tier = "default"`。
+
+### Fast sibling 配置与发布方法
+
+在无密 catalog source 的普通 route 上声明 Fast 行；slug 由 compiler 固定生成，不允许另写
+一份平行 route：
+
+```json
+{
+  "slug": "auto/gpt-5.6-sol",
+  "supports_fast": true,
+  "fast_selector": {
+    "display_name": "Auto · Fast · Codex A → B",
+    "fallback_policy": "fast_capable_only"
+  }
+}
+```
+
+完整字段与 A/B/Ark profile 见 [`examples/request.json`](examples/request.json)。发布顺序是：
+
+1. 对真实支持 Fast 的 profile 设置 `supports_fast: true`；不支持的 provider 保持 false。
+2. 只在需要额外菜单行的普通 route 上声明 `fast_selector`；Luna 当前不声明。
+3. 运行 `compile_catalog`，确认八个可见 `selector_rows`、普通行 tier 为 `default`、三条 Fast
+   行 tier 为 `fast`，且 Fast candidates 只有 A/B。
+4. App catalog adapter 写入这些 selector rows；CPA adapter/plugin 必须在 alias mapping 前执行
+   [`normalize_selector_request`](examples/normalize-request.json) 的同构规则。
+5. 在隔离 App Server 读回 `model/list` 与 normalizer active 状态，再切换本机/SSH 的受控 catalog
+   指针；不要覆盖唯一可回滚版本。
+6. 重启或重连同一个 App Server 以刷新目录 cache。保留原 `CODEX_HOME` 和 task store；目录升级
+   不需要删除、新建或复制 session。
+7. 任一逐行 tier、normalizer、A/B traversal 或 commit-barrier 检查失败时，恢复旧 catalog 与旧
+   adapter/plugin 指针，并重新 readback；不要只隐藏 Fast 行后继续运行不一致的 normalizer。
 
 ## 身份与路由状态双投影
 
@@ -424,7 +467,8 @@ request_max_retries = 30
 stream_max_retries = 30
 ```
 
-受控 model catalog 同时描述 Auto、Prefer A、Prefer B、Luna、Ark 五个虚拟模型 ID；未配置的 C 不写入 catalog。
+受控 model catalog 同时描述三条普通 Sol route、它们生成的三条 Fast sibling、Luna 与 Ark，
+共八个可见 selector；未配置的 C 不写入 catalog。
 App 的原生模型下拉框就是唯一手动切换入口。`30 / 30` 只保留 CPA 之外的外层恢复余量；
 credential 遍历、provider 选择和 commit barrier 仍由 CPA 独占。两层都必须遵守前文的
 提交边界和 wall-clock budget，不能无界相乘。不要再让 CC Switch 在 App 运行期间替换
@@ -432,11 +476,12 @@ credential 遍历、provider 选择和 commit barrier 仍由 CPA 独占。两层
 
 受控 catalog 至少要同时验证四类字段：
 
-1. `slug / visibility / priority`：五个可见 route 与一个隐藏 bare compatibility alias；
-2. `input_modalities`：Auto/Prefer A/Prefer B/Luna 为 `text, image`，Ark 为 `text`；
+1. `slug / visibility / priority`：八个可见 selector 与一个隐藏 bare compatibility alias；
+2. `input_modalities`：Standard/Fast Sol 与 Luna 为 `text, image`，Ark 为 `text`；
 3. `supported_reasoning_levels`：Sol 与 Luna 都只声明已验证的 `low / medium / high / xhigh / max`；
-4. `additional_speed_tiers / service_tiers`：Auto/Prefer A/Prefer B/Luna 暴露 `fast → priority`，Ark 不暴露，
-   `default_service_tier` 保持空或 default。
+4. `selector_default_service_tiers`：普通行、Luna、Ark 为 `default`，三条 `fast/` 行为 `fast`；
+5. `request_normalizer`：`fast/` 在 alias mapping 前强制 `priority`，普通行保持原请求；
+6. `route_traversal`：普通 Sol 允许一次 A/B 环后接 Ark，Fast Sol 只允许一次 A/B 环。
 
 App Server 的 `model/list` readback 是 catalog 验收面。只检查 JSON 文件内容不够，因为旧
 App Server 可能仍缓存升级前的目录。
@@ -477,7 +522,7 @@ stream_max_retries = 30
 ```
 
 远端默认使用隐藏 `gpt-5.6-sol` compatibility alias，避免旧 task 或跨 host metadata 只保存
-裸 model slug 时回落到未知模型；模型下拉框仍只显示 Auto、Prefer A、Prefer B、Luna、Ark。
+裸 model slug 时回落到未知模型；模型下拉框显示三组 Standard/Fast Sol 行、Luna 与 Ark。
 
 SSH host 的 session 安全边界：
 
@@ -493,10 +538,11 @@ SSH host 的 session 安全边界：
 1. `ssh <host-alias>` 能正常进入，远端 login shell 可以找到 `codex`；
 2. `codex --version` 达到锁定版本；
 3. reverse tunnel 两端都只监听 loopback；
-4. App Server `model/list` 返回五个可见 route、隐藏 bare alias、正确图片能力与 Fast tier；
-5. Auto 发送一张公开安全的测试图片，模型实际返回成功；
-6. 打开一个已有 task，确认历史仍在，再验证 A/B 切换；
-7. 最后才在真实工作 task 上使用。
+4. App Server `model/list` 返回八个可见 selector、隐藏 bare alias、逐行默认 tier 与正确图片能力；
+5. Fast selector 的 request-normalizer active，`fast/` 强制 `priority` 且候选不含 Ark；
+6. Auto 发送一张公开安全的测试图片，模型实际返回成功；
+7. 打开一个已有 task，确认历史仍在，再验证 A/B 切换；
+8. 最后才在真实工作 task 上使用。
 
 模型目录或 Codex CLI 更新后，已有 App Server 可能继续使用旧 cache。优先重启或重连同一个
 SSH host，再打开原 task；不要先删除 host、项目或 session store。
@@ -690,7 +736,8 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 | Auto / A / B 图片输入 | App admission 通过，图片实际到达 A/B；A/B 均不可用时明确失败，不降级为 Ark 文本请求 |
 | Auto affinity + 图片 + Codex 故障 | 每个 attempt 重算 required modalities；旧 Ark affinity 失效；A/B 无 eligible target 时首字节前返回 typed error |
 | Ark 图片输入 | App 或 provider 明确拒绝；不把 Ark catalog 伪装为 image-capable |
-| Fast tier | Auto/Prefer A/Prefer B/Luna 显示 Fast 按钮，但新 task 默认 `service_tier = "default"`；手动开启后请求才使用 `priority` |
+| Fast selector rows | Auto/Prefer A/Prefer B 各有 Standard 与 Fast 行；普通行和 Luna 默认 `default`，Fast 行强制 `priority`；Fast A/B 都失败时不落 Ark |
+| Fast request normalization | 在 alias mapping 前捕获原始 `fast/` selector；剥离前缀后保持同一底层 route；普通 selector 的 model/tier 不被误改 |
 | SSH host 重连 | 同 alias、同远端 `CODEX_HOME` 下旧 task 可继续；catalog/CLI 刷新不删除或复制 session store |
 | 首字节前 quota / overload | CPA 可重试下一 eligible auth；客户端只看到一条回答 |
 | 空闲 HTTP/2 连接断开 | 下一条安全请求自动重建连接；TLS session 恢复；不重复已提交输出 |
@@ -725,16 +772,16 @@ commit 作为升级候选并重跑 qualification。#5261 已进入 integrated se
 
 1. **影子验证（已完成）**：保持现有 App 不变，在隔离 home、loopback fault server 和 stale
    task 上跑完整矩阵。
-2. **单 App / 显式路由（self-use 已完成）**：App 指向固定 CPA；开放 A、B、Luna、Ark，未配置的
-   C 不出现在 selector；A/B 是同一环的两个 Prefer 入口，公共分发依赖 #5336。
+2. **单 App / 显式路由（self-use 已完成）**：App 指向固定 CPA；开放 Standard/Fast A/B、Luna、
+   Ark，未配置的 C 不出现在 selector；A/B 是同一环的两个 Prefer 入口，公共分发依赖 #5336。
 3. **Codex 账号环（self-use 已完成）**：priority + fill-first + affinity 已通过 A → B 与
    Prefer B → A；上游 #5336 合并后仍需对 exact merge commit 重跑资格验证。
 4. **跨 provider 自动切换（self-use 已启用）**：固定 build 已通过 history projection、
    `additional_tools`、Ark SSE、commit barrier、真实 Ark 与故障注入矩阵，文本请求可由
    `auto/...` 降级到 Ark；foreign compaction barrier 仍 fail closed 并走显式 fork。
-5. **本机与 SSH selector（self-use 已完成）**：五个可见 selector、hidden bare alias、图片
-   能力和 Fast default-off contract 已在两端 App Server readback 通过；上游 release 升级仍要
-   重启对应 App Server 并重复 readback。
+5. **本机与 SSH selector（self-use 已完成）**：八个可见 selector、hidden bare alias、图片
+   能力、逐行 tier 与 Fast request-normalizer contract 已在两端 App Server readback 通过；
+   上游 release 升级仍要重启对应 App Server 并重复 readback。
 6. **多模态 Auto 负向路径（待修复）**：健康 A/B 的图片 E2E 已通过；modality-aware
    affinity、A/B 全不可用时的 typed fail-closed，以及 settings revision / turn-start 竞态仍要
    修复并重跑矩阵。在此之前不宣称 Auto 图片 failover 已完整资格化。

--- a/packages/loopx-codex-provider-routing/examples/normalize-request.json
+++ b/packages/loopx-codex-provider-routing/examples/normalize-request.json
@@ -1,0 +1,58 @@
+{
+  "normalization": {
+    "catalog_source": {
+      "profiles": [
+        {
+          "id": "codex-a",
+          "input_modalities": ["text", "image"],
+          "priority": 300,
+          "provider": "codex",
+          "supports_fast": true
+        },
+        {
+          "id": "codex-b",
+          "input_modalities": ["text", "image"],
+          "priority": 200,
+          "provider": "codex",
+          "supports_fast": true
+        },
+        {
+          "id": "ark-text",
+          "input_modalities": ["text"],
+          "priority": 100,
+          "provider": "openai_compatibility",
+          "supports_fast": false
+        }
+      ],
+      "rings": [
+        {
+          "id": "codex-accounts",
+          "max_cycles": 1,
+          "members": ["codex-a", "codex-b"]
+        }
+      ],
+      "routes": [
+        {
+          "display_name": "Auto · Codex A → B → Ark",
+          "entrypoint": "affinity_then_first",
+          "fallback_tail": ["ark-text"],
+          "fast_selector": {
+            "display_name": "Auto · Fast · Codex A → B",
+            "fallback_policy": "fast_capable_only"
+          },
+          "input_modalities": ["text", "image"],
+          "mode": "auto",
+          "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
+          "ring": "codex-accounts",
+          "slug": "auto/gpt-5.6-sol",
+          "supports_fast": true,
+          "visible": true
+        }
+      ]
+    },
+    "model_selector": "fast/auto/gpt-5.6-sol",
+    "service_tier": "default"
+  },
+  "operation": "normalize_selector_request",
+  "schema_version": "loopx_codex_provider_routing_request_v0"
+}

--- a/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
+++ b/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
@@ -16,6 +16,15 @@
           "ark-text"
         ]
       },
+      "fast/auto/gpt-5.6-sol": {
+        "entrypoint": "affinity_then_first",
+        "fallback_tail": [],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-a",
+          "codex-b"
+        ]
+      },
       "codex-a/gpt-5.6-sol": {
         "entrypoint": "codex-a",
         "fallback_tail": [
@@ -28,6 +37,15 @@
           "ark-text"
         ]
       },
+      "fast/codex-a/gpt-5.6-sol": {
+        "entrypoint": "codex-a",
+        "fallback_tail": [],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-a",
+          "codex-b"
+        ]
+      },
       "codex-b/gpt-5.6-sol": {
         "entrypoint": "codex-b",
         "fallback_tail": [
@@ -38,6 +56,15 @@
           "codex-b",
           "codex-a",
           "ark-text"
+        ]
+      },
+      "fast/codex-b/gpt-5.6-sol": {
+        "entrypoint": "codex-b",
+        "fallback_tail": [],
+        "max_cycles": 1,
+        "ordered_candidates": [
+          "codex-b",
+          "codex-a"
         ]
       },
       "gpt-5.6-luna": {
@@ -54,10 +81,9 @@
     "default_service_tier": "default",
     "endpoint_host": "127.0.0.1",
     "fast_models": [
-      "auto/gpt-5.6-sol",
-      "codex-a/gpt-5.6-sol",
-      "codex-b/gpt-5.6-sol",
-      "gpt-5.6-luna"
+      "fast/auto/gpt-5.6-sol",
+      "fast/codex-a/gpt-5.6-sol",
+      "fast/codex-b/gpt-5.6-sol"
     ],
     "hidden_models": [
       "gpt-5.6-sol"
@@ -70,11 +96,23 @@
         "text",
         "image"
       ],
+      "fast/auto/gpt-5.6-sol": [
+        "text",
+        "image"
+      ],
       "codex-a/gpt-5.6-sol": [
         "text",
         "image"
       ],
+      "fast/codex-a/gpt-5.6-sol": [
+        "text",
+        "image"
+      ],
       "codex-b/gpt-5.6-sol": [
+        "text",
+        "image"
+      ],
+      "fast/codex-b/gpt-5.6-sol": [
         "text",
         "image"
       ],
@@ -83,12 +121,31 @@
         "image"
       ]
     },
+    "request_normalizer": {
+      "active": true,
+      "fast_request_service_tier": "priority",
+      "ordinary_selector_action": "preserve",
+      "selector_prefix": "fast/"
+    },
+    "selector_default_service_tiers": {
+      "ark/deepseek-v4-flash": "default",
+      "auto/gpt-5.6-sol": "default",
+      "codex-a/gpt-5.6-sol": "default",
+      "codex-b/gpt-5.6-sol": "default",
+      "fast/auto/gpt-5.6-sol": "fast",
+      "fast/codex-a/gpt-5.6-sol": "fast",
+      "fast/codex-b/gpt-5.6-sol": "fast",
+      "gpt-5.6-luna": "default"
+    },
     "settings_revision_durable": true,
     "turn_revision_matches": true,
     "visible_models": [
       "auto/gpt-5.6-sol",
+      "fast/auto/gpt-5.6-sol",
       "codex-a/gpt-5.6-sol",
+      "fast/codex-a/gpt-5.6-sol",
       "codex-b/gpt-5.6-sol",
+      "fast/codex-b/gpt-5.6-sol",
       "gpt-5.6-luna",
       "ark/deepseek-v4-flash"
     ]

--- a/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
+++ b/packages/loopx-codex-provider-routing/examples/qualification-snapshot.json
@@ -123,6 +123,7 @@
     },
     "request_normalizer": {
       "active": true,
+      "effective_priority_admission": "fast_capable_only",
       "fast_request_service_tier": "priority",
       "ordinary_selector_action": "preserve",
       "selector_prefix": "fast/"

--- a/packages/loopx-codex-provider-routing/examples/request.json
+++ b/packages/loopx-codex-provider-routing/examples/request.json
@@ -45,11 +45,15 @@
     ],
     "routes": [
       {
-        "display_name": "Auto · Sol (A/B → Ark)",
+        "display_name": "Auto · Codex A → B → Ark",
         "entrypoint": "affinity_then_first",
         "fallback_tail": [
           "ark-text"
         ],
+        "fast_selector": {
+          "display_name": "Auto · Fast · Codex A → B",
+          "fallback_policy": "fast_capable_only"
+        },
         "input_modalities": [
           "text",
           "image"
@@ -68,11 +72,15 @@
         "visible": true
       },
       {
-        "display_name": "Sol · Prefer A",
+        "display_name": "Prefer A · Codex A → B → Ark",
         "entrypoint": "codex-a",
         "fallback_tail": [
           "ark-text"
         ],
+        "fast_selector": {
+          "display_name": "Prefer A · Fast · Codex A → B",
+          "fallback_policy": "fast_capable_only"
+        },
         "input_modalities": [
           "text",
           "image"
@@ -91,11 +99,15 @@
         "visible": true
       },
       {
-        "display_name": "Sol · Prefer B",
+        "display_name": "Prefer B · Codex B → A → Ark",
         "entrypoint": "codex-b",
         "fallback_tail": [
           "ark-text"
         ],
+        "fast_selector": {
+          "display_name": "Prefer B · Fast · Codex B → A",
+          "fallback_policy": "fast_capable_only"
+        },
         "input_modalities": [
           "text",
           "image"
@@ -114,7 +126,7 @@
         "visible": true
       },
       {
-        "display_name": "Luna · A/B",
+        "display_name": "Luna · Codex A → B",
         "entrypoint": "affinity_then_first",
         "input_modalities": [
           "text",
@@ -137,7 +149,7 @@
         "candidates": [
           "ark-text"
         ],
-        "display_name": "Ark text fallback",
+        "display_name": "Ark · DeepSeek V4 Flash",
         "input_modalities": [
           "text"
         ],

--- a/packages/loopx-codex-provider-routing/examples/runtime-status.json
+++ b/packages/loopx-codex-provider-routing/examples/runtime-status.json
@@ -107,7 +107,6 @@
         "codex-b",
         "codex-a"
       ],
-      "fast": false,
       "modality": "text",
       "observed_at": "2026-09-01T08:00:00Z",
       "outcome": "success",

--- a/packages/loopx-codex-provider-routing/examples/upgrade-request.json
+++ b/packages/loopx-codex-provider-routing/examples/upgrade-request.json
@@ -7,6 +7,7 @@
       "transport_pool",
       "model_catalog",
       "modality_routing",
+      "request_normalizer",
       "settings_revision"
     ],
     "current_ref": "public-current-ref",

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.2.0"
+version = "0.3.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.2.0"
+version = "0.3.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/schemas/request.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/request.schema.json
@@ -7,6 +7,7 @@
         "operation": {
           "const": "project_runtime_status"
         },
+        "normalization": false,
         "snapshot": false,
         "source": false,
         "upgrade": false
@@ -20,6 +21,7 @@
         "operation": {
           "const": "compile_catalog"
         },
+        "normalization": false,
         "snapshot": false,
         "status": false,
         "upgrade": false
@@ -31,8 +33,23 @@
     {
       "properties": {
         "operation": {
+          "const": "normalize_selector_request"
+        },
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "upgrade": false
+      },
+      "required": [
+        "normalization"
+      ]
+    },
+    {
+      "properties": {
+        "operation": {
           "const": "qualify_snapshot"
         },
+        "normalization": false,
         "source": false,
         "status": false,
         "upgrade": false
@@ -46,6 +63,7 @@
         "operation": {
           "const": "upgrade_plan"
         },
+        "normalization": false,
         "snapshot": false,
         "source": false,
         "status": false
@@ -59,6 +77,7 @@
     "operation": {
       "enum": [
         "compile_catalog",
+        "normalize_selector_request",
         "project_runtime_status",
         "qualify_snapshot",
         "upgrade_plan"
@@ -66,6 +85,9 @@
     },
     "schema_version": {
       "const": "loopx_codex_provider_routing_request_v0"
+    },
+    "normalization": {
+      "type": "object"
     },
     "snapshot": {
       "type": "object"

--- a/packages/loopx-codex-provider-routing/schemas/response.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/response.schema.json
@@ -43,6 +43,7 @@
     "operation": {
       "enum": [
         "compile_catalog",
+        "normalize_selector_request",
         "project_runtime_status",
         "qualify_snapshot",
         "upgrade_plan"

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -76,6 +76,7 @@ def _valid_snapshot() -> dict[str, Any]:
             "selector_prefix": "fast/",
             "fast_request_service_tier": "priority",
             "ordinary_selector_action": "preserve",
+            "effective_priority_admission": "fast_capable_only",
         },
         "endpoint_host": "127.0.0.1",
         "affinity_policy": "hint_revalidated_per_attempt",
@@ -249,6 +250,22 @@ def main() -> int:
     )
     assert normalized_standard["normalized_model_selector"] == ("codex-b/gpt-5.6-sol")
     assert normalized_standard["service_tier"] == {"action": "preserve"}
+    normalized_standard_priority = normalize_selector_request(
+        {
+            "catalog_source": _source(),
+            "model_selector": "auto/gpt-5.6-sol",
+            "service_tier": "priority",
+        }
+    )
+    assert normalized_standard_priority["service_tier"] == {
+        "action": "preserve",
+        "value": "priority",
+    }
+    assert normalized_standard_priority["fallback_policy"] == "fast_capable_only"
+    assert normalized_standard_priority["eligible_candidates"] == [
+        "codex-a",
+        "codex-b",
+    ]
 
     runtime = project_runtime_status(_runtime_status())
     assert runtime["credential_free"] is True
@@ -294,11 +311,44 @@ def main() -> int:
         "Fast selector was allowed to fall back to a non-Fast provider",
     )
 
-    mismatched_fast_flag = _runtime_status()
-    mismatched_fast_flag["execution_observation"]["fast"] = True
+    ordinary_priority = _runtime_status()
+    ordinary_priority["execution_observation"].update(
+        {
+            "fast": True,
+            "attempted_profiles": ["codex-a", "codex-b"],
+            "selected_profile": "codex-b",
+        }
+    )
+    runtime = project_runtime_status(ordinary_priority)
+    assert runtime["route_intent"]["fast"] is True
+    assert runtime["route_intent"]["legal_attempt_orders"] == [
+        ["codex-a", "codex-b"],
+        ["codex-b", "codex-a"],
+    ]
+
+    ordinary_priority_to_ark = _runtime_status()
+    ordinary_priority_to_ark["execution_observation"].update(
+        {
+            "fast": True,
+            "attempted_profiles": ["codex-a", "codex-b", "ark-text"],
+            "selected_profile": "ark-text",
+        }
+    )
     expect_error(
-        lambda: project_runtime_status(mismatched_fast_flag),
-        "runtime Fast state was not inferred from the route slug",
+        lambda: project_runtime_status(ordinary_priority_to_ark),
+        "ordinary selector with priority was allowed to fall back to Ark",
+    )
+
+    fast_selector_reported_standard = _runtime_status()
+    fast_selector_reported_standard["execution_observation"].update(
+        {
+            "route_slug": "fast/auto/gpt-5.6-sol",
+            "fast": False,
+        }
+    )
+    expect_error(
+        lambda: project_runtime_status(fast_selector_reported_standard),
+        "Fast selector was allowed to report a non-Fast execution",
     )
 
     image_affinity = _runtime_status()
@@ -441,6 +491,15 @@ def main() -> int:
         item["id"] for item in failed["checks"] if not item["passed"]
     }
 
+    unsafe_priority_admission = _valid_snapshot()
+    unsafe_priority_admission["request_normalizer"]["effective_priority_admission"] = (
+        "route_default"
+    )
+    failed = qualify_snapshot(unsafe_priority_admission)
+    assert "request_normalizer" in {
+        item["id"] for item in failed["checks"] if not item["passed"]
+    }
+
     stale = _valid_snapshot()
     stale["affinity_policy"] = "sticky_without_revalidation"
     stale["turn_revision_matches"] = False
@@ -492,6 +551,7 @@ def main() -> int:
     assert "h2_reuse" in plan["required_checks"]
     assert "no_eligible_fail_closed" in plan["required_checks"]
     assert "ordinary_selector_preserved" in plan["required_checks"]
+    assert "effective_priority_admission" in plan["required_checks"]
     assert "turn_revision_match" in plan["required_checks"]
 
     response = _run_request(

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -6,7 +6,9 @@ import copy
 import importlib
 import json
 import sys
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any, cast
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PACKAGE_ROOT / "src"))
@@ -17,40 +19,64 @@ _run_request = cli._run_request
 REQUEST_SCHEMA_VERSION = contract.REQUEST_SCHEMA_VERSION
 build_upgrade_plan = contract.build_upgrade_plan
 compile_catalog = contract.compile_catalog
+normalize_selector_request = contract.normalize_selector_request
 project_runtime_status = contract.project_runtime_status
 qualify_snapshot = contract.qualify_snapshot
 
 
-def _source() -> dict:
-    return json.loads((PACKAGE_ROOT / "examples" / "request.json").read_text())[
-        "source"
-    ]
+def _source() -> dict[str, Any]:
+    request = cast(
+        dict[str, Any],
+        json.loads((PACKAGE_ROOT / "examples" / "request.json").read_text()),
+    )
+    return cast(dict[str, Any], request["source"])
 
 
-def _valid_snapshot() -> dict:
+def _valid_snapshot() -> dict[str, Any]:
     return {
         "visible_models": [
             "auto/gpt-5.6-sol",
+            "fast/auto/gpt-5.6-sol",
             "codex-a/gpt-5.6-sol",
+            "fast/codex-a/gpt-5.6-sol",
             "codex-b/gpt-5.6-sol",
+            "fast/codex-b/gpt-5.6-sol",
             "gpt-5.6-luna",
             "ark/deepseek-v4-flash",
         ],
         "hidden_models": ["gpt-5.6-sol"],
         "input_modalities": {
             "auto/gpt-5.6-sol": ["text", "image"],
+            "fast/auto/gpt-5.6-sol": ["text", "image"],
             "codex-a/gpt-5.6-sol": ["text", "image"],
+            "fast/codex-a/gpt-5.6-sol": ["text", "image"],
             "codex-b/gpt-5.6-sol": ["text", "image"],
+            "fast/codex-b/gpt-5.6-sol": ["text", "image"],
             "gpt-5.6-luna": ["text", "image"],
             "ark/deepseek-v4-flash": ["text"],
         },
         "fast_models": [
-            "auto/gpt-5.6-sol",
-            "codex-a/gpt-5.6-sol",
-            "codex-b/gpt-5.6-sol",
-            "gpt-5.6-luna",
+            "fast/auto/gpt-5.6-sol",
+            "fast/codex-a/gpt-5.6-sol",
+            "fast/codex-b/gpt-5.6-sol",
         ],
         "default_service_tier": "default",
+        "selector_default_service_tiers": {
+            "auto/gpt-5.6-sol": "default",
+            "fast/auto/gpt-5.6-sol": "fast",
+            "codex-a/gpt-5.6-sol": "default",
+            "fast/codex-a/gpt-5.6-sol": "fast",
+            "codex-b/gpt-5.6-sol": "default",
+            "fast/codex-b/gpt-5.6-sol": "fast",
+            "gpt-5.6-luna": "default",
+            "ark/deepseek-v4-flash": "default",
+        },
+        "request_normalizer": {
+            "active": True,
+            "selector_prefix": "fast/",
+            "fast_request_service_tier": "priority",
+            "ordinary_selector_action": "preserve",
+        },
         "endpoint_host": "127.0.0.1",
         "affinity_policy": "hint_revalidated_per_attempt",
         "route_traversal": {
@@ -60,16 +86,34 @@ def _valid_snapshot() -> dict:
                 "fallback_tail": ["ark-text"],
                 "max_cycles": 1,
             },
+            "fast/auto/gpt-5.6-sol": {
+                "entrypoint": "affinity_then_first",
+                "ordered_candidates": ["codex-a", "codex-b"],
+                "fallback_tail": [],
+                "max_cycles": 1,
+            },
             "codex-a/gpt-5.6-sol": {
                 "entrypoint": "codex-a",
                 "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
                 "fallback_tail": ["ark-text"],
                 "max_cycles": 1,
             },
+            "fast/codex-a/gpt-5.6-sol": {
+                "entrypoint": "codex-a",
+                "ordered_candidates": ["codex-a", "codex-b"],
+                "fallback_tail": [],
+                "max_cycles": 1,
+            },
             "codex-b/gpt-5.6-sol": {
                 "entrypoint": "codex-b",
                 "ordered_candidates": ["codex-b", "codex-a", "ark-text"],
                 "fallback_tail": ["ark-text"],
+                "max_cycles": 1,
+            },
+            "fast/codex-b/gpt-5.6-sol": {
+                "entrypoint": "codex-b",
+                "ordered_candidates": ["codex-b", "codex-a"],
+                "fallback_tail": [],
                 "max_cycles": 1,
             },
             "gpt-5.6-luna": {
@@ -85,7 +129,7 @@ def _valid_snapshot() -> dict:
     }
 
 
-def _runtime_status() -> dict:
+def _runtime_status() -> dict[str, Any]:
     return {
         "catalog_source": _source(),
         "host_identity": {
@@ -96,7 +140,6 @@ def _runtime_status() -> dict:
         "execution_observation": {
             "route_slug": "auto/gpt-5.6-sol",
             "modality": "text",
-            "fast": False,
             "observed_at": "2026-09-01T08:00:00Z",
             "attempted_profiles": ["codex-b"],
             "selected_profile": "codex-b",
@@ -137,7 +180,7 @@ def _runtime_status() -> dict:
     }
 
 
-def expect_error(action, message: str) -> None:
+def expect_error(action: Callable[[], Any], message: str) -> None:
     try:
         action()
     except (TypeError, ValueError):
@@ -172,6 +215,40 @@ def main() -> int:
     assert luna["eligible_candidates"]["image"] == ["codex-a", "codex-b"]
     assert luna["reasoning_levels"] == ["low", "medium", "high", "xhigh", "max"]
     assert luna["fast_candidates"] == ["codex-a", "codex-b"]
+    selector_rows = {row["slug"]: row for row in catalog["selector_rows"]}
+    assert (
+        len([row for row in selector_rows.values() if row["visibility"] == "visible"])
+        == 8
+    )
+    assert selector_rows["auto/gpt-5.6-sol"]["default_service_tier"] == "default"
+    assert selector_rows["fast/auto/gpt-5.6-sol"]["default_service_tier"] == "fast"
+    assert selector_rows["fast/auto/gpt-5.6-sol"]["candidates"] == [
+        "codex-a",
+        "codex-b",
+    ]
+    assert "fast/gpt-5.6-luna" not in selector_rows
+
+    normalized_fast = normalize_selector_request(
+        {
+            "catalog_source": _source(),
+            "model_selector": "fast/codex-b/gpt-5.6-sol",
+            "service_tier": "default",
+        }
+    )
+    assert normalized_fast["normalized_model_selector"] == "codex-b/gpt-5.6-sol"
+    assert normalized_fast["service_tier"] == {
+        "action": "force_priority",
+        "value": "priority",
+    }
+    assert normalized_fast["eligible_candidates"] == ["codex-b", "codex-a"]
+    normalized_standard = normalize_selector_request(
+        {
+            "catalog_source": _source(),
+            "model_selector": "codex-b/gpt-5.6-sol",
+        }
+    )
+    assert normalized_standard["normalized_model_selector"] == ("codex-b/gpt-5.6-sol")
+    assert normalized_standard["service_tier"] == {"action": "preserve"}
 
     runtime = project_runtime_status(_runtime_status())
     assert runtime["credential_free"] is True
@@ -194,14 +271,35 @@ def main() -> int:
     fast_fallback = _runtime_status()
     fast_fallback["execution_observation"].update(
         {
-            "route_slug": "codex-b/gpt-5.6-sol",
-            "fast": True,
+            "route_slug": "fast/codex-b/gpt-5.6-sol",
             "attempted_profiles": ["codex-b", "codex-a"],
             "selected_profile": "codex-a",
         }
     )
     runtime = project_runtime_status(fast_fallback)
+    assert runtime["route_intent"]["fast"] is True
+    assert runtime["route_intent"]["selector_slug"] == ("fast/codex-b/gpt-5.6-sol")
     assert runtime["route_intent"]["legal_attempt_orders"] == [["codex-b", "codex-a"]]
+
+    fast_to_ark = _runtime_status()
+    fast_to_ark["execution_observation"].update(
+        {
+            "route_slug": "fast/auto/gpt-5.6-sol",
+            "attempted_profiles": ["codex-a", "codex-b", "ark-text"],
+            "selected_profile": "ark-text",
+        }
+    )
+    expect_error(
+        lambda: project_runtime_status(fast_to_ark),
+        "Fast selector was allowed to fall back to a non-Fast provider",
+    )
+
+    mismatched_fast_flag = _runtime_status()
+    mismatched_fast_flag["execution_observation"]["fast"] = True
+    expect_error(
+        lambda: project_runtime_status(mismatched_fast_flag),
+        "runtime Fast state was not inferred from the route slug",
+    )
 
     image_affinity = _runtime_status()
     image_affinity["execution_observation"]["modality"] = "image"
@@ -284,6 +382,33 @@ def main() -> int:
         lambda: compile_catalog(ambiguous_boolean), "string boolean was accepted"
     )
 
+    unsafe_fast_fallback = copy.deepcopy(_source())
+    unsafe_fast_fallback["routes"][0]["fast_selector"]["fallback_policy"] = (
+        "route_default"
+    )
+    expect_error(
+        lambda: compile_catalog(unsafe_fast_fallback),
+        "Fast selector was allowed to retain a non-Fast fallback",
+    )
+
+    colliding_fast_slug = copy.deepcopy(_source())
+    colliding_fast_slug["routes"].append(
+        {
+            "candidates": ["ark-text"],
+            "display_name": "Collision",
+            "input_modalities": ["text"],
+            "mode": "manual",
+            "reasoning_levels": ["low"],
+            "slug": "fast/auto/gpt-5.6-sol",
+            "supports_fast": False,
+            "visible": False,
+        }
+    )
+    expect_error(
+        lambda: compile_catalog(colliding_fast_slug),
+        "generated Fast selector collision was accepted",
+    )
+
     no_image_provider = copy.deepcopy(_source())
     no_image_provider["profiles"][0]["input_modalities"] = ["text"]
     no_image_provider["profiles"][1]["input_modalities"] = ["text"]
@@ -300,6 +425,22 @@ def main() -> int:
 
     snapshot = qualify_snapshot(_valid_snapshot())
     assert snapshot["qualified"] is True
+    ordinary_row_forced_fast = _valid_snapshot()
+    ordinary_row_forced_fast["selector_default_service_tiers"]["auto/gpt-5.6-sol"] = (
+        "fast"
+    )
+    failed = qualify_snapshot(ordinary_row_forced_fast)
+    assert "fast_default_off" in {
+        item["id"] for item in failed["checks"] if not item["passed"]
+    }
+
+    inactive_normalizer = _valid_snapshot()
+    inactive_normalizer["request_normalizer"]["active"] = False
+    failed = qualify_snapshot(inactive_normalizer)
+    assert "request_normalizer" in {
+        item["id"] for item in failed["checks"] if not item["passed"]
+    }
+
     stale = _valid_snapshot()
     stale["affinity_policy"] = "sticky_without_revalidation"
     stale["turn_revision_matches"] = False
@@ -343,12 +484,14 @@ def main() -> int:
             "changed_seams": [
                 "transport_pool",
                 "modality_routing",
+                "request_normalizer",
                 "settings_revision",
             ],
         }
     )
     assert "h2_reuse" in plan["required_checks"]
     assert "no_eligible_fail_closed" in plan["required_checks"]
+    assert "ordinary_selector_preserved" in plan["required_checks"]
     assert "turn_revision_match" in plan["required_checks"]
 
     response = _run_request(
@@ -361,6 +504,7 @@ def main() -> int:
     assert response["ok"] is True and response["result"]["qualified"] is True
     for example_name in (
         "request.json",
+        "normalize-request.json",
         "runtime-status.json",
         "qualification-snapshot.json",
         "upgrade-request.json",

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.3.0"

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -11,6 +11,7 @@ from .contract import (
     RESPONSE_SCHEMA_VERSION,
     build_upgrade_plan,
     compile_catalog,
+    normalize_selector_request,
     project_runtime_status,
     qualify_snapshot,
     reject_private_material,
@@ -41,6 +42,7 @@ def _doctor() -> int:
             "doctor": "ready",
             "operations": [
                 "compile_catalog",
+                "normalize_selector_request",
                 "project_runtime_status",
                 "qualify_snapshot",
                 "upgrade_plan",
@@ -60,6 +62,7 @@ def _run_request(request: Any) -> dict[str, Any]:
     operation = request.get("operation")
     operation_fields = {
         "compile_catalog": "source",
+        "normalize_selector_request": "normalization",
         "project_runtime_status": "status",
         "qualify_snapshot": "snapshot",
         "upgrade_plan": "upgrade",
@@ -77,6 +80,13 @@ def _run_request(request: Any) -> dict[str, Any]:
         if not isinstance(source, Mapping):
             raise ValueError("compile_catalog requires object `source`")
         result = compile_catalog(source)
+    elif operation == "normalize_selector_request":
+        normalization = request.get("normalization")
+        if not isinstance(normalization, Mapping):
+            raise ValueError(
+                "normalize_selector_request requires object `normalization`"
+            )
+        result = normalize_selector_request(normalization)
     elif operation == "project_runtime_status":
         status = request.get("status")
         if not isinstance(status, Mapping):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -323,6 +323,37 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
             )
         ):
             raise ValueError(f"route {slug} has no fast-eligible candidate")
+        fast_selector = raw.get("fast_selector")
+        compiled_fast_selector = None
+        if fast_selector is not None:
+            if not isinstance(fast_selector, Mapping):
+                raise TypeError(f"routes[{index}].fast_selector must be an object")
+            _reject_unexpected_keys(
+                fast_selector,
+                {"display_name", "fallback_policy"},
+                f"routes[{index}].fast_selector",
+            )
+            if mode == "alias" or not visible:
+                raise ValueError(
+                    f"Fast selector requires a visible concrete route: {slug}"
+                )
+            if not supports_fast:
+                raise ValueError(f"Fast selector requires Fast support: {slug}")
+            fallback_policy = _non_empty_string(
+                fast_selector.get("fallback_policy"),
+                f"routes[{index}].fast_selector.fallback_policy",
+            )
+            if fallback_policy != "fast_capable_only":
+                raise ValueError(
+                    f"route {slug} Fast selector must fail closed to Fast-capable providers"
+                )
+            compiled_fast_selector = {
+                "display_name": _non_empty_string(
+                    fast_selector.get("display_name"),
+                    f"routes[{index}].fast_selector.display_name",
+                ),
+                "fallback_policy": fallback_policy,
+            }
         max_cycles = rings[ring_id]["max_cycles"] if isinstance(ring_id, str) else 1
 
         routes.append(
@@ -347,6 +378,7 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
                 if mode != "alias"
                 else {},
                 "supports_fast": supports_fast,
+                "fast_selector": compiled_fast_selector,
                 "fast_candidates": _eligible_profiles(
                     candidates,
                     profiles,
@@ -388,13 +420,101 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
         if alias["supports_fast"] != target["supports_fast"]:
             raise ValueError(f"alias {alias['slug']} Fast support differs from target")
 
+    selector_rows: list[dict[str, Any]] = []
+    for route in routes:
+        target = (
+            non_alias_routes[route["alias_for"]]
+            if route["routing_mode"] == "alias"
+            else route
+        )
+        selector_rows.append(
+            {
+                "slug": route["slug"],
+                "route_slug": target["slug"],
+                "display_name": route["display_name"],
+                "visibility": route["visibility"],
+                "input_modalities": route["input_modalities"],
+                "reasoning_levels": route["reasoning_levels"],
+                "candidates": target["candidates"],
+                "default_service_tier": "default",
+                "request_service_tier_action": "preserve",
+                "fallback_policy": "route_default",
+            }
+        )
+        fast_selector = route["fast_selector"]
+        if fast_selector is None:
+            continue
+        selector_rows.append(
+            {
+                "slug": f"fast/{route['slug']}",
+                "route_slug": route["slug"],
+                "display_name": fast_selector["display_name"],
+                "visibility": route["visibility"],
+                "input_modalities": route["input_modalities"],
+                "reasoning_levels": route["reasoning_levels"],
+                "candidates": route["fast_candidates"],
+                "default_service_tier": "fast",
+                "request_service_tier_action": "force_priority",
+                "fallback_policy": fast_selector["fallback_policy"],
+            }
+        )
+    selector_slugs = [row["slug"] for row in selector_rows]
+    if len(selector_slugs) != len(set(selector_slugs)):
+        raise ValueError("generated Fast selector collides with a declared route slug")
+
     return {
         "schema_version": CATALOG_SCHEMA_VERSION,
         "credential_free": True,
         "default_service_tier": "default",
+        "fast_selector_prefix": "fast/",
+        "fast_request_service_tier": "priority",
         "profiles": list(profiles.values()),
         "rings": list(rings.values()),
         "routes": routes,
+        "selector_rows": selector_rows,
+    }
+
+
+def normalize_selector_request(normalization: Mapping[str, Any]) -> dict[str, Any]:
+    """Resolve one public selector before provider alias mapping or body handling."""
+
+    reject_private_material(normalization)
+    _reject_unexpected_keys(
+        normalization,
+        {"catalog_source", "model_selector", "service_tier"},
+        "normalization",
+    )
+    source = normalization.get("catalog_source")
+    if not isinstance(source, Mapping):
+        raise TypeError("normalization.catalog_source must be an object")
+    catalog = compile_catalog(source)
+    selector_slug = _non_empty_string(
+        normalization.get("model_selector"), "normalization.model_selector"
+    )
+    selectors = {row["slug"]: row for row in catalog["selector_rows"]}
+    selector = selectors.get(selector_slug)
+    if selector is None:
+        raise ValueError(f"unknown model selector: {selector_slug}")
+
+    requested_tier = normalization.get("service_tier")
+    if requested_tier is not None:
+        requested_tier = _non_empty_string(requested_tier, "normalization.service_tier")
+        if requested_tier not in {"default", "priority"}:
+            raise ValueError("normalization.service_tier must be default or priority")
+
+    tier_action: dict[str, str] = {"action": selector["request_service_tier_action"]}
+    if selector["request_service_tier_action"] == "force_priority":
+        tier_action["value"] = catalog["fast_request_service_tier"]
+    elif requested_tier is not None:
+        tier_action["value"] = requested_tier
+
+    return {
+        "original_model_selector": selector_slug,
+        "normalized_model_selector": selector["route_slug"],
+        "default_service_tier": selector["default_service_tier"],
+        "service_tier": tier_action,
+        "fallback_policy": selector["fallback_policy"],
+        "eligible_candidates": selector["candidates"],
     }
 
 
@@ -518,6 +638,7 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
         for item in catalog["routes"]
         if item["routing_mode"] != "alias"
     }
+    selectors = {item["slug"]: item for item in catalog["selector_rows"]}
 
     host = status.get("host_identity")
     if not isinstance(host, Mapping):
@@ -548,22 +669,27 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
         },
         "status.execution_observation",
     )
-    route_slug = _non_empty_string(
+    selector_slug = _non_empty_string(
         observation.get("route_slug"), "status.execution_observation.route_slug"
     )
-    route = routes.get(route_slug)
-    if route is None:
-        raise ValueError(
-            "execution observation must reference a concrete catalog route"
-        )
+    selector = selectors.get(selector_slug)
+    if selector is None:
+        raise ValueError("execution observation must reference a catalog selector")
+    route = routes[selector["route_slug"]]
     modality = _non_empty_string(
         observation.get("modality"), "status.execution_observation.modality"
     )
     if modality not in route["input_modalities"]:
-        raise ValueError(f"route {route_slug} does not admit modality {modality}")
-    fast = _boolean(observation.get("fast"), "status.execution_observation.fast")
-    if fast and not route["supports_fast"]:
-        raise ValueError(f"route {route_slug} does not support Fast")
+        raise ValueError(f"selector {selector_slug} does not admit modality {modality}")
+    fast = selector["default_service_tier"] == "fast"
+    if "fast" in observation:
+        declared_fast = _boolean(
+            observation.get("fast"), "status.execution_observation.fast"
+        )
+        if declared_fast != fast:
+            raise ValueError(
+                "execution Fast state must be inferred from the selected route slug"
+            )
     observed_at = _timestamp(
         observation.get("observed_at"), "status.execution_observation.observed_at"
     )
@@ -581,7 +707,7 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
     ]
     if not matching_orders:
         raise ValueError(
-            f"attempted profiles are not a legal prefix for route {route_slug}"
+            f"attempted profiles are not a legal prefix for selector {selector_slug}"
         )
     outcome = _non_empty_string(
         observation.get("outcome"), "status.execution_observation.outcome"
@@ -677,7 +803,8 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
         "credential_free": True,
         "host_identity": expected_host,
         "route_intent": {
-            "route_slug": route_slug,
+            "selector_slug": selector_slug,
+            "route_slug": route["slug"],
             "routing_mode": route["routing_mode"],
             "modality": modality,
             "fast": fast,
@@ -692,8 +819,11 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     reject_private_material(snapshot)
     expected_visible = {
         "auto/gpt-5.6-sol",
+        "fast/auto/gpt-5.6-sol",
         "codex-a/gpt-5.6-sol",
+        "fast/codex-a/gpt-5.6-sol",
         "codex-b/gpt-5.6-sol",
+        "fast/codex-b/gpt-5.6-sol",
         "gpt-5.6-luna",
         "ark/deepseek-v4-flash",
     }
@@ -709,7 +839,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     check(
         "visible_routes",
         visible == expected_visible,
-        "selector exposes exactly Auto/Prefer A/Prefer B/Luna/Ark",
+        "selector exposes Standard and Fast Sol rows plus Luna and Ark",
     )
     check(
         "hidden_alias",
@@ -725,12 +855,15 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             set(modalities.get(slug, [])) == {"text", "image"}
             for slug in (
                 "auto/gpt-5.6-sol",
+                "fast/auto/gpt-5.6-sol",
                 "codex-a/gpt-5.6-sol",
+                "fast/codex-a/gpt-5.6-sol",
                 "codex-b/gpt-5.6-sol",
+                "fast/codex-b/gpt-5.6-sol",
                 "gpt-5.6-luna",
             )
         ),
-        "Auto/Prefer A/Prefer B/Luna declare text and image",
+        "Standard/Fast Sol selectors and Luna declare text and image",
     )
     check(
         "ark_text_only",
@@ -742,17 +875,32 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "fast_projection",
         fast_models
         == {
-            "auto/gpt-5.6-sol",
-            "codex-a/gpt-5.6-sol",
-            "codex-b/gpt-5.6-sol",
-            "gpt-5.6-luna",
+            "fast/auto/gpt-5.6-sol",
+            "fast/codex-a/gpt-5.6-sol",
+            "fast/codex-b/gpt-5.6-sol",
         },
-        "Fast is exposed only for Auto/Prefer A/Prefer B/Luna",
+        "Fast is exposed only as explicit Auto/Prefer A/Prefer B sibling rows",
     )
+    selector_tiers = snapshot.get("selector_default_service_tiers")
+    if not isinstance(selector_tiers, Mapping):
+        raise TypeError("snapshot.selector_default_service_tiers must be an object")
+    standard_selectors = expected_visible - fast_models
     check(
         "fast_default_off",
-        snapshot.get("default_service_tier") == "default",
-        "Fast is available but defaults to off",
+        snapshot.get("default_service_tier") == "default"
+        and all(selector_tiers.get(slug) == "default" for slug in standard_selectors)
+        and all(selector_tiers.get(slug) == "fast" for slug in fast_models),
+        "ordinary rows stay Standard while explicit Fast rows opt into Fast",
+    )
+    normalizer = snapshot.get("request_normalizer")
+    check(
+        "request_normalizer",
+        isinstance(normalizer, Mapping)
+        and normalizer.get("active") is True
+        and normalizer.get("selector_prefix") == "fast/"
+        and normalizer.get("fast_request_service_tier") == "priority"
+        and normalizer.get("ordinary_selector_action") == "preserve",
+        "normalizer captures the original selector and changes only Fast rows",
     )
     check(
         "loopback_endpoint",
@@ -773,15 +921,30 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
             "fallback_tail": ["ark-text"],
         },
+        "fast/auto/gpt-5.6-sol": {
+            "entrypoint": "affinity_then_first",
+            "ordered_candidates": ["codex-a", "codex-b"],
+            "fallback_tail": [],
+        },
         "codex-a/gpt-5.6-sol": {
             "entrypoint": "codex-a",
             "ordered_candidates": ["codex-a", "codex-b", "ark-text"],
             "fallback_tail": ["ark-text"],
         },
+        "fast/codex-a/gpt-5.6-sol": {
+            "entrypoint": "codex-a",
+            "ordered_candidates": ["codex-a", "codex-b"],
+            "fallback_tail": [],
+        },
         "codex-b/gpt-5.6-sol": {
             "entrypoint": "codex-b",
             "ordered_candidates": ["codex-b", "codex-a", "ark-text"],
             "fallback_tail": ["ark-text"],
+        },
+        "fast/codex-b/gpt-5.6-sol": {
+            "entrypoint": "codex-b",
+            "ordered_candidates": ["codex-b", "codex-a"],
+            "fallback_tail": [],
         },
         "gpt-5.6-luna": {
             "entrypoint": "affinity_then_first",
@@ -811,7 +974,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             == expected["ordered_candidates"]
             for slug, expected in expected_traversal.items()
         ),
-        "Auto/Prefer A/Prefer B/Luna use the expected account-ring entrypoint and order",
+        "Standard/Fast Sol selectors and Luna use the expected ring entrypoint and order",
     )
     check(
         "terminal_fallback_tail",
@@ -819,7 +982,17 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             traversal_rows[slug].get("fallback_tail") == expected["fallback_tail"]
             for slug, expected in expected_traversal.items()
         ),
-        "Sol routes append Ark once and Luna has no heterogeneous fallback tail",
+        "only Standard Sol routes append Ark; Fast and Luna have no heterogeneous tail",
+    )
+    check(
+        "fast_capable_only",
+        all(
+            traversal_rows[slug].get("ordered_candidates")
+            in (["codex-a", "codex-b"], ["codex-b", "codex-a"])
+            and traversal_rows[slug].get("fallback_tail") == []
+            for slug in fast_models
+        ),
+        "Fast rows remain inside the A/B Fast-capable ring",
     )
     check(
         "single_cycle_traversal",
@@ -854,6 +1027,7 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
         "retry_policy",
         "transport_pool",
         "model_catalog",
+        "request_normalizer",
         "ssh_bridge",
         "modality_routing",
         "settings_revision",
@@ -876,7 +1050,18 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
             "draining_rebuild",
             "no_replay",
         ],
-        "model_catalog": ["visible_routes", "hidden_alias", "fast_default_off"],
+        "model_catalog": [
+            "visible_routes",
+            "hidden_alias",
+            "fast_selector_rows",
+            "fast_default_off",
+        ],
+        "request_normalizer": [
+            "selector_prefix_capture",
+            "priority_injection",
+            "ordinary_selector_preserved",
+            "fast_route_no_unsupported_fallback",
+        ],
         "ssh_bridge": ["loopback_binds", "reconnect", "existing_task_resume"],
         "modality_routing": ["image_a_b", "ark_text_only", "no_eligible_fail_closed"],
         "settings_revision": [

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -508,13 +508,31 @@ def normalize_selector_request(normalization: Mapping[str, Any]) -> dict[str, An
     elif requested_tier is not None:
         tier_action["value"] = requested_tier
 
+    effective_fast = (
+        selector["default_service_tier"] == "fast"
+        or requested_tier == catalog["fast_request_service_tier"]
+    )
+    eligible_candidates = selector["candidates"]
+    fallback_policy = selector["fallback_policy"]
+    if effective_fast:
+        profiles = {item["id"]: item for item in catalog["profiles"]}
+        eligible_candidates = _eligible_profiles(
+            selector["candidates"],
+            profiles,
+            required_modalities=set(),
+            require_fast=True,
+        )
+        if not eligible_candidates:
+            raise ValueError(f"selector {selector_slug} has no Fast-capable candidates")
+        fallback_policy = "fast_capable_only"
+
     return {
         "original_model_selector": selector_slug,
         "normalized_model_selector": selector["route_slug"],
         "default_service_tier": selector["default_service_tier"],
         "service_tier": tier_action,
-        "fallback_policy": selector["fallback_policy"],
-        "eligible_candidates": selector["candidates"],
+        "fallback_policy": fallback_policy,
+        "eligible_candidates": eligible_candidates,
     }
 
 
@@ -681,15 +699,15 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
     )
     if modality not in route["input_modalities"]:
         raise ValueError(f"selector {selector_slug} does not admit modality {modality}")
-    fast = selector["default_service_tier"] == "fast"
+    selector_defaults_fast = selector["default_service_tier"] == "fast"
+    fast = selector_defaults_fast
     if "fast" in observation:
         declared_fast = _boolean(
             observation.get("fast"), "status.execution_observation.fast"
         )
-        if declared_fast != fast:
-            raise ValueError(
-                "execution Fast state must be inferred from the selected route slug"
-            )
+        if selector_defaults_fast and not declared_fast:
+            raise ValueError("a Fast selector cannot report a non-Fast execution")
+        fast = declared_fast
     observed_at = _timestamp(
         observation.get("observed_at"), "status.execution_observation.observed_at"
     )
@@ -899,8 +917,9 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         and normalizer.get("active") is True
         and normalizer.get("selector_prefix") == "fast/"
         and normalizer.get("fast_request_service_tier") == "priority"
-        and normalizer.get("ordinary_selector_action") == "preserve",
-        "normalizer captures the original selector and changes only Fast rows",
+        and normalizer.get("ordinary_selector_action") == "preserve"
+        and normalizer.get("effective_priority_admission") == "fast_capable_only",
+        "normalizer preserves ordinary tiers and constrains effective Fast requests",
     )
     check(
         "loopback_endpoint",
@@ -1060,6 +1079,7 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
             "selector_prefix_capture",
             "priority_injection",
             "ordinary_selector_preserved",
+            "effective_priority_admission",
             "fast_route_no_unsupported_fallback",
         ],
         "ssh_bridge": ["loopback_binds", "reconnect", "existing_task_resume"],

--- a/packages/loopx-codex-provider-routing/templates/codex-app-config.toml
+++ b/packages/loopx-codex-provider-routing/templates/codex-app-config.toml
@@ -6,6 +6,8 @@ model_catalog_json = "<CONTROLLED_MODEL_CATALOG_JSON>"
 service_tier = "default"
 
 [features]
+# Keep the native feature available for hosts that can render it. The explicit
+# fast/<route> catalog rows do not depend on the desktop Fast button.
 fast_mode = true
 
 [model_providers.local-cpa]
@@ -16,3 +18,5 @@ requires_openai_auth = false
 supports_websockets = false
 request_max_retries = 30
 stream_max_retries = 30
+# The catalog compiler keeps ordinary rows on `default`; only generated Fast
+# sibling rows carry `default_service_tier = "fast"`.

--- a/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
+++ b/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
@@ -20,3 +20,8 @@ routing:
 codex:
   stream-bootstrap-buffering: true
   optimize-multi-agent-v2: false
+
+# Adapter/plugin contract (not a native CPA YAML key): inspect the original
+# model selector before alias mapping. For `fast/<route>`, strip the prefix,
+# set the request service tier to `priority`, and admit only Fast-capable route
+# members. Preserve both model and service tier for ordinary selectors.

--- a/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
+++ b/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
@@ -24,4 +24,6 @@ codex:
 # Adapter/plugin contract (not a native CPA YAML key): inspect the original
 # model selector before alias mapping. For `fast/<route>`, strip the prefix,
 # set the request service tier to `priority`, and admit only Fast-capable route
-# members. Preserve both model and service tier for ordinary selectors.
+# members. Preserve both model and service tier for ordinary selectors; if an
+# ordinary selector already carries `priority`, apply the same Fast-capable-only
+# admission so the native Fast entry cannot reach a non-Fast fallback.


### PR DESCRIPTION
## Summary

- generate explicit `fast/<route>` model rows from the existing provider-routing catalog instead of duplicating route graphs
- normalize Fast selectors before alias mapping and force the wire tier to `priority`
- preserve an ordinary selector's requested tier while treating an effective `priority` request as Fast-capable-only, so the native Fast entry cannot reach Ark
- project effective Fast runtime state from the selector default plus the content-free execution observation
- document the eight-row App/SSH catalog, rollout/readback, rollback, and current public PR lineage

## Behavior

The default remains Standard. Auto, Prefer A, and Prefer B each gain one explicit Fast sibling row. Luna keeps one Standard row because duplicate aliases for the same upstream can hide the ordinary Luna entry. Fast rows reuse the A/B account ring and filter out providers without Fast support.

Both App interaction shapes now share the same safety invariant: selecting an explicit `fast/<route>` row forces `priority`, while an ordinary selector carrying the native Fast wire tier preserves that tier but still switches candidate admission to `fast_capable_only`. Runtime readback and qualification expose the same effective-priority contract, and neither path can fall through to Ark.

The extension remains read-only and credential-free. It compiles and qualifies public-safe configuration but does not write a Codex home, install CPA, inspect auth files, or proxy model requests.

## Validation

- provider-routing offline smoke: passed, including ordinary selector + `priority`, runtime Fast readback, Ark negative path, and qualification regression
- `pytest -q tests/extensions`: 560 passed
- focused strict mypy: passed
- focused Ruff check/format: passed
- JSON Schema validation for all five examples: passed
- `loopx check --scan-path packages/loopx-codex-provider-routing`: public boundary clean
- `git diff --check`: passed
- exact change-quality receipt: `cqr_0d529bb834350a913593`, valid for head `e40cf6242d537a711f1bdb13fe83a75f052d2104`
- premerge direct checks, Python compile, 8/9 catalog canaries, all 8 risk-profile smokes, and public-boundary gate: passed
- standalone `examples/install-local-smoke.py` under supported Python 3.13: passed

## Premerge caveat

The premerge wrapper still reports failure because its repository-wide `examples/install-local-smoke.py` subprocess has a fixed 120-second budget and timed out at 120.007 seconds. The identical smoke completed successfully when allowed to finish under the supported Python 3.13 runtime. This is a canary timeout-budget mismatch, not a provider-routing assertion or install failure; it is recorded here rather than hidden.

## Scope review

The future-facing pass stayed inside the existing `loopx-codex-provider-routing` extension. It reused the current catalog compiler, `_eligible_profiles` admission helper, selector rows, runtime projection, qualification checks, schemas, examples, and upgrade planner. No parallel capability, router, credential store, or live proxy was added.
