### PR TITLE
feat(lark): reconcile collector routes safely

### DIFF
--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -26,6 +26,9 @@ from ..extensions.lark.event_collector import (
     install_lark_event_collector,
     plan_lark_event_collector,
 )
+from ..extensions.lark.event_collector_routes import (
+    reconcile_lark_event_collector_route,
+)
 from ..extensions.lark.event_collector_runtime import run_lark_event_collector
 from ..extensions.lark.event_inbox import (
     acknowledge_lark_event_inbox,
@@ -260,6 +263,20 @@ def register_lark_inbox_commands(
     collector_install.add_argument("--project", default=".")
     collector_install.add_argument("--config", required=True)
     collector_install.add_argument("--execute", action="store_true")
+    collector_route = sub.add_parser(
+        "collector-route-reconcile",
+        help=(
+            "Plan or atomically add one collector route; receipts redact chat and "
+            "local inbox bindings."
+        ),
+    )
+    add_subcommand_format(collector_route)
+    collector_route.add_argument("--project", default=".")
+    collector_route.add_argument("--config", required=True)
+    collector_route.add_argument("--route-key", required=True)
+    collector_route.add_argument("--chat-id", required=True)
+    collector_route.add_argument("--event-inbox-config", required=True)
+    collector_route.add_argument("--execute", action="store_true")
     collector_status = sub.add_parser(
         "collector-status",
         help="Inspect collector installation, supervisor state, and event evidence.",
@@ -638,6 +655,15 @@ def handle_lark_inbox_command(
                 project=args.project,
                 config_path=args.config,
                 runtime_root=runtime_root_arg,
+                execute=args.execute,
+            )
+        elif args.lark_inbox_command == "collector-route-reconcile":
+            payload = reconcile_lark_event_collector_route(
+                project=args.project,
+                config_path=args.config,
+                route_key=args.route_key,
+                chat_id=args.chat_id,
+                event_inbox_config=args.event_inbox_config,
                 execute=args.execute,
             )
         elif args.lark_inbox_command == "collector-run":

--- a/loopx/extensions/lark/README.md
+++ b/loopx/extensions/lark/README.md
@@ -104,6 +104,44 @@ member of the group, the application to be published, and
 as typed `group_history_permission_required`; it never advances the inbox or
 cursor.
 
+### Dynamic collector route reconcile
+
+An already provisioned inbox can be enrolled into a v1 multi-chat collector
+without rewriting the complete owner-local collector file by hand. Preview the
+route first, then apply it explicitly:
+
+```bash
+loopx lark-inbox collector-route-reconcile \
+  --project . \
+  --config .loopx/config/lark-collector.json \
+  --route-key project-feedback \
+  --chat-id oc_<local-private-chat-id> \
+  --event-inbox-config .loopx/config/lark/project-feedback.json
+
+loopx lark-inbox collector-route-reconcile \
+  --project . \
+  --config .loopx/config/lark-collector.json \
+  --route-key project-feedback \
+  --chat-id oc_<local-private-chat-id> \
+  --event-inbox-config .loopx/config/lark/project-feedback.json \
+  --execute
+```
+
+The operation validates unique route, chat, inbox-config, and inbox-path
+bindings; serializes concurrent writers; writes through an atomic replacement;
+and reads the exact binding and config digest back. Repeating the same request
+is a zero-write `already_applied` result, while any binding drift fails closed.
+Receipts return the public-safe `route_key` but never the chat id, inbox config,
+local path, profile, or credentials.
+
+Config readback does not prove that a running collector has reloaded the new
+route. Every successful plan/apply receipt therefore keeps
+`runtime_reload_required=true`, `runtime_reload_performed=false`, and
+`runtime_readback_verified=false`. The deployment owner must restart or
+reinstall the collector and independently verify its runtime before treating
+the route as live. Removing routes remains a separate owner-authorized
+lifecycle operation; this additive command never deletes or rebinds one.
+
 ## Lifecycle
 
 Install the bundled provider explicitly, then read back its readiness:

--- a/loopx/extensions/lark/event_collector_routes.py
+++ b/loopx/extensions/lark/event_collector_routes.py
@@ -1,0 +1,343 @@
+"""Additive, owner-local route reconciliation for a Lark event collector."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .event_collector import (
+    CHAT_RE,
+    CONFIG_SCHEMA_VERSION,
+    MAX_ROUTE_COUNT,
+    _project_config_path,
+    _relative_project_path,
+    load_lark_event_collector_config,
+)
+from .event_inbox import (
+    ROUTE_KEY_PATTERN,
+    load_lark_event_inbox_config,
+)
+
+ROUTE_RECONCILE_SCHEMA_VERSION = "lark_event_collector_route_reconcile_v0"
+
+
+def _route_reconcile_candidate(
+    config: Mapping[str, Any],
+    *,
+    route_key: str,
+    chat_id: str,
+    event_inbox_config: str,
+) -> tuple[dict[str, str], Path]:
+    if config["schema_version"] != CONFIG_SCHEMA_VERSION:
+        raise ValueError("collector route reconcile requires a v1 collector config")
+    if not ROUTE_KEY_PATTERN.fullmatch(route_key):
+        raise ValueError("route_key must be a lowercase public-safe token")
+    if not CHAT_RE.fullmatch(chat_id):
+        raise ValueError("chat_id must be a Lark oc_ chat id")
+    root = Path(config["project"])
+    inbox_ref, inbox_config_path = _relative_project_path(
+        root,
+        event_inbox_config,
+        "event_inbox_config",
+    )
+    inbox = load_lark_event_inbox_config(
+        project=root,
+        config_path=inbox_config_path,
+    )
+    if config["enabled"] and not inbox["enabled"]:
+        raise ValueError("enabled collector requires an enabled event inbox")
+    if config["enabled"] and not inbox["thread_complete"]:
+        raise ValueError(
+            "collector lifecycle currently requires configured_chat_all capture"
+        )
+    reply = inbox["reply"]
+    if reply.get("enabled") is True:
+        if str(reply.get("chat_id") or "").strip() != chat_id:
+            raise ValueError("collector route chat_id must match inbox reply chat_id")
+        reply_profile = str(reply.get("sender_profile") or "").strip()
+        if config.get("profile") and reply_profile != config["profile"]:
+            raise ValueError(
+                "collector route reply profile must match the collector profile"
+            )
+    if config["turn_start_sync"]["enabled"] and (
+        inbox["material_review"].get("enabled") is not True
+    ):
+        raise ValueError(
+            "collector turn_start_sync requires material_review on every route"
+        )
+    return (
+        {
+            "route_key": route_key,
+            "chat_id": chat_id,
+            "event_inbox_config": inbox_ref,
+        },
+        inbox["inbox_path"],
+    )
+
+
+def _collector_config_payload(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError("lark collector config must be readable JSON") from exc
+    if not isinstance(payload, dict):
+        raise TypeError("lark collector config must be a JSON object")
+    return payload
+
+
+def _collector_config_digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def _atomic_write_collector_config(path: Path, payload: Mapping[str, Any]) -> None:
+    mode = path.stat().st_mode & 0o777
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.chmod(temporary, mode)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            descriptor = -1
+            stream.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary.replace(path)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+@contextmanager
+def _collector_route_reconcile_lock(path: Path) -> Iterator[None]:
+    lock_path = path.with_suffix(path.suffix + ".route-reconcile.lock")
+    try:
+        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError as exc:
+        raise ValueError("collector route reconcile is already in progress") from exc
+    try:
+        os.write(descriptor, b"locked\n")
+        yield
+    finally:
+        os.close(descriptor)
+        lock_path.unlink(missing_ok=True)
+
+
+def _prepare_route_reconcile(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    route_key: str,
+    chat_id: str,
+    event_inbox_config: str,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, str], bool]:
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=config_path,
+    )
+    raw = _collector_config_payload(Path(config["config_path"]))
+    candidate, candidate_inbox_path = _route_reconcile_candidate(
+        config,
+        route_key=route_key,
+        chat_id=chat_id,
+        event_inbox_config=event_inbox_config,
+    )
+    exact_present = False
+    for route in config["routes"]:
+        if route["route_key"] == route_key:
+            if (
+                route["chat_id"] != chat_id
+                or route["event_inbox_config_ref"] != candidate["event_inbox_config"]
+            ):
+                raise ValueError("collector route_key is already bound differently")
+            exact_present = True
+        elif route["chat_id"] == chat_id:
+            raise ValueError("collector chat_id is already bound to another route")
+        elif route["event_inbox_config_ref"] == candidate["event_inbox_config"]:
+            raise ValueError(
+                "collector event_inbox_config is already bound to another route"
+            )
+    if not exact_present:
+        if len(config["routes"]) >= MAX_ROUTE_COUNT:
+            raise ValueError(f"collector routes cannot exceed {MAX_ROUTE_COUNT}")
+        existing_inbox_paths = {
+            route["inbox"]["inbox_path"]
+            for route in config["routes"]
+            if route["inbox"]["inbox_path"] is not None
+        }
+        if candidate_inbox_path in existing_inbox_paths:
+            raise ValueError("collector routes must use independent event inbox paths")
+    return config, raw, candidate, exact_present
+
+
+def _route_reconcile_receipt(
+    *,
+    status: str,
+    route_key: str,
+    route_count_before: int,
+    route_count_after: int,
+    config_digest_before: str,
+    config_digest_after: str,
+    write_performed: bool,
+    readback_verified: bool,
+    route_state: str,
+) -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": ROUTE_RECONCILE_SCHEMA_VERSION,
+        "status": status,
+        "route_key": route_key,
+        "route_count_before": route_count_before,
+        "route_count_after": route_count_after,
+        "config_digest_before": config_digest_before,
+        "config_digest_after": config_digest_after,
+        "write_performed": write_performed,
+        "runtime_reload_required": True,
+        "runtime_reload_performed": False,
+        "runtime_readback_verified": False,
+        "chat_id_returned": False,
+        "event_inbox_config_returned": False,
+        "local_path_returned": False,
+        "readback": {"verified": readback_verified, "route_state": route_state},
+    }
+
+
+def _restore_collector_config(
+    path: Path,
+    payload: Mapping[str, Any],
+    *,
+    expected_digest: str,
+) -> None:
+    _atomic_write_collector_config(path, payload)
+    restored = _collector_config_payload(path)
+    if _collector_config_digest(restored) != expected_digest:
+        raise ValueError("collector route rollback readback mismatch")
+
+
+def _reconcile_lark_event_collector_route_once(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    route_key: str,
+    chat_id: str,
+    event_inbox_config: str,
+    execute: bool = False,
+) -> dict[str, Any]:
+    config, raw, candidate, exact_present = _prepare_route_reconcile(
+        project=project,
+        config_path=config_path,
+        route_key=route_key,
+        chat_id=chat_id,
+        event_inbox_config=event_inbox_config,
+    )
+    before_digest = _collector_config_digest(raw)
+    if exact_present:
+        return _route_reconcile_receipt(
+            status="already_applied",
+            route_key=route_key,
+            route_count_before=len(config["routes"]),
+            route_count_after=len(config["routes"]),
+            config_digest_before=before_digest,
+            config_digest_after=before_digest,
+            write_performed=False,
+            readback_verified=True,
+            route_state="present",
+        )
+    proposed = {**raw, "routes": [*raw["routes"], candidate]}
+    after_digest = _collector_config_digest(proposed)
+    if not execute:
+        return _route_reconcile_receipt(
+            status="preview_ready",
+            route_key=route_key,
+            route_count_before=len(config["routes"]),
+            route_count_after=len(config["routes"]) + 1,
+            config_digest_before=before_digest,
+            config_digest_after=after_digest,
+            write_performed=False,
+            readback_verified=False,
+            route_state="planned",
+        )
+    path = Path(config["config_path"])
+    _atomic_write_collector_config(path, proposed)
+    try:
+        readback = load_lark_event_collector_config(
+            project=project,
+            config_path=path,
+        )
+        matches = [
+            route
+            for route in readback["routes"]
+            if route["route_key"] == route_key
+            and route["chat_id"] == chat_id
+            and route["event_inbox_config_ref"] == candidate["event_inbox_config"]
+        ]
+        readback_raw = _collector_config_payload(path)
+        if len(matches) != 1 or _collector_config_digest(readback_raw) != after_digest:
+            raise ValueError("collector route readback mismatch")
+    except (OSError, TypeError, ValueError) as readback_error:
+        try:
+            _restore_collector_config(
+                path,
+                raw,
+                expected_digest=before_digest,
+            )
+        except (OSError, TypeError, ValueError) as rollback_error:
+            raise ValueError(
+                "collector route apply failed readback and rollback was not verified"
+            ) from rollback_error
+        raise ValueError(
+            "collector route apply failed readback and was rolled back"
+        ) from readback_error
+    return _route_reconcile_receipt(
+        status="applied",
+        route_key=route_key,
+        route_count_before=len(config["routes"]),
+        route_count_after=len(readback["routes"]),
+        config_digest_before=before_digest,
+        config_digest_after=after_digest,
+        write_performed=True,
+        readback_verified=True,
+        route_state="present",
+    )
+
+
+def reconcile_lark_event_collector_route(
+    *,
+    project: str | Path,
+    config_path: str | Path,
+    route_key: str,
+    chat_id: str,
+    event_inbox_config: str,
+    execute: bool = False,
+) -> dict[str, Any]:
+    """Plan or atomically apply one redacted, idempotent collector route."""
+
+    if not execute:
+        return _reconcile_lark_event_collector_route_once(
+            project=project,
+            config_path=config_path,
+            route_key=route_key,
+            chat_id=chat_id,
+            event_inbox_config=event_inbox_config,
+            execute=False,
+        )
+    path = _project_config_path(project, config_path)
+    with _collector_route_reconcile_lock(path):
+        return _reconcile_lark_event_collector_route_once(
+            project=project,
+            config_path=path,
+            route_key=route_key,
+            chat_id=chat_id,
+            event_inbox_config=event_inbox_config,
+            execute=True,
+        )

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -9,10 +9,14 @@ from typing import Any
 import pytest
 
 from loopx.cli_commands import lark_inbox
+from loopx.extensions.lark import event_collector_routes
 from loopx.extensions.lark.event_collector import (
     _jq_projection,
     load_lark_event_collector_config,
     plan_lark_event_collector,
+)
+from loopx.extensions.lark.event_collector_routes import (
+    reconcile_lark_event_collector_route,
 )
 from loopx.extensions.lark.event_collector_runtime import (
     _is_profile_self_message,
@@ -158,6 +162,201 @@ def test_v1_plan_binds_one_profile_to_isolated_multi_chat_routes(
     assert first_chat not in serialized
     assert second_chat not in serialized
     assert "shared-context-bot" not in serialized
+    assert str(project) not in serialized
+
+
+def test_collector_route_reconcile_previews_applies_and_replays_with_readback(
+    tmp_path: Path,
+) -> None:
+    project, collector, first_chat, second_chat = _two_route_config(tmp_path)
+    third_chat = "oc_public_fixture_gamma"
+    third_inbox = _write_inbox(
+        project,
+        name="requirements-gamma",
+        chat_id=third_chat,
+    )
+    collector.chmod(0o600)
+
+    preview = reconcile_lark_event_collector_route(
+        project=project,
+        config_path=collector,
+        route_key="requirements-gamma",
+        chat_id=third_chat,
+        event_inbox_config=third_inbox,
+    )
+
+    assert preview["status"] == "preview_ready"
+    assert preview["route_count_before"] == 2
+    assert preview["route_count_after"] == 3
+    assert preview["write_performed"] is False
+    assert preview["runtime_reload_required"] is True
+    assert preview["readback"] == {"verified": False, "route_state": "planned"}
+    serialized = json.dumps(preview)
+    assert first_chat not in serialized
+    assert second_chat not in serialized
+    assert third_chat not in serialized
+    assert third_inbox not in serialized
+    assert str(project) not in serialized
+
+    applied = reconcile_lark_event_collector_route(
+        project=project,
+        config_path=collector,
+        route_key="requirements-gamma",
+        chat_id=third_chat,
+        event_inbox_config=third_inbox,
+        execute=True,
+    )
+    replayed = reconcile_lark_event_collector_route(
+        project=project,
+        config_path=collector,
+        route_key="requirements-gamma",
+        chat_id=third_chat,
+        event_inbox_config=third_inbox,
+        execute=True,
+    )
+
+    assert applied["status"] == "applied"
+    assert applied["write_performed"] is True
+    assert applied["runtime_reload_required"] is True
+    assert applied["runtime_reload_performed"] is False
+    assert applied["readback"] == {"verified": True, "route_state": "present"}
+    assert replayed["status"] == "already_applied"
+    assert replayed["write_performed"] is False
+    assert replayed["runtime_reload_required"] is True
+    assert replayed["runtime_readback_verified"] is False
+    assert replayed["readback"] == {"verified": True, "route_state": "present"}
+    assert collector.stat().st_mode & 0o777 == 0o600
+    assert not list(collector.parent.glob(f".{collector.name}.*.tmp"))
+    config = load_lark_event_collector_config(project=project, config_path=collector)
+    assert [route["route_key"] for route in config["routes"]] == [
+        "requirements-alpha",
+        "requirements-beta",
+        "requirements-gamma",
+    ]
+
+
+def test_collector_route_reconcile_rejects_binding_conflicts_without_writing(
+    tmp_path: Path,
+) -> None:
+    project, collector, first_chat, _ = _two_route_config(tmp_path)
+    before = collector.read_bytes()
+    conflicting_inbox = _write_inbox(
+        project,
+        name="requirements-conflict",
+        chat_id=first_chat,
+    )
+
+    with pytest.raises(ValueError, match="chat_id is already bound"):
+        reconcile_lark_event_collector_route(
+            project=project,
+            config_path=collector,
+            route_key="requirements-conflict",
+            chat_id=first_chat,
+            event_inbox_config=conflicting_inbox,
+            execute=True,
+        )
+
+    assert collector.read_bytes() == before
+
+
+def test_collector_route_reconcile_rejects_concurrent_writer_without_writing(
+    tmp_path: Path,
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+    before = collector.read_bytes()
+    chat_id = "oc_public_fixture_locked"
+    inbox = _write_inbox(project, name="requirements-locked", chat_id=chat_id)
+    lock = collector.with_suffix(collector.suffix + ".route-reconcile.lock")
+    lock.write_text("locked\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="already in progress"):
+        reconcile_lark_event_collector_route(
+            project=project,
+            config_path=collector,
+            route_key="requirements-locked",
+            chat_id=chat_id,
+            event_inbox_config=inbox,
+            execute=True,
+        )
+
+    assert collector.read_bytes() == before
+
+
+def test_collector_route_reconcile_rolls_back_unverified_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+    before = json.loads(collector.read_text(encoding="utf-8"))
+    chat_id = "oc_public_fixture_rollback"
+    inbox = _write_inbox(project, name="requirements-rollback", chat_id=chat_id)
+    original_load = event_collector_routes.load_lark_event_collector_config
+    calls = 0
+
+    def fail_apply_readback(**kwargs: object) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise ValueError("synthetic readback failure")
+        return original_load(**kwargs)
+
+    monkeypatch.setattr(
+        event_collector_routes,
+        "load_lark_event_collector_config",
+        fail_apply_readback,
+    )
+
+    with pytest.raises(ValueError, match="was rolled back"):
+        reconcile_lark_event_collector_route(
+            project=project,
+            config_path=collector,
+            route_key="requirements-rollback",
+            chat_id=chat_id,
+            event_inbox_config=inbox,
+            execute=True,
+        )
+
+    assert json.loads(collector.read_text(encoding="utf-8")) == before
+    assert not list(collector.parent.glob(f".{collector.name}.*.tmp"))
+
+
+def test_cli_collector_route_reconcile_returns_only_redacted_plan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+    chat_id = "oc_public_fixture_cli"
+    inbox = _write_inbox(project, name="requirements-cli", chat_id=chat_id)
+    monkeypatch.setattr(
+        lark_inbox,
+        "_resolve_lark_activation",
+        lambda *_args, **_kwargs: {"enabled": True},
+    )
+    rendered: list[dict[str, object]] = []
+    args = argparse.Namespace(
+        command="lark-inbox",
+        lark_inbox_command="collector-route-reconcile",
+        project=str(project),
+        config=str(collector),
+        route_key="requirements-cli",
+        chat_id=chat_id,
+        event_inbox_config=inbox,
+        execute=False,
+    )
+
+    code = lark_inbox.handle_lark_inbox_command(
+        args,
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        output_format=lambda _args: "json",
+        print_payload=lambda payload, *_args: rendered.append(payload),
+    )
+
+    assert code == 0
+    assert rendered[0]["status"] == "preview_ready"
+    assert rendered[0]["extension_activation"] == {"enabled": True}
+    serialized = json.dumps(rendered[0])
+    assert chat_id not in serialized
+    assert inbox not in serialized
     assert str(project) not in serialized
 
 


### PR DESCRIPTION
## Summary

- add an explicit preview/apply/readback command for one additive Lark collector route
- validate route, chat, inbox-config, inbox-path, profile, and turn-start constraints before mutation
- serialize writers, atomically replace the owner-local config, verify readback, and verify rollback on failure
- keep receipts redacted and distinguish config application from runtime reload

## Validation

- 60 focused collector/runtime/turn-start/architecture tests passed
- focused Ruff and supported `mypy 1.20.2` passed
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --goal-id ark-flow-goal --tier standard` (17/17 selected checks passed; 0 failures; 0 manual holds)
- changed-file public/private boundary scan (4 files clean)

## Future-facing review

Route mutation lives in a focused module under the existing Lark extension instead of growing the collector lifecycle module. This remains an additive provider operation, not a new kernel capability; removal and runtime reload stay separate owner-authorized lifecycle steps.