### PR TITLE
fix: reconcile final cadence authority

### DIFF
--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ...long_task_cadence import reconcile_long_task_cadence_hint
 from ...state_projection import (
     next_action_projection_warning,
 )
@@ -1473,6 +1474,11 @@ def _build_quota_should_run_payload(
         codex_app_current_rrule=prepared.codex_app_current_rrule,
         codex_app_automation_id=prepared.codex_app_automation_id,
         scheduler_execution_context=prepared.resolved_scheduler_context,
+    )
+    payload["long_task_cadence_hint"] = reconcile_long_task_cadence_hint(
+        payload.get("long_task_cadence_hint"),
+        interaction_contract=payload.get("interaction_contract"),
+        scheduler_hint=payload.get("scheduler_hint"),
     )
     finalize_user_gate_notification_cooldown(
         payload,

--- a/loopx/long_task_cadence.py
+++ b/loopx/long_task_cadence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from .control_plane.work_items.delivery_batch_scale import DeliveryBatchScale, normalize_delivery_batch_scale
@@ -187,6 +188,49 @@ def build_long_task_cadence_policy(**kwargs: Any) -> dict[str, Any]:
     """Compatibility wrapper for older callers while this projection rolls out."""
 
     return build_long_task_cadence_hint(**kwargs)
+
+
+def reconcile_long_task_cadence_hint(
+    value: Any,
+    *,
+    interaction_contract: Mapping[str, Any] | None,
+    scheduler_hint: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Align the legacy work-cadence hint with final interaction authority.
+
+    Status builds this advisory before agent-scoped quota overrides are known.
+    Once the final interaction contract and scheduler both require active work,
+    an earlier goal-level ``wait`` hint must not survive in the same packet.
+    """
+
+    if not isinstance(value, Mapping):
+        return None
+    hint = dict(value)
+    agent_channel: Mapping[str, Any] = {}
+    if isinstance(interaction_contract, Mapping):
+        candidate = interaction_contract.get("agent_channel")
+        if isinstance(candidate, Mapping):
+            agent_channel = candidate
+    scheduler: Mapping[str, Any] = (
+        scheduler_hint if isinstance(scheduler_hint, Mapping) else {}
+    )
+    active_work_required = (
+        agent_channel.get("must_attempt") is True
+        and agent_channel.get("quiet_noop_allowed") is False
+        and scheduler.get("action") == "run_now"
+        and scheduler.get("cadence_class") == "active_work"
+    )
+    if not active_work_required or hint.get("recommendation") != "wait":
+        return hint
+    return {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "active_work",
+        "recommendation": "keep",
+        "reason_codes": ["interaction_agent_attempt_required"],
+        "authority": "interaction_contract",
+        "superseded_signal": hint.get("signal"),
+        "superseded_reason_codes": list(hint.get("reason_codes") or []),
+    }
 
 
 def long_task_cadence_hint_summary(value: Any) -> str:

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -99,8 +99,16 @@ def _quality_vision_run() -> dict:
 
 
 def test_unrelated_user_gate_allows_ready_deferred_successor_replan() -> None:
+    status = _status_payload(gate_action_kind="approve_product_first_screen")
+    status["attention_queue"]["items"][0]["long_task_cadence_hint"] = {
+        "schema_version": "cadence_hint_v0",
+        "signal": "blocked",
+        "recommendation": "wait",
+        "reason_codes": ["quota_state_operator_gate", "open_user_todos_visible"],
+    }
+
     payload = build_quota_should_run(
-        _status_payload(gate_action_kind="approve_product_first_screen"),
+        status,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         scheduler_execution_context=APP_CONTEXT,
@@ -119,6 +127,18 @@ def test_unrelated_user_gate_allows_ready_deferred_successor_replan() -> None:
         "agent_channel"
     ]["primary_action"]
     assert payload["scheduler_hint"]["cadence_class"] == "active_work"
+    assert payload["long_task_cadence_hint"] == {
+        "schema_version": "cadence_hint_v0",
+        "signal": "active_work",
+        "recommendation": "keep",
+        "reason_codes": ["interaction_agent_attempt_required"],
+        "authority": "interaction_contract",
+        "superseded_signal": "blocked",
+        "superseded_reason_codes": [
+            "quota_state_operator_gate",
+            "open_user_todos_visible",
+        ],
+    }
 
 
 def test_consumed_review_gate_exposes_quality_vision_replan() -> None:
@@ -176,8 +196,15 @@ def test_consumed_review_gate_exposes_quality_vision_replan() -> None:
 
 
 def test_blocking_user_gate_backs_off_instead_of_polling_as_active_work() -> None:
+    status = _status_payload(gate_action_kind="refine_benchmark_treatment")
+    status["attention_queue"]["items"][0]["long_task_cadence_hint"] = {
+        "schema_version": "cadence_hint_v0",
+        "signal": "blocked",
+        "recommendation": "wait",
+        "reason_codes": ["quota_state_operator_gate"],
+    }
     payload = build_quota_should_run(
-        _status_payload(gate_action_kind="refine_benchmark_treatment"),
+        status,
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
         scheduler_execution_context=APP_CONTEXT,
@@ -202,6 +229,9 @@ def test_blocking_user_gate_backs_off_instead_of_polling_as_active_work() -> Non
     )
     assert payload["scheduler_hint"]["cadence_class"] == "human_gate"
     assert payload["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 30
+    assert payload["long_task_cadence_hint"]["signal"] == "blocked"
+    assert payload["long_task_cadence_hint"]["recommendation"] == "wait"
+    assert "authority" not in payload["long_task_cadence_hint"]
 
     initial_backoff = payload["scheduler_hint"]["codex_app"]["stateful_backoff"]
     next_hint = build_scheduler_hint(


### PR DESCRIPTION
## Summary

- reconcile the compatibility `long_task_cadence_hint` after final agent-scoped interaction and scheduler arbitration
- supersede a stale goal-level `wait` advisory only when the final agent channel requires work and the scheduler selects `run_now` / `active_work`
- preserve the superseded signal and reason codes for diagnosis while retaining genuine human-gate backoff

## Root cause

Status computes the legacy cadence advisory before agent-scoped quota overrides are known. The final quota packet previously copied that advisory unchanged after building the authoritative interaction and scheduler projections, allowing one packet to contain both `run_now` and `wait`.

## Validation

- `26 passed` across the focused user-gate, fine-grained-turn, and quota-plan tests
- `npm run test:control-plane` (`386 passed`, one environment-gated PostgreSQL integration test skipped)
- `npm run typecheck:control-plane`
- `python -m mypy` (`15 source files`)
- Ruff and changed-file Python compilation
- risk-based premerge: `17/17` selected checks passed, no failures or manual holds
- change-quality receipt: `cqr_1d96f393c6058caa8518`, exact committed fingerprint `1d96f393c6058caa851889bc264cce0450af2d0d58ac815839f4c7e6ff3121f8`

Future-facing scope review: the repair reuses the existing cadence owner and final quota assembly boundary; no broader scheduler abstraction is needed.

Closes #3830
