### PR TITLE
test(status): align dashboard interface budget

### DIFF
--- a/docs/reference/contracts/interface-budget-contract.md
+++ b/docs/reference/contracts/interface-budget-contract.md
@@ -11,7 +11,7 @@ and size/count budgets.
 | `heartbeat_prompt_json` | heartbeat automation | wake and route one bounded turn | `quota should-run`, `status`, or `review-packet --handoff-only` | `json_chars <= 3500` plus `interface_budget.within_budget=true` | `nested_keys <= 40` | `top_level_keys <= 30` |
 | `review_packet_handoff_only_json` | project-agent handoff | forward the smallest sufficient task packet | full `review-packet` or run-history artifact | `json_chars <= 3000` plus `handoff_interface_budget.within_budget=true` | `nested_keys <= 40` | `top_level_keys <= 18` |
 | `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 13000` | `nested_keys <= 330` | `top_level_keys <= 52` |
-| `dashboard_status_json` | operator dashboard | render first-screen operator state | `history`, run artifacts, or project-local adapter output | `json_chars <= 18200` | `nested_keys <= 260` | `top_level_keys <= 25` |
+| `dashboard_status_json` | operator dashboard | render first-screen operator state | `history`, run artifacts, or project-local adapter output | `json_chars <= 18215` | `nested_keys <= 260` | `top_level_keys <= 25` |
 
 These four budgets measure compact in-memory machine payloads. They do not
 measure the exact text written to stdout: JSON indentation, compatibility

--- a/examples/control_plane/hot-path-interface-budget-smoke.py
+++ b/examples/control_plane/hot-path-interface-budget-smoke.py
@@ -71,7 +71,7 @@ SURFACE_BUDGETS = {
         "owner": "operator dashboard",
         "consumer": "render first-screen operator state",
         "cold_path": "history, run artifacts, or project-local adapter output",
-        "max_json_chars": 18_200,
+        "max_json_chars": 18_215,
         "max_nested_keys": 260,
         "max_top_level_keys": 25,
     },


### PR DESCRIPTION
## Summary

- align the canonical dashboard status payload budget with the intentional `advancement_done_count` projection merged in #3561
- keep the executable smoke and documented contract at the same exact limit

## Validation

- `hot-path-interface-budget-smoke.py`: passed; dashboard status is exactly `18215/18215`
- public/private boundary scan: clean for both changed files
- diff check: passed
- change-quality receipt: `cqr_2a593cb443f811e94409`

The broader canary's selected `cli-output-budget-regression-smoke.py` exceeded its 120-second harness timeout under the current local repository gate, but the same smoke passed directly in about 99 seconds. This two-line repair changes no runtime behavior.
