### PR TITLE
fix(lark): catch up messages after completed history windows

### DIFF
--- a/loopx/extensions/lark/README.md
+++ b/loopx/extensions/lark/README.md
@@ -80,10 +80,15 @@ loopx lark-inbox history-catch-up \
   --execute
 ```
 
-Retries resume the exact private page token, and a completed window replays
-without another provider read. A caller may extend one completed history
+Retries resume the exact private page token. A completed window replays
+without another provider read only while its upper coverage bound is current;
+a later invocation opens one bounded forward window from the previous end, so
+new messages in an existing group or topic are not stranded behind an old
+`history_complete` state. A caller may also extend one completed history
 window to an earlier start once; the provider covers only the missing earlier
-window and rejects later source/config drift. The returned link-evidence packet
+window and rejects later source/config drift. Legacy v0 cursors migrate
+conservatively: they may replay already ingested messages, but never advance a
+coverage bound that could skip unseen history. The returned link-evidence packet
 contains URL plus message and route lineage for the owner-local Agent, but not
 the surrounding message body, sender, chat id, profile, cursor, or raw provider
 payload. Inbox and cursor directories are restricted to the owner, and their

--- a/loopx/extensions/lark/group_history.py
+++ b/loopx/extensions/lark/group_history.py
@@ -555,8 +555,11 @@ def catch_up_lark_group_history(
         "message_count": int(state["message_count"]) + len(events),
         "last_page_digest": _page_digest(events, next_page_token),
     }
-    if not has_more and updated["window_kind"] == "earlier":
-        updated["coverage_start"] = updated["window_start"]
+    if not has_more:
+        if updated["window_kind"] == "earlier":
+            updated["coverage_start"] = updated["window_start"]
+        else:
+            updated["coverage_end"] = updated["window_end"]
     try:
         write_group_history_cursor(cursor_path, updated)
         readback = load_group_history_cursor(

--- a/loopx/extensions/lark/group_history_cursor.py
+++ b/loopx/extensions/lark/group_history_cursor.py
@@ -11,7 +11,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-CURSOR_SCHEMA_VERSION = "lark_group_history_cursor_v0"
+CURSOR_SCHEMA_VERSION = "lark_group_history_cursor_v1"
+LEGACY_CURSOR_SCHEMA_VERSION = "lark_group_history_cursor_v0"
 
 
 def normalize_group_history_timestamp(value: str, *, field: str) -> str:
@@ -34,15 +35,9 @@ def group_history_source_fingerprint(
     inbox_path_ref: str,
     capture_scope: str,
 ) -> str:
-    value = "\0".join(
-        (
-            route_key,
-            profile,
-            chat_id,
-            event_inbox_config_ref,
-            inbox_path_ref,
-            capture_scope,
-        )
+    value = (
+        f"{route_key}\0{profile}\0{chat_id}\0{event_inbox_config_ref}"
+        f"\0{inbox_path_ref}\0{capture_scope}"
     ).encode()
     return f"sha256:{hashlib.sha256(value).hexdigest()[:24]}"
 
@@ -68,16 +63,18 @@ def load_group_history_cursor(
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError("Lark group-history cursor is unreadable") from exc
-    if not isinstance(payload, Mapping) or payload.get("schema_version") != (
-        CURSOR_SCHEMA_VERSION
-    ):
+    if not isinstance(payload, Mapping) or payload.get("schema_version") not in {
+        LEGACY_CURSOR_SCHEMA_VERSION,
+        CURSOR_SCHEMA_VERSION,
+    }:
         raise ValueError("Lark group-history cursor schema is invalid")
+    legacy_cursor = payload.get("schema_version") == LEGACY_CURSOR_SCHEMA_VERSION
     if payload.get("route_key") != route_key:
         raise ValueError("Lark group-history cursor route binding changed")
     if payload.get("source_fingerprint") != source_fingerprint:
         raise ValueError("Lark group-history cursor source binding changed")
     window_kind = str(payload.get("window_kind") or "")
-    if window_kind not in {"initial", "earlier"}:
+    if window_kind not in {"initial", "earlier", "forward"}:
         raise ValueError("Lark group-history cursor window kind is invalid")
     window_start = normalize_group_history_timestamp(
         str(payload.get("window_start") or ""), field="window_start"
@@ -88,7 +85,24 @@ def load_group_history_cursor(
     coverage_start = normalize_group_history_timestamp(
         str(payload.get("coverage_start") or ""), field="coverage_start"
     )
-    if not window_start < window_end or not coverage_start <= window_end:
+    raw_coverage_end = payload.get("coverage_end")
+    if legacy_cursor:
+        # v0 did not retain the latest completed upper bound after an earlier
+        # backfill.  Falling back to that window's end may replay already
+        # ingested messages, but it cannot skip unseen provider history.
+        raw_coverage_end = (
+            window_end
+            if window_kind == "earlier" or payload.get("history_complete")
+            else window_start
+        )
+    coverage_end = normalize_group_history_timestamp(
+        str(raw_coverage_end or ""), field="coverage_end"
+    )
+    if (
+        not window_start < window_end
+        or not coverage_start <= coverage_end
+        or (coverage_end > window_end and window_kind != "earlier")
+    ):
         raise ValueError("Lark group-history cursor window is invalid")
     history_complete = payload.get("history_complete")
     earlier_start_used = payload.get("earlier_start_used")
@@ -121,14 +135,22 @@ def load_group_history_cursor(
     ):
         raise ValueError("Lark group-history cursor counters are invalid")
     if window_kind == "initial" and (
-        coverage_start != window_start or earlier_start_used
+        coverage_start != window_start
+        or earlier_start_used
+        or coverage_end != (window_end if history_complete else window_start)
     ):
         raise ValueError("initial Lark group-history cursor state is inconsistent")
     if window_kind == "earlier" and (
         not earlier_start_used
         or coverage_start != (window_start if history_complete else window_end)
+        or coverage_end < window_end
     ):
         raise ValueError("earlier Lark group-history cursor state is inconsistent")
+    if window_kind == "forward" and (
+        coverage_start > window_start
+        or coverage_end != (window_end if history_complete else window_start)
+    ):
+        raise ValueError("forward Lark group-history cursor state is inconsistent")
     last_page_digest = str(payload.get("last_page_digest") or "")
     if not re.fullmatch(r"[0-9a-f]{16}", last_page_digest):
         raise ValueError("Lark group-history cursor page digest is invalid")
@@ -140,6 +162,7 @@ def load_group_history_cursor(
         "window_start": window_start,
         "window_end": window_end,
         "coverage_start": coverage_start,
+        "coverage_end": coverage_end,
         "next_page_token": next_page_token,
         "history_complete": history_complete,
         "earlier_start_used": earlier_start_used,
@@ -170,6 +193,7 @@ def _new_group_history_cursor(
     window_end: str,
     window_kind: str,
     coverage_start: str,
+    coverage_end: str,
     earlier_start_used: bool,
 ) -> dict[str, Any]:
     return {
@@ -180,6 +204,7 @@ def _new_group_history_cursor(
         "window_start": window_start,
         "window_end": window_end,
         "coverage_start": coverage_start,
+        "coverage_end": coverage_end,
         "next_page_token": None,
         "history_complete": False,
         "earlier_start_used": earlier_start_used,
@@ -208,6 +233,7 @@ def resolve_group_history_window(
                 window_end=snapshot_end,
                 window_kind="initial",
                 coverage_start=requested_start,
+                coverage_end=requested_start,
                 earlier_start_used=False,
             ),
             "initialized",
@@ -215,25 +241,50 @@ def resolve_group_history_window(
         )
     state = dict(existing)
     if state["history_complete"] is not True:
-        if requested_start != state["window_start"]:
+        forward_start_is_covered = (
+            state["window_kind"] == "forward"
+            and state["coverage_start"] <= requested_start <= state["window_start"]
+        )
+        if requested_start != state["window_start"] and not forward_start_is_covered:
             raise ValueError(
                 "active Lark group-history catch-up requires the same start"
             )
         return state, "resumed", False
-    if requested_start >= state["coverage_start"]:
+    if (
+        requested_start >= state["coverage_start"]
+        and snapshot_end <= state["coverage_end"]
+    ):
         return state, "replayed", True
-    if state["earlier_start_used"] is True:
-        raise ValueError("Lark group-history earlier-start backfill is already used")
+    if requested_start < state["coverage_start"]:
+        if state["earlier_start_used"] is True:
+            raise ValueError(
+                "Lark group-history earlier-start backfill is already used"
+            )
+        return (
+            _new_group_history_cursor(
+                route_key=route_key,
+                source_fingerprint=source_fingerprint,
+                window_start=requested_start,
+                window_end=str(state["coverage_start"]),
+                window_kind="earlier",
+                coverage_start=str(state["coverage_start"]),
+                coverage_end=str(state["coverage_end"]),
+                earlier_start_used=True,
+            ),
+            "earlier_window_initialized",
+            False,
+        )
     return (
         _new_group_history_cursor(
             route_key=route_key,
             source_fingerprint=source_fingerprint,
-            window_start=requested_start,
-            window_end=str(state["coverage_start"]),
-            window_kind="earlier",
+            window_start=str(state["coverage_end"]),
+            window_end=snapshot_end,
+            window_kind="forward",
             coverage_start=str(state["coverage_start"]),
-            earlier_start_used=True,
+            coverage_end=str(state["coverage_end"]),
+            earlier_start_used=bool(state["earlier_start_used"]),
         ),
-        "earlier_window_initialized",
+        "forward_window_initialized",
         False,
     )

--- a/tests/extensions/test_lark_group_history.py
+++ b/tests/extensions/test_lark_group_history.py
@@ -378,6 +378,260 @@ def test_cursor_resumes_then_replays_completed_history_without_provider_read(
     assert replay_runner.calls == []
 
 
+@pytest.mark.parametrize("legacy_cursor", [False, True])
+def test_completed_cursor_fetches_new_messages_from_a_later_provider_window(
+    tmp_path: Path, legacy_cursor: bool
+) -> None:
+    project, config = _project(tmp_path)
+    initial = PageRunner(
+        [
+            {
+                "messages": [_message("om_initial", "initial context")],
+                "total": 1,
+                "has_more": False,
+                "page_token": "",
+            }
+        ]
+    )
+    completed = _catch_up(project, config, initial, execute=True)
+    if legacy_cursor:
+        cursor_path = project / ".loopx" / "inbox" / ".history" / "requirements-a.json"
+        cursor = json.loads(cursor_path.read_text(encoding="utf-8"))
+        cursor["schema_version"] = "lark_group_history_cursor_v0"
+        cursor.pop("coverage_end")
+        cursor_path.write_text(json.dumps(cursor), encoding="utf-8")
+    later_now = datetime(2026, 8, 22, tzinfo=UTC)
+    later = PageRunner(
+        [
+            {
+                "messages": [
+                    _message(
+                        "om_later",
+                        "new follow-up in an existing topic",
+                        create_time="2026-08-21T12:00:00Z",
+                    )
+                ],
+                "total": 1,
+                "has_more": False,
+                "page_token": "",
+            }
+        ]
+    )
+
+    receipt = catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=later,
+        now=later_now,
+    )
+
+    assert completed["status"] == "history_complete"
+    assert receipt["status"] == "history_complete"
+    assert receipt["cursor_transition"] == "forward_window_initialized"
+    assert receipt["external_read_performed"] is True
+    assert receipt["accepted_count"] == 1
+    argv = later.calls[0]
+    assert argv[argv.index("--start") + 1] == "2026-08-21T00:00:00Z"
+    assert argv[argv.index("--end") + 1] == "2026-08-22T00:00:00Z"
+    assert (project / ".loopx" / "inbox" / "requirements-a" / "om_later.json").is_file()
+
+    replay_runner = PageRunner([])
+    replayed = catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=replay_runner,
+        now=later_now,
+    )
+    assert replayed["cursor_transition"] == "replayed"
+    assert replayed["external_read_performed"] is False
+    assert replay_runner.calls == []
+
+
+def test_forward_window_resumes_pagination_with_original_requested_start(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    _catch_up(
+        project,
+        config,
+        PageRunner(
+            [
+                {
+                    "messages": [_message("om_initial", "initial context")],
+                    "total": 1,
+                    "has_more": False,
+                    "page_token": "",
+                }
+            ]
+        ),
+        execute=True,
+    )
+    later_now = datetime(2026, 8, 22, tzinfo=UTC)
+    first_page = PageRunner(
+        [
+            {
+                "messages": [
+                    _message(
+                        "om_later_1",
+                        "first new page",
+                        create_time="2026-08-21T10:00:00Z",
+                    )
+                ],
+                "total": 2,
+                "has_more": True,
+                "page_token": "opaque-forward-page-2",
+            }
+        ]
+    )
+    first_receipt = catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=first_page,
+        now=later_now,
+    )
+    second_page = PageRunner(
+        [
+            {
+                "messages": [
+                    _message(
+                        "om_later_2",
+                        "second new page",
+                        create_time="2026-08-21T11:00:00Z",
+                    )
+                ],
+                "total": 1,
+                "has_more": False,
+                "page_token": "",
+            }
+        ]
+    )
+
+    completed = catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=second_page,
+        now=later_now,
+    )
+
+    assert first_receipt["status"] == "page_captured"
+    assert first_receipt["cursor_transition"] == "forward_window_initialized"
+    assert completed["status"] == "history_complete"
+    assert completed["cursor_transition"] == "resumed"
+    argv = second_page.calls[0]
+    assert argv[argv.index("--page-token") + 1] == "opaque-forward-page-2"
+    assert (
+        project / ".loopx" / "inbox" / "requirements-a" / "om_later_2.json"
+    ).is_file()
+
+
+def test_forward_window_after_earlier_backfill_resumes_from_covered_start(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    _catch_up(
+        project,
+        config,
+        PageRunner(
+            [
+                {
+                    "messages": [_message("om_initial", "initial context")],
+                    "total": 1,
+                    "has_more": False,
+                    "page_token": "",
+                }
+            ]
+        ),
+        execute=True,
+    )
+    _catch_up(
+        project,
+        config,
+        PageRunner(
+            [
+                {
+                    "messages": [_message("om_earlier", "earlier context")],
+                    "total": 1,
+                    "has_more": False,
+                    "page_token": "",
+                }
+            ]
+        ),
+        start="2026-08-19T00:00:00Z",
+        execute=True,
+    )
+    later_now = datetime(2026, 8, 22, tzinfo=UTC)
+    first_page = PageRunner(
+        [
+            {
+                "messages": [
+                    _message(
+                        "om_later_1",
+                        "first new page",
+                        create_time="2026-08-21T10:00:00Z",
+                    )
+                ],
+                "total": 2,
+                "has_more": True,
+                "page_token": "opaque-forward-page-2",
+            }
+        ]
+    )
+    catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=first_page,
+        now=later_now,
+    )
+    second_page = PageRunner(
+        [
+            {
+                "messages": [
+                    _message(
+                        "om_later_2",
+                        "second new page",
+                        create_time="2026-08-21T11:00:00Z",
+                    )
+                ],
+                "total": 1,
+                "has_more": False,
+                "page_token": "",
+            }
+        ]
+    )
+
+    completed = catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=second_page,
+        now=later_now,
+    )
+
+    assert completed["status"] == "history_complete"
+    assert completed["cursor_transition"] == "resumed"
+    assert (
+        second_page.calls[0][second_page.calls[0].index("--page-token") + 1]
+        == "opaque-forward-page-2"
+    )
+
+
 def test_completed_cursor_rejects_inbox_destination_drift(tmp_path: Path) -> None:
     project, config = _project(tmp_path)
     _catch_up(


### PR DESCRIPTION
## Summary

- track lower and upper coverage bounds independently in the private group-history cursor
- open a bounded forward window when a completed route has newer provider history
- conservatively migrate v0 cursors and preserve multi-page forward catch-up

## Validation

- `pytest -q tests/extensions/test_lark_group_history.py` (20 passed)
- focused Ruff and `git diff --check`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --goal-id ark-flow-goal --tier standard` (14/14 selected checks passed; 0 failures; 0 manual holds)
- changed-file public/private boundary scan (4 files clean)

## Future-facing review

The existing Lark extension remains the single owner. This change extends its cursor state machine directly; no parallel adapter or speculative abstraction was added.