### PR TITLE
feat: add task-bound local synthetic overlay

### DIFF
--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -26,6 +26,9 @@ from .explore.catalog_entry import EXPLORE_CATALOG_ENTRY
 from .deep_research.catalog_entry import DEEP_RESEARCH_CATALOG_ENTRY
 from .public_safe_outbound.catalog_entry import PUBLIC_SAFE_OUTBOUND_CATALOG_ENTRY
 from .connector_registry.catalog_entry import CONNECTOR_REGISTRY_CATALOG_ENTRY
+from .local_synthetic_overlay.catalog_entry import (
+    LOCAL_SYNTHETIC_OVERLAY_CATALOG_ENTRY,
+)
 from .registry import CapabilityRegistry
 
 CAPABILITY_CATALOG_SCHEMA_VERSION = "loopx_capability_catalog_v0"
@@ -52,6 +55,7 @@ BUILTIN_CAPABILITIES: tuple[dict[str, Any], ...] = (
     DEEP_RESEARCH_CATALOG_ENTRY,
     PUBLIC_SAFE_OUTBOUND_CATALOG_ENTRY,
     CONNECTOR_REGISTRY_CATALOG_ENTRY,
+    LOCAL_SYNTHETIC_OVERLAY_CATALOG_ENTRY,
 )
 # Preserve the original import surface while routing all reads through the registry.
 CAPABILITIES = BUILTIN_CAPABILITIES

--- a/loopx/capabilities/local_synthetic_overlay/README.md
+++ b/loopx/capabilities/local_synthetic_overlay/README.md
@@ -1,0 +1,68 @@
+# Local Synthetic Overlay
+
+`local-synthetic-overlay` is a built-in LoopX authority path for one narrow
+case: a task needs a disposable local container and synthetic database to
+validate an exact candidate, while product-write authority remains exactly
+zero.
+
+It does not use the legacy Dispatcher task schema. It does not enqueue work,
+issue leases, inherit historical grants, or turn runtime availability into
+product authority.
+
+## Closed envelope
+
+Every issued receipt binds all of the following:
+
+- one live Goal and one active Todo;
+- one exact local Git worktree, 40-character HEAD, and commit tree;
+- a tracked-clean candidate;
+- exactly `local_container` and `synthetic_database`;
+- `scope=local_synthetic_validation_only`;
+- `product_write_scope=ZERO`;
+- `lifetime=task_bound`, a short expiry, and no cross-task reuse;
+- no real customer or child data, real audio, real provider, or production;
+- one digest-pinned database image already present on the local machine.
+
+Changing any binding invalidates the receipt. The validator re-reads the live
+Goal/Todo and Git state; the digest alone is not authority.
+
+## Provider doctor
+
+The doctor performs read-only checks:
+
+```bash
+loopx local-synthetic-overlay doctor \
+  --synthetic-database-image '<image>@sha256:<digest>' \
+  --format json
+```
+
+`local_container` is ready only when the Docker client can reach a Docker
+daemon. `synthetic_database` is ready only when the exact digest-pinned image
+is already local. The doctor never pulls an image or creates a resource.
+
+## Issue and validate
+
+Preview is the default. `--execute` is required to create a system-managed
+receipt beneath the configured LoopX runtime root:
+
+```bash
+loopx local-synthetic-overlay issue \
+  --goal-id <goal> --todo-id <todo> \
+  --repo-path <candidate-worktree> \
+  --candidate-head <40-char-head> --candidate-tree <40-char-tree> \
+  --capability local_container --capability synthetic_database \
+  --synthetic-database-image '<image>@sha256:<digest>' \
+  --product-write-scope ZERO --lifetime task_bound \
+  --execute --format json
+```
+
+Before every governed action, call `validate` with the same exact bindings and
+the returned `receipt_id`. Receipt files are mode `0600`; their containing
+directory is mode `0700`.
+
+## Cleanup readback
+
+The caller owns its known validation flow and cleanup command. LoopX does not
+accept an arbitrary container command. After cleanup, `cleanup-check` uses the
+task's Compose project label to prove no container, volume, or network remains.
+An unavailable Docker daemon or any residual resource fails closed.

--- a/loopx/capabilities/local_synthetic_overlay/README.md
+++ b/loopx/capabilities/local_synthetic_overlay/README.md
@@ -14,8 +14,11 @@ product authority.
 Every issued receipt binds all of the following:
 
 - one live Goal and one active Todo;
-- one exact local Git worktree, 40-character HEAD, and commit tree;
+- one exact local Git worktree, 40-character HEAD, and commit tree, belonging
+  to the same Git repository as the Goal registry entry (linked worktrees are
+  supported);
 - a tracked-clean candidate;
+- one task-specific Compose project used for cleanup readback;
 - exactly `local_container` and `synthetic_database`;
 - `scope=local_synthetic_validation_only`;
 - `product_write_scope=ZERO`;
@@ -52,17 +55,19 @@ loopx local-synthetic-overlay issue \
   --candidate-head <40-char-head> --candidate-tree <40-char-tree> \
   --capability local_container --capability synthetic_database \
   --synthetic-database-image '<image>@sha256:<digest>' \
+  --compose-project <task-project> \
   --product-write-scope ZERO --lifetime task_bound \
   --execute --format json
 ```
 
-Before every governed action, call `validate` with the same exact bindings and
-the returned `receipt_id`. Receipt files are mode `0600`; their containing
-directory is mode `0700`.
+Before every governed action, call `validate` with the same exact bindings,
+including `compose_project`, and the returned `receipt_id`. Receipt files are
+mode `0600`; their containing directory is mode `0700`.
 
 ## Cleanup readback
 
 The caller owns its known validation flow and cleanup command. LoopX does not
 accept an arbitrary container command. After cleanup, `cleanup-check` uses the
-task's Compose project label to prove no container, volume, or network remains.
-An unavailable Docker daemon or any residual resource fails closed.
+Compose project bound into the digest-protected receipt to prove no container,
+volume, or network remains. A different caller-supplied project, an unavailable
+Docker daemon, or any residual resource fails closed.

--- a/loopx/capabilities/local_synthetic_overlay/__init__.py
+++ b/loopx/capabilities/local_synthetic_overlay/__init__.py
@@ -1,0 +1,19 @@
+from .core import (
+    ALLOWED_CAPABILITIES,
+    LOCAL_SYNTHETIC_SCOPE,
+    PRODUCT_WRITE_SCOPE_ZERO,
+    doctor_local_synthetic_providers,
+    issue_local_synthetic_overlay_receipt,
+    validate_local_synthetic_overlay_receipt,
+    verify_compose_cleanup,
+)
+
+__all__ = [
+    "ALLOWED_CAPABILITIES",
+    "LOCAL_SYNTHETIC_SCOPE",
+    "PRODUCT_WRITE_SCOPE_ZERO",
+    "doctor_local_synthetic_providers",
+    "issue_local_synthetic_overlay_receipt",
+    "validate_local_synthetic_overlay_receipt",
+    "verify_compose_cleanup",
+]

--- a/loopx/capabilities/local_synthetic_overlay/catalog_entry.py
+++ b/loopx/capabilities/local_synthetic_overlay/catalog_entry.py
@@ -32,23 +32,23 @@ LOCAL_SYNTHETIC_OVERLAY_CATALOG_ENTRY: dict[str, Any] = {
         },
         {
             "command": "loopx local-synthetic-overlay issue [exact task and candidate bindings] --execute --format json",
-            "purpose": "Persist one short-lived system-managed receipt for the exact Goal, Todo, candidate, and closed capability set.",
+            "purpose": "Persist one short-lived system-managed receipt for the exact Goal, Todo, candidate, Compose project, and closed capability set.",
             "write_boundary": "LoopX runtime receipt directory only; product-write scope remains ZERO",
         },
         {
             "command": "loopx local-synthetic-overlay validate [receipt and exact bindings] --format json",
-            "purpose": "Revalidate digest, task lifetime, active Goal/Todo, tracked-clean HEAD/tree, and the restrictive envelope.",
+            "purpose": "Revalidate digest, task lifetime, active Goal/Todo, registered Git repository identity, exact tracked-clean worktree HEAD/tree, Compose project, and the restrictive envelope.",
             "write_boundary": "read-only LoopX state and Git inspection",
         },
         {
             "command": "loopx local-synthetic-overlay cleanup-check [receipt and exact bindings] --compose-project <task-project> --format json",
-            "purpose": "Prove the task-labelled Compose project has no remaining container, volume, or network.",
+            "purpose": "Prove the receipt-bound Compose project has no remaining container, volume, or network, rejecting any caller mismatch.",
             "write_boundary": "read-only Docker metadata inspection",
         },
     ],
     "implemented_protocols": [
         {
-            "schema_version": "loopx_local_synthetic_overlay_receipt_v0",
+            "schema_version": "loopx_local_synthetic_overlay_receipt_v1",
             "module": "loopx.capabilities.local_synthetic_overlay.core",
             "doc": "loopx/capabilities/local_synthetic_overlay/README.md",
         },
@@ -58,7 +58,7 @@ LOCAL_SYNTHETIC_OVERLAY_CATALOG_ENTRY: dict[str, Any] = {
             "doc": "loopx/capabilities/local_synthetic_overlay/README.md",
         },
         {
-            "schema_version": "loopx_local_synthetic_overlay_cleanup_v0",
+            "schema_version": "loopx_local_synthetic_overlay_cleanup_v1",
             "module": "loopx.capabilities.local_synthetic_overlay.core",
             "doc": "loopx/capabilities/local_synthetic_overlay/README.md",
         },
@@ -70,7 +70,7 @@ LOCAL_SYNTHETIC_OVERLAY_CATALOG_ENTRY: dict[str, Any] = {
     "boundaries": [
         "The only allowed capabilities are the exact pair local_container and synthetic_database.",
         "Product-write scope is exactly ZERO; a non-empty file allowlist is neither accepted nor required.",
-        "Every receipt is bound to one live Goal/Todo, exact tracked-clean candidate HEAD/tree, local repository, provider revision, and short expiry.",
+        "Every receipt is bound to one live Goal/Todo, the Goal registry Git repository identity, one exact tracked-clean candidate worktree HEAD/tree, one Compose project, provider revision, and short expiry.",
         "Real customer or child data, real audio, real providers, hosted databases, production, cross-task reuse, network image pulls, arbitrary container commands, and deployment are rejected.",
         "Legacy Dispatcher schemas, queues, leases, grants, and databases are not read by this capability.",
         "The provider doctor reports unavailable runtimes as unavailable and never manufactures readiness.",

--- a/loopx/capabilities/local_synthetic_overlay/catalog_entry.py
+++ b/loopx/capabilities/local_synthetic_overlay/catalog_entry.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+LOCAL_SYNTHETIC_OVERLAY_CATALOG_ENTRY: dict[str, Any] = {
+    "id": "local-synthetic-overlay",
+    "origin": "builtin",
+    "visibility": "public",
+    "provider_id": "loopx-core",
+    "documentation": {
+        "source_root": "loopx/capabilities/local_synthetic_overlay",
+        "site_root": "capabilities/local-synthetic-overlay",
+        "canonical": "README.md",
+    },
+    "title": "Task-bound local synthetic validation overlay",
+    "status": "active-preview",
+    "real_world_anchor": (
+        "local disposable validation that needs containers and a synthetic database but no product write authority"
+    ),
+    "user_value": (
+        "Issue one short-lived exact-candidate receipt for a strictly local synthetic validation task without using a legacy queue or granting product writes."
+    ),
+    "entry_command": (
+        "loopx local-synthetic-overlay doctor --synthetic-database-image <digest-pinned-image> --format json"
+    ),
+    "commands": [
+        {
+            "command": "loopx local-synthetic-overlay doctor --synthetic-database-image <digest-pinned-image> --format json",
+            "purpose": "Truthfully inspect the local Docker daemon and an already-local digest-pinned database image without pulling or creating anything.",
+            "write_boundary": "read-only local runtime inspection",
+        },
+        {
+            "command": "loopx local-synthetic-overlay issue [exact task and candidate bindings] --execute --format json",
+            "purpose": "Persist one short-lived system-managed receipt for the exact Goal, Todo, candidate, and closed capability set.",
+            "write_boundary": "LoopX runtime receipt directory only; product-write scope remains ZERO",
+        },
+        {
+            "command": "loopx local-synthetic-overlay validate [receipt and exact bindings] --format json",
+            "purpose": "Revalidate digest, task lifetime, active Goal/Todo, tracked-clean HEAD/tree, and the restrictive envelope.",
+            "write_boundary": "read-only LoopX state and Git inspection",
+        },
+        {
+            "command": "loopx local-synthetic-overlay cleanup-check [receipt and exact bindings] --compose-project <task-project> --format json",
+            "purpose": "Prove the task-labelled Compose project has no remaining container, volume, or network.",
+            "write_boundary": "read-only Docker metadata inspection",
+        },
+    ],
+    "implemented_protocols": [
+        {
+            "schema_version": "loopx_local_synthetic_overlay_receipt_v0",
+            "module": "loopx.capabilities.local_synthetic_overlay.core",
+            "doc": "loopx/capabilities/local_synthetic_overlay/README.md",
+        },
+        {
+            "schema_version": "loopx_local_synthetic_overlay_provider_doctor_v0",
+            "module": "loopx.capabilities.local_synthetic_overlay.core",
+            "doc": "loopx/capabilities/local_synthetic_overlay/README.md",
+        },
+        {
+            "schema_version": "loopx_local_synthetic_overlay_cleanup_v0",
+            "module": "loopx.capabilities.local_synthetic_overlay.core",
+            "doc": "loopx/capabilities/local_synthetic_overlay/README.md",
+        },
+    ],
+    "smokes": [
+        "python -m pytest tests/capabilities/test_local_synthetic_overlay.py -q"
+    ],
+    "docs": ["loopx/capabilities/local_synthetic_overlay/README.md"],
+    "boundaries": [
+        "The only allowed capabilities are the exact pair local_container and synthetic_database.",
+        "Product-write scope is exactly ZERO; a non-empty file allowlist is neither accepted nor required.",
+        "Every receipt is bound to one live Goal/Todo, exact tracked-clean candidate HEAD/tree, local repository, provider revision, and short expiry.",
+        "Real customer or child data, real audio, real providers, hosted databases, production, cross-task reuse, network image pulls, arbitrary container commands, and deployment are rejected.",
+        "Legacy Dispatcher schemas, queues, leases, grants, and databases are not read by this capability.",
+        "The provider doctor reports unavailable runtimes as unavailable and never manufactures readiness.",
+    ],
+    "next_real_step": (
+        "Issue one task-bound receipt for an exact local synthetic candidate, run the caller-owned validation, and prove Compose cleanup."
+    ),
+}

--- a/loopx/capabilities/local_synthetic_overlay/cli.py
+++ b/loopx/capabilities/local_synthetic_overlay/cli.py
@@ -37,10 +37,9 @@ def _binding_arguments(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument("--synthetic-database-image", required=True)
+    parser.add_argument("--compose-project", required=True)
     parser.add_argument("--scope", default=LOCAL_SYNTHETIC_SCOPE)
-    parser.add_argument(
-        "--product-write-scope", default=PRODUCT_WRITE_SCOPE_ZERO
-    )
+    parser.add_argument("--product-write-scope", default=PRODUCT_WRITE_SCOPE_ZERO)
     parser.add_argument("--lifetime", default="task_bound")
 
 
@@ -100,7 +99,6 @@ def register_local_synthetic_overlay_commands(
     )
     add_subcommand_format(cleanup)
     cleanup.add_argument("--receipt-id", required=True)
-    cleanup.add_argument("--compose-project", required=True)
     _binding_arguments(cleanup)
 
 
@@ -119,6 +117,7 @@ def render_local_synthetic_overlay_markdown(payload: dict[str, object]) -> str:
         "todo_id",
         "candidate_head",
         "candidate_tree",
+        "compose_project",
         "scope",
         "product_write_scope",
         "error",
@@ -156,6 +155,7 @@ def handle_local_synthetic_overlay_command(
                 candidate_tree=args.candidate_tree,
                 capabilities=args.capability,
                 synthetic_database_image=args.synthetic_database_image,
+                compose_project=args.compose_project,
                 scope=args.scope,
                 product_write_scope=args.product_write_scope,
                 lifetime=args.lifetime,
@@ -181,6 +181,7 @@ def handle_local_synthetic_overlay_command(
                 candidate_tree=args.candidate_tree,
                 capabilities=args.capability,
                 synthetic_database_image=args.synthetic_database_image,
+                compose_project=args.compose_project,
                 scope=args.scope,
                 product_write_scope=args.product_write_scope,
                 lifetime=args.lifetime,
@@ -198,6 +199,7 @@ def handle_local_synthetic_overlay_command(
                 candidate_tree=args.candidate_tree,
                 capabilities=args.capability,
                 synthetic_database_image=args.synthetic_database_image,
+                compose_project=args.compose_project,
                 scope=args.scope,
                 product_write_scope=args.product_write_scope,
                 lifetime=args.lifetime,

--- a/loopx/capabilities/local_synthetic_overlay/cli.py
+++ b/loopx/capabilities/local_synthetic_overlay/cli.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from .core import (
+    ALLOWED_CAPABILITIES,
+    LOCAL_SYNTHETIC_SCOPE,
+    PRODUCT_WRITE_SCOPE_ZERO,
+    doctor_local_synthetic_providers,
+    issue_local_synthetic_overlay_receipt,
+    validate_local_synthetic_overlay_receipt,
+    verify_compose_cleanup,
+)
+
+AddFormat = Callable[[argparse.ArgumentParser], None]
+FormatSelector = Callable[..., str]
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]], None
+]
+
+
+def _binding_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument("--todo-id", required=True)
+    parser.add_argument("--repo-path", type=Path, required=True)
+    parser.add_argument("--candidate-head", required=True)
+    parser.add_argument("--candidate-tree", required=True)
+    parser.add_argument(
+        "--capability",
+        action="append",
+        required=True,
+        help=(
+            "Requested overlay capability. Repeat exactly for local_container and "
+            "synthetic_database; subsets and additions are rejected."
+        ),
+    )
+    parser.add_argument("--synthetic-database-image", required=True)
+    parser.add_argument("--scope", default=LOCAL_SYNTHETIC_SCOPE)
+    parser.add_argument(
+        "--product-write-scope", default=PRODUCT_WRITE_SCOPE_ZERO
+    )
+    parser.add_argument("--lifetime", default="task_bound")
+
+
+def register_local_synthetic_overlay_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "local-synthetic-overlay",
+        help="Issue and verify task-bound local synthetic validation authority.",
+    )
+    commands = parser.add_subparsers(
+        dest="local_synthetic_overlay_command", required=True
+    )
+
+    doctor = commands.add_parser(
+        "doctor",
+        help="Inspect local providers without pulling or creating resources.",
+    )
+    add_subcommand_format(doctor)
+    doctor.add_argument("--synthetic-database-image", required=True)
+
+    issue = commands.add_parser(
+        "issue",
+        help="Preview or issue one system-managed exact task-bound receipt.",
+    )
+    add_subcommand_format(issue)
+    _binding_arguments(issue)
+    issue.add_argument("--ttl-seconds", type=int, default=4 * 60 * 60)
+    issue.add_argument(
+        "--reusable-across-tasks",
+        choices=("NO", "YES"),
+        default="NO",
+    )
+    issue.add_argument("--real-customer-data", choices=("NO", "YES"), default="NO")
+    issue.add_argument("--real-child-data", choices=("NO", "YES"), default="NO")
+    issue.add_argument("--real-audio", choices=("NO", "YES"), default="NO")
+    issue.add_argument("--real-provider", choices=("NO", "YES"), default="NO")
+    issue.add_argument("--production", choices=("NO", "YES"), default="NO")
+    issue.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist the receipt in LoopX-managed runtime state; preview is default.",
+    )
+
+    validate = commands.add_parser(
+        "validate",
+        help="Validate a stored receipt against the live Goal, Todo, and candidate.",
+    )
+    add_subcommand_format(validate)
+    validate.add_argument("--receipt-id", required=True)
+    _binding_arguments(validate)
+
+    cleanup = commands.add_parser(
+        "cleanup-check",
+        help="Verify no task-labelled Compose container, volume, or network remains.",
+    )
+    add_subcommand_format(cleanup)
+    cleanup.add_argument("--receipt-id", required=True)
+    cleanup.add_argument("--compose-project", required=True)
+    _binding_arguments(cleanup)
+
+
+def render_local_synthetic_overlay_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# LoopX Local Synthetic Overlay",
+        "",
+        f"- ok: `{str(payload.get('ok')).lower()}`",
+        f"- status: `{payload.get('status')}`",
+    ]
+    for key in (
+        "receipt_id",
+        "receipt_digest",
+        "system_managed",
+        "goal_id",
+        "todo_id",
+        "candidate_head",
+        "candidate_tree",
+        "scope",
+        "product_write_scope",
+        "error",
+    ):
+        if key in payload:
+            lines.append(f"- {key}: `{payload.get(key)}`")
+    return "\n".join(lines) + "\n"
+
+
+def handle_local_synthetic_overlay_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "local-synthetic-overlay":
+        return None
+    command = args.local_synthetic_overlay_command
+    try:
+        if command == "doctor":
+            payload = doctor_local_synthetic_providers(
+                synthetic_database_image=args.synthetic_database_image
+            )
+            exit_code = 0 if payload.get("ok") is True else 2
+        elif command == "issue":
+            payload = issue_local_synthetic_overlay_receipt(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                repository=args.repo_path,
+                candidate_head=args.candidate_head,
+                candidate_tree=args.candidate_tree,
+                capabilities=args.capability,
+                synthetic_database_image=args.synthetic_database_image,
+                scope=args.scope,
+                product_write_scope=args.product_write_scope,
+                lifetime=args.lifetime,
+                reusable_across_tasks=args.reusable_across_tasks == "YES",
+                real_customer_data=args.real_customer_data == "YES",
+                real_child_data=args.real_child_data == "YES",
+                real_audio=args.real_audio == "YES",
+                real_provider=args.real_provider == "YES",
+                production=args.production == "YES",
+                ttl_seconds=args.ttl_seconds,
+                execute=args.execute,
+            )
+            exit_code = 0
+        elif command == "validate":
+            payload = validate_local_synthetic_overlay_receipt(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                receipt_id=args.receipt_id,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                repository=args.repo_path,
+                candidate_head=args.candidate_head,
+                candidate_tree=args.candidate_tree,
+                capabilities=args.capability,
+                synthetic_database_image=args.synthetic_database_image,
+                scope=args.scope,
+                product_write_scope=args.product_write_scope,
+                lifetime=args.lifetime,
+            )
+            exit_code = 0
+        elif command == "cleanup-check":
+            validation = validate_local_synthetic_overlay_receipt(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                receipt_id=args.receipt_id,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                repository=args.repo_path,
+                candidate_head=args.candidate_head,
+                candidate_tree=args.candidate_tree,
+                capabilities=args.capability,
+                synthetic_database_image=args.synthetic_database_image,
+                scope=args.scope,
+                product_write_scope=args.product_write_scope,
+                lifetime=args.lifetime,
+            )
+            payload = verify_compose_cleanup(
+                validation=validation,
+                compose_project=args.compose_project,
+            )
+            exit_code = 0 if payload.get("ok") is True else 2
+        else:  # pragma: no cover - argparse owns command selection
+            raise ValueError("unknown local synthetic overlay command")
+    except (OSError, RuntimeError, ValueError) as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_local_synthetic_overlay_error_v0",
+            "status": "rejected",
+            "error": str(exc),
+            "allowed_capabilities": list(ALLOWED_CAPABILITIES),
+            "legacy_dispatcher_used": False,
+        }
+        exit_code = 2
+    print_payload(
+        payload,
+        output_format(args),
+        render_local_synthetic_overlay_markdown,
+    )
+    return exit_code

--- a/loopx/capabilities/local_synthetic_overlay/core.py
+++ b/loopx/capabilities/local_synthetic_overlay/core.py
@@ -1,0 +1,652 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.runtime.time import parse_timestamp, utc_isoformat
+from ...control_plane.todos.active_state_editing import find_todo_block
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ...registry import atomic_write_json, find_registry_goal
+from ...state_refresh import resolve_goal_state
+
+
+LOCAL_SYNTHETIC_SCOPE = "local_synthetic_validation_only"
+PRODUCT_WRITE_SCOPE_ZERO = "ZERO"
+ALLOWED_CAPABILITIES = ("local_container", "synthetic_database")
+RECEIPT_SCHEMA_VERSION = "loopx_local_synthetic_overlay_receipt_v0"
+STORE_SCHEMA_VERSION = "loopx_local_synthetic_overlay_store_record_v0"
+DOCTOR_SCHEMA_VERSION = "loopx_local_synthetic_overlay_provider_doctor_v0"
+VALIDATION_SCHEMA_VERSION = "loopx_local_synthetic_overlay_validation_v0"
+CLEANUP_SCHEMA_VERSION = "loopx_local_synthetic_overlay_cleanup_v0"
+ISSUER_ID = "loopx-native-local-synthetic-overlay"
+PROVIDER_REVISION = "local-docker-disposable-v0"
+MIN_TTL_SECONDS = 60
+MAX_TTL_SECONDS = 8 * 60 * 60
+
+_HEX40 = re.compile(r"^[0-9a-f]{40}$")
+_DIGEST_PINNED_IMAGE = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+_RECEIPT_ID = re.compile(r"^overlay_[0-9a-f]{24}$")
+_COMPOSE_PROJECT = re.compile(r"^[a-z0-9][a-z0-9_-]{0,62}$")
+
+CommandRunner = Callable[[Sequence[str], float], subprocess.CompletedProcess[str]]
+Which = Callable[[str], str | None]
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _canonical_digest(value: object) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("overlay receipt must be JSON serializable") from exc
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _run(argv: Sequence[str], timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _required_token(value: object, label: str, *, maximum: int = 200) -> str:
+    token = str(value or "").strip()
+    if not token or len(token) > maximum or any(char.isspace() for char in token):
+        raise ValueError(f"{label} must be a non-empty bounded token")
+    return token
+
+
+def _commit(value: object, label: str) -> str:
+    commit = str(value or "").strip().lower()
+    if not _HEX40.fullmatch(commit):
+        raise ValueError(f"{label} must be an exact 40-character lowercase Git id")
+    return commit
+
+
+def _capabilities(values: object) -> list[str]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise ValueError("capabilities must be a sequence")
+    normalized = sorted({_required_token(item, "capability") for item in values})
+    if normalized != sorted(ALLOWED_CAPABILITIES):
+        raise ValueError(
+            "local synthetic validation requires exactly capabilities "
+            f"{list(ALLOWED_CAPABILITIES)}; subsets and escalation are rejected"
+        )
+    return normalized
+
+
+def _require_restrictive_envelope(
+    *,
+    scope: str,
+    product_write_scope: str,
+    lifetime: str,
+    reusable_across_tasks: bool,
+    real_customer_data: bool,
+    real_child_data: bool,
+    real_audio: bool,
+    real_provider: bool,
+    production: bool,
+) -> dict[str, bool]:
+    if scope != LOCAL_SYNTHETIC_SCOPE:
+        raise ValueError(f"scope must be exact `{LOCAL_SYNTHETIC_SCOPE}`")
+    if product_write_scope != PRODUCT_WRITE_SCOPE_ZERO:
+        raise ValueError("product_write_scope must be exact `ZERO`")
+    if lifetime != "task_bound":
+        raise ValueError("lifetime must be exact `task_bound`")
+    restrictions = {
+        "real_customer_data": bool(real_customer_data),
+        "real_child_data": bool(real_child_data),
+        "real_audio": bool(real_audio),
+        "real_provider": bool(real_provider),
+        "production": bool(production),
+    }
+    if reusable_across_tasks or any(restrictions.values()):
+        raise ValueError(
+            "local synthetic overlay rejects cross-task reuse and every real or production resource"
+        )
+    return restrictions
+
+
+def _image_reference(value: object) -> str:
+    image = str(value or "").strip()
+    if not _DIGEST_PINNED_IMAGE.fullmatch(image):
+        raise ValueError(
+            "synthetic database image must be an exact local digest-pinned reference"
+        )
+    return image
+
+
+def doctor_local_synthetic_providers(
+    *,
+    synthetic_database_image: str,
+    runner: CommandRunner = _run,
+    which: Which = shutil.which,
+    checked_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Truthfully inspect local providers without pulling or creating resources."""
+
+    image = _image_reference(synthetic_database_image)
+    observed_at = checked_at or _now_utc()
+    docker = which("docker")
+    docker_client = bool(docker)
+    daemon_ready = False
+    image_ready = False
+    daemon_status = "docker_client_missing"
+    image_status = "not_checked"
+    if docker:
+        try:
+            daemon = runner(
+                [docker, "version", "--format", "{{json .Server.Version}}"],
+                8.0,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            daemon_status = "docker_daemon_unavailable"
+        else:
+            daemon_ready = daemon.returncode == 0 and bool(daemon.stdout.strip())
+            daemon_status = "ready" if daemon_ready else "docker_daemon_unavailable"
+        if daemon_ready:
+            try:
+                inspected = runner(
+                    [docker, "image", "inspect", "--format", "{{json .Id}}", image],
+                    8.0,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                image_status = "local_image_unavailable"
+            else:
+                image_ready = (
+                    inspected.returncode == 0
+                    and "sha256:" in inspected.stdout
+                )
+                image_status = "ready" if image_ready else "local_image_unavailable"
+
+    local_container_ready = docker_client and daemon_ready
+    synthetic_database_ready = local_container_ready and image_ready
+    payload: dict[str, Any] = {
+        "ok": local_container_ready and synthetic_database_ready,
+        "schema_version": DOCTOR_SCHEMA_VERSION,
+        "checked_at": utc_isoformat(observed_at),
+        "provider_revision": PROVIDER_REVISION,
+        "network_pull_attempted": False,
+        "resource_created": False,
+        "providers": {
+            "local_container": {
+                "provider_id": "loopx-local-docker-container",
+                "ready": local_container_ready,
+                "status": daemon_status,
+                "scope": LOCAL_SYNTHETIC_SCOPE,
+                "arbitrary_command_execution": False,
+                "production_deployment": False,
+            },
+            "synthetic_database": {
+                "provider_id": "loopx-local-disposable-synthetic-database",
+                "ready": synthetic_database_ready,
+                "status": image_status,
+                "image": image,
+                "pull_policy": "never",
+                "database_class": "disposable_local_synthetic_only",
+                "hosted_or_production": False,
+                "cleanup_readback_required": True,
+            },
+        },
+    }
+    payload["doctor_digest"] = _canonical_digest(
+        {key: value for key, value in payload.items() if key != "doctor_digest"}
+    )
+    return payload
+
+
+def _git(repo: Path, *args: str) -> str:
+    try:
+        result = _run(["git", "-C", str(repo), *args], 10.0)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ValueError("candidate Git state could not be inspected") from exc
+    if result.returncode != 0:
+        raise ValueError("candidate Git state could not be inspected")
+    return result.stdout.strip()
+
+
+def _candidate_snapshot(
+    repository: str | Path,
+    *,
+    candidate_head: str,
+    candidate_tree: str,
+) -> dict[str, str]:
+    repo = Path(repository).expanduser().resolve()
+    if not repo.is_dir():
+        raise ValueError("repository must be an existing local directory")
+    expected_head = _commit(candidate_head, "candidate_head")
+    expected_tree = _commit(candidate_tree, "candidate_tree")
+    root = Path(_git(repo, "rev-parse", "--show-toplevel")).resolve()
+    if root != repo:
+        raise ValueError("repository must be the exact Git worktree root")
+    observed_head = _git(repo, "rev-parse", "HEAD").lower()
+    observed_tree = _git(repo, "rev-parse", "HEAD^{tree}").lower()
+    if observed_head != expected_head:
+        raise ValueError("candidate HEAD does not match the live repository")
+    if observed_tree != expected_tree:
+        raise ValueError("candidate tree does not match the live repository")
+    if _git(repo, "status", "--porcelain=v1", "--untracked-files=no"):
+        raise ValueError("candidate tracked worktree must be clean")
+    return {
+        "repository": str(repo),
+        "head": observed_head,
+        "tree": observed_tree,
+        "tracked_state": "clean",
+    }
+
+
+def _active_goal_todo(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    todo_id: str,
+) -> dict[str, Any]:
+    registry = load_registry(registry_path)
+    goal = find_registry_goal(registry, goal_id)
+    if goal is None:
+        raise ValueError(f"Goal `{goal_id}` is not present in the LoopX registry")
+    _, _, state_file = resolve_goal_state(
+        registry=registry,
+        goal_id=goal_id,
+        project_override=None,
+        state_file_override=None,
+    )
+    if not state_file.is_file():
+        raise ValueError(f"Goal `{goal_id}` active state does not exist")
+    match = find_todo_block(
+        state_file.read_text(encoding="utf-8").splitlines(),
+        todo_id=todo_id,
+    )
+    if match is None:
+        raise ValueError(f"Todo `{todo_id}` is not active and unique for Goal `{goal_id}`")
+    todo = match[-1]
+    status = str(todo.get("status") or "open").strip().lower()
+    if status not in {"open", "blocked"}:
+        raise ValueError("overlay receipt requires an active open or blocked Todo")
+    return dict(todo)
+
+
+def _receipt_directory(runtime_root: Path) -> Path:
+    return runtime_root / "special-overlays" / "local-synthetic-validation-v0"
+
+
+def _receipt_path(runtime_root: Path, receipt_id: str) -> Path:
+    normalized = str(receipt_id or "").strip()
+    if not _RECEIPT_ID.fullmatch(normalized):
+        raise ValueError("receipt_id is invalid")
+    return _receipt_directory(runtime_root) / f"{normalized}.json"
+
+
+def _resolved_runtime_root(
+    *, registry_path: Path, runtime_root_arg: str | None
+) -> Path:
+    resolved = resolve_runtime_root(
+        load_registry(registry_path),
+        runtime_root_arg,
+        registry_path=registry_path,
+    )
+    return Path(resolved).expanduser().resolve()
+
+
+def issue_local_synthetic_overlay_receipt(
+    *,
+    registry_path: str | Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    todo_id: str,
+    repository: str | Path,
+    candidate_head: str,
+    candidate_tree: str,
+    capabilities: Sequence[str],
+    synthetic_database_image: str,
+    scope: str = LOCAL_SYNTHETIC_SCOPE,
+    product_write_scope: str = PRODUCT_WRITE_SCOPE_ZERO,
+    lifetime: str = "task_bound",
+    reusable_across_tasks: bool = False,
+    real_customer_data: bool = False,
+    real_child_data: bool = False,
+    real_audio: bool = False,
+    real_provider: bool = False,
+    production: bool = False,
+    ttl_seconds: int = 4 * 60 * 60,
+    execute: bool = False,
+    now: datetime | None = None,
+    token_factory: Callable[[], str] = lambda: secrets.token_hex(24),
+    doctor: Callable[..., dict[str, Any]] = doctor_local_synthetic_providers,
+) -> dict[str, Any]:
+    """Issue one exact task-bound receipt into LoopX-managed local state."""
+
+    registry = Path(registry_path).expanduser().resolve()
+    normalized_goal = _required_token(goal_id, "goal_id")
+    normalized_todo = _required_token(todo_id, "todo_id")
+    normalized_capabilities = _capabilities(capabilities)
+    restrictions = _require_restrictive_envelope(
+        scope=scope,
+        product_write_scope=product_write_scope,
+        lifetime=lifetime,
+        reusable_across_tasks=reusable_across_tasks,
+        real_customer_data=real_customer_data,
+        real_child_data=real_child_data,
+        real_audio=real_audio,
+        real_provider=real_provider,
+        production=production,
+    )
+    try:
+        normalized_ttl = int(ttl_seconds)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("ttl_seconds must be an integer") from exc
+    if not MIN_TTL_SECONDS <= normalized_ttl <= MAX_TTL_SECONDS:
+        raise ValueError(
+            f"ttl_seconds must be between {MIN_TTL_SECONDS} and {MAX_TTL_SECONDS}"
+        )
+    image = _image_reference(synthetic_database_image)
+    _active_goal_todo(
+        registry_path=registry,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=normalized_goal,
+        todo_id=normalized_todo,
+    )
+    candidate = _candidate_snapshot(
+        repository,
+        candidate_head=candidate_head,
+        candidate_tree=candidate_tree,
+    )
+    provider_doctor = doctor(synthetic_database_image=image)
+    if provider_doctor.get("ok") is not True:
+        raise ValueError("local synthetic overlay providers are not doctor-ready")
+    doctor_digest = str(provider_doctor.get("doctor_digest") or "")
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", doctor_digest):
+        raise ValueError("provider doctor did not return a valid evidence digest")
+
+    issued_at = (now or _now_utc()).astimezone(timezone.utc).replace(microsecond=0)
+    expires_at = issued_at + timedelta(seconds=normalized_ttl)
+    receipt_id = "overlay_" + hashlib.sha256(
+        (
+            token_factory()
+            + "\0"
+            + normalized_goal
+            + "\0"
+            + normalized_todo
+            + "\0"
+            + candidate["head"]
+            + "\0"
+            + candidate["tree"]
+        ).encode("utf-8")
+    ).hexdigest()[:24]
+    receipt: dict[str, Any] = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "receipt_id": receipt_id,
+        "issued_by": ISSUER_ID,
+        "authority_path": "loopx_native",
+        "system_managed": True,
+        "goal_id": normalized_goal,
+        "todo_id": normalized_todo,
+        "candidate": candidate,
+        "scope": scope,
+        "capabilities": normalized_capabilities,
+        "product_write_scope": product_write_scope,
+        "lifetime": lifetime,
+        "reusable_across_tasks": False,
+        "restrictions": restrictions,
+        "provider_binding": {
+            "revision": PROVIDER_REVISION,
+            "synthetic_database_image": image,
+            "doctor_digest": doctor_digest,
+        },
+        "issued_at": utc_isoformat(issued_at),
+        "expires_at": utc_isoformat(expires_at),
+    }
+    digest = _canonical_digest(receipt)
+    runtime_root = _resolved_runtime_root(
+        registry_path=registry, runtime_root_arg=runtime_root_arg
+    )
+    path = _receipt_path(runtime_root, receipt_id)
+    packet: dict[str, Any] = {
+        "ok": True,
+        "schema_version": STORE_SCHEMA_VERSION,
+        "status": "ready" if not execute else "issued",
+        "dry_run": not execute,
+        "executed": execute,
+        "system_managed": execute,
+        "receipt": receipt if execute else None,
+        "receipt_id": receipt_id if execute else None,
+        "receipt_digest": digest if execute else None,
+        "receipt_path": str(path) if execute else None,
+        "provider_doctor": provider_doctor,
+        "would_bind": receipt if not execute else None,
+        "legacy_dispatcher_used": False,
+    }
+    if execute:
+        directory = path.parent
+        directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+        if path.exists():
+            raise ValueError("system-generated overlay receipt identity collision")
+        atomic_write_json(
+            path,
+            {
+                "schema_version": STORE_SCHEMA_VERSION,
+                "receipt": receipt,
+                "receipt_digest": digest,
+            },
+        )
+        os.chmod(path, 0o600)
+    return packet
+
+
+def _load_store_record(runtime_root: Path, receipt_id: str) -> tuple[Path, dict[str, Any]]:
+    path = _receipt_path(runtime_root, receipt_id)
+    if not path.is_file():
+        raise ValueError("system-managed overlay receipt does not exist")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("system-managed overlay receipt is unreadable") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != STORE_SCHEMA_VERSION:
+        raise ValueError("system-managed overlay receipt store record is invalid")
+    return path, payload
+
+
+def validate_local_synthetic_overlay_receipt(
+    *,
+    registry_path: str | Path,
+    runtime_root_arg: str | None,
+    receipt_id: str,
+    goal_id: str,
+    todo_id: str,
+    repository: str | Path,
+    candidate_head: str,
+    candidate_tree: str,
+    capabilities: Sequence[str],
+    synthetic_database_image: str,
+    scope: str = LOCAL_SYNTHETIC_SCOPE,
+    product_write_scope: str = PRODUCT_WRITE_SCOPE_ZERO,
+    lifetime: str = "task_bound",
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Validate a stored receipt against the exact live task and candidate."""
+
+    registry = Path(registry_path).expanduser().resolve()
+    normalized_goal = _required_token(goal_id, "goal_id")
+    normalized_todo = _required_token(todo_id, "todo_id")
+    normalized_capabilities = _capabilities(capabilities)
+    _require_restrictive_envelope(
+        scope=scope,
+        product_write_scope=product_write_scope,
+        lifetime=lifetime,
+        reusable_across_tasks=False,
+        real_customer_data=False,
+        real_child_data=False,
+        real_audio=False,
+        real_provider=False,
+        production=False,
+    )
+    image = _image_reference(synthetic_database_image)
+    runtime_root = _resolved_runtime_root(
+        registry_path=registry, runtime_root_arg=runtime_root_arg
+    )
+    path, record = _load_store_record(runtime_root, receipt_id)
+    receipt = record.get("receipt")
+    digest = str(record.get("receipt_digest") or "")
+    if not isinstance(receipt, Mapping) or digest != _canonical_digest(receipt):
+        raise ValueError("system-managed overlay receipt digest is invalid")
+    expected_candidate = _candidate_snapshot(
+        repository,
+        candidate_head=candidate_head,
+        candidate_tree=candidate_tree,
+    )
+    _active_goal_todo(
+        registry_path=registry,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=normalized_goal,
+        todo_id=normalized_todo,
+    )
+    expires = parse_timestamp(receipt.get("expires_at"))
+    current = (now or _now_utc()).astimezone(timezone.utc)
+    if expires is None or expires <= current:
+        raise ValueError("system-managed overlay receipt is expired")
+    expected = {
+        "receipt_id": receipt_id,
+        "issued_by": ISSUER_ID,
+        "authority_path": "loopx_native",
+        "system_managed": True,
+        "goal_id": normalized_goal,
+        "todo_id": normalized_todo,
+        "candidate": expected_candidate,
+        "scope": scope,
+        "capabilities": normalized_capabilities,
+        "product_write_scope": product_write_scope,
+        "lifetime": lifetime,
+        "reusable_across_tasks": False,
+        "restrictions": {
+            "real_customer_data": False,
+            "real_child_data": False,
+            "real_audio": False,
+            "real_provider": False,
+            "production": False,
+        },
+    }
+    mismatches = [key for key, value in expected.items() if receipt.get(key) != value]
+    provider_binding = receipt.get("provider_binding")
+    if not isinstance(provider_binding, Mapping):
+        mismatches.append("provider_binding")
+    else:
+        if provider_binding.get("revision") != PROVIDER_REVISION:
+            mismatches.append("provider_revision")
+        if provider_binding.get("synthetic_database_image") != image:
+            mismatches.append("synthetic_database_image")
+    if receipt.get("schema_version") != RECEIPT_SCHEMA_VERSION:
+        mismatches.append("schema_version")
+    if mismatches:
+        raise ValueError(
+            "system-managed overlay receipt binding mismatch: "
+            + ", ".join(sorted(set(mismatches)))
+        )
+    return {
+        "ok": True,
+        "schema_version": VALIDATION_SCHEMA_VERSION,
+        "status": "valid",
+        "valid": True,
+        "system_managed": True,
+        "receipt_id": receipt_id,
+        "receipt_digest": digest,
+        "receipt_path": str(path),
+        "goal_id": normalized_goal,
+        "todo_id": normalized_todo,
+        "candidate_head": expected_candidate["head"],
+        "candidate_tree": expected_candidate["tree"],
+        "capabilities": normalized_capabilities,
+        "scope": scope,
+        "product_write_scope": product_write_scope,
+        "expires_at": receipt.get("expires_at"),
+        "legacy_dispatcher_used": False,
+    }
+
+
+def verify_compose_cleanup(
+    *,
+    validation: Mapping[str, Any],
+    compose_project: str,
+    runner: CommandRunner = _run,
+    which: Which = shutil.which,
+) -> dict[str, Any]:
+    """Prove a task-labelled Compose project left no container/volume/network."""
+
+    if validation.get("valid") is not True:
+        raise ValueError("cleanup readback requires a valid task-bound overlay receipt")
+    project = str(compose_project or "").strip()
+    if not _COMPOSE_PROJECT.fullmatch(project):
+        raise ValueError("compose_project must be a bounded lowercase local token")
+    docker = which("docker")
+    if not docker:
+        raise ValueError("Docker client is unavailable for cleanup readback")
+    filters = {
+        "containers": [
+            docker,
+            "ps",
+            "-aq",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+        ],
+        "volumes": [
+            docker,
+            "volume",
+            "ls",
+            "-q",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+        ],
+        "networks": [
+            docker,
+            "network",
+            "ls",
+            "-q",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
+        ],
+    }
+    residual_counts: dict[str, int] = {}
+    for kind, argv in filters.items():
+        try:
+            result = runner(argv, 8.0)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ValueError("Docker cleanup readback failed") from exc
+        if result.returncode != 0:
+            raise ValueError("Docker cleanup readback failed")
+        residual_counts[kind] = len(
+            [line for line in result.stdout.splitlines() if line.strip()]
+        )
+    clean = not any(residual_counts.values())
+    return {
+        "ok": clean,
+        "schema_version": CLEANUP_SCHEMA_VERSION,
+        "status": "clean" if clean else "residue_detected",
+        "clean": clean,
+        "compose_project": project,
+        "residual_counts": residual_counts,
+        "receipt_id": validation.get("receipt_id"),
+    }

--- a/loopx/capabilities/local_synthetic_overlay/core.py
+++ b/loopx/capabilities/local_synthetic_overlay/core.py
@@ -23,11 +23,11 @@ from ...state_refresh import resolve_goal_state
 LOCAL_SYNTHETIC_SCOPE = "local_synthetic_validation_only"
 PRODUCT_WRITE_SCOPE_ZERO = "ZERO"
 ALLOWED_CAPABILITIES = ("local_container", "synthetic_database")
-RECEIPT_SCHEMA_VERSION = "loopx_local_synthetic_overlay_receipt_v0"
+RECEIPT_SCHEMA_VERSION = "loopx_local_synthetic_overlay_receipt_v1"
 STORE_SCHEMA_VERSION = "loopx_local_synthetic_overlay_store_record_v0"
 DOCTOR_SCHEMA_VERSION = "loopx_local_synthetic_overlay_provider_doctor_v0"
-VALIDATION_SCHEMA_VERSION = "loopx_local_synthetic_overlay_validation_v0"
-CLEANUP_SCHEMA_VERSION = "loopx_local_synthetic_overlay_cleanup_v0"
+VALIDATION_SCHEMA_VERSION = "loopx_local_synthetic_overlay_validation_v1"
+CLEANUP_SCHEMA_VERSION = "loopx_local_synthetic_overlay_cleanup_v1"
 ISSUER_ID = "loopx-native-local-synthetic-overlay"
 PROVIDER_REVISION = "local-docker-disposable-v0"
 MIN_TTL_SECONDS = 60
@@ -139,6 +139,13 @@ def _image_reference(value: object) -> str:
     return image
 
 
+def _compose_project(value: object) -> str:
+    project = str(value or "").strip()
+    if not _COMPOSE_PROJECT.fullmatch(project):
+        raise ValueError("compose_project must be a bounded lowercase local token")
+    return project
+
+
 def doctor_local_synthetic_providers(
     *,
     synthetic_database_image: str,
@@ -177,8 +184,7 @@ def doctor_local_synthetic_providers(
                 image_status = "local_image_unavailable"
             else:
                 image_ready = (
-                    inspected.returncode == 0
-                    and "sha256:" in inspected.stdout
+                    inspected.returncode == 0 and "sha256:" in inspected.stdout
                 )
                 image_status = "ready" if image_ready else "local_image_unavailable"
 
@@ -228,20 +234,57 @@ def _git(repo: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
+def _git_worktree_identity(repository: str | Path, *, label: str) -> tuple[Path, Path]:
+    repo = Path(repository).expanduser().resolve()
+    if not repo.is_dir():
+        raise ValueError(f"{label} must be an existing local directory")
+    root = Path(_git(repo, "rev-parse", "--show-toplevel")).resolve()
+    if root != repo:
+        raise ValueError(f"{label} must be the exact Git worktree root")
+    common_directory = Path(
+        _git(
+            repo,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        )
+    ).resolve()
+    if not common_directory.is_dir():
+        raise ValueError(f"{label} Git repository identity is unavailable")
+    return root, common_directory
+
+
+def _same_git_repository(candidate: Path, registered: Path) -> bool:
+    try:
+        return candidate.samefile(registered)
+    except OSError:
+        return False
+
+
 def _candidate_snapshot(
     repository: str | Path,
     *,
+    registered_repository: str | Path,
     candidate_head: str,
     candidate_tree: str,
 ) -> dict[str, str]:
-    repo = Path(repository).expanduser().resolve()
-    if not repo.is_dir():
-        raise ValueError("repository must be an existing local directory")
+    repo, candidate_common_directory = _git_worktree_identity(
+        repository,
+        label="repository",
+    )
+    _, registered_common_directory = _git_worktree_identity(
+        registered_repository,
+        label="Goal registry repository",
+    )
+    if not _same_git_repository(
+        candidate_common_directory,
+        registered_common_directory,
+    ):
+        raise ValueError(
+            "candidate repository does not match the Goal registry Git repository"
+        )
     expected_head = _commit(candidate_head, "candidate_head")
     expected_tree = _commit(candidate_tree, "candidate_tree")
-    root = Path(_git(repo, "rev-parse", "--show-toplevel")).resolve()
-    if root != repo:
-        raise ValueError("repository must be the exact Git worktree root")
     observed_head = _git(repo, "rev-parse", "HEAD").lower()
     observed_tree = _git(repo, "rev-parse", "HEAD^{tree}").lower()
     if observed_head != expected_head:
@@ -264,7 +307,7 @@ def _active_goal_todo(
     runtime_root_arg: str | None,
     goal_id: str,
     todo_id: str,
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], dict[str, Any]]:
     registry = load_registry(registry_path)
     goal = find_registry_goal(registry, goal_id)
     if goal is None:
@@ -282,12 +325,21 @@ def _active_goal_todo(
         todo_id=todo_id,
     )
     if match is None:
-        raise ValueError(f"Todo `{todo_id}` is not active and unique for Goal `{goal_id}`")
+        raise ValueError(
+            f"Todo `{todo_id}` is not active and unique for Goal `{goal_id}`"
+        )
     todo = match[-1]
     status = str(todo.get("status") or "open").strip().lower()
     if status not in {"open", "blocked"}:
         raise ValueError("overlay receipt requires an active open or blocked Todo")
-    return dict(todo)
+    return dict(goal), dict(todo)
+
+
+def _registered_goal_repository(goal: Mapping[str, Any]) -> Path:
+    repository = str(goal.get("repo") or "").strip()
+    if not repository:
+        raise ValueError("Goal registry entry does not name a repository")
+    return Path(repository).expanduser()
 
 
 def _receipt_directory(runtime_root: Path) -> Path:
@@ -323,6 +375,7 @@ def issue_local_synthetic_overlay_receipt(
     candidate_tree: str,
     capabilities: Sequence[str],
     synthetic_database_image: str,
+    compose_project: str,
     scope: str = LOCAL_SYNTHETIC_SCOPE,
     product_write_scope: str = PRODUCT_WRITE_SCOPE_ZERO,
     lifetime: str = "task_bound",
@@ -364,7 +417,8 @@ def issue_local_synthetic_overlay_receipt(
             f"ttl_seconds must be between {MIN_TTL_SECONDS} and {MAX_TTL_SECONDS}"
         )
     image = _image_reference(synthetic_database_image)
-    _active_goal_todo(
+    project = _compose_project(compose_project)
+    goal, _ = _active_goal_todo(
         registry_path=registry,
         runtime_root_arg=runtime_root_arg,
         goal_id=normalized_goal,
@@ -372,6 +426,7 @@ def issue_local_synthetic_overlay_receipt(
     )
     candidate = _candidate_snapshot(
         repository,
+        registered_repository=_registered_goal_repository(goal),
         candidate_head=candidate_head,
         candidate_tree=candidate_tree,
     )
@@ -384,19 +439,22 @@ def issue_local_synthetic_overlay_receipt(
 
     issued_at = (now or _now_utc()).astimezone(timezone.utc).replace(microsecond=0)
     expires_at = issued_at + timedelta(seconds=normalized_ttl)
-    receipt_id = "overlay_" + hashlib.sha256(
-        (
-            token_factory()
-            + "\0"
-            + normalized_goal
-            + "\0"
-            + normalized_todo
-            + "\0"
-            + candidate["head"]
-            + "\0"
-            + candidate["tree"]
-        ).encode("utf-8")
-    ).hexdigest()[:24]
+    receipt_id = (
+        "overlay_"
+        + hashlib.sha256(
+            (
+                token_factory()
+                + "\0"
+                + normalized_goal
+                + "\0"
+                + normalized_todo
+                + "\0"
+                + candidate["head"]
+                + "\0"
+                + candidate["tree"]
+            ).encode("utf-8")
+        ).hexdigest()[:24]
+    )
     receipt: dict[str, Any] = {
         "schema_version": RECEIPT_SCHEMA_VERSION,
         "receipt_id": receipt_id,
@@ -406,6 +464,7 @@ def issue_local_synthetic_overlay_receipt(
         "goal_id": normalized_goal,
         "todo_id": normalized_todo,
         "candidate": candidate,
+        "compose_project": project,
         "scope": scope,
         "capabilities": normalized_capabilities,
         "product_write_scope": product_write_scope,
@@ -458,7 +517,9 @@ def issue_local_synthetic_overlay_receipt(
     return packet
 
 
-def _load_store_record(runtime_root: Path, receipt_id: str) -> tuple[Path, dict[str, Any]]:
+def _load_store_record(
+    runtime_root: Path, receipt_id: str
+) -> tuple[Path, dict[str, Any]]:
     path = _receipt_path(runtime_root, receipt_id)
     if not path.is_file():
         raise ValueError("system-managed overlay receipt does not exist")
@@ -466,7 +527,10 @@ def _load_store_record(runtime_root: Path, receipt_id: str) -> tuple[Path, dict[
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError("system-managed overlay receipt is unreadable") from exc
-    if not isinstance(payload, dict) or payload.get("schema_version") != STORE_SCHEMA_VERSION:
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != STORE_SCHEMA_VERSION
+    ):
         raise ValueError("system-managed overlay receipt store record is invalid")
     return path, payload
 
@@ -483,6 +547,7 @@ def validate_local_synthetic_overlay_receipt(
     candidate_tree: str,
     capabilities: Sequence[str],
     synthetic_database_image: str,
+    compose_project: str,
     scope: str = LOCAL_SYNTHETIC_SCOPE,
     product_write_scope: str = PRODUCT_WRITE_SCOPE_ZERO,
     lifetime: str = "task_bound",
@@ -506,6 +571,7 @@ def validate_local_synthetic_overlay_receipt(
         production=False,
     )
     image = _image_reference(synthetic_database_image)
+    project = _compose_project(compose_project)
     runtime_root = _resolved_runtime_root(
         registry_path=registry, runtime_root_arg=runtime_root_arg
     )
@@ -514,16 +580,17 @@ def validate_local_synthetic_overlay_receipt(
     digest = str(record.get("receipt_digest") or "")
     if not isinstance(receipt, Mapping) or digest != _canonical_digest(receipt):
         raise ValueError("system-managed overlay receipt digest is invalid")
-    expected_candidate = _candidate_snapshot(
-        repository,
-        candidate_head=candidate_head,
-        candidate_tree=candidate_tree,
-    )
-    _active_goal_todo(
+    goal, _ = _active_goal_todo(
         registry_path=registry,
         runtime_root_arg=runtime_root_arg,
         goal_id=normalized_goal,
         todo_id=normalized_todo,
+    )
+    expected_candidate = _candidate_snapshot(
+        repository,
+        registered_repository=_registered_goal_repository(goal),
+        candidate_head=candidate_head,
+        candidate_tree=candidate_tree,
     )
     expires = parse_timestamp(receipt.get("expires_at"))
     current = (now or _now_utc()).astimezone(timezone.utc)
@@ -537,6 +604,7 @@ def validate_local_synthetic_overlay_receipt(
         "goal_id": normalized_goal,
         "todo_id": normalized_todo,
         "candidate": expected_candidate,
+        "compose_project": project,
         "scope": scope,
         "capabilities": normalized_capabilities,
         "product_write_scope": product_write_scope,
@@ -579,6 +647,7 @@ def validate_local_synthetic_overlay_receipt(
         "todo_id": normalized_todo,
         "candidate_head": expected_candidate["head"],
         "candidate_tree": expected_candidate["tree"],
+        "compose_project": project,
         "capabilities": normalized_capabilities,
         "scope": scope,
         "product_write_scope": product_write_scope,
@@ -598,9 +667,11 @@ def verify_compose_cleanup(
 
     if validation.get("valid") is not True:
         raise ValueError("cleanup readback requires a valid task-bound overlay receipt")
-    project = str(compose_project or "").strip()
-    if not _COMPOSE_PROJECT.fullmatch(project):
-        raise ValueError("compose_project must be a bounded lowercase local token")
+    project = _compose_project(compose_project)
+    bound_project = _compose_project(validation.get("compose_project"))
+    if project != bound_project:
+        raise ValueError("compose_project does not match the validated overlay receipt")
+    project = bound_project
     docker = which("docker")
     if not docker:
         raise ValueError("Docker client is unavailable for cleanup readback")

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -59,6 +59,10 @@ from .capabilities.connector_registry.cli import (
     handle_connector_command,
     register_connector_commands,
 )
+from .capabilities.local_synthetic_overlay.cli import (
+    handle_local_synthetic_overlay_command,
+    register_local_synthetic_overlay_commands,
+)
 from .cli_commands import (
     handle_turn_command,
     handle_benchmark_command,
@@ -275,6 +279,8 @@ def build_parser() -> LoopXArgumentParser:
 
     register_connector_commands(sub, add_subcommand_format)
 
+    register_local_synthetic_overlay_commands(sub, add_subcommand_format)
+
     register_ml_experiment_commands(sub, add_subcommand_format)
 
     _register_demo_commands(sub, add_subcommand_format)
@@ -421,6 +427,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if capability_result is not None:
         return capability_result
+
+    local_synthetic_overlay_result = handle_local_synthetic_overlay_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if local_synthetic_overlay_result is not None:
+        return local_synthetic_overlay_result
 
     extension_result = handle_extension_command(
         args,

--- a/tests/capabilities/test_local_synthetic_overlay.py
+++ b/tests/capabilities/test_local_synthetic_overlay.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.catalog import build_capability_detail_packet
+from loopx.capabilities.local_synthetic_overlay.core import (
+    ALLOWED_CAPABILITIES,
+    doctor_local_synthetic_providers,
+    issue_local_synthetic_overlay_receipt,
+    validate_local_synthetic_overlay_receipt,
+    verify_compose_cleanup,
+)
+from loopx.cli import build_parser
+
+
+IMAGE = "postgres:17-test@sha256:" + "a" * 64
+GOAL_ID = "goal-local-synthetic"
+TODO_ID = "todo_local_synthetic"
+NOW = datetime(2026, 9, 2, 8, 0, tzinfo=timezone.utc)
+
+
+def _command(argv: list[str], timeout: float = 5.0) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        text=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _doctor_ready(**_kwargs: object) -> dict[str, object]:
+    return {
+        "ok": True,
+        "schema_version": "loopx_local_synthetic_overlay_provider_doctor_v0",
+        "doctor_digest": "sha256:" + "d" * 64,
+        "providers": {
+            "local_container": {"ready": True},
+            "synthetic_database": {"ready": True},
+        },
+    }
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, str, str]:
+    repository = tmp_path / "candidate"
+    repository.mkdir()
+    assert _command(["git", "init", "-q", str(repository)]).returncode == 0
+    assert _command(["git", "-C", str(repository), "config", "user.name", "LoopX Test"]).returncode == 0
+    assert _command(["git", "-C", str(repository), "config", "user.email", "loopx-test@example.invalid"]).returncode == 0
+    (repository / "candidate.txt").write_text("synthetic candidate\n", encoding="utf-8")
+    assert _command(["git", "-C", str(repository), "add", "candidate.txt"]).returncode == 0
+    assert _command(["git", "-C", str(repository), "commit", "-q", "-m", "fixture"]).returncode == 0
+    head = _command(["git", "-C", str(repository), "rev-parse", "HEAD"]).stdout.strip()
+    tree = _command(["git", "-C", str(repository), "rev-parse", "HEAD^{tree}"]).stdout.strip()
+
+    project = tmp_path / "project"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        """---
+status: active
+objective: local synthetic fixture
+updated_at: 2026-09-02T08:00:00Z
+---
+
+# Fixture
+
+## Agent Todo
+
+- [ ] Run exact local synthetic validation.
+  <!-- loopx:todo todo_id=todo_local_synthetic status=open task_class=advancement_task action_kind=local_validation -->
+""",
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry_path, runtime_root, repository, head, tree
+
+
+def _issue(tmp_path: Path) -> tuple[dict[str, object], tuple[Path, Path, Path, str, str]]:
+    fixture = _fixture(tmp_path)
+    registry_path, _runtime_root, repository, head, tree = fixture
+    packet = issue_local_synthetic_overlay_receipt(
+        registry_path=registry_path,
+        runtime_root_arg=None,
+        goal_id=GOAL_ID,
+        todo_id=TODO_ID,
+        repository=repository,
+        candidate_head=head,
+        candidate_tree=tree,
+        capabilities=ALLOWED_CAPABILITIES,
+        synthetic_database_image=IMAGE,
+        product_write_scope="ZERO",
+        ttl_seconds=600,
+        execute=True,
+        now=NOW,
+        token_factory=lambda: "deterministic-system-token",
+        doctor=_doctor_ready,
+    )
+    return packet, fixture
+
+
+def _validate(
+    packet: dict[str, object],
+    fixture: tuple[Path, Path, Path, str, str],
+    **overrides: object,
+) -> dict[str, object]:
+    registry_path, _runtime_root, repository, head, tree = fixture
+    kwargs: dict[str, object] = {
+        "registry_path": registry_path,
+        "runtime_root_arg": None,
+        "receipt_id": packet["receipt_id"],
+        "goal_id": GOAL_ID,
+        "todo_id": TODO_ID,
+        "repository": repository,
+        "candidate_head": head,
+        "candidate_tree": tree,
+        "capabilities": ALLOWED_CAPABILITIES,
+        "synthetic_database_image": IMAGE,
+        "product_write_scope": "ZERO",
+        "now": NOW + timedelta(seconds=1),
+    }
+    kwargs.update(overrides)
+    return validate_local_synthetic_overlay_receipt(**kwargs)
+
+
+def test_zero_write_receipt_is_system_managed_and_exactly_bound(tmp_path: Path) -> None:
+    packet, fixture = _issue(tmp_path)
+    validation = _validate(packet, fixture)
+    receipt = packet["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["product_write_scope"] == "ZERO"
+    assert receipt["capabilities"] == sorted(ALLOWED_CAPABILITIES)
+    assert receipt["reusable_across_tasks"] is False
+    assert set(receipt["restrictions"].values()) == {False}
+    assert receipt["authority_path"] == "loopx_native"
+    assert packet["legacy_dispatcher_used"] is False
+    assert validation["valid"] is True
+    assert validation["receipt_digest"] == packet["receipt_digest"]
+
+    receipt_path = Path(str(packet["receipt_path"]))
+    assert stat.S_IMODE(receipt_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(receipt_path.parent.stat().st_mode) == 0o700
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"todo_id": "todo_other"}, "Todo"),
+        ({"candidate_head": "b" * 40}, "HEAD"),
+        ({"candidate_tree": "c" * 40}, "tree"),
+        (
+            {"capabilities": [*ALLOWED_CAPABILITIES, "production_deploy"]},
+            "exactly capabilities",
+        ),
+    ],
+)
+def test_task_candidate_and_capability_drift_invalidates_receipt(
+    tmp_path: Path,
+    override: dict[str, object],
+    message: str,
+) -> None:
+    packet, fixture = _issue(tmp_path)
+    with pytest.raises(ValueError, match=message):
+        _validate(packet, fixture, **override)
+
+
+def test_expiry_and_receipt_tamper_fail_closed(tmp_path: Path) -> None:
+    packet, fixture = _issue(tmp_path)
+    with pytest.raises(ValueError, match="expired"):
+        _validate(packet, fixture, now=NOW + timedelta(seconds=601))
+
+    receipt_path = Path(str(packet["receipt_path"]))
+    stored = json.loads(receipt_path.read_text(encoding="utf-8"))
+    stored["receipt"]["candidate"]["tree"] = "f" * 40
+    receipt_path.write_text(json.dumps(stored), encoding="utf-8")
+    os.chmod(receipt_path, 0o600)
+    with pytest.raises(ValueError, match="digest"):
+        _validate(packet, fixture)
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        {"product_write_scope": "apps/web/app"},
+        {"reusable_across_tasks": True},
+        {"real_customer_data": True},
+        {"real_child_data": True},
+        {"real_audio": True},
+        {"real_provider": True},
+        {"production": True},
+    ],
+)
+def test_real_production_reuse_and_nonzero_write_scope_are_rejected(
+    tmp_path: Path, unsafe: dict[str, object]
+) -> None:
+    registry_path, _runtime_root, repository, head, tree = _fixture(tmp_path)
+    kwargs: dict[str, object] = {
+        "registry_path": registry_path,
+        "runtime_root_arg": None,
+        "goal_id": GOAL_ID,
+        "todo_id": TODO_ID,
+        "repository": repository,
+        "candidate_head": head,
+        "candidate_tree": tree,
+        "capabilities": ALLOWED_CAPABILITIES,
+        "synthetic_database_image": IMAGE,
+        "execute": True,
+        "now": NOW,
+        "doctor": _doctor_ready,
+    }
+    kwargs.update(unsafe)
+    with pytest.raises(ValueError):
+        issue_local_synthetic_overlay_receipt(**kwargs)
+
+
+def test_doctor_is_truthful_and_never_pulls_or_creates() -> None:
+    calls: list[list[str]] = []
+
+    def ready_runner(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        stdout = '"27.0"\n' if argv[1] == "version" else '"sha256:image"\n'
+        return subprocess.CompletedProcess(argv, 0, stdout, "")
+
+    ready = doctor_local_synthetic_providers(
+        synthetic_database_image=IMAGE,
+        runner=ready_runner,
+        which=lambda name: f"/fixture/{name}" if name == "docker" else None,
+        checked_at=NOW,
+    )
+    assert ready["ok"] is True
+    assert ready["network_pull_attempted"] is False
+    assert ready["resource_created"] is False
+    assert all("pull" not in argv and "run" not in argv for argv in calls)
+
+    def missing_image(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            argv,
+            0 if argv[1] == "version" else 1,
+            '"27.0"\n' if argv[1] == "version" else "",
+            "",
+        )
+
+    unavailable = doctor_local_synthetic_providers(
+        synthetic_database_image=IMAGE,
+        runner=missing_image,
+        which=lambda _name: "/fixture/docker",
+        checked_at=NOW,
+    )
+    assert unavailable["ok"] is False
+    assert unavailable["providers"]["synthetic_database"]["ready"] is False
+
+
+def test_cleanup_readback_reports_clean_and_residue() -> None:
+    validation = {"valid": True, "receipt_id": "overlay_" + "a" * 24}
+
+    def clean_runner(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    clean = verify_compose_cleanup(
+        validation=validation,
+        compose_project="loopx_synthetic_task",
+        runner=clean_runner,
+        which=lambda _name: "/fixture/docker",
+    )
+    assert clean["clean"] is True
+    assert clean["residual_counts"] == {
+        "containers": 0,
+        "volumes": 0,
+        "networks": 0,
+    }
+
+    def residue_runner(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+        stdout = "container-id\n" if argv[1] == "ps" else ""
+        return subprocess.CompletedProcess(argv, 0, stdout, "")
+
+    residue = verify_compose_cleanup(
+        validation=validation,
+        compose_project="loopx_synthetic_task",
+        runner=residue_runner,
+        which=lambda _name: "/fixture/docker",
+    )
+    assert residue["ok"] is False
+    assert residue["status"] == "residue_detected"
+
+
+def test_cli_and_capability_catalog_expose_native_path() -> None:
+    args = build_parser().parse_args(
+        [
+            "local-synthetic-overlay",
+            "doctor",
+            "--synthetic-database-image",
+            IMAGE,
+            "--format",
+            "json",
+        ]
+    )
+    assert args.command == "local-synthetic-overlay"
+    assert args.local_synthetic_overlay_command == "doctor"
+    detail = build_capability_detail_packet("local-synthetic-overlay")
+    capability = detail["capability"]
+    assert capability["provider_id"] == "loopx-core"
+    assert any(
+        "Legacy Dispatcher" in boundary for boundary in capability["boundaries"]
+    )

--- a/tests/capabilities/test_local_synthetic_overlay.py
+++ b/tests/capabilities/test_local_synthetic_overlay.py
@@ -23,6 +23,7 @@ from loopx.cli import build_parser
 IMAGE = "postgres:17-test@sha256:" + "a" * 64
 GOAL_ID = "goal-local-synthetic"
 TODO_ID = "todo_local_synthetic"
+COMPOSE_PROJECT = "loopx_synthetic_task"
 NOW = datetime(2026, 9, 2, 8, 0, tzinfo=timezone.utc)
 
 
@@ -50,17 +51,48 @@ def _doctor_ready(**_kwargs: object) -> dict[str, object]:
     }
 
 
-def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, str, str]:
-    repository = tmp_path / "candidate"
+def _create_repository(repository: Path) -> tuple[str, str]:
     repository.mkdir()
     assert _command(["git", "init", "-q", str(repository)]).returncode == 0
-    assert _command(["git", "-C", str(repository), "config", "user.name", "LoopX Test"]).returncode == 0
-    assert _command(["git", "-C", str(repository), "config", "user.email", "loopx-test@example.invalid"]).returncode == 0
+    assert (
+        _command(
+            ["git", "-C", str(repository), "config", "user.name", "LoopX Test"]
+        ).returncode
+        == 0
+    )
+    assert (
+        _command(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "config",
+                "user.email",
+                "loopx-test@example.invalid",
+            ]
+        ).returncode
+        == 0
+    )
     (repository / "candidate.txt").write_text("synthetic candidate\n", encoding="utf-8")
-    assert _command(["git", "-C", str(repository), "add", "candidate.txt"]).returncode == 0
-    assert _command(["git", "-C", str(repository), "commit", "-q", "-m", "fixture"]).returncode == 0
+    assert (
+        _command(["git", "-C", str(repository), "add", "candidate.txt"]).returncode == 0
+    )
+    assert (
+        _command(
+            ["git", "-C", str(repository), "commit", "-q", "-m", "fixture"]
+        ).returncode
+        == 0
+    )
     head = _command(["git", "-C", str(repository), "rev-parse", "HEAD"]).stdout.strip()
-    tree = _command(["git", "-C", str(repository), "rev-parse", "HEAD^{tree}"]).stdout.strip()
+    tree = _command(
+        ["git", "-C", str(repository), "rev-parse", "HEAD^{tree}"]
+    ).stdout.strip()
+    return head, tree
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, str, str]:
+    repository = tmp_path / "candidate"
+    head, tree = _create_repository(repository)
 
     project = tmp_path / "project"
     state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
@@ -93,8 +125,8 @@ updated_at: 2026-09-02T08:00:00Z
                     {
                         "id": GOAL_ID,
                         "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "repo": str(repository),
+                        "state_file": str(state_file),
                     }
                 ],
             }
@@ -104,19 +136,31 @@ updated_at: 2026-09-02T08:00:00Z
     return registry_path, runtime_root, repository, head, tree
 
 
-def _issue(tmp_path: Path) -> tuple[dict[str, object], tuple[Path, Path, Path, str, str]]:
-    fixture = _fixture(tmp_path)
-    registry_path, _runtime_root, repository, head, tree = fixture
-    packet = issue_local_synthetic_overlay_receipt(
+def _issue_fixture(
+    fixture: tuple[Path, Path, Path, str, str],
+    *,
+    repository: Path | None = None,
+    head: str | None = None,
+    tree: str | None = None,
+) -> dict[str, object]:
+    (
+        registry_path,
+        _runtime_root,
+        registered_repository,
+        registered_head,
+        registered_tree,
+    ) = fixture
+    return issue_local_synthetic_overlay_receipt(
         registry_path=registry_path,
         runtime_root_arg=None,
         goal_id=GOAL_ID,
         todo_id=TODO_ID,
-        repository=repository,
-        candidate_head=head,
-        candidate_tree=tree,
+        repository=repository or registered_repository,
+        candidate_head=head or registered_head,
+        candidate_tree=tree or registered_tree,
         capabilities=ALLOWED_CAPABILITIES,
         synthetic_database_image=IMAGE,
+        compose_project=COMPOSE_PROJECT,
         product_write_scope="ZERO",
         ttl_seconds=600,
         execute=True,
@@ -124,7 +168,38 @@ def _issue(tmp_path: Path) -> tuple[dict[str, object], tuple[Path, Path, Path, s
         token_factory=lambda: "deterministic-system-token",
         doctor=_doctor_ready,
     )
-    return packet, fixture
+
+
+def _linked_worktree(
+    tmp_path: Path,
+    fixture: tuple[Path, Path, Path, str, str],
+) -> Path:
+    _registry_path, _runtime_root, repository, head, _tree = fixture
+    worktree = tmp_path / "candidate-worktree"
+    assert (
+        _command(
+            [
+                "git",
+                "-C",
+                str(repository),
+                "worktree",
+                "add",
+                "-q",
+                "--detach",
+                str(worktree),
+                head,
+            ]
+        ).returncode
+        == 0
+    )
+    return worktree
+
+
+def _issue(
+    tmp_path: Path,
+) -> tuple[dict[str, object], tuple[Path, Path, Path, str, str]]:
+    fixture = _fixture(tmp_path)
+    return _issue_fixture(fixture), fixture
 
 
 def _validate(
@@ -144,6 +219,7 @@ def _validate(
         "candidate_tree": tree,
         "capabilities": ALLOWED_CAPABILITIES,
         "synthetic_database_image": IMAGE,
+        "compose_project": COMPOSE_PROJECT,
         "product_write_scope": "ZERO",
         "now": NOW + timedelta(seconds=1),
     }
@@ -161,6 +237,7 @@ def test_zero_write_receipt_is_system_managed_and_exactly_bound(tmp_path: Path) 
     assert receipt["reusable_across_tasks"] is False
     assert set(receipt["restrictions"].values()) == {False}
     assert receipt["authority_path"] == "loopx_native"
+    assert receipt["compose_project"] == COMPOSE_PROJECT
     assert packet["legacy_dispatcher_used"] is False
     assert validation["valid"] is True
     assert validation["receipt_digest"] == packet["receipt_digest"]
@@ -206,6 +283,65 @@ def test_expiry_and_receipt_tamper_fail_closed(tmp_path: Path) -> None:
         _validate(packet, fixture)
 
 
+def test_unrelated_repository_is_rejected_at_issue_and_validation(
+    tmp_path: Path,
+) -> None:
+    fixture = _fixture(tmp_path)
+    unrelated = tmp_path / "unrelated"
+    unrelated_head, unrelated_tree = _create_repository(unrelated)
+    with pytest.raises(ValueError, match="Goal registry Git repository"):
+        _issue_fixture(
+            fixture,
+            repository=unrelated,
+            head=unrelated_head,
+            tree=unrelated_tree,
+        )
+
+    packet = _issue_fixture(fixture)
+    with pytest.raises(ValueError, match="Goal registry Git repository"):
+        _validate(
+            packet,
+            fixture,
+            repository=unrelated,
+            candidate_head=unrelated_head,
+            candidate_tree=unrelated_tree,
+        )
+
+
+def test_registered_repository_linked_worktree_is_valid(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    worktree = _linked_worktree(tmp_path, fixture)
+    packet = _issue_fixture(fixture, repository=worktree)
+    validation = _validate(packet, fixture, repository=worktree)
+    receipt = packet["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["candidate"]["repository"] == str(worktree.resolve())
+    assert validation["valid"] is True
+
+
+def test_receipt_stays_bound_to_exact_candidate_worktree(tmp_path: Path) -> None:
+    fixture = _fixture(tmp_path)
+    _registry_path, _runtime_root, repository, _head, _tree = fixture
+    worktree = _linked_worktree(tmp_path, fixture)
+    packet = _issue_fixture(fixture, repository=worktree)
+    with pytest.raises(ValueError, match="candidate"):
+        _validate(packet, fixture, repository=repository)
+
+
+def test_compose_project_mismatch_and_tamper_are_rejected(tmp_path: Path) -> None:
+    packet, fixture = _issue(tmp_path)
+    with pytest.raises(ValueError, match="compose_project"):
+        _validate(packet, fixture, compose_project="unrelated_empty_project")
+
+    receipt_path = Path(str(packet["receipt_path"]))
+    stored = json.loads(receipt_path.read_text(encoding="utf-8"))
+    stored["receipt"]["compose_project"] = "unrelated_empty_project"
+    receipt_path.write_text(json.dumps(stored), encoding="utf-8")
+    os.chmod(receipt_path, 0o600)
+    with pytest.raises(ValueError, match="digest"):
+        _validate(packet, fixture)
+
+
 @pytest.mark.parametrize(
     "unsafe",
     [
@@ -232,6 +368,7 @@ def test_real_production_reuse_and_nonzero_write_scope_are_rejected(
         "candidate_tree": tree,
         "capabilities": ALLOWED_CAPABILITIES,
         "synthetic_database_image": IMAGE,
+        "compose_project": COMPOSE_PROJECT,
         "execute": True,
         "now": NOW,
         "doctor": _doctor_ready,
@@ -244,7 +381,9 @@ def test_real_production_reuse_and_nonzero_write_scope_are_rejected(
 def test_doctor_is_truthful_and_never_pulls_or_creates() -> None:
     calls: list[list[str]] = []
 
-    def ready_runner(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+    def ready_runner(
+        argv: list[str], _timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         calls.append(argv)
         stdout = '"27.0"\n' if argv[1] == "version" else '"sha256:image"\n'
         return subprocess.CompletedProcess(argv, 0, stdout, "")
@@ -260,7 +399,9 @@ def test_doctor_is_truthful_and_never_pulls_or_creates() -> None:
     assert ready["resource_created"] is False
     assert all("pull" not in argv and "run" not in argv for argv in calls)
 
-    def missing_image(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+    def missing_image(
+        argv: list[str], _timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
             argv,
             0 if argv[1] == "version" else 1,
@@ -279,14 +420,20 @@ def test_doctor_is_truthful_and_never_pulls_or_creates() -> None:
 
 
 def test_cleanup_readback_reports_clean_and_residue() -> None:
-    validation = {"valid": True, "receipt_id": "overlay_" + "a" * 24}
+    validation = {
+        "valid": True,
+        "receipt_id": "overlay_" + "a" * 24,
+        "compose_project": COMPOSE_PROJECT,
+    }
 
-    def clean_runner(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+    def clean_runner(
+        argv: list[str], _timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(argv, 0, "", "")
 
     clean = verify_compose_cleanup(
         validation=validation,
-        compose_project="loopx_synthetic_task",
+        compose_project=COMPOSE_PROJECT,
         runner=clean_runner,
         which=lambda _name: "/fixture/docker",
     )
@@ -297,18 +444,54 @@ def test_cleanup_readback_reports_clean_and_residue() -> None:
         "networks": 0,
     }
 
-    def residue_runner(argv: list[str], _timeout: float) -> subprocess.CompletedProcess[str]:
+    def residue_runner(
+        argv: list[str], _timeout: float
+    ) -> subprocess.CompletedProcess[str]:
         stdout = "container-id\n" if argv[1] == "ps" else ""
         return subprocess.CompletedProcess(argv, 0, stdout, "")
 
     residue = verify_compose_cleanup(
         validation=validation,
-        compose_project="loopx_synthetic_task",
+        compose_project=COMPOSE_PROJECT,
         runner=residue_runner,
         which=lambda _name: "/fixture/docker",
     )
     assert residue["ok"] is False
     assert residue["status"] == "residue_detected"
+
+
+def test_cleanup_uses_only_receipt_bound_compose_project(tmp_path: Path) -> None:
+    packet, fixture = _issue(tmp_path)
+    validation = _validate(packet, fixture)
+    calls: list[list[str]] = []
+
+    def clean_runner(
+        argv: list[str], _timeout: float
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    clean = verify_compose_cleanup(
+        validation=validation,
+        compose_project=COMPOSE_PROJECT,
+        runner=clean_runner,
+        which=lambda _name: "/fixture/docker",
+    )
+    assert clean["clean"] is True
+    assert len(calls) == 3
+    assert all(
+        f"label=com.docker.compose.project={COMPOSE_PROJECT}" in argv for argv in calls
+    )
+
+    calls.clear()
+    with pytest.raises(ValueError, match="does not match"):
+        verify_compose_cleanup(
+            validation=validation,
+            compose_project="unrelated_empty_project",
+            runner=clean_runner,
+            which=lambda _name: "/fixture/docker",
+        )
+    assert calls == []
 
 
 def test_cli_and_capability_catalog_expose_native_path() -> None:
@@ -327,6 +510,4 @@ def test_cli_and_capability_catalog_expose_native_path() -> None:
     detail = build_capability_detail_packet("local-synthetic-overlay")
     capability = detail["capability"]
     assert capability["provider_id"] == "loopx-core"
-    assert any(
-        "Legacy Dispatcher" in boundary for boundary in capability["boundaries"]
-    )
+    assert any("Legacy Dispatcher" in boundary for boundary in capability["boundaries"])


### PR DESCRIPTION
## Summary

- add a LoopX-native, task-bound local synthetic overlay with ZERO product write authority
- bind issuance and validation to the Goal registry Git repository while supporting legitimate linked worktrees
- bind the exact candidate worktree, HEAD, tree, digest-protected Compose project, and cleanup readback
- fail closed for unrelated repositories, receipt tampering, provider unavailability, and cleanup mismatch or residue

## Validation

- focused local synthetic overlay tests: 21 passed
- related capability tests: 14 passed
- CLI tests: 17 passed
- Ruff: passed
- Ruff format check: passed
- mypy: 15 source files passed
- loopx check: errors 0, warnings 0
- premerge canary from Git diff: 17 selected, 0 failures, 0 manual holds
- independent read-only semantic review: PASS, 0 findings

No checks were skipped. The current main advancement is limited to disjoint install and release documentation paths; Git merge-tree reports no conflict. The PR changes only the eight local-synthetic overlay capability, CLI, documentation, catalog, and test paths.

## Scope

No Legacy Dispatcher changes, real-resource access, product repository mutation, iPad execution, or capability expansion beyond local_container and synthetic_database. The future-facing scope pass found the repository identity and Compose token helpers cohesive; no broader refactor is needed.