### PR TITLE
fix(stride): avoid authority marker substring matches

### DIFF
--- a/loopx/control_plane/runtime/stride_observation.py
+++ b/loopx/control_plane/runtime/stride_observation.py
@@ -11,7 +11,6 @@ than being guessed from prose or command names.
 from __future__ import annotations
 
 import json
-import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -19,26 +18,14 @@ from typing import Any
 STRIDE_OBSERVATION_SCHEMA_VERSION = "hierarchical_stride_observation_v0"
 STRIDE_EVALUATION_SCHEMA_VERSION = "hierarchical_stride_evaluation_v0"
 EVIDENCE_FRESH_WINDOW_HOURS = 6
-AUTHORITY_CHANGE_MARKERS = ("replan", "vision", "gate")
-_AUTHORITY_CLASSIFICATION_TOKEN_RE = re.compile(r"[a-z0-9]+")
-_AUTHORITY_TOKEN_MARKERS = frozenset(AUTHORITY_CHANGE_MARKERS[:2])
-_AUTHORITY_GATE_DECISION_TOKENS = frozenset(
+AUTHORITY_CHANGE_CLASSIFICATIONS = frozenset(
     {
-        "accepted",
-        "added",
-        "approved",
-        "canceled",
-        "cancelled",
-        "changed",
-        "closed",
-        "deferred",
-        "denied",
-        "opened",
-        "passed",
-        "recorded",
-        "rejected",
-        "resolved",
-        "revoked",
+        # These are the complete values emitted by the current controlled
+        # authority/replan writers. Unknown classifications stay no-change.
+        "bounded_replan_progress",
+        "operator_gate_approved",
+        "operator_gate_rejected",
+        "operator_gate_deferred",
     }
 )
 
@@ -48,29 +35,17 @@ def _compact_text(value: Any, *, limit: int = 180) -> str:
 
 
 def _has_authority_change_marker(value: Any) -> bool:
-    """Return whether a classification explicitly denotes an authority change.
+    """Return true only for an exact value from the controlled writer set.
 
-    Run classifications are caller-supplied free text, so substring matches
-    are not semantic evidence (for example, ``revision`` contains ``vision``).
-    Replan and vision are reserved whole-token markers. A gate token is
-    ambiguous in waiting/gated states, and therefore requires either a
-    standalone ``gate`` value or a known decision/transition token.
+    ``classification`` remains a descriptive, caller-supplied field in M1.
+    It therefore cannot be parsed as semantic evidence: token, substring,
+    negation, and co-occurrence heuristics all admit false authority changes.
+    Until run receipts carry a typed authority-change field, this closed set is
+    the fail-closed compatibility boundary.
     """
 
-    tokens = set(
-        _AUTHORITY_CLASSIFICATION_TOKEN_RE.findall(
-            _compact_text(value, limit=240).casefold()
-        )
-    )
-    if not tokens:
-        return False
-    if tokens.intersection(_AUTHORITY_TOKEN_MARKERS):
-        return True
-    if "gate" not in tokens:
-        return False
-    return tokens == {"gate"} or bool(
-        tokens.intersection(_AUTHORITY_GATE_DECISION_TOKENS)
-    )
+    classification = _compact_text(value, limit=240).casefold()
+    return classification in AUTHORITY_CHANGE_CLASSIFICATIONS
 
 
 def read_run_index(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:

--- a/loopx/control_plane/runtime/stride_observation.py
+++ b/loopx/control_plane/runtime/stride_observation.py
@@ -11,6 +11,7 @@ than being guessed from prose or command names.
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -19,10 +20,57 @@ STRIDE_OBSERVATION_SCHEMA_VERSION = "hierarchical_stride_observation_v0"
 STRIDE_EVALUATION_SCHEMA_VERSION = "hierarchical_stride_evaluation_v0"
 EVIDENCE_FRESH_WINDOW_HOURS = 6
 AUTHORITY_CHANGE_MARKERS = ("replan", "vision", "gate")
+_AUTHORITY_CLASSIFICATION_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_AUTHORITY_TOKEN_MARKERS = frozenset(AUTHORITY_CHANGE_MARKERS[:2])
+_AUTHORITY_GATE_DECISION_TOKENS = frozenset(
+    {
+        "accepted",
+        "added",
+        "approved",
+        "canceled",
+        "cancelled",
+        "changed",
+        "closed",
+        "deferred",
+        "denied",
+        "opened",
+        "passed",
+        "recorded",
+        "rejected",
+        "resolved",
+        "revoked",
+    }
+)
 
 
 def _compact_text(value: Any, *, limit: int = 180) -> str:
     return " ".join(str(value or "").strip().split())[:limit]
+
+
+def _has_authority_change_marker(value: Any) -> bool:
+    """Return whether a classification explicitly denotes an authority change.
+
+    Run classifications are caller-supplied free text, so substring matches
+    are not semantic evidence (for example, ``revision`` contains ``vision``).
+    Replan and vision are reserved whole-token markers. A gate token is
+    ambiguous in waiting/gated states, and therefore requires either a
+    standalone ``gate`` value or a known decision/transition token.
+    """
+
+    tokens = set(
+        _AUTHORITY_CLASSIFICATION_TOKEN_RE.findall(
+            _compact_text(value, limit=240).casefold()
+        )
+    )
+    if not tokens:
+        return False
+    if tokens.intersection(_AUTHORITY_TOKEN_MARKERS):
+        return True
+    if "gate" not in tokens:
+        return False
+    return tokens == {"gate"} or bool(
+        tokens.intersection(_AUTHORITY_GATE_DECISION_TOKENS)
+    )
 
 
 def read_run_index(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:
@@ -84,9 +132,7 @@ def build_stride_observation(
 
     authority_change_index: int | None = None
     for index, run in enumerate(agent_runs):
-        classification = _compact_text(run.get("classification"), limit=240)
-        lowered = classification.lower()
-        if any(marker in lowered for marker in AUTHORITY_CHANGE_MARKERS):
+        if _has_authority_change_marker(run.get("classification")):
             authority_change_index = index
     bounded_slices_since_change = (
         len(agent_runs) - authority_change_index - 1

--- a/tests/control_plane/test_stride_observation.py
+++ b/tests/control_plane/test_stride_observation.py
@@ -4,6 +4,8 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
 from loopx.control_plane.runtime.stride_observation import (
     STRIDE_EVALUATION_SCHEMA_VERSION,
     STRIDE_OBSERVATION_SCHEMA_VERSION,
@@ -356,6 +358,94 @@ def test_boundary_authority_changes_require_explicit_markers(
         agent_id=AGENT_ID,
     )
     assert unmarked["authority"]["bounded_slices_since_change"] == 3
+
+
+@pytest.mark.parametrize(
+    "classification",
+    [
+        "revision_review",
+        "supervision_check",
+        "waiting_at_approval_gate",
+        "provisional_benchmark_reward",
+    ],
+)
+def test_boundary_authority_markers_do_not_use_substring_or_waiting_state(
+    tmp_path: Path,
+    classification: str,
+) -> None:
+    _write_run_index(
+        tmp_path,
+        [
+            _run(
+                classification="bounded_progress_report",
+                outcome="outcome_progress",
+                minutes_ago=120,
+            ),
+            _run(
+                classification=classification,
+                outcome="surface_only",
+                minutes_ago=60,
+            ),
+            _run(
+                classification="exact_head_review_delivered",
+                outcome="outcome_progress",
+                minutes_ago=10,
+            ),
+        ],
+    )
+
+    observation = build_stride_observation(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert observation["authority"]["bounded_slices_since_change"] == 3
+
+
+@pytest.mark.parametrize(
+    "classification",
+    [
+        "replan",
+        "vision",
+        "gate",
+        "bounded_replan_progress",
+        "vision_refresh_accepted",
+        "operator_gate_approved",
+    ],
+)
+def test_boundary_authority_markers_preserve_explicit_positive_values(
+    tmp_path: Path,
+    classification: str,
+) -> None:
+    _write_run_index(
+        tmp_path,
+        [
+            _run(
+                classification="bounded_progress_report",
+                outcome="outcome_progress",
+                minutes_ago=120,
+            ),
+            _run(
+                classification=classification,
+                outcome="surface_only",
+                minutes_ago=60,
+            ),
+            _run(
+                classification="exact_head_review_delivered",
+                outcome="outcome_progress",
+                minutes_ago=10,
+            ),
+        ],
+    )
+
+    observation = build_stride_observation(
+        tmp_path,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    assert observation["authority"]["bounded_slices_since_change"] == 1
 
 
 def test_boundary_projection_replays_byte_identical(tmp_path: Path) -> None:

--- a/tests/control_plane/test_stride_observation.py
+++ b/tests/control_plane/test_stride_observation.py
@@ -284,9 +284,9 @@ def test_boundary_authority_changes_require_explicit_markers(
     tmp_path: Path,
 ) -> None:
     # Criterion 6: reports with no authority delta are not counted as heavy
-    # steering. Only explicit replan/vision/gate classifications restart the
-    # bounded-slice count; status, monitor, and review classifications never
-    # do, and the latest explicit marker wins.
+    # steering. Only complete values from the controlled writer allowlist
+    # restart the bounded-slice count; status, monitor, review, and vision
+    # checkpoint classifications never do, and the latest explicit value wins.
     _write_run_index(
         tmp_path / "with_markers",
         [
@@ -311,8 +311,8 @@ def test_boundary_authority_changes_require_explicit_markers(
                 minutes_ago=60,
             ),
             _run(
-                classification="vision_refresh_accepted",
-                outcome="outcome_progress",
+                classification="operator_gate_deferred",
+                outcome="surface_only",
                 minutes_ago=30,
             ),
             _run(
@@ -328,7 +328,8 @@ def test_boundary_authority_changes_require_explicit_markers(
         goal_id=GOAL_ID,
         agent_id=AGENT_ID,
     )
-    # Latest explicit marker sits at index 4; only the final review follows.
+    # Latest controlled authority value sits at index 4; only the final review
+    # follows.
     assert marked["authority"]["bounded_slices_since_change"] == 1
 
     _write_run_index(
@@ -367,9 +368,20 @@ def test_boundary_authority_changes_require_explicit_markers(
         "supervision_check",
         "waiting_at_approval_gate",
         "provisional_benchmark_reward",
+        "not_replan",
+        "vision_check",
+        "gate_not_approved",
+        "gate_status_recorded_without_transition",
+        "no_gate_changed",
+        "replan_noop",
+        "autonomous_replan_recorded",
+        "route_continuation_replan_recorded",
+        "successor_replan_recorded",
+        "monitor_poll_autonomous_replan_recorded_v0",
+        "goal_vision_checkpoint",
     ],
 )
-def test_boundary_authority_markers_do_not_use_substring_or_waiting_state(
+def test_boundary_unknown_classifications_stay_no_change(
     tmp_path: Path,
     classification: str,
 ) -> None:
@@ -406,15 +418,13 @@ def test_boundary_authority_markers_do_not_use_substring_or_waiting_state(
 @pytest.mark.parametrize(
     "classification",
     [
-        "replan",
-        "vision",
-        "gate",
         "bounded_replan_progress",
-        "vision_refresh_accepted",
         "operator_gate_approved",
+        "operator_gate_rejected",
+        "operator_gate_deferred",
     ],
 )
-def test_boundary_authority_markers_preserve_explicit_positive_values(
+def test_boundary_controlled_authority_classifications_reset_stride(
     tmp_path: Path,
     classification: str,
 ) -> None:


### PR DESCRIPTION
## Summary

This is the remaining M1 observation-correctness hardening for #3203 and RFC #3204.

- Replace substring containment when deriving authority changes from caller-supplied run classifications.
- Match `replan` and `vision` as complete classification tokens.
- Treat `gate` as an authority change only when it is standalone or paired with an explicit gate decision/transition token.
- Add regression coverage for the reported false positives and for existing explicit positives.

## Why

`classification` is a bounded, caller-supplied field rather than a typed enum. The previous `marker in classification` check treated values such as `revision_review`, `supervision_check`, and `waiting_at_approval_gate` as authority changes. That reset `authority.bounded_slices_since_change` even though no authority delta was recorded.

The new classifier is still deliberately read-only and conservative at the ambiguous `gate` boundary. It does not infer authority changes from summaries, notes, command names, or file paths.

## Scope and Compatibility

- No run-record schema changes.
- No changes to scheduler cadence, Todo selection, quota spend, notification, execution, or user/protected-operation authority.
- `shadow_only` behavior and existing observation/evaluation schemas are unchanged.
- Explicit values such as `replan`, `vision`, `gate`, `bounded_replan_progress`, `vision_refresh_accepted`, and `operator_gate_approved` remain recognized.

## Validation

- `pytest -q tests/control_plane/test_stride_observation.py tests/control_plane/test_goal_outcome_continuity_characterization.py` — 21 passed
- `ruff check loopx/control_plane/runtime/stride_observation.py tests/control_plane/test_stride_observation.py` — passed
- `python -m compileall -q loopx/control_plane/runtime/stride_observation.py tests/control_plane/test_stride_observation.py` — passed
- `loopx check` — no errors; public boundary scan clean
- `loopx canary premerge --from-git-diff` — passed, 12 checks selected, 0 blocking failures, 0 manual holds

The full `tests/control_plane` run finished with 2,092 passed and 3 baseline/environment failures unrelated to these files:

- 2 fine-grained CLI tests selected the system Python 3.9 instead of the configured Python 3.13 runtime.
- 1 effect-runtime doctor test observed the current Node/readiness environment before reaching its assertion.

The canary classified one maintainability smoke result as an inherited advisory; it did not mention either changed file, and the smoke passes when run directly.

Tracks #3203.
