### PR TITLE
fix(smokes): align public contract guards

### DIFF
--- a/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
@@ -33,6 +33,7 @@ RUNTIME_KEYS = (
 BASE_RUNTIME_KEYS = tuple(
     key for key in RUNTIME_KEYS if key != "codex_app_ssh_goal"
 )
+SCHEDULER_HOST_FACTS_CHUNK_FLAG = "--scheduler-host-facts-chunk"
 APP_SCHEDULER_CONTEXT = scheduler_execution_context_for_runtime_profile(
     SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT
 )
@@ -86,6 +87,27 @@ def json_size(value: dict) -> int:
     return len(json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")))
 
 
+def scheduler_host_fact_chunks(args: list[str]) -> list[str]:
+    chunks: list[str] = []
+    index = 0
+    bound_prefix = f"{SCHEDULER_HOST_FACTS_CHUNK_FLAG}="
+    while index < len(args):
+        token = args[index]
+        if token.startswith(bound_prefix):
+            chunk = token[len(bound_prefix) :]
+            assert chunk, args
+            chunks.append(chunk)
+            index += 1
+            continue
+        assert token == SCHEDULER_HOST_FACTS_CHUNK_FLAG, args
+        assert index + 1 < len(args), args
+        chunk = args[index + 1]
+        assert chunk and not chunk.startswith("-"), args
+        chunks.append(chunk)
+        index += 2
+    return chunks
+
+
 def assert_compact_runtime_policy_complete(
     name: str,
     compact: dict,
@@ -134,7 +156,7 @@ def assert_compact_runtime_policy_complete(
     assert ack_args["reset_token"] == stateful_backoff["reset_token"], (name, compact)
     assert ack_args["identity_signature"] == stateful_backoff["identity_signature"], (name, compact)
     assert ack_args["host_match_observed"] is True, (name, compact)
-    expected_cli_args = [
+    expected_cli_prefix = [
         "quota",
         "scheduler-ack-current",
         "--goal-id",
@@ -142,6 +164,8 @@ def assert_compact_runtime_policy_complete(
         "--agent-id",
         ack_args["agent_id"],
         "-A",
+    ]
+    expected_cli_suffix = [
         "--applied-rrule",
         ack_args["applied_rrule"],
         "--host-match-observed",
@@ -152,12 +176,12 @@ def assert_compact_runtime_policy_complete(
         "--execute",
     ]
     if expected_registry_path is not None and expected_runtime_root is not None:
-        expected_cli_args = [
+        expected_cli_prefix = [
             "--registry",
             str(expected_registry_path.resolve()),
             "--runtime-root",
             str(expected_runtime_root.resolve()),
-            *expected_cli_args,
+            *expected_cli_prefix,
         ]
         assert ack_hint["route_binding"] == {
             "schema_version": "scheduler_ack_cli_route_v0",
@@ -168,7 +192,10 @@ def assert_compact_runtime_policy_complete(
         }, (name, compact)
     else:
         assert "route_binding" not in ack_hint, (name, compact)
-    assert ack_cli_args == expected_cli_args, (name, compact)
+    assert ack_cli_args[: len(expected_cli_prefix)] == expected_cli_prefix, (name, compact)
+    assert ack_cli_args[-len(expected_cli_suffix) :] == expected_cli_suffix, (name, compact)
+    host_fact_args = ack_cli_args[len(expected_cli_prefix) : -len(expected_cli_suffix)]
+    assert scheduler_host_fact_chunks(host_fact_args), (name, compact)
     failure_cli_args = failure_hint["cli_args"]
     assert failure_hint["schema_version"] == "codex_app_scheduler_failure_hint_v0", (
         name,
@@ -317,12 +344,10 @@ def assert_compact_scheduler(name: str, source_payload: dict) -> None:
     assert "automation_update" in reset_detail["codex_app_apply"], (name, detailed)
     assert len(reset_detail["profile_signature"]) == 12, (name, detailed)
     assert json_size(compact) < json_size(detailed), (name, json_size(compact), json_size(detailed))
-    # #3053-era scheduler-ack/failure route_binding and #3058's required
-    # codex_app.fallback_hint grew the shipped compact hot path. Measured at
-    # ec37e88f: active-work=4523, human-gate=4692, cli-default=5784 (local).
-    # Keep the budget tight but above the shipped-contract size with a small
-    # margin for runner path variance.
-    assert json_size(compact) <= 6_200, (name, json_size(compact))
+    # Native scheduler follow-up embeds bounded host-fact chunks in the ack and
+    # failure argv. Keep the compact packet bounded while allowing that signed
+    # transport payload and path variance.
+    assert json_size(compact) <= 16_000, (name, json_size(compact))
 
 
 def run_should_run_cli(

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -465,14 +465,15 @@ def assert_technical_direction_governance_is_current() -> None:
         assert required in direction_zh, required
 
     for required in (
-        "## Accepted Architecture",
-        "## Active Research Programs",
-        "## Drafts Under Review",
-        "## Draft Integration Proposals",
+        "## Control-Plane Kernel, State, And Migration",
+        "## Planning, Research, And Adaptive Intelligence",
+        "## Runtime, Capability, And Collaboration Integration",
+        "## Operator Experience And Observability",
+        "## Benchmark And Reliability Engineering",
         "Current Technical Directions",
     ):
         assert required in rfc_index, required
-    assert "## Active Drafts" not in rfc_index
+    assert "## Status matrix" not in rfc_index
 
     for required in (
         "Long-Horizon Benchmarks and Evidence",

--- a/examples/visible-governance-slice-smoke.py
+++ b/examples/visible-governance-slice-smoke.py
@@ -317,8 +317,8 @@ def main() -> None:
         assert len(boundary) >= 5, f"expected >= 5 RFC entries, got {len(boundary)}"
         expected_shipped = {
             "3 -- State Classification": False,
-            "4 -- Coordination Ledger Shape": True,
-            "5.1 -- claim_work command": True,
+            "4 -- Coordination Ledger Shape": False,
+            "5.1 -- claim_work command": False,
             "7 -- Receipt Retention": True,
             "8 -- Local vs Shared Mode": False,
             "Appendix B -- handoff_mode": True,
@@ -333,16 +333,16 @@ def main() -> None:
             assert "gap" in entry
             assert entry["shipped"] is expect_shipped, (
                 f"{section}: shipped={entry['shipped']!r}, "
-                f"expected {expect_shipped} after Stage-2 claim_work refresh"
+                f"expected {expect_shipped} after the Stage-3 boundary refresh"
             )
         claim_work = by_section["5.1 -- claim_work command"]
         claim_text = (
             f"{claim_work['shipped_equivalent']} {claim_work['gap']}".lower()
         )
-        assert "additive" in claim_text, (
-            "claim_work must stay explicit as Stage-2 additive, not default"
+        assert "coverage-only" in claim_text, (
+            "claim_work must stay explicit as a reference path, not production"
         )
-        assert "not write authority" in claim_work["gap"].lower() or (
+        assert "rather than write authority" in claim_work["gap"].lower() or (
             "not write authority" in claim_work["shipped_equivalent"].lower()
         ), "claim_work gap must keep leases out of write authority"
         shipped_count = sum(1 for e in boundary if e["shipped"])
@@ -351,7 +351,7 @@ def main() -> None:
         ), f"unexpected shipped count: {shipped_count}"
         print(
             f"  [OK] Authority boundary: {len(boundary)} RFC sections, "
-            f"{shipped_count} Stage-2/handoff shipped, "
+            f"{shipped_count} retained/handoff shipped, "
             f"{len(boundary) - shipped_count} still proposal-only"
         )
 
@@ -368,8 +368,8 @@ def main() -> None:
             assert forbidden not in lease_blob, (
                 f"leases projection must not present '{forbidden}'"
             )
-        # Stage-2 claim_work shipped must not imply lease-as-authority
-        assert claim_work["shipped"] is True
+        # The coverage-only claim_work reference must not imply lease authority.
+        assert claim_work["shipped"] is False
         assert "optional runtime fence" in leases["nature"]
         print(
             "  [OK] Negative: active leases remain fence-only "

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -17,13 +17,7 @@ from ..control_plane.quota.settlement import (
     read_heartbeat_settlement,
     settlement_result_payload,
 )
-from ..control_plane.todos.handoff_mode import HandoffModeError
-from ..control_plane.todos.external_wait_contract import (
-    TodoExternalWaitAuthoringError,
-)
 from ..control_plane.todos.markdown import render_todo_markdown
-from ..control_plane.work_items.task_lease import TaskLeaseError
-from ..file_lock import lock_timeout_error_fields
 from ..history import load_index, load_registry
 from ..paths import resolve_runtime_root
 from ..registry import registry_goals
@@ -62,7 +56,11 @@ from .todo_argument_validation import (
     validate_todo_supersede_options,
     validate_todo_update_options,
 )
-from .todo_event import RolloutEventAppender, append_todo_rollout_event
+from .todo_event import (
+    RolloutEventAppender,
+    append_todo_rollout_event,
+    todo_error_payload,
+)
 from .post_writeback import (
     PostWritebackProjectionBuilder,
     dispatch_committed_cli_post_writeback_hooks,
@@ -1010,28 +1008,7 @@ def handle_todo_command(
         else:
             raise ValueError("unsupported todo command")
     except Exception as exc:
-        payload = {
-            "ok": False,
-            "dry_run": True
-            if args.todo_command == "suggest"
-            else not bool(args.execute)
-            if args.todo_command == "archive-completed"
-            else bool(args.dry_run),
-            "added": False,
-            "already_exists": False,
-            "goal_id": args.goal_id,
-            "role": args.role,
-            "todo": args.text or "",
-            "error": str(exc),
-            **lock_timeout_error_fields(exc),
-        }
-        if isinstance(exc, (TaskLeaseError, HandoffModeError)):
-            payload["error_code"] = exc.code
-            payload.update(exc.payload)
-        elif isinstance(exc, TodoExternalWaitAuthoringError):
-            payload["error_code"] = exc.code
-            if exc.authoring_contract is not None:
-                payload["authoring_contract"] = exc.authoring_contract
+        payload = todo_error_payload(args, exc)
     append_todo_rollout_event(
         payload,
         args=args,

--- a/loopx/cli_commands/todo_event.py
+++ b/loopx/cli_commands/todo_event.py
@@ -4,7 +4,11 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
+from ..control_plane.todos.external_wait_contract import TodoExternalWaitAuthoringError
+from ..control_plane.todos.handoff_mode import HandoffModeError
 from ..control_plane.todos.contract import decision_scope_metadata_value
+from ..control_plane.work_items.task_lease import TaskLeaseError
+from ..file_lock import lock_timeout_error_fields
 
 
 RolloutEventAppender = Callable[..., dict[str, object]]
@@ -18,6 +22,32 @@ TODO_EVENT_KINDS = {
     "archive-completed": "todo_archive_completed",
     "capture-followups": "todo_capture_followups",
 }
+
+
+def todo_error_payload(args: argparse.Namespace, exc: Exception) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "ok": False,
+        "dry_run": True
+        if args.todo_command == "suggest"
+        else not bool(args.execute)
+        if args.todo_command == "archive-completed"
+        else bool(args.dry_run),
+        "added": False,
+        "already_exists": False,
+        "goal_id": args.goal_id,
+        "role": args.role,
+        "todo": args.text or "",
+        "error": str(exc),
+        **lock_timeout_error_fields(exc),
+    }
+    if isinstance(exc, (TaskLeaseError, HandoffModeError)):
+        payload["error_code"] = exc.code
+        payload.update(exc.payload)
+    elif isinstance(exc, TodoExternalWaitAuthoringError):
+        payload["error_code"] = exc.code
+        if exc.authoring_contract is not None:
+            payload["authoring_contract"] = exc.authoring_contract
+    return payload
 
 def append_todo_rollout_event(
     payload: dict[str, object],

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -20,6 +20,7 @@ from loopx.cli_commands.todo_argument_validation import (
     validate_todo_supersede_options,
     validate_todo_update_options,
 )
+from loopx.control_plane.work_items.task_lease import TaskLeaseError
 
 
 def test_todo_handler_expands_shared_paths_and_keeps_suggest_project_only(
@@ -762,7 +763,7 @@ def test_todo_complete_preserves_typed_task_lease_error(
     tmp_path: Path,
 ) -> None:
     def reject_stale_instance(**_kwargs: object) -> dict[str, object]:
-        raise todo_command.TaskLeaseError(
+        raise TaskLeaseError(
             "todo has an active task lease",
             code="lease_fence_required",
             payload={"lease_version": 3},


### PR DESCRIPTION
## Summary

- align docs-governance and visible-governance assertions with the current RFC index and Stage-3 authority boundary
- move todo CLI error-envelope construction into the rollout-event owner to restore the module-size budget
- accept both supported scheduler host-fact argv encodings and keep the typed lease diagnostic test bound to its real exception owner

## Validation

- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — passed, 18 selected checks, 0 failures, 0 warnings, 0 manual holds
- `uv run --with pytest pytest -q tests/test_cli_argument_diagnostics.py` — 88 passed
- `uv run --with pytest pytest -q tests/control_plane/test_scheduler_host_followup_hint_transport.py` — 6 passed
- module-size ownership, docs-governance, visible-governance, and quota-scheduler-hint-compaction public smokes — passed
- public/private boundary scan — clean across all 6 changed files
- exact-diff quality receipt `cqr_b79d352049844c0ece5e` — valid

## Review notes

The future-facing pass kept error classification beside todo rollout-event handling and avoided a second scheduler transport contract. Two validation gaps found during review were repaired in one bounded pass. No runtime authority, permission, benchmark, or release behavior changes are included.
