### PR TITLE
docs(rfc): govern shared goal alignment

### DIFF
--- a/docs/architecture/rfcs/README.md
+++ b/docs/architecture/rfcs/README.md
@@ -58,6 +58,15 @@ changes.
     [#3669](https://github.com/huangruiteng/loopx/pull/3669),
     [#3798](https://github.com/huangruiteng/loopx/pull/3798)). No remote
     provider is the promoted authority; PostgreSQL remains planned.
+- [Shared Goal Alignment and Governed Amendment Protocol v0](shared-goal-alignment-and-governed-amendment-v0.md)
+  ([中文版](shared-goal-alignment-and-governed-amendment-v0.zh-CN.md))
+  - **RFC status:** Draft, under maintainer review.
+  - **Delivery on `main`:** Proposal only.
+  - **Current boundary:** Existing peer lanes, unclaimed work, claims/leases,
+    Agent-scoped Goal Vision/Replan, and provider-neutral authority are inputs.
+    A read-only shared-alignment projection, automated amendment policy,
+    verifier boundary, and canonical Goal-amendment transaction have not
+    shipped.
 - [Goal Artifact Lifecycle Projection v0](goal-artifact-lifecycle-projection-v0.md)
   ([中文版](goal-artifact-lifecycle-projection-v0.zh-CN.md))
   - **RFC status:** Draft, under maintainer review.

--- a/docs/architecture/rfcs/shared-goal-alignment-and-governed-amendment-v0.md
+++ b/docs/architecture/rfcs/shared-goal-alignment-and-governed-amendment-v0.md
@@ -1,0 +1,403 @@
+# RFC: Shared Goal Alignment and Governed Amendment Protocol (v0)
+
+- Status: Draft; under maintainer review
+- Tracking issue: [#3836](https://github.com/huangruiteng/loopx/issues/3836)
+- Date: 2026-09-02
+- Scope: peer Agents collaborating around one shared Goal while preserving
+  canonical intent, per-Agent execution frontiers, claim/lease ownership, and
+  auditable replan/amendment decisions
+- Related contracts:
+  [Goal Vision and Replan](../../reference/protocols/goal-vision-replan-contract-v0.md)
+  and
+  [Shared Control-Plane Authority and Pluggable State Providers](./shared-goal-authority-state-provider-v0.md)
+- Language note: the
+  [Chinese version](./shared-goal-alignment-and-governed-amendment-v0.zh-CN.md)
+  and this English version are semantic mirrors. A difference between them is
+  a defect.
+
+---
+
+## 1. Summary and decision
+
+LoopX will distinguish four kinds of state that must not collapse into one
+mutable plan:
+
+1. a **canonical shared Goal intent envelope**;
+2. a **shared eligible work graph**;
+3. one **per-Agent frontier** for each registered peer; and
+4. **proposal and receipt records** for governed shared amendments.
+
+An Agent may correct its own frontier while remaining inside canonical intent.
+It may propose a shared amendment when evidence invalidates shared assumptions.
+The proposal does not change the Goal, block unrelated work, or grant the
+proposer unilateral commit authority. A shared amendment becomes effective
+only after LoopX's `GoalAmendmentAuthority` validates it against the pre-authorized
+policy and exact base revision, commits it with compare-and-set (CAS), and
+produces a durable receipt. Every Agent then rebinds its frontier to the new
+canonical revision.
+
+The normal path is automated. It does not require every peer to vote or a human
+to approve routine Goal evolution. `peer_v1` describes equal execution rank,
+not universal authority to escape the root user intent or acquire new
+permissions. Goal creation freezes a `root_intent` and an amendment-policy
+envelope. Inside that envelope, policy checks and, for higher-risk classes, an
+independent verifier Agent authorize automatic commit. Outside it, the old Goal
+remains effective and the proposal is rejected or structurally blocked; human
+escalation occurs only when the Goal explicitly configured it.
+
+```text
+canonical shared Goal intent envelope
+  (objective, non-goals, acceptance, permissions, stop conditions, revision)
+                 |
+                 v
+shared eligible work graph
+                 |
+        +--------+--------+
+        |                 |
+        v                 v
+per-Agent frontier A   per-Agent frontier B
+        |                 |
+claim + lease/fence    claim + lease/fence
+        |                 |
+bounded evidence       bounded evidence
+        +--------+--------+
+                 |
+       lane replan or amendment proposal
+                 |
+     automated policy + optional verifier
+                 |
+       base-revision CAS commit
+                 |
+ committed shared amendment + receipt
+                 |
+       every frontier rebases or gates
+```
+
+## 2. Problem and current boundary
+
+LoopX already coordinates execution usefully:
+
+- registered peer identities and Agent-scoped Todo lanes;
+- visible/selectable unclaimed Todos with claim-before-work guidance;
+- soft claims plus hard lease/fence ownership;
+- per-Agent vision and checkpoint state;
+- typed autonomous-replan obligations and settlement;
+- action-scoped cross-owner Todo lifecycle grants; and
+- provider-neutral coordination CAS and receipt foundations.
+
+[#3693](https://github.com/huangruiteng/loopx/pull/3693) is a positive bounded
+fix in this layer. It prevents shared `Next Action` prose from shadowing an
+exact settlement-bound or current-Agent Todo. It does not define shared Goal
+alignment or shared semantic amendment authority.
+
+The missing seam appears when multiple Agents independently discover that the
+shared plan or acceptance boundary is wrong. Per-Agent vision can remain
+internally consistent while the combined work no longer proves the original
+Goal. Conversely, letting every Agent rewrite shared prose turns the latest
+writer into accidental authority.
+
+No type system can prove that arbitrary natural-language changes preserve the
+user's intent. LoopX can instead make silent reinterpretation impossible: an
+amendment must name what is retained, changed, and stopped; cite evidence; bind
+the exact base revision and digest; pass an explicit authority policy; and
+leave a recoverable receipt.
+
+## 3. State partition and invariants
+
+### 3.1 Canonical intent envelope
+
+`shared_goal_intent_v0` contains:
+
+- `goal_id`, `goal_revision`, and `intent_digest`;
+- objective and non-goals;
+- acceptance conditions;
+- permission/write scope;
+- stop and terminal conditions; and
+- the root intent that Agents cannot amend;
+- the authority policy that governs each amendment class; and
+- the configured disposition for out-of-policy proposals (`reject`, `block`,
+  or explicit `human_escalation`).
+
+This is semantic authority, not a status projection. `Next Action`, Agent
+vision, chat messages, scheduler hints, and provider heads cannot overwrite it.
+
+### 3.2 Shared work graph
+
+The shared work graph contains Todos, dependencies, eligibility, blocking
+gates, and lifecycle state. It describes candidate work, not who may currently
+execute it. Work-graph edits must remain traceable to the canonical intent
+revision they are intended to advance.
+
+### 3.3 Per-Agent frontier
+
+Each registered Agent receives a bounded `shared_goal_alignment_v0` projection:
+
+- canonical Goal revision/digest;
+- that Agent's frontier and `based_on_goal_revision`;
+- its claims and lease/fence facts;
+- eligible unclaimed work;
+- open lane replan or shared amendment obligations; and
+- conflicts or stale-basis facts.
+
+An Agent may replan its own route without a shared amendment when the change
+stays within current objective, non-goals, acceptance, permissions, and stop
+conditions and does not mutate another Agent's claimed work.
+
+### 3.4 Proposals and receipts
+
+Proposals are advisory, durable inputs. Receipts prove canonical transitions.
+Neither is a substitute for the other. A pending or approved proposal has no
+effect until a successful commit receipt names the new Goal revision.
+
+## 4. Authority matrix
+
+### 4.1 What `GoalAmendmentAuthority` means
+
+`GoalAmendmentAuthority` is not a person, a leader Agent, a model, or a storage
+service. It is LoopX's single typed write boundary for canonical Goal
+amendments. A concrete implementation is expected to separate:
+
+```text
+proposal + current Goal + policy + lease impact + optional verifier decision
+                                  |
+                                  v
+                 GoalAmendmentAuthority.decide()
+                       reject | needs_rebase | commit
+                                  |
+                                  v
+                  provider CAS + canonical receipt
+```
+
+The decision reducer enforces deterministic policy, identities, digests,
+revisions, and impact rules. An optional verifier Agent supplies a typed input
+for semantic questions, but cannot commit. The transaction executor persists an
+accepted decision through the provider-neutral store, but cannot widen it.
+Calling this boundary an authority means all canonical writers must pass
+through it; it does not mean that one privileged Agent decides for its peers.
+
+### 4.2 Amendment classes
+
+| Amendment class | Example | Proposal authority | Automated commit rule | Default effect while pending |
+| --- | --- | --- | --- | --- |
+| `lane_route` | reorder one Agent's unclaimed local steps | owning Agent | deterministic lane policy | none outside that lane |
+| `shared_work_graph` | add a Todo or dependency that preserves intent | registered Agent | policy validation plus impact check | unrelated work continues |
+| `shared_acceptance` | refine an acceptance condition or non-goal inside root intent | registered Agent | policy validation plus independent verifier Agent | affected acceptance path is gated |
+| `protected_authority` | acquire new permission or escape root intent | registered Agent | never auto-commit unless the immutable envelope already delegates the exact class | affected work fails closed |
+
+`GoalAmendmentAuthority` is the normal commit boundary. A verifier Agent returns a
+typed, evidence-bound decision; it does not become a durable leader and cannot
+edit the proposal it verifies. Proposer and verifier identities must differ for
+classes whose policy requires independence. Deterministic checks remain the
+first gate; model judgment cannot override permissions, scope, stop conditions,
+or a stale base.
+
+Being a scheduler, Supervisor, latest writer, lease holder, or provider
+operator does not grant semantic commit authority. Out-of-policy proposals are
+rejected or left structurally blocked while the old Goal continues. They ask a
+human only when `human_escalation` was explicitly enabled, rather than turning
+every Goal change into an approval queue.
+
+## 5. Amendment lifecycle: how a proposal becomes effective
+
+```text
+draft -> submitted -> admitted -> policy_check -> verified -> committing
+  |          |            |             |             |
+  +--------> rejected <----+-------------+-------------+
+                             stale/conflict -> needs_rebase
+
+committing --CAS success--> committed + receipt -> frontier reconciliation
+          \--unknown------> ambiguous -> readReceipt/reconcile
+          \--CAS conflict-> needs_rebase
+```
+
+The effective path is:
+
+1. **Propose.** Any authorized proposer submits
+   `goal_amendment_proposal_v0`, including the base revision/digest, amendment
+   class, retained/changed/stopped intent, evidence references, affected Todos,
+   and linked replan obligation.
+2. **Admit.** LoopX validates schema, actor identity, bounded evidence pointers,
+   amendment class, and impact scope. Admission does not approve or apply it.
+3. **Policy decision and optional verification.** LoopX evaluates deterministic
+   invariants and the pre-authorized amendment envelope. A higher-risk but
+   in-envelope class may invoke an independent verifier Agent that returns a
+   typed decision bound to the exact proposal digest. The policy may reject or
+   request rebase. A verifier decision cannot be reused for edited content.
+4. **Impact decision.** Before commit, the authority decides how in-flight
+   claimed/leased Todos are handled: unaffected, allowed to finish under the
+   old revision, explicitly cancelled with a new fence epoch, or blocked by
+   policy. A semantic amendment cannot silently invalidate work already
+   authorized by a lease.
+5. **Commit.** The `GoalAmendmentAuthority` transaction submits the policy-authorized digest
+   with an `operation_id`, expected `base_goal_revision`, and
+   `base_intent_digest`. It revalidates policy and performs one CAS. A stale
+   base fails closed. Routine in-envelope amendments do not wait for a human.
+6. **Receipt.** The same transaction records the proposal digest, actor,
+   authority source, old/new revisions, retained/changed/stopped delta,
+   evidence references, affected Todos, lease disposition, and exact replan
+   obligation settlement.
+7. **Reconcile.** Projections rotate to the new revision. Every Agent either
+   rebinds its frontier, opens a lane replan, or is gated if its current work is
+   incompatible. Old-revision semantic writes are rejected.
+
+Only step 5 makes the amendment canonical. Step 6 makes that fact recoverable
+when a response is lost; step 7 makes it operational for all peers.
+
+## 6. Proposed schemas
+
+Illustrative `goal_amendment_proposal_v0`:
+
+```json
+{
+  "schema_version": "goal_amendment_proposal_v0",
+  "proposal_id": "gap_...",
+  "goal_id": "goal-1",
+  "proposer_agent_id": "agent-a",
+  "amendment_class": "shared_acceptance",
+  "base_goal_revision": 17,
+  "base_intent_digest": "sha256:...",
+  "retained": ["original outcome remains unchanged"],
+  "changed": ["acceptance now requires the recovered receipt"],
+  "stopped": [],
+  "evidence_refs": ["evidence:..."],
+  "affected_todo_ids": ["todo-a", "todo-b"],
+  "replan_obligation_id": "replan:..."
+}
+```
+
+Illustrative `goal_amendment_receipt_v0` adds:
+
+```json
+{
+  "schema_version": "goal_amendment_receipt_v0",
+  "operation_id": "op_...",
+  "proposal_id": "gap_...",
+  "proposal_digest": "sha256:...",
+  "decision": "committed",
+  "authority_actor_id": "goal-amendment-authority",
+  "authority_source": "goal_amendment_policy_v0",
+  "verifier_decision_digest": "sha256:...",
+  "previous_goal_revision": 17,
+  "new_goal_revision": 18,
+  "new_intent_digest": "sha256:...",
+  "lease_dispositions": [],
+  "settled_replan_obligation_id": "replan:..."
+}
+```
+
+The read-only `shared_goal_alignment_v0` projection must identify pending,
+approved, conflicting, and committed proposals without treating any pre-commit
+state as canonical intent.
+
+## 7. Concurrency, recovery, and multi-Agent behavior
+
+Multiple proposals from one base may coexist. Policy/verifier decisions and
+commit are bound to the exact proposal digest. Canonical commit is serialized by Goal revision:
+after one proposal commits, another proposal from the old base becomes
+`needs_rebase`; it is never silently merged or applied last-writer-wins.
+
+Independent lane work continues while a proposal is pending unless a typed
+impact gate names that Todo or acceptance path. An Agent may claim eligible
+unclaimed work only through the existing atomic claim and, when configured,
+lease/fence acquisition. Proposal authorship does not reserve a Todo, and Todo
+claim ownership does not authorize a Goal amendment.
+
+If provider commit succeeds but the response is lost, the caller does not
+blindly retry with a new operation identity. It calls `readReceipt` using the
+same `operation_id`. A found receipt proves the canonical revision. An absent
+receipt plus a changed head requires reconciliation; ambiguity is not treated
+as failure. Provider-specific file, NoKV, or PostgreSQL behavior remains behind
+the provider-neutral authority store contract.
+
+## 8. Replan integration
+
+Replan classifies a discovered gap before choosing a writer:
+
+- a route correction wholly inside canonical intent opens or settles an
+  Agent-scoped replan obligation;
+- a cross-lane dependency/work-graph gap opens a shared amendment obligation;
+- evidence that changes acceptance, non-goals, or the operational objective
+  inside the root-intent envelope opens an automatically governed amendment
+  obligation; and
+- a change outside delegated permissions or root intent is rejected or remains
+  structurally blocked under the configured escalation disposition.
+
+Each obligation has a stable id. Proposal ACK alone does not settle it.
+Settlement requires either a committed receipt for that exact obligation, a
+rejected/no-change decision with a structured rationale accepted by policy, or
+a superseding obligation that explicitly preserves the causal chain.
+
+After commit, an Agent whose `based_on_goal_revision` is stale may observe but
+cannot make controlled semantic writes until it rebases or receives an explicit
+grandfathered-work disposition. This connects shared change to existing
+per-Agent Goal Vision without turning one Agent's vision into peer authority.
+
+## 9. Provider and projection boundaries
+
+The `GoalAmendmentAuthority` decides whether a proposal is legal and may commit.
+File, NoKV, and PostgreSQL providers persist normalized transactions, CAS
+heads, and receipts; they do not interpret Goal prose or choose amendment
+policy.
+
+This RFC does not expand the current coordination aggregate in its first
+implementation slice. The existing shared-authority RFC continues to own
+Todo/claim/lease/receipt persistence. Goal semantic amendment first ships as a
+read-only projection and proposal contract. Mapping its commit into a
+provider-neutral aggregate requires a separate reviewed transaction boundary.
+
+`Next Action` remains compatibility prose and a read projection. It is never a
+claim, lease, Goal amendment, replan settlement, or authority decision.
+
+## 10. Staged delivery
+
+1. **Stage 0 — characterization and RFC.** Record own-lane, unclaimed,
+   peer-claimed, replan, concurrent proposal, and in-flight lease scenarios.
+2. **Stage 1 — read-only alignment.** Add `shared_goal_alignment_v0` with
+   canonical revision binding, per-Agent frontier basis, unclaimed work, and
+   drift/conflict facts. No writer changes.
+3. **Stage 2 — proposal only.** Validate and retain
+   `goal_amendment_proposal_v0`; proposals have no canonical effect.
+4. **Stage 3 — one bounded commit class.** Implement governed commit for a
+   shared work-graph amendment that preserves root intent, including automated
+   policy commit, CAS, receipt, replan settlement, and lease impact handling.
+5. **Stage 4 — provider-neutral shadow/parity.** Map the reviewed transaction
+   to the file reference provider and optional NoKV/PostgreSQL candidates;
+   compare projections and recovery without changing default authority.
+6. **Stage 5 — TEST ONLY shared canary.** Exercise two peers, concurrent
+   proposals, unclaimed claim, response-loss recovery, stale bases, and
+   protected changes before any authority-source promotion.
+
+Acceptance and operational-objective commits are not the first runtime slice.
+They require demonstrated need and a separately reviewed automated policy and
+verifier contract. Permission expansion or escape from root intent cannot be
+auto-committed unless Goal creation explicitly delegated that exact class.
+
+## 11. Validation matrix
+
+At minimum, tests must prove:
+
+- own-lane replan cannot change canonical intent;
+- unclaimed work is visible but cannot execute before claim/lease;
+- a pending proposal does not affect unrelated peers;
+- policy and verifier decisions are bound to the exact proposal digest;
+- two conflicting proposals from one base yield at most one canonical commit;
+- stale revision/digest commits fail closed;
+- response-loss recovery returns the original receipt;
+- protected changes cannot be committed by proposer, scheduler, lease holder,
+  verifier, or provider operator identity alone;
+- routine in-envelope amendments complete without human approval, while an
+  out-of-policy proposal never silently expands authority;
+- in-flight leased work receives an explicit disposition; and
+- all Agent projections rotate or gate after a canonical revision changes.
+
+## 12. Non-goals
+
+This version does not define automatic voting or consensus, CRDT/offline
+multi-writer merge, an omniscient planner, a permanent leader, direct Agent
+writes to storage providers, broad migration of LoopX state, or autonomous
+escape from the immutable root user intent. Human approval is not a required
+step in the normal amendment lifecycle.
+
+The smallest useful outcome is a legible, read-only alignment projection and a
+proposal that is visibly non-authoritative. Runtime commit follows only after
+that boundary proves useful in real multi-Agent work.

--- a/docs/architecture/rfcs/shared-goal-alignment-and-governed-amendment-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-alignment-and-governed-amendment-v0.zh-CN.md
@@ -1,0 +1,372 @@
+# RFC：共享 Goal 对齐与受治理 Amendment 协议（v0）
+
+- 状态：草案；维护者评审中
+- 跟踪 Issue：[#3836](https://github.com/huangruiteng/loopx/issues/3836)
+- 日期：2026-09-02
+- 范围：多个对等 Agent 围绕同一个共享 Goal 协作，同时保留 canonical
+  intent、每个 Agent 的执行 frontier、claim/lease 所有权，以及可审计的
+  replan/amendment 决策
+- 相关契约：
+  [Goal Vision 与 Replan](../../reference/protocols/goal-vision-replan-contract-v0.md)
+  和
+  [共享控制面 Authority 与可插拔状态 Provider](./shared-goal-authority-state-provider-v0.zh-CN.md)
+- 语言说明：
+  [英文版](./shared-goal-alignment-and-governed-amendment-v0.md)与本中文版是语义镜像；
+  二者存在实质差异即为缺陷。
+
+---
+
+## 1. 摘要与决策
+
+LoopX 将区分四类不能坍缩为一份可变计划的状态：
+
+1. **canonical 共享 Goal intent envelope**；
+2. **共享 eligible work graph**；
+3. 每个已注册 peer 各自的 **per-Agent frontier**；
+4. 用于治理共享 amendment 的 **proposal 与 receipt 记录**。
+
+Agent 可以在 canonical intent 内修正自己的 frontier。当证据推翻共享假设时，
+它可以提出共享 amendment。Proposal 不会改变 Goal、阻塞无关工作，也不会赋予
+提出者单方面 commit authority。只有 LoopX `GoalAmendmentAuthority` 根据预授权 policy
+和精确 base revision 校验、通过 compare-and-set（CAS）提交并生成 durable receipt
+后，共享 amendment 才会生效；此后所有 Agent 都必须把自己的 frontier 重新绑定到
+新的 canonical revision。
+
+正常路径是自动化的，不要求所有 peer 投票，也不要求人审批日常 Goal 演化。
+`peer_v1` 表示执行层级平等，不代表每个 Agent 都能越过 root user intent 或取得新
+permission。Goal 创建时会冻结 `root_intent` 与 amendment-policy envelope。在该
+envelope 内，policy check 以及高风险 class 所需的独立 verifier Agent 授权自动
+commit；超出 envelope 时，旧 Goal 继续有效，proposal 被 reject 或结构化 blocked，
+只有 Goal 显式配置时才升级给人。
+
+```text
+canonical 共享 Goal intent envelope
+  (objective, non-goals, acceptance, permissions, stop conditions, revision)
+                 |
+                 v
+共享 eligible work graph
+                 |
+        +--------+--------+
+        |                 |
+        v                 v
+per-Agent frontier A   per-Agent frontier B
+        |                 |
+claim + lease/fence    claim + lease/fence
+        |                 |
+bounded evidence       bounded evidence
+        +--------+--------+
+                 |
+       lane replan 或 amendment proposal
+                 |
+      自动 policy + 可选 verifier
+                 |
+          base-revision CAS commit
+                 |
+      committed shared amendment + receipt
+                 |
+          每个 frontier rebase 或被 gate
+```
+
+## 2. 问题与当前边界
+
+LoopX 已经能较好地协调执行：
+
+- 已注册 peer identity 与 Agent-scoped Todo lane；
+- 可见、可选择的 unclaimed Todo，以及 work 前必须 claim 的提示；
+- soft claim 与 hard lease/fence 所有权；
+- per-Agent vision 与 checkpoint 状态；
+- typed autonomous-replan obligation 与 settlement；
+- action-scoped cross-owner Todo lifecycle grant；
+- provider-neutral coordination CAS 与 receipt 基础。
+
+[#3693](https://github.com/huangruiteng/loopx/pull/3693) 是这一层的正向、
+边界明确的修复：它避免共享 `Next Action` prose 遮蔽精确 settlement-bound 或当前
+Agent 的 Todo。它没有定义共享 Goal 对齐，也没有定义共享语义 amendment authority。
+
+当多个 Agent 独立发现共享计划或 acceptance boundary 有误时，缺失的 seam 就会
+出现：各个 per-Agent vision 可以各自自洽，但合并后的工作已经无法证明原始 Goal。
+反过来，如果允许每个 Agent 直接重写共享 prose，最后写入者就会意外成为 authority。
+
+类型系统无法证明任意自然语言修改保留了用户原意。LoopX 能做到的是让静默重解释
+变得不可能：amendment 必须说明 retained、changed、stopped，引用 evidence，绑定
+精确 base revision 与 digest，通过显式 authority policy，并留下可恢复 receipt。
+
+## 3. 状态分区与不变量
+
+### 3.1 Canonical intent envelope
+
+`shared_goal_intent_v0` 包含：
+
+- `goal_id`、`goal_revision` 与 `intent_digest`；
+- objective 与 non-goals；
+- acceptance conditions；
+- permission/write scope；
+- stop 与 terminal conditions；
+- Agent 不能 amendment 的 root intent；
+- 治理每种 amendment class 的 authority policy；
+- out-of-policy proposal 的配置处置方式（`reject`、`block` 或显式
+  `human_escalation`）。
+
+它是 semantic authority，不是 status projection。`Next Action`、Agent vision、聊天
+消息、scheduler hint 和 provider head 都不能覆盖它。
+
+### 3.2 Shared work graph
+
+共享 work graph 包含 Todo、dependency、eligibility、blocking gate 和 lifecycle
+state。它描述候选工作，而不是谁现在可以执行。Work-graph 变更必须可追溯到它希望
+推进的 canonical intent revision。
+
+### 3.3 Per-Agent frontier
+
+每个注册 Agent 获得一份有界 `shared_goal_alignment_v0` projection：
+
+- canonical Goal revision/digest；
+- 当前 Agent 的 frontier 与 `based_on_goal_revision`；
+- 它的 claim 与 lease/fence facts；
+- eligible unclaimed work；
+- open lane replan 或 shared amendment obligation；
+- conflict 或 stale-basis facts。
+
+当 route 变更仍在当前 objective、non-goals、acceptance、permission 与 stop
+condition 内，且不修改另一 Agent 已 claim 的工作时，Agent 可以 replan 自己的
+route，而不需要 shared amendment。
+
+### 3.4 Proposal 与 receipt
+
+Proposal 是 advisory、durable input；receipt 证明 canonical transition。二者不能
+互相替代。Pending 或 approved proposal 都不会生效，直到成功的 commit receipt
+明确记录新的 Goal revision。
+
+## 4. Authority matrix
+
+### 4.1 `GoalAmendmentAuthority` 到底是什么
+
+`GoalAmendmentAuthority` 不是人、leader Agent、模型或存储服务。它是 LoopX 对
+canonical Goal amendment 的唯一 typed write boundary。具体实现应拆成：
+
+```text
+proposal + current Goal + policy + lease impact + optional verifier decision
+                                  |
+                                  v
+                 GoalAmendmentAuthority.decide()
+                       reject | needs_rebase | commit
+                                  |
+                                  v
+                  provider CAS + canonical receipt
+```
+
+Decision reducer 执行 deterministic policy、identity、digest、revision 与 impact
+规则。可选 verifier Agent 只为语义问题提供 typed input，不能 commit；transaction
+executor 通过 provider-neutral store 持久化已接受 decision，但不能扩张 decision。
+称它为 authority，含义是所有 canonical writer 都必须经过这个边界，而不是某个高位
+Agent 替 peers 做决定。
+
+### 4.2 Amendment class
+
+| Amendment class | 示例 | Proposal authority | 自动 commit 规则 | Pending 时的默认影响 |
+| --- | --- | --- | --- | --- |
+| `lane_route` | 调整一个 Agent 的未认领本地步骤顺序 | owning Agent | deterministic lane policy | lane 外无影响 |
+| `shared_work_graph` | 新增不改变 intent 的 Todo 或 dependency | registered Agent | policy validation + impact check | 无关工作继续 |
+| `shared_acceptance` | 在 root intent 内细化 acceptance condition 或 non-goal | registered Agent | policy validation + independent verifier Agent | gate 受影响的 acceptance path |
+| `protected_authority` | 取得新 permission 或越出 root intent | registered Agent | 除非 immutable envelope 已精确委托该 class，否则绝不自动 commit | 受影响工作 fail closed |
+
+`GoalAmendmentAuthority` 是正常 commit boundary。Verifier Agent 返回绑定 evidence 的
+typed decision；它不会成为 durable leader，也不能编辑它所验证的 proposal。Policy
+要求独立性时，proposer 与 verifier identity 必须不同。Deterministic check 始终是
+第一道 gate；model judgment 不能覆盖 permission、scope、stop condition 或 stale base。
+
+Scheduler、Supervisor、latest writer、lease holder 或 provider operator 的身份都不
+授予 semantic commit authority。Out-of-policy proposal 会被 reject 或保持结构化
+blocked，旧 Goal 继续运行；只有显式启用 `human_escalation` 才询问人，而不是把每次
+Goal 变更变成人工审批队列。
+
+## 5. Amendment lifecycle：proposal 最终如何生效
+
+```text
+draft -> submitted -> admitted -> policy_check -> verified -> committing
+  |          |            |             |             |
+  +--------> rejected <----+-------------+-------------+
+                             stale/conflict -> needs_rebase
+
+committing --CAS success--> committed + receipt -> frontier reconciliation
+          \--unknown------> ambiguous -> readReceipt/reconcile
+          \--CAS conflict-> needs_rebase
+```
+
+完整生效路径如下：
+
+1. **Propose。** 任一有 proposal 权限的 actor 提交
+   `goal_amendment_proposal_v0`，其中包含 base revision/digest、amendment
+   class、retained/changed/stopped intent、evidence references、affected Todos
+   与关联的 replan obligation。
+2. **Admit。** LoopX 校验 schema、actor identity、有界 evidence pointer、
+   amendment class 与影响范围。Admission 不等于 approve 或 apply。
+3. **Policy decision 与可选 verification。** LoopX 检查 deterministic invariant
+   与预授权 amendment envelope。较高风险但仍在 envelope 内的 class 可调用独立
+   verifier Agent，由其返回绑定精确 proposal digest 的 typed decision。Policy 可以
+   reject 或要求 rebase；verifier decision 不能复用于被编辑过的内容。
+4. **Impact decision。** Commit 前，authority 必须决定如何处理在途 claimed/leased
+   Todo：不受影响、允许基于旧 revision 完成、通过新 fence epoch 显式取消，或由
+   policy 阻塞。Semantic amendment 不能静默使 lease 已授权的工作失效。
+5. **Commit。** `GoalAmendmentAuthority` transaction 带 `operation_id`、期望的
+   `base_goal_revision` 与 `base_intent_digest` 提交 policy-authorized digest，
+   再次校验 policy 并执行一次 CAS。Base 过期时 fail closed。日常 in-envelope
+   amendment 不等待人。
+6. **Receipt。** 同一事务记录 proposal digest、actor、authority source、旧/新
+   revision、retained/changed/stopped delta、evidence references、affected Todos、
+   lease disposition 与精确 replan obligation settlement。
+7. **Reconcile。** Projection 旋转到新 revision。每个 Agent 要么 rebind frontier、
+   要么打开 lane replan，或者在当前工作不兼容时被 gate。旧 revision 上的 semantic
+   write 会被拒绝。
+
+只有第 5 步会让 amendment 成为 canonical。第 6 步保证响应丢失时仍能恢复这一事实；
+第 7 步让它对所有 peer 真正产生运行时影响。
+
+## 6. 提议的 schema
+
+示意 `goal_amendment_proposal_v0`：
+
+```json
+{
+  "schema_version": "goal_amendment_proposal_v0",
+  "proposal_id": "gap_...",
+  "goal_id": "goal-1",
+  "proposer_agent_id": "agent-a",
+  "amendment_class": "shared_acceptance",
+  "base_goal_revision": 17,
+  "base_intent_digest": "sha256:...",
+  "retained": ["original outcome remains unchanged"],
+  "changed": ["acceptance now requires the recovered receipt"],
+  "stopped": [],
+  "evidence_refs": ["evidence:..."],
+  "affected_todo_ids": ["todo-a", "todo-b"],
+  "replan_obligation_id": "replan:..."
+}
+```
+
+示意 `goal_amendment_receipt_v0` 额外包含：
+
+```json
+{
+  "schema_version": "goal_amendment_receipt_v0",
+  "operation_id": "op_...",
+  "proposal_id": "gap_...",
+  "proposal_digest": "sha256:...",
+  "decision": "committed",
+  "authority_actor_id": "goal-amendment-authority",
+  "authority_source": "goal_amendment_policy_v0",
+  "verifier_decision_digest": "sha256:...",
+  "previous_goal_revision": 17,
+  "new_goal_revision": 18,
+  "new_intent_digest": "sha256:...",
+  "lease_dispositions": [],
+  "settled_replan_obligation_id": "replan:..."
+}
+```
+
+只读 `shared_goal_alignment_v0` projection 必须区分 pending、approved、conflicting
+与 committed proposal，不能把任何 pre-commit 状态当成 canonical intent。
+
+## 7. 并发、恢复与多 Agent 行为
+
+同一 base 上可以并存多个 proposal。Policy/verifier decision 与 commit 绑定精确 proposal digest。
+Canonical commit 按 Goal revision 串行化：一个 proposal commit 后，另一个基于旧
+base 的 proposal 进入 `needs_rebase`；绝不静默合并，也不采用 last-writer-wins。
+
+Proposal pending 时，独立 lane work 继续，除非 typed impact gate 明确覆盖该 Todo
+或 acceptance path。Agent 只能通过现有 atomic claim，并在配置要求时获取
+lease/fence 后，才能执行 eligible unclaimed work。提出 proposal 不会预留 Todo，
+拥有 Todo claim 也不会授权 Goal amendment。
+
+如果 provider commit 成功但响应丢失，调用方不会用新 operation identity 盲目重试。
+它使用相同 `operation_id` 调用 `readReceipt`。找到 receipt 即证明 canonical
+revision；receipt 缺失且 head 已变化时必须 reconciliation，不能把 ambiguous 当作
+failure。File、NoKV 或 PostgreSQL 的 provider-specific 行为继续留在
+provider-neutral authority store contract 后面。
+
+## 8. Replan 集成
+
+Replan 在选择 writer 前先分类发现的 gap：
+
+- 完全位于 canonical intent 内的 route correction 打开或结算 Agent-scoped
+  replan obligation；
+- cross-lane dependency/work-graph gap 打开 shared amendment obligation；
+- 会在 root-intent envelope 内改变 acceptance、non-goals 或 operational objective
+  的证据打开 automatically governed amendment obligation；
+- 超出 delegated permission 或 root intent 的变更按配置被 reject 或保持结构化
+  blocked。
+
+每个 obligation 都有 stable id。仅 ACK proposal 不会结算它。Settlement 必须是：
+该精确 obligation 对应的 committed receipt；被 policy 接受的 reject/no-change
+结构化 rationale；或显式保留因果链的 superseding obligation。
+
+Commit 后，`based_on_goal_revision` 已过期的 Agent 可以观察，但在 rebase 或取得
+显式 grandfathered-work disposition 前，不能执行 controlled semantic write。
+这样 shared change 就能连接现有 per-Agent Goal Vision，同时不会把一个 Agent 的
+vision 变成 peer authority。
+
+## 9. Provider 与 projection 边界
+
+Semantic authority 决定 proposal 是否合法、谁可以 commit。File、NoKV 与
+PostgreSQL provider 只持久化 normalized transaction、CAS head 与 receipt；它们不
+解释 Goal prose，也不选择 amendment policy。
+
+本 RFC 的第一个实现切片不扩大当前 coordination aggregate。现有 shared-authority
+RFC 继续拥有 Todo/claim/lease/receipt 持久化。Goal semantic amendment 首先以只读
+projection 与 proposal contract 交付；把 commit 映射进 provider-neutral aggregate
+需要单独评审的 transaction boundary。
+
+`Next Action` 继续是 compatibility prose 与 read projection。它永远不是 claim、
+lease、Goal amendment、replan settlement 或 authority decision。
+
+## 10. 分阶段交付
+
+1. **Stage 0 — characterization 与 RFC。** 记录 own-lane、unclaimed、
+   peer-claimed、replan、并发 proposal 与 in-flight lease 场景。
+2. **Stage 1 — read-only alignment。** 增加 `shared_goal_alignment_v0`，包含
+   canonical revision binding、per-Agent frontier basis、unclaimed work 与
+   drift/conflict facts；不改变 writer。
+3. **Stage 2 — proposal only。** 校验并保留 `goal_amendment_proposal_v0`；
+   proposal 不产生 canonical effect。
+4. **Stage 3 — 一个有界 commit class。** 实现保留 intent 的 shared work-graph
+   amendment 自动治理 commit，覆盖 policy、CAS、receipt、replan settlement 与
+   lease impact。
+5. **Stage 4 — provider-neutral shadow/parity。** 把经过评审的 transaction 映射到
+   file reference provider 与可选 NoKV/PostgreSQL candidate；在不改变默认 authority
+   的情况下比较 projection 与 recovery。
+6. **Stage 5 — TEST ONLY shared canary。** 在 authority-source promotion 前验证两个
+   peer、并发 proposal、unclaimed claim、响应丢失恢复、stale base 与 protected
+   change。
+
+Acceptance 与 operational-objective commit 不是第一个 runtime 切片；它们需要真实
+需求证据和单独评审的 automated policy/verifier contract。Permission 扩张或越出
+root intent 不能自动 commit，除非 Goal 创建时已经精确委托该 class。
+
+## 11. 验证矩阵
+
+测试至少必须证明：
+
+- own-lane replan 不能改变 canonical intent；
+- unclaimed work 可见，但 claim/lease 前不能执行；
+- pending proposal 不影响无关 peer；
+- policy 与 verifier decision 绑定精确 proposal digest；
+- 同一 base 的两个冲突 proposal 最多只能有一个 canonical commit；
+- stale revision/digest commit fail closed；
+- 响应丢失恢复返回原始 receipt；
+- protected change 不能仅凭 proposer、scheduler、lease holder、verifier 或 provider
+  operator 身份提交；
+- 日常 in-envelope amendment 无需人审批即可完成，而 out-of-policy proposal 永不
+  静默扩大 authority；
+- in-flight leased work 获得显式 disposition；
+- canonical revision 改变后，所有 Agent projection 都会 rotate 或 gate。
+
+## 12. 非目标
+
+本版本不定义自动投票或共识、CRDT/offline multi-writer merge、omniscient planner、
+permanent leader、Agent 直写 storage provider、LoopX 状态的广泛迁移，也不允许自动
+越出 immutable root user intent。Human approval 不是正常 amendment lifecycle 的
+必需步骤。
+
+最小有用结果是一份清晰的只读 alignment projection，以及一份显式不具 authority
+的 proposal。只有这条边界在真实多 Agent 工作中证明有价值后，runtime commit 才
+继续推进。


### PR DESCRIPTION
## Summary

- define the missing semantic layer between per-Agent Goal Vision/Replan and provider-neutral shared coordination authority
- separate canonical root intent, the shared work graph, per-Agent frontiers, amendment proposals, and commit receipts
- make routine in-envelope Goal evolution automated through a typed `GoalAmendmentAuthority` policy/CAS boundary, with an optional independent verifier Agent rather than mandatory human approval
- specify unclaimed Todo claiming, concurrent proposal conflicts, in-flight lease disposition, exact replan-obligation settlement, response-loss recovery, and staged delivery
- add semantically mirrored English and Chinese RFCs and index them

## Architectural boundary

[#3693](https://github.com/huangruiteng/loopx/pull/3693) remains a positive Agent-lane recommendation projection fix. This RFC does not turn that read model into shared Goal authority. It composes the existing Goal Vision/Replan and shared state-provider contracts without expanding the current coordination aggregate in the first slice.

Normal amendments inside the immutable root-intent and pre-authorized policy envelope are automatic. Out-of-policy proposals keep the old Goal effective and reject or block structurally; they notify a human only when the Goal explicitly opts into that escalation.

Tracks #3836.

## Validation

- `git diff --check`
- `loopx check --scan-path docs/architecture/rfcs/README.md --scan-path docs/architecture/rfcs/shared-goal-alignment-and-governed-amendment-v0.md --scan-path docs/architecture/rfcs/shared-goal-alignment-and-governed-amendment-v0.zh-CN.md`
- `loopx change-quality verify --goal-id loopx-meta --repo-path . --base-ref origin/main` (`cqr_fd291fecbfc14973145f`)
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (14 selected checks passed; no failures or manual holds)
