### PR TITLE
perf(history): reuse duplicate artifact checks

### DIFF
--- a/loopx/history.py
+++ b/loopx/history.py
@@ -181,7 +181,19 @@ def load_index(
 
     records: list[dict[str, Any]] = []
     positions: dict[tuple[str, str, str], int] = {}
+    artifact_exists: dict[tuple[str, str], bool] = {}
     raw_count = 0
+
+    def artifact_is_present(value: Any) -> bool:
+        text = str(value or "").strip()
+        cache_key = (text, str(artifact_root or ""))
+        if cache_key not in artifact_exists:
+            artifact_exists[cache_key] = _indexed_artifact_exists(
+                value,
+                artifact_root=artifact_root,
+            )
+        return artifact_exists[cache_key]
+
     with path.open(encoding="utf-8") as f:
         for line in f:
             if not line.strip():
@@ -200,14 +212,8 @@ def load_index(
                 str(item.get("markdown_path") or ""),
             )
             item = dict(item)
-            item["json_exists"] = _indexed_artifact_exists(
-                item.get("json_path"),
-                artifact_root=artifact_root,
-            )
-            item["markdown_exists"] = _indexed_artifact_exists(
-                item.get("markdown_path"),
-                artifact_root=artifact_root,
-            )
+            item["json_exists"] = artifact_is_present(item.get("json_path"))
+            item["markdown_exists"] = artifact_is_present(item.get("markdown_path"))
             if key in positions:
                 records[positions[key]].update(item)
             else:

--- a/tests/test_history_chronology.py
+++ b/tests/test_history_chronology.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import loopx.history as history_module
 from loopx.history import collect_history
 
 
@@ -146,3 +147,41 @@ def test_collect_history_keeps_invalid_legacy_timestamps_below_valid_runs(
         "overflow",
         "missing",
     ]
+
+
+def test_load_index_reuses_artifact_existence_checks_for_duplicate_rows(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    index_path = tmp_path / "index.jsonl"
+    row = {
+        "generated_at": "2026-01-01T00:00:00Z",
+        "json_path": "artifacts/run.json",
+        "markdown_path": "artifacts/run.md",
+    }
+    index_path.write_text(
+        "".join(json.dumps(row) + "\n" for _ in range(100)),
+        encoding="utf-8",
+    )
+    calls: list[tuple[Any, Path | None]] = []
+    original = history_module._indexed_artifact_exists
+
+    def count_exists(value: Any, *, artifact_root: Path | None) -> bool:
+        calls.append((value, artifact_root))
+        return original(value, artifact_root=artifact_root)
+
+    monkeypatch.setattr(history_module, "_indexed_artifact_exists", count_exists)
+
+    records, raw_count = history_module.load_index(
+        index_path,
+        artifact_root=tmp_path,
+    )
+
+    assert raw_count == 100
+    assert len(records) == 1
+    assert calls == [
+        ("artifacts/run.json", tmp_path),
+        ("artifacts/run.md", tmp_path),
+    ]
+    assert records[0]["json_exists"] is False
+    assert records[0]["markdown_exists"] is False


### PR DESCRIPTION
## Summary

`load_index()` 会在读取每一条 index 行时分别检查 `json_path` 和 `markdown_path` 是否存在。历史索引包含重复 receipt/重放记录时，这些路径完全相同，但当前实现会重复执行相同的 `Path.exists()` I/O。

本 PR 在单次 `load_index()` 调用内按 `(path, artifact_root)` 复用存在性结果：

- 不改变返回字段、排序、去重或 raw record 计数；
- 不引入跨请求或跨进程缓存，不会产生陈旧文件状态；
- 唯一索引路径仍保持原有行为；
- 只增加一条针对重复索引行的回归测试。

## Measurement

在 10,000 条内容完全相同的重复 index 行上：

- 优化前：20,000 次 artifact existence checks，约 `0.65s`；
- 优化后：2 次 checks，约 `0.025s`；
- 该合成重复索引读取路径耗时减少约 96%。

## Validation

- History/status/summary focused tests: `26 passed`
- `status-quota-perf-budget-smoke.py`: passed
- `ruff check`: passed
- `py_compile`: passed
- `loopx check`: passed with 2 expected warnings because this isolated checkout has no `.loopx/registry.json`
- `loopx canary premerge --from-git-diff`: passed
- Full pytest: `5063 passed, 12 skipped, 2 transient failures` in the first run; both failing tests pass in isolation on rerun.

The two full-suite failures were unrelated existing environment-sensitive tests: a Codex fake-host capacity-event timing case and an optional extension provider availability case. No new dependency was added.