### PR TITLE
feat(extension): reconcile CPA integration candidates

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -10,6 +10,8 @@ Catalog: `codex_provider_routing_catalog_v1`
 
 Runtime status: `codex_provider_routing_runtime_status_v0`
 
+Integration candidate: `codex_provider_integration_candidate_v0`
+
 The provider accepts exactly one public-safe operation per invocation and
 returns a deterministic JSON result. An input containing credential-shaped
 keys fails before any operation runs.
@@ -18,6 +20,20 @@ The provider has no Kernel transition authority and no external write
 permission. A qualification result is evidence, not permission to edit a
 Codex home, install CPA, change a model, start a turn, rotate a credential or
 merge an upstream PR.
+
+The integration-candidate operation composes with, but does not replace,
+LoopX core `integration-branch`. It accepts only public Git refs, full commit
+SHAs, symbolic source IDs, source kinds and changed-seam labels. The caller
+must supply both current observations and the last successful sync receipt.
+Every observed source head must equal its declared exact head, and the ordered
+source set must cover every required seam. Base movement, source movement or an
+unexpected integration head produces `sync_required`; no Git effect is run.
+
+After a separately authorized core sync, deployment remains operator-owned.
+The returned contract requires a content-addressed binary, isolated smoke,
+field-level configuration comparison, catalog/retry/runtime readback and a
+retained previous binary/config pointer. Task/session stores are preserved in
+place and are never copied or deleted as part of candidate maintenance.
 
 Runtime status deliberately has two projections. `host_identity` records only
 that the operator's ChatGPT identity is retained but is not projected by the

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -57,6 +57,12 @@ qualification.
   remaining quota and reports fallback only when more than one provider was
   attempted. It never accepts account identity, auth-file names or tokens.
 
+`reconcile_integration_candidate`
+: Validates one ordered multi-source CPA candidate against its last sync
+  receipt. It proves exact base/source heads, required runtime-seam coverage and
+  whether reconciliation is needed, then returns inputs for LoopX core
+  `integration-branch`. It never fetches, merges, pushes, builds or deploys.
+
 `upgrade_plan`
 : Produces a bounded upgrade/rollback checklist from public current and target
   refs plus the changed seams. It never installs, switches or deletes a
@@ -81,6 +87,10 @@ loopx extension run loopx-codex-provider-routing \
   --input-json packages/loopx-codex-provider-routing/examples/normalize-request.json \
   --execute \
   --format json
+loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/integration-candidate.json \
+  --execute \
+  --format json
 ```
 
 The extension runtime owns install/enable/disable/doctor registration. Package
@@ -96,6 +106,7 @@ The earlier operator scripts split into three classes:
 | Secret-free profile/catalog compiler | Migrated into `compile_catalog` and strengthened with modality/service-tier eligibility |
 | Fast selector catalog generation and request-tier normalization | Migrated into `compile_catalog` plus `normalize_selector_request`; the CPA adapter remains the online enforcement point |
 | App/CPA model readback assertions | Migrated as the content-free `qualify_snapshot` contract |
+| Ordered PR/patch candidate inventory and drift detection | Migrated as `reconcile_integration_candidate`; Git composition remains owned by LoopX core `integration-branch` |
 | Upgrade matrix, snapshot order and rollback triggers | Migrated as `upgrade_plan`; effect execution remains operator-owned |
 | CPA process launcher, OAuth login/reconcile, Ark key loading | Excluded; these are provider runtime and credential lifecycle, not LoopX state |
 | Direct App config writes, private snapshots and rollback copies | Excluded from v0; require an explicit permissioned execution envelope before productization |

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -12,18 +12,20 @@ ports, accounts or private receipts.
 | Generate explicit Fast sibling rows and inject the Fast request tier | Migrated as a public-safe compiler/normalizer contract | `contract.py::compile_catalog` plus `normalize_selector_request`; the live CPA adapter/plugin enforces the same decision before alias mapping |
 | Project host identity separately from actual A/B routing and quota | Migrated as a public-safe adapter boundary | `contract.py::project_runtime_status`; raw CPA management responses and logs remain operator-local |
 | Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
+| Reconcile an ordered multi-PR candidate against exact heads and required seams | Migrated as a public-safe planning contract | `reconcile_integration_candidate` returns core `integration-branch` inputs; Git effects remain outside the extension |
 | Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
 | Snapshot App/selector configuration, validate hashes and roll back selected files | Planning contract migrated | `upgrade_plan` owns order, matrix and rollback trigger; filesystem effects need a future request-bound execution envelope |
 | Scan local config/auth files for secret patterns | Split | `reject_private_material` protects extension input/output; scanning owner-local files remains an operator preflight |
 | Emit failover evidence rows | Replaced | `upgrade_plan.required_checks` and `qualify_snapshot.checks` are the public evidence vocabulary; raw evidence directories are excluded |
 | Read CC Switch SQLite and enable its failover toggle | Retired | CPA is the only online data plane; CC Switch remains bootstrap/rollback and must not regain routing authority |
 | Python routing, transaction, outbox and turn-lease simulators | Reference-only prototypes | Stable rules moved into the runbook, contract and CPA upstream tests; LoopX does not ship a second router implementation |
-| Provider history and SSE normalizer prototypes | Upstreamed, not duplicated | CLIProxyAPI PR #5220 is the implementation owner |
+| Provider history and SSE normalizer prototypes | Upstreamed, not duplicated | CLIProxyAPI PR #5410 supersedes closed PR #5220 as the implementation owner |
 | uTLS connection experiments | Upstreamed, not duplicated | CLIProxyAPI PR #5261 is the implementation owner |
+| Route-specific fallback ring | Upstreamed, not duplicated | CLIProxyAPI PR #5336 is the implementation owner |
 
 ## Configuration References
 
-The package keeps five credential-free examples:
+The package keeps six credential-free examples:
 
 - [`examples/request.json`](examples/request.json): logical profiles and model
   routes backed by one bounded account ring for `compile_catalog`;
@@ -35,6 +37,9 @@ The package keeps five credential-free examples:
   content-free App/CPA readback for `qualify_snapshot`;
 - [`examples/upgrade-request.json`](examples/upgrade-request.json): exact public
   refs and changed seams for `upgrade_plan`.
+- [`examples/integration-candidate.json`](examples/integration-candidate.json):
+  ordered source refs, exact heads, required seams and last-sync observations
+  for `reconcile_integration_candidate`.
 
 [`templates/codex-app-config.toml`](templates/codex-app-config.toml) and
 [`templates/cpa-config.public.yaml`](templates/cpa-config.public.yaml) preserve

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -64,9 +64,9 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | LoopX | [#3711](https://github.com/huangruiteng/loopx/pull/3711) | merged | 将 runbook、脚本迁移清单、无密配置和资格 contract 升级为独立 extension |
 | LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | merged | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
 | LoopX | [#3804](https://github.com/huangruiteng/loopx/pull/3804) | merged | 将宿主身份、路由选择、额度与真实 attempt chain 投影为无密运行状态 |
-| LoopX | [#3805](https://github.com/huangruiteng/loopx/pull/3805) | open | 生成显式 Fast sibling rows，固化 `fast/` request normalization、默认 tier 与 A/B-only fallback |
+| LoopX | [#3805](https://github.com/huangruiteng/loopx/pull/3805) | merged | 生成显式 Fast sibling rows，固化 `fast/` request normalization、默认 tier 与 A/B-only fallback |
 | CLIProxyAPI | [#5211](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | merged | 被动观测 per-auth quota header 与最近请求计数；management 原始身份字段仍须由 operator adapter 脱敏 |
-| CLIProxyAPI | [#5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | open / conflicts | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer；CI 通过但需 rebase 后再 review |
+| CLIProxyAPI | [#5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) | open / review required | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer；替代被自动关闭且无法 reopen 的 #5220 |
 | CLIProxyAPI | [#5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | open / review required | ChatGPT uTLS HTTP/2 连接池、TLS session resumption 与异常重建 |
 | CLIProxyAPI | [#5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) | open / review required | per-route credential priority；同一 A/B 账号环支持 Prefer A 与 Prefer B 两个入口 |
 
@@ -86,15 +86,28 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 5. 私有证据只回写错误类型、能力边界、结果和可公开的版本；不回写原始 prompt、账号、
    task ID、路径、端口、header、响应体或日志片段。
 
+### 持久整合候选
+
+三个公开 PR 与一个 operator-owned public-safe modality patch 通过
+[`codex/integrated-dev`](https://github.com/huangruiteng/CLIProxyAPI/tree/codex/integrated-dev)
+按依赖顺序组合：history/SSE → uTLS transport → modality admission/normalizer → route fallback。
+当前锁定 base 为 `origin/dev@8deeb4a`，候选 head 为 `4df2bf1`。这只是可回滚的 self-use
+candidate，不是 upstream release。
+
+`reconcile_integration_candidate` 保存 source order、exact heads、required seams、current
+observation 与 last-sync receipt，并把 Git 合并输入交给 LoopX core `integration-branch`。任何
+base/source/head 漂移都只产生 `sync_required`；monitor 不自动合并或 push。显式同步后必须重新
+执行 build、changed-seam matrix、字段级配置 diff 与 App Server readback，才允许更新部署指针。
+
 ## 锁定的 qualification baseline
 
 在升级前锁定 commit，不直接跟随上游 `main`：
 
 | 项目 | 锁定版本 | 本 runbook 使用的边界 |
 | --- | --- | --- |
-| CPA self-use build | operator-owned private receipt（基于公共 fork commit `2aa8c43a`；公共等价修复已进入 PR #5220 head `9357def`） | 多 Codex OAuth、provider-bound history、`additional_tools`、commit-before-failover、Ark Responses/SSE normalizer；私有补丁 commit、二进制 digest 与安装位置不进入公共仓库 |
+| CPA self-use build | operator-owned private receipt；当前公共整合候选为 `codex/integrated-dev@4df2bf1` | 多 Codex OAuth、provider-bound history、`additional_tools`、commit-before-failover、Ark Responses/SSE normalizer；二进制 digest 与安装位置不进入公共仓库 |
 | CPA upstream release baseline | [`a7e3596b7e351d800e58ed29529fbca3d1c18737`](https://github.com/router-for-me/CLIProxyAPI/commit/a7e3596b7e351d800e58ed29529fbca3d1c18737) | `fill-first`、priority、prefix、session affinity、stream bootstrap buffering、OpenAI-compatible provider 的原始基线 |
-| CPA public candidate | [PR #5220 head `9357def40dfccc3151e4797cbfa400d4df8e1d26`](https://github.com/router-for-me/CLIProxyAPI/pull/5220) | 当前 `dev` 上的 provider-history / SSE candidate；CI 已通过且 mergeable，仍在等待 review，不等于 upstream release |
+| CPA public history candidate | [PR #5410 head `6f1c08c3603fe318d3cdde1db4f3cf8b030f6742`](https://github.com/router-for-me/CLIProxyAPI/pull/5410) | 当前 `dev` 上的 provider-history / SSE candidate；CI 通过，等待 review，不等于 upstream release |
 | ChatGPT uTLS transport candidate | [PR #5261 head `c8e76e1e76aba4cc2206cec9d2a6444c9f527998`](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | 复用 HTTP/2 transport、TLS session resumption、draining/异常连接重建；CI 已通过且 mergeable，仍在等待 review |
 | Passive quota observation | [PR #5211 merge `ca601db05d858472b25e7c56580555ab62b90e68`](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | management API 暴露 bounded quota signal 与 200 分钟 recent-request buckets；原始 auth identity 只在 operator adapter 内使用 |
 | AgentSwap | [`c9b76f4a4adae81274eb8f52d428bba925a1a7ef`](https://github.com/bojieli/agentswap/commit/c9b76f4a4adae81274eb8f52d428bba925a1a7ef) | `teleport` / `handoff`、`--dry-run`、`--compact`、`--budget` |
@@ -111,10 +124,10 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 当前生产 selector 或 failover 队列中。目标态仍允许增加 C，但配置和验收必须以“实际
 存在的 credential”为准，不能用空 profile 假装第三个可用账号。
 
-锁定 CPA baseline 上形成的 candidate 已 forward-port 到当前 `dev`，并提交为
-[CLIProxyAPI PR #5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220)。当前 self-use
-二进制由 operator-owned private receipt 锁定，公共 candidate head 为 `9357def`。两者都已覆盖
-provider-neutral `additional_tools`；公共 head 还包含当前 PR 分支上的完整 review fixes。
+锁定 CPA baseline 上形成的 candidate 已 forward-port 到当前 `dev`，原 PR #5220 被 stale-base
+guard 自动关闭后由 [CLIProxyAPI PR #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410)
+替代。当前 self-use 二进制由 operator-owned private receipt 锁定，公共 history candidate head
+为 `6f1c08c`；它覆盖 provider-neutral `additional_tools` 与当前 review fixes。
 上游 merge 仍是升级与公共分发渠道，不再是本机自用的前置条件。上游合并后仍须锁定
 merge commit，并重新运行本文矩阵。
 当前证据边界如下：
@@ -131,7 +144,7 @@ merge commit，并重新运行本文矩阵。
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
 | Fast tier 投影 | 本机与 SSH App Server readback 通过 | Auto、Prefer A、Prefer B 各有显式 `fast/` sibling 行，默认 tier 为 `fast` 并在请求规整时强制 `priority`；普通行与 Luna 保持 `default`，Fast 行不进入 Ark |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | quota PR 已合并；三个分发 PR CI 通过 | #5211 merge `ca601db0`；#5220 head `9357def` 当前 conflicts；#5261 head `c8e76e1`、#5336 head `3d038a27` 当前 blocked pending review；后三者仍等待 maintainer review |
+| CPA upstream review | quota PR 已合并；三个分发 PR CI 通过 | #5211 merge `ca601db0`；#5410 head `6f1c08c`、#5261 head `c8e76e1`、#5336 head `cc16e38` 均等待 maintainer review |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
 | 当前 Codex App | self-use 配置已安装并完成 CLI / App Server readback | 主 App 与 SSH host 都指向 loopback CPA；模型目录变化需要重启或重连对应 App Server 才能刷新 UI cache，旧 task store 不复制、不删除 |
@@ -268,15 +281,15 @@ provider 下 `requiresOpenaiAuth = false`，因此不能根据模型 route 同�
 git clone https://github.com/router-for-me/CLIProxyAPI.git
 cd CLIProxyAPI
 git remote add self-use https://github.com/huangruiteng/CLIProxyAPI.git
-git fetch self-use codex/provider-bound-history-sse-normalizers
-git checkout --detach 9357def40dfccc3151e4797cbfa400d4df8e1d26
+git fetch self-use codex/integrated-dev
+git checkout --detach 4df2bf1991ce1c9ebde7a2637d1158ddba3cdb14
 go build -o ./bin/cliproxyapi ./cmd/server
 ```
 
 把二进制 checksum、commit 和本机安装时间写入私有运维记录。升级使用新的隔离目录构建，
-验证通过后原子切换 symlink；不要覆盖唯一可回滚的旧二进制。当前 self-use receipt 使用
-基于 `2aa8c43a` 的最小私有构建，公共安装候选改为上面的 `9357def` 后必须重跑
-矩阵，不能因为 diff 包含同一修复就直接替换。
+验证通过后原子切换 symlink；不要覆盖唯一可回滚的旧二进制。上面的整合 commit 只在
+`reconcile_integration_candidate` 与 core `integration-branch status` 都无漂移、完整 changed-seam
+matrix 通过后才可安装；不能因为各来源 PR 分别 CI 通过就直接替换运行版本。
 
 ### 基础配置
 
@@ -758,7 +771,7 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 | Upstream | 计划 | 合并门槛 |
 | --- | --- | --- |
-| CPA | **公共分发 PR**：[history / SSE normalization #5220](https://github.com/router-for-me/CLIProxyAPI/pull/5220) head `9357def`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `3d038a27` | 截至 2026-09-01，三者 CI 通过；#5220 与 `dev` 冲突，后两者 mergeable，均等待 review；self-use 可锁定 integrated fork SHA，但不得把它表述为 upstream release |
+| CPA | **公共分发 PR**：[history / SSE normalization #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) head `6f1c08c`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `cc16e38` | 截至 2026-09-02，三者 CI 通过并等待 review；self-use 锁定 integrated fork SHA，但不得把它表述为 upstream release |
 | CPA modality-aware Auto | **待提交公共 PR**：required-modality admission、affinity invalidation、无 eligible provider 的 typed error | 先用 text-only fallback + image history 复现；验证 A/B 正常、B 网络失败、A/B 全不可用与旧 Ark affinity 四类路径；不得把图片剥离后继续文本请求 |
 | AgentSwap | **条件 PR**：只有 locked commit 的 Codex writer 不能保持 multipart tool-result 1:1，或需要 provider-neutral checkpoint export 时才提交 | round-trip test 先复现真实缺口；不增加在线 retry、模型选择或第二 data plane |
 | Codex App / App Server | **待验证上游 seam**：settings revision 持久化/readback 与 turn-start 原子顺序；compaction barrier 仍只需要 fork + navigate host hook | 新 turn 必须证明采用新 revision；旧 turn 的 retry 不得被 UI 显示伪装为新模型；hook 不获得 provider 路由、凭据或 LoopX authority |
@@ -766,8 +779,8 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 | LoopX | 维护本 runbook、pin、门禁和脱敏 evidence contract | 不实现代理、不保存 credential、不接管 Codex session store |
 
 所以近期技术选型不是 CPA 或 AgentSwap 二选一，而是 **CPA online + AgentSwap offline**，
-同时保持单一在线 authority。当前自用运行锁定 operator-owned private receipt，公共候选跟踪
-#5220 head `9357def`，都不等待 upstream review 才能做本机资格验证；上游合并后再把 merge
+同时保持单一在线 authority。当前自用运行锁定 operator-owned private receipt，公共 history
+候选跟踪 #5410 head `6f1c08c`，都不等待 upstream review 才能做本机资格验证；上游合并后再把 merge
 commit 作为升级候选并重跑 qualification。#5261 已进入 integrated self-use candidate 并完成连接
 复用、异常重建、session resumption 与安全重放矩阵；上游合并版本仍需重新资格化。AgentSwap 只有在独立、可复现的迁移
 缺口出现时才改。Codex App PR 不阻塞日常切换，只决定 barrier case 能否“一键 fork

--- a/packages/loopx-codex-provider-routing/examples/integration-candidate.json
+++ b/packages/loopx-codex-provider-routing/examples/integration-candidate.json
@@ -1,0 +1,76 @@
+{
+  "integration": {
+    "base_ref": "origin/dev",
+    "integration_branch": "codex/integrated-dev",
+    "last_sync": {
+      "base_sha": "1111111111111111111111111111111111111111",
+      "integration_sha": "6666666666666666666666666666666666666666",
+      "source_heads": {
+        "history-normalization": "2222222222222222222222222222222222222222",
+        "modality-routing": "4444444444444444444444444444444444444444",
+        "route-fallback": "5555555555555555555555555555555555555555",
+        "transport-pool": "3333333333333333333333333333333333333333"
+      }
+    },
+    "observed": {
+      "base_sha": "1111111111111111111111111111111111111111",
+      "integration_sha": "6666666666666666666666666666666666666666",
+      "source_heads": {
+        "history-normalization": "2222222222222222222222222222222222222222",
+        "modality-routing": "4444444444444444444444444444444444444444",
+        "route-fallback": "5555555555555555555555555555555555555555",
+        "transport-pool": "3333333333333333333333333333333333333333"
+      }
+    },
+    "required_seams": [
+      "history_projection",
+      "sse_lifecycle",
+      "transport_pool",
+      "modality_routing",
+      "request_normalizer",
+      "route_fallback"
+    ],
+    "sources": [
+      {
+        "changed_seams": [
+          "history_projection",
+          "sse_lifecycle"
+        ],
+        "head_sha": "2222222222222222222222222222222222222222",
+        "id": "history-normalization",
+        "kind": "pull_request",
+        "ref": "fork/provider-history-normalization"
+      },
+      {
+        "changed_seams": [
+          "transport_pool"
+        ],
+        "head_sha": "3333333333333333333333333333333333333333",
+        "id": "transport-pool",
+        "kind": "pull_request",
+        "ref": "fork/reusable-http2-transport"
+      },
+      {
+        "changed_seams": [
+          "modality_routing",
+          "request_normalizer"
+        ],
+        "head_sha": "4444444444444444444444444444444444444444",
+        "id": "modality-routing",
+        "kind": "public_safe_patch",
+        "ref": "operator/modality-routing"
+      },
+      {
+        "changed_seams": [
+          "route_fallback"
+        ],
+        "head_sha": "5555555555555555555555555555555555555555",
+        "id": "route-fallback",
+        "kind": "pull_request",
+        "ref": "fork/route-specific-fallback"
+      }
+    ]
+  },
+  "operation": "reconcile_integration_candidate",
+  "schema_version": "loopx_codex_provider_routing_request_v0"
+}

--- a/packages/loopx-codex-provider-routing/examples/upgrade-request.json
+++ b/packages/loopx-codex-provider-routing/examples/upgrade-request.json
@@ -4,10 +4,12 @@
   "upgrade": {
     "changed_seams": [
       "history_projection",
+      "integration_candidate",
       "transport_pool",
       "model_catalog",
       "modality_routing",
       "request_normalizer",
+      "route_fallback",
       "settings_revision"
     ],
     "current_ref": "public-current-ref",

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.3.0"
+version = "0.4.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.3.0"
+version = "0.4.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/schemas/request.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/request.schema.json
@@ -5,8 +5,24 @@
     {
       "properties": {
         "operation": {
+          "const": "reconcile_integration_candidate"
+        },
+        "normalization": false,
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "upgrade": false
+      },
+      "required": [
+        "integration"
+      ]
+    },
+    {
+      "properties": {
+        "operation": {
           "const": "project_runtime_status"
         },
+        "integration": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
@@ -21,6 +37,7 @@
         "operation": {
           "const": "compile_catalog"
         },
+        "integration": false,
         "normalization": false,
         "snapshot": false,
         "status": false,
@@ -35,6 +52,7 @@
         "operation": {
           "const": "normalize_selector_request"
         },
+        "integration": false,
         "snapshot": false,
         "source": false,
         "status": false,
@@ -49,6 +67,7 @@
         "operation": {
           "const": "qualify_snapshot"
         },
+        "integration": false,
         "normalization": false,
         "source": false,
         "status": false,
@@ -63,6 +82,7 @@
         "operation": {
           "const": "upgrade_plan"
         },
+        "integration": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
@@ -80,6 +100,7 @@
         "normalize_selector_request",
         "project_runtime_status",
         "qualify_snapshot",
+        "reconcile_integration_candidate",
         "upgrade_plan"
       ]
     },
@@ -87,6 +108,9 @@
       "const": "loopx_codex_provider_routing_request_v0"
     },
     "normalization": {
+      "type": "object"
+    },
+    "integration": {
       "type": "object"
     },
     "snapshot": {

--- a/packages/loopx-codex-provider-routing/schemas/response.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/response.schema.json
@@ -46,6 +46,7 @@
         "normalize_selector_request",
         "project_runtime_status",
         "qualify_snapshot",
+        "reconcile_integration_candidate",
         "upgrade_plan"
       ]
     },

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -22,6 +22,7 @@ compile_catalog = contract.compile_catalog
 normalize_selector_request = contract.normalize_selector_request
 project_runtime_status = contract.project_runtime_status
 qualify_snapshot = contract.qualify_snapshot
+reconcile_integration_candidate = contract.reconcile_integration_candidate
 
 
 def _source() -> dict[str, Any]:
@@ -554,6 +555,45 @@ def main() -> int:
     assert "effective_priority_admission" in plan["required_checks"]
     assert "turn_revision_match" in plan["required_checks"]
 
+    integration_request = json.loads(
+        (PACKAGE_ROOT / "examples" / "integration-candidate.json").read_text()
+    )
+    integration = reconcile_integration_candidate(integration_request["integration"])
+    assert integration["status"] == "in_sync"
+    assert integration["sync_required"] is False
+    assert integration["core_integration_plan"]["source_refs"] == [
+        "fork/provider-history-normalization",
+        "fork/reusable-http2-transport",
+        "operator/modality-routing",
+        "fork/route-specific-fallback",
+    ]
+    assert integration["deployment_contract"]["session_store_policy"] == (
+        "preserve_in_place_never_copy_or_delete"
+    )
+
+    moved_source = copy.deepcopy(integration_request["integration"])
+    moved_source["observed"]["source_heads"]["transport-pool"] = (
+        "7777777777777777777777777777777777777777"
+    )
+    moved_source["sources"][1]["head_sha"] = "7777777777777777777777777777777777777777"
+    integration = reconcile_integration_candidate(moved_source)
+    assert integration["sync_required"] is True
+    assert integration["drift_reasons"] == [
+        {
+            "kind": "source_moved",
+            "source_id": "transport-pool",
+            "last_sync_sha": "3333333333333333333333333333333333333333",
+            "observed_sha": "7777777777777777777777777777777777777777",
+        }
+    ]
+
+    uncovered = copy.deepcopy(integration_request["integration"])
+    uncovered["required_seams"].append("retry_policy")
+    expect_error(
+        lambda: reconcile_integration_candidate(uncovered),
+        "integration candidate without a required seam was accepted",
+    )
+
     response = _run_request(
         {
             "schema_version": REQUEST_SCHEMA_VERSION,
@@ -567,6 +607,7 @@ def main() -> int:
         "normalize-request.json",
         "runtime-status.json",
         "qualification-snapshot.json",
+        "integration-candidate.json",
         "upgrade-request.json",
     ):
         example_request = json.loads(

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -14,6 +14,7 @@ from .contract import (
     normalize_selector_request,
     project_runtime_status,
     qualify_snapshot,
+    reconcile_integration_candidate,
     reject_private_material,
 )
 
@@ -45,6 +46,7 @@ def _doctor() -> int:
                 "normalize_selector_request",
                 "project_runtime_status",
                 "qualify_snapshot",
+                "reconcile_integration_candidate",
                 "upgrade_plan",
             ],
             "effect_boundary": "read_only_public_safe",
@@ -65,10 +67,11 @@ def _run_request(request: Any) -> dict[str, Any]:
         "normalize_selector_request": "normalization",
         "project_runtime_status": "status",
         "qualify_snapshot": "snapshot",
+        "reconcile_integration_candidate": "integration",
         "upgrade_plan": "upgrade",
     }
     if not isinstance(operation, str):
-        raise ValueError(f"unsupported operation: {operation!r}")
+        raise TypeError(f"operation must be a string, got {operation!r}")
     expected_field = operation_fields.get(operation)
     if expected_field is None:
         raise ValueError(f"unsupported operation: {operation!r}")
@@ -97,6 +100,13 @@ def _run_request(request: Any) -> dict[str, Any]:
         if not isinstance(snapshot, Mapping):
             raise ValueError("qualify_snapshot requires object `snapshot`")
         result = qualify_snapshot(snapshot)
+    elif operation == "reconcile_integration_candidate":
+        integration = request.get("integration")
+        if not isinstance(integration, Mapping):
+            raise ValueError(
+                "reconcile_integration_candidate requires object `integration`"
+            )
+        result = reconcile_integration_candidate(integration)
     else:
         upgrade = request.get("upgrade")
         if not isinstance(upgrade, Mapping):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -9,6 +9,7 @@ CATALOG_SCHEMA_VERSION = "codex_provider_routing_catalog_v1"
 RUNTIME_STATUS_SCHEMA_VERSION = "codex_provider_routing_runtime_status_v0"
 REQUEST_SCHEMA_VERSION = "loopx_codex_provider_routing_request_v0"
 RESPONSE_SCHEMA_VERSION = "loopx_codex_provider_routing_response_v0"
+INTEGRATION_CANDIDATE_SCHEMA_VERSION = "codex_provider_integration_candidate_v0"
 
 FORBIDDEN_KEYS = {
     "account_id",
@@ -31,8 +32,23 @@ FORBIDDEN_KEYS = {
 ALLOWED_MODALITIES = {"text", "image"}
 ALLOWED_PROVIDERS = {"codex", "openai_compatibility"}
 ALLOWED_REASONING_LEVELS = {"low", "medium", "high", "xhigh", "max", "ultra"}
+ALLOWED_CHANGE_SEAMS = {
+    "history_projection",
+    "integration_candidate",
+    "modality_routing",
+    "model_catalog",
+    "request_normalizer",
+    "retry_policy",
+    "route_fallback",
+    "settings_revision",
+    "sse_lifecycle",
+    "ssh_bridge",
+    "transport_pool",
+}
 SYMBOLIC_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 MODEL_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9./-]{0,127}$")
+GIT_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,191}$")
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 SENSITIVE_VALUE_PATTERNS = (
     re.compile(r"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}", re.IGNORECASE),
     re.compile(r"(?:^|\s)/(?:Users|home|var/folders)/"),
@@ -88,6 +104,25 @@ def _reject_unexpected_keys(
         raise ValueError(f"{field} has unsupported fields: {unexpected}")
 
 
+def _git_ref(value: Any, field: str) -> str:
+    ref = _non_empty_string(value, field)
+    if (
+        GIT_REF_RE.fullmatch(ref) is None
+        or ".." in ref
+        or "@{" in ref
+        or ref.endswith(("/", ".", ".lock"))
+    ):
+        raise ValueError(f"{field} must be a bounded public Git ref")
+    return ref
+
+
+def _git_sha(value: Any, field: str) -> str:
+    sha = _non_empty_string(value, field)
+    if GIT_SHA_RE.fullmatch(sha) is None:
+        raise ValueError(f"{field} must be a full lowercase Git SHA")
+    return sha
+
+
 def _compile_profiles(raw_profiles: Any) -> dict[str, dict[str, Any]]:
     if not isinstance(raw_profiles, list) or not raw_profiles:
         raise ValueError("profiles must be a non-empty list")
@@ -131,7 +166,7 @@ def _compile_rings(
     if raw_rings is None:
         return {}
     if not isinstance(raw_rings, list):
-        raise ValueError("rings must be a list")
+        raise TypeError("rings must be a list")
     rings: dict[str, dict[str, Any]] = {}
     for index, raw in enumerate(raw_rings):
         if not isinstance(raw, Mapping):
@@ -1040,18 +1075,7 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
     current = _non_empty_string(upgrade.get("current_ref"), "upgrade.current_ref")
     target = _non_empty_string(upgrade.get("target_ref"), "upgrade.target_ref")
     changed_seams = _string_list(upgrade.get("changed_seams"), "upgrade.changed_seams")
-    allowed_seams = {
-        "history_projection",
-        "sse_lifecycle",
-        "retry_policy",
-        "transport_pool",
-        "model_catalog",
-        "request_normalizer",
-        "ssh_bridge",
-        "modality_routing",
-        "settings_revision",
-    }
-    unknown = sorted(set(changed_seams) - allowed_seams)
+    unknown = sorted(set(changed_seams) - ALLOWED_CHANGE_SEAMS)
     if unknown:
         raise ValueError(f"unsupported changed seams: {unknown}")
     matrix = ["public_boundary", "doctor", "catalog_readback", "rollback_receipt"]
@@ -1060,6 +1084,12 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
             "additional_tools",
             "foreign_reasoning",
             "tool_causality",
+        ],
+        "integration_candidate": [
+            "exact_base_head",
+            "exact_ordered_source_heads",
+            "required_seam_coverage",
+            "integration_tree_receipt",
         ],
         "sse_lifecycle": ["unique_terminal", "active_item_pairing"],
         "retry_policy": ["bounded_attempts", "ttfb_p50_p95", "commit_barrier"],
@@ -1081,6 +1111,11 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
             "ordinary_selector_preserved",
             "effective_priority_admission",
             "fast_route_no_unsupported_fallback",
+        ],
+        "route_fallback": [
+            "preferred_entrypoint_order",
+            "single_ring_cycle",
+            "terminal_tail_once",
         ],
         "ssh_bridge": ["loopback_binds", "reconnect", "existing_task_resume"],
         "modality_routing": ["image_a_b", "ark_text_only", "no_eligible_fail_closed"],
@@ -1107,4 +1142,191 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
         ],
         "required_checks": list(dict.fromkeys(matrix)),
         "rollback_trigger": "any_failed_check_or_unexplained_regression",
+    }
+
+
+def reconcile_integration_candidate(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    """Compare a public-safe multi-source candidate with its last sync receipt.
+
+    This operation owns provider-specific source coverage and upgrade policy.
+    It returns inputs for LoopX's core integration-branch capability instead of
+    implementing Git fetch, merge, push, or deployment effects.
+    """
+
+    reject_private_material(candidate)
+    _reject_unexpected_keys(
+        candidate,
+        {
+            "base_ref",
+            "integration_branch",
+            "required_seams",
+            "sources",
+            "observed",
+            "last_sync",
+        },
+        "integration",
+    )
+    base_ref = _git_ref(candidate.get("base_ref"), "integration.base_ref")
+    integration_branch = _git_ref(
+        candidate.get("integration_branch"), "integration.integration_branch"
+    )
+    required_seams = _string_list(
+        candidate.get("required_seams"), "integration.required_seams"
+    )
+    if not required_seams:
+        raise ValueError("integration.required_seams must not be empty")
+    unknown_required = sorted(set(required_seams) - ALLOWED_CHANGE_SEAMS)
+    if unknown_required:
+        raise ValueError(f"unsupported required seams: {unknown_required}")
+
+    raw_sources = candidate.get("sources")
+    if not isinstance(raw_sources, list) or len(raw_sources) < 2:
+        raise ValueError("integration.sources needs at least two ordered sources")
+    sources: list[dict[str, Any]] = []
+    source_ids: set[str] = set()
+    source_refs: set[str] = set()
+    covered_seams: set[str] = set()
+    for index, raw in enumerate(raw_sources):
+        field = f"integration.sources[{index}]"
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"{field} must be an object")
+        _reject_unexpected_keys(
+            raw,
+            {"id", "kind", "ref", "head_sha", "changed_seams"},
+            field,
+        )
+        source_id = _non_empty_string(raw.get("id"), f"{field}.id")
+        if SYMBOLIC_ID_RE.fullmatch(source_id) is None:
+            raise ValueError(f"{field}.id must be a public symbolic id")
+        if source_id in source_ids:
+            raise ValueError(f"duplicate integration source id: {source_id}")
+        source_ids.add(source_id)
+        kind = _non_empty_string(raw.get("kind"), f"{field}.kind")
+        if kind not in {"pull_request", "public_safe_patch"}:
+            raise ValueError(f"{field}.kind must be pull_request or public_safe_patch")
+        source_ref = _git_ref(raw.get("ref"), f"{field}.ref")
+        if source_ref in source_refs:
+            raise ValueError(f"duplicate integration source ref: {source_ref}")
+        source_refs.add(source_ref)
+        changed_seams = _string_list(raw.get("changed_seams"), f"{field}.changed_seams")
+        if not changed_seams:
+            raise ValueError(f"{field}.changed_seams must not be empty")
+        unknown = sorted(set(changed_seams) - ALLOWED_CHANGE_SEAMS)
+        if unknown:
+            raise ValueError(f"{field} has unsupported changed seams: {unknown}")
+        covered_seams.update(changed_seams)
+        sources.append(
+            {
+                "id": source_id,
+                "kind": kind,
+                "ref": source_ref,
+                "head_sha": _git_sha(raw.get("head_sha"), f"{field}.head_sha"),
+                "changed_seams": changed_seams,
+            }
+        )
+
+    missing_seams = sorted(set(required_seams) - covered_seams)
+    if missing_seams:
+        raise ValueError(
+            f"integration candidate does not cover required seams: {missing_seams}"
+        )
+
+    def receipt(raw: Any, field: str) -> dict[str, Any]:
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"{field} must be an object")
+        _reject_unexpected_keys(
+            raw, {"base_sha", "integration_sha", "source_heads"}, field
+        )
+        raw_heads = raw.get("source_heads")
+        if not isinstance(raw_heads, Mapping):
+            raise TypeError(f"{field}.source_heads must be an object")
+        if set(raw_heads) != source_ids:
+            raise ValueError(f"{field}.source_heads must match integration source ids")
+        return {
+            "base_sha": _git_sha(raw.get("base_sha"), f"{field}.base_sha"),
+            "integration_sha": _git_sha(
+                raw.get("integration_sha"), f"{field}.integration_sha"
+            ),
+            "source_heads": {
+                source_id: _git_sha(
+                    raw_heads[source_id], f"{field}.source_heads.{source_id}"
+                )
+                for source_id in sorted(source_ids)
+            },
+        }
+
+    observed = receipt(candidate.get("observed"), "integration.observed")
+    last_sync = receipt(candidate.get("last_sync"), "integration.last_sync")
+    for source in sources:
+        if observed["source_heads"][source["id"]] != source["head_sha"]:
+            raise ValueError(
+                f"observed source head does not match declared head for {source['id']}"
+            )
+
+    drift_reasons: list[dict[str, str]] = []
+    if observed["base_sha"] != last_sync["base_sha"]:
+        drift_reasons.append(
+            {
+                "kind": "base_moved",
+                "ref": base_ref,
+                "last_sync_sha": last_sync["base_sha"],
+                "observed_sha": observed["base_sha"],
+            }
+        )
+    for source in sources:
+        source_id = source["id"]
+        if observed["source_heads"][source_id] != last_sync["source_heads"][source_id]:
+            drift_reasons.append(
+                {
+                    "kind": "source_moved",
+                    "source_id": source_id,
+                    "last_sync_sha": last_sync["source_heads"][source_id],
+                    "observed_sha": observed["source_heads"][source_id],
+                }
+            )
+    if observed["integration_sha"] != last_sync["integration_sha"]:
+        drift_reasons.append(
+            {
+                "kind": "integration_head_moved",
+                "ref": integration_branch,
+                "last_sync_sha": last_sync["integration_sha"],
+                "observed_sha": observed["integration_sha"],
+            }
+        )
+
+    sync_required = bool(drift_reasons)
+    return {
+        "schema_version": INTEGRATION_CANDIDATE_SCHEMA_VERSION,
+        "status": "sync_required" if sync_required else "in_sync",
+        "sync_required": sync_required,
+        "drift_reasons": drift_reasons,
+        "required_seams": required_seams,
+        "covered_seams": sorted(covered_seams),
+        "source_order": sources,
+        "core_integration_plan": {
+            "base_ref": base_ref,
+            "integration_branch": integration_branch,
+            "source_refs": [source["ref"] for source in sources],
+        },
+        "reconcile_steps": [
+            "refresh_declared_remote_refs_read_only",
+            "verify_every_ref_resolves_to_declared_head",
+            "preview_core_integration_branch_sync",
+            "execute_local_sync_with_explicit_write_authority",
+            "run_changed_seam_and_build_validation",
+            "push_candidate_only_after_validation",
+        ],
+        "deployment_contract": {
+            "artifact": "content_addressed_binary_with_sha256",
+            "sequence": [
+                "retain_previous_binary_and_config_pointer",
+                "run_isolated_smoke",
+                "compare_configuration_by_field",
+                "switch_operator_owned_pointer",
+                "read_back_catalog_retry_and_runtime",
+            ],
+            "rollback_trigger": "any_failed_readback_or_unexplained_regression",
+            "session_store_policy": "preserve_in_place_never_copy_or_delete",
+        },
+        "effect_boundary": "read_only_public_safe_plan",
     }


### PR DESCRIPTION
## Summary

- add the public-safe `reconcile_integration_candidate` operation to the Codex provider routing extension
- validate exact base/source heads, ordered PR/patch composition, required seam coverage, and last-sync drift
- return typed inputs for LoopX core `integration-branch` plus content-addressed build, deployment, readback, rollback, and session-store preservation contracts
- update the CPA runbook to track the durable `codex/integrated-dev` candidate and current public PR heads

## Commit grouping

1. `feat(extension): reconcile CPA integration candidates`
2. `docs(extension): maintain the CPA integrated candidate`

## Validation

- extension smoke passed
- request/response schemas and all examples passed Draft 2020-12 validation
- co-located extension pytest: 2 passed
- Ruff and mypy passed
- Python 3.11 wheel build, external console doctor, and integration-candidate readback passed
- `loopx check --scan-path packages/loopx-codex-provider-routing` reported a clean package boundary
- LoopX change-quality receipt `cqr_5fd5b250bd2fe1e71dfa` is valid for the exact 14-file diff
- `loopx canary premerge --from-git-diff --goal-id career-loopx-decision-advisor` passed 18/18 selected checks with no failures or manual holds
- `git diff --check origin/main...HEAD` passed

## Boundaries and residual risk

- the extension remains read-only and public-safe; it does not fetch, merge, push, build, deploy, restart, or manage credentials
- Git effects remain owned by LoopX core `integration-branch`; runtime installation and secret lifecycle remain operator-owned
- no local state, credentials, raw logs, session data, private paths, build artifacts, or quality receipts are committed
- a self-use integrated candidate is not represented as an upstream CPA release

## Future-facing pass

The change reuses the existing core integration capability and one shared changed-seam catalog. No broader refactor was needed; adding a second Git or deployment authority would make ownership less clear.
