### PR TITLE
fix(control-plane): bind semantic replans to turn guards

### DIFF
--- a/loopx/control_plane/quota/heartbeat_receipt.py
+++ b/loopx/control_plane/quota/heartbeat_receipt.py
@@ -95,6 +95,26 @@ def heartbeat_receipt_settlement_replan_obligation_id(
     return identity[1]
 
 
+def heartbeat_receipt_semantic_replan_obligation_id(
+    event: Mapping[str, object] | None,
+) -> str | None:
+    """Return the semantic replan target selected by the original guard.
+
+    This is deliberately separate from the settlement identity: a replan Turn
+    may settle through a concrete Todo while that same guard requires a typed
+    semantic delta for an autonomous replan obligation.
+    """
+
+    if not isinstance(event, Mapping):
+        return None
+    details = event.get("details")
+    if not isinstance(details, Mapping):
+        return None
+    return normalize_todo_replan_obligation_id(
+        details.get("semantic_replan_obligation_id")
+    )
+
+
 def _effective_heartbeat_receipt(
     events: list[dict[str, object]],
 ) -> dict[str, object] | None:
@@ -373,6 +393,13 @@ def heartbeat_receipt_view(
         )
         if workspace_causality:
             receipt["delivery_workspace_causality"] = workspace_causality
+    semantic_replan_obligation_id = (
+        heartbeat_receipt_semantic_replan_obligation_id(event)
+    )
+    if semantic_replan_obligation_id:
+        receipt["semantic_replan_obligation_id"] = (
+            semantic_replan_obligation_id
+        )
     return receipt
 
 

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -34,6 +34,7 @@ QUOTA_SETTLEMENT_READBACK_REQUEST_SCHEMA = (
 QUOTA_SETTLEMENT_READBACK_RESULT_SCHEMA = (
     "loopx_quota_settlement_readback_result_v0"
 )
+SEMANTIC_REPLAN_GUARD_SCHEMA = "semantic_replan_guard_v0"
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +47,7 @@ class QuotaSettlementReadback:
     terminal_closeout: SettlementResult[dict[str, Any]]
     terminal_settlement: SettlementResult[dict[str, Any]]
     workspace_causality: dict[str, str] | None
+    semantic_replan_guard: dict[str, str | None] | None
     writeback_run: dict[str, Any] | None
     spend_run: dict[str, Any] | None
     heartbeat_receipt: dict[str, Any] | None
@@ -102,6 +104,33 @@ def _optional_readback_record(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, Mapping):
         raise RuntimeError("TypeScript quota settlement readback result shape mismatch")
     return dict(value)
+
+
+def _semantic_replan_guard(value: Any) -> dict[str, str | None] | None:
+    guard = _optional_readback_record(value)
+    if guard is None:
+        return None
+    scope = guard.get("scope")
+    selected_obligation_id = guard.get("selected_obligation_id")
+    selected_obligation_is_malformed = (
+        selected_obligation_id is not None
+        and not isinstance(selected_obligation_id, str)
+    )
+    legacy_guard_claims_selection = (
+        scope == "legacy_unscoped" and selected_obligation_id is not None
+    )
+    if (
+        guard.get("schema_version") != SEMANTIC_REPLAN_GUARD_SCHEMA
+        or scope not in {"legacy_unscoped", "turn_guard"}
+        or selected_obligation_is_malformed
+        or legacy_guard_claims_selection
+    ):
+        raise RuntimeError("TypeScript semantic replan guard shape mismatch")
+    return {
+        "schema_version": SEMANTIC_REPLAN_GUARD_SCHEMA,
+        "scope": str(scope),
+        "selected_obligation_id": selected_obligation_id,
+    }
 
 
 def read_heartbeat_settlement(
@@ -168,6 +197,9 @@ def read_heartbeat_settlement(
             {str(key): str(value) for key, value in workspace_causality.items()}
             if workspace_causality is not None
             else None
+        ),
+        semantic_replan_guard=_semantic_replan_guard(
+            payload.get("semantic_replan_guard")
         ),
         writeback_run=_optional_readback_record(payload.get("writeback_run")),
         spend_run=_optional_readback_record(payload.get("spend_run")),

--- a/loopx/control_plane/quota/settlement_cli.py
+++ b/loopx/control_plane/quota/settlement_cli.py
@@ -10,6 +10,9 @@ from ..todos.contract import (
     normalize_todo_id,
     normalize_todo_replan_obligation_id,
 )
+from ..work_items.autonomous_replan_obligation import (
+    replan_obligation_id_from_packet,
+)
 from .effect_program import SettlementIdentity
 from .error_codes import HeartbeatReceiptIdentityConflictError
 from .heartbeat_receipt import (
@@ -294,6 +297,9 @@ def quota_rollout_details(
         if isinstance(payload.get("selected_todo"), Mapping)
         else None
     )
+    semantic_replan_obligation_id = replan_obligation_id_from_packet(
+        payload.get("replan_action_packet")
+    )
     workspace_causality = build_delivery_workspace_causality(selected_todo)
     details: dict[str, object] = {
         "command": "quota",
@@ -305,6 +311,7 @@ def quota_rollout_details(
         "source": payload.get("source") or "",
         "todo_id": todo_id or "",
         "replan_obligation_id": replan_obligation_id or "",
+        "semantic_replan_obligation_id": semantic_replan_obligation_id or "",
         "target_key": payload.get("target_key") or "",
         "successor_todo_ids": ",".join(
             str(successor_id)

--- a/loopx/control_plane/quota/settlement_readback.ts
+++ b/loopx/control_plane/quota/settlement_readback.ts
@@ -34,6 +34,7 @@ export const QUOTA_SETTLEMENT_READBACK_REQUEST_SCHEMA =
   "loopx_quota_settlement_readback_request_v0";
 export const QUOTA_SETTLEMENT_READBACK_RESULT_SCHEMA =
   "loopx_quota_settlement_readback_result_v0";
+export const SEMANTIC_REPLAN_GUARD_SCHEMA = "semantic_replan_guard_v0";
 
 const ROLLOUT_EVENT_SCHEMA_VERSION = "loopx_rollout_event_v0";
 const TURN_INSTANCE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
@@ -200,6 +201,38 @@ function runEffectMatches(
 
 function details(event: JsonObject | null): JsonObject {
   return jsonObject(event?.details) ?? {};
+}
+
+export function projectSemanticReplanGuard(
+  receiptDetails: JsonObject,
+): JsonObject {
+  if (!Object.hasOwn(receiptDetails, "semantic_replan_obligation_id")) {
+    return {
+      schema_version: SEMANTIC_REPLAN_GUARD_SCHEMA,
+      scope: "legacy_unscoped",
+      selected_obligation_id: null,
+    };
+  }
+  const rawObligationId = receiptDetails.semantic_replan_obligation_id;
+  if (rawObligationId === "" || rawObligationId === null) {
+    return {
+      schema_version: SEMANTIC_REPLAN_GUARD_SCHEMA,
+      scope: "turn_guard",
+      selected_obligation_id: null,
+    };
+  }
+  const selectedObligationId = normalizeReplanObligationId(rawObligationId);
+  if (selectedObligationId === null) {
+    throw new EffectRuntimeRequestError(
+      "heartbeat receipt semantic replan guard is malformed",
+      "malformed_settlement_state",
+    );
+  }
+  return {
+    schema_version: SEMANTIC_REPLAN_GUARD_SCHEMA,
+    scope: "turn_guard",
+    selected_obligation_id: selectedObligationId,
+  };
 }
 
 function receiptIdentity(
@@ -639,6 +672,7 @@ function failedReadback(
     terminal_closeout: bundle(terminalFailure),
     terminal_settlement: bundle(downstreamFailure),
     workspace_causality: null,
+    semantic_replan_guard: null,
     writeback_run: null,
     spend_run: null,
     heartbeat_receipt: null,
@@ -731,6 +765,7 @@ export async function readQuotaSettlement(value: unknown): Promise<JsonObject> {
     terminal_closeout: bundle(terminalCloseout),
     terminal_settlement: bundle(terminalSettlement),
     workspace_causality: workspaceCausality,
+    semantic_replan_guard: projectSemanticReplanGuard(receiptDetails),
     writeback_run: writebackRun,
     spend_run: spendRun,
     heartbeat_receipt: heartbeatReceipt,

--- a/loopx/control_plane/work_items/semantic_replan_writeback.py
+++ b/loopx/control_plane/work_items/semantic_replan_writeback.py
@@ -331,8 +331,17 @@ def enforce_open_replan_writeback(
     agent_vision: dict[str, Any] | None = None,
     completion_todo_id: str | None = None,
     completion_turn_key: str | None = None,
+    guard_scoped: bool = False,
+    guard_semantic_replan_obligation_id: str | None = None,
 ) -> dict[str, Any] | None:
-    """Fail closed unless concrete typed evidence satisfies the open replan."""
+    """Fail closed unless concrete typed evidence satisfies the selected replan.
+
+    An exact Turn guard is the authority for work admitted in that Turn. When
+    ``guard_scoped`` is true, a replan obligation applies only if that guard
+    selected its exact generation. A different or newly derived obligation is
+    preserved for the next Turn instead of retroactively rejecting authorized
+    delivery.
+    """
 
     obligation, semantic_delta = qualify_replan_writeback(
         newest_first_runs=newest_first_runs,
@@ -346,6 +355,10 @@ def enforce_open_replan_writeback(
         completion_turn_key=completion_turn_key,
     )
     if not obligation:
+        return None
+    if guard_scoped and str(obligation.get("obligation_id") or "").strip() != str(
+        guard_semantic_replan_obligation_id or ""
+    ).strip():
         return None
     if isinstance(semantic_delta, dict) and semantic_delta.get("accepted") is True:
         return semantic_delta
@@ -378,6 +391,8 @@ def qualify_refresh_replan_writeback(
     agent_id: str,
     dry_run: bool,
     settlement_todo_id: str | None,
+    settlement_guard_scoped: bool,
+    settlement_guard_semantic_replan_obligation_id: str | None,
     newest_first_runs: list[dict[str, Any]],
     state_text: str,
     goal_id: str,
@@ -446,6 +461,10 @@ def qualify_refresh_replan_writeback(
         agent_vision=agent_vision,
         completion_todo_id=completion_todo_id,
         completion_turn_key=completion_turn_key,
+        guard_scoped=settlement_guard_scoped,
+        guard_semantic_replan_obligation_id=(
+            settlement_guard_semantic_replan_obligation_id
+        ),
     )
     if semantic_delta:
         effective_recorded = True

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -103,8 +103,6 @@ BULLET_PREFIX_RE = re.compile(r"^(?:[-*]\s+|\d+[.)]\s+)")
 CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
 REPAIR_NOOP_SCHEMA_VERSION = "repair_noop_v0"
-
-
 def _delivery_workspace_supplement_required(
     *,
     prior_writeback: dict[str, Any],
@@ -865,6 +863,7 @@ def refresh_state_run(
     settlement_result = None
     delivery_workspace_causality = None
     settlement_workspace_requirement = None
+    settlement_readback = None
     if todo_id or normalized_replan_obligation_id or turn_instance_id:
         if not turn_scoped_settlement_qualified:
             raise ValueError(
@@ -1099,6 +1098,12 @@ def refresh_state_run(
         recommendation_resolution["recommended_action_source"]
     )
     requested_classification = classification
+    settlement_replan_guard = (
+        settlement_readback.semantic_replan_guard
+        if settlement_readback is not None
+        and settlement_readback.semantic_replan_guard is not None
+        else {}
+    )
     replan_qualification = qualify_refresh_replan_writeback(
         autonomous_replan_recorded=autonomous_replan_recorded,
         requested_delta_kinds=normalized_repair_delta_kinds,
@@ -1108,6 +1113,16 @@ def refresh_state_run(
         agent_id=normalized_agent_id,
         dry_run=dry_run,
         settlement_todo_id=(settlement_identity.todo_id if settlement_identity else None),
+        settlement_guard_scoped=(
+            settlement_replan_guard.get("scope") == "turn_guard"
+        ),
+        settlement_guard_semantic_replan_obligation_id=(
+            settlement_replan_guard.get("selected_obligation_id")
+            if isinstance(
+                settlement_replan_guard.get("selected_obligation_id"), str
+            )
+            else None
+        ),
         newest_first_runs=newest_first_runs,
         state_text=state_text,
         goal_id=safe_goal_id,

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -15,6 +15,9 @@ from loopx.control_plane.work_items.delivery_outcome import (
     PROGRESS_DELIVERY_OUTCOMES,
     DeliveryOutcome,
 )
+from loopx.control_plane.status.autonomous_replan_projection import (
+    AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
+)
 from loopx.heartbeat_prompt import build_heartbeat_prompt
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -174,6 +177,28 @@ def _classification_count(runtime: Path, classification: str) -> int:
         for line in index_path.read_text(encoding="utf-8").splitlines()
         if json.loads(line).get("classification") == classification
     )
+
+
+def _append_surface_only_runs(runtime: Path, *, count: int) -> None:
+    index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    with index_path.open("a", encoding="utf-8") as handle:
+        for index in range(count):
+            handle.write(
+                json.dumps(
+                    {
+                        "generated_at": (
+                            f"2026-08-13T00:{index:02d}:00+00:00"
+                        ),
+                        "goal_id": GOAL_ID,
+                        "classification": "surface_only_progress",
+                        "agent_id": AGENT_ID,
+                        "progress_scope": "agent_lane",
+                        "delivery_outcome": "surface_only",
+                    }
+                )
+                + "\n"
+            )
 
 
 def _heartbeat_receipt_count(runtime: Path, turn_instance_id: str) -> int:
@@ -1752,6 +1777,133 @@ def test_visible_goal_refresh_and_spend_preserve_selected_todo_causality(
     assert _spend_run_count(runtime) == 1
 
 
+def test_todo_guard_defers_replan_obligation_created_after_admission(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_read_only_todo(project)
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--runtime-profile",
+        "codex_app_ssh_goal",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--begin-turn",
+        "--scan-path",
+        str(project),
+    )
+
+    assert guard_rc == 0, guard
+    receipt = guard["heartbeat_receipt"]
+    assert "semantic_replan_obligation_id" not in receipt
+    identity = receipt["settlement_identity"]
+
+    _append_surface_only_runs(
+        runtime,
+        count=AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
+    )
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--classification",
+        "turn_admitted_progress",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        TODO_ID,
+        "--turn-instance-id",
+        identity["turn_instance_id"],
+        "--no-global-sync",
+        "--suppress-external-sinks",
+    )
+
+    assert refresh_rc == 0, refresh
+    assert refresh["todo_id"] == TODO_ID
+    assert refresh["turn_instance_id"] == identity["turn_instance_id"]
+
+
+def test_legacy_todo_guard_keeps_current_replan_gate_strict(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    _configure_selected_todo_replan_fixture(project, registry_path)
+    _initialize_git_checkout(project)
+    turn_instance_id = "turn-legacy-replan-guard"
+
+    guard_rc, guard = _run_cli(
+        registry_path,
+        runtime,
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+    assert guard_rc == 0, guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+
+    log_path = runtime / "goals" / GOAL_ID / "rollout-event-log.jsonl"
+    events = [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    for event in events:
+        if event.get("event_kind") == "quota_should_run":
+            event["details"].pop("semantic_replan_obligation_id", None)
+    log_path.write_text(
+        "".join(json.dumps(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+    refresh_rc, refresh = _run_cli(
+        registry_path,
+        runtime,
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--todo-id",
+        SELECTED_REPLAN_TODO_ID,
+        "--delivery-workspace-path",
+        str(project),
+        "--delivery-outcome",
+        "outcome_progress",
+        "--classification",
+        "validated_progress",
+        "--progress-result-class",
+        "advanced",
+        "--progress-evidence-id",
+        "evidence:legacy-guard",
+    )
+
+    assert refresh_rc == 1, refresh
+    assert "requires a typed semantic delta" in refresh["error"]
+
+
 def test_visible_goal_unbound_spend_recovers_delivery_after_capability_replan(
     tmp_path: Path,
 ) -> None:
@@ -2652,6 +2804,9 @@ def test_todo_bound_autonomous_replan_uses_one_binding_for_refresh_and_spend(
     assert guard["decision"] == "autonomous_replan_required", guard
     assert guard["selected_todo"]["todo_id"] == SELECTED_REPLAN_TODO_ID
     obligation_id = guard["replan_action_packet"]["obligation_id"]
+    assert guard["heartbeat_receipt"]["semantic_replan_obligation_id"] == (
+        obligation_id
+    )
     cli_channel = guard["interaction_contract"]["cli_channel"]
     contract = cli_channel["replan_settlement_contract"]
     assert contract["settlement_binding"] == {

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -166,6 +166,36 @@ def test_writeback_allowed_when_replan_not_due() -> None:
     _call_gate(runs=_durable_runs(5))
 
 
+def test_turn_guard_without_replan_target_defers_new_obligation() -> None:
+    runs = _durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD)
+
+    semantic_delta = enforce_open_replan_writeback(
+        newest_first_runs=runs,
+        state_text=STATE_TEXT,
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+        guard_scoped=True,
+        guard_semantic_replan_obligation_id=None,
+    )
+
+    assert semantic_delta is None
+
+
+def test_turn_guard_keeps_its_exact_replan_target_strict() -> None:
+    runs = _durable_runs(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD)
+    obligation_id = _current_obligation_id(runs)
+
+    with pytest.raises(ReplanWritebackRejected):
+        enforce_open_replan_writeback(
+            newest_first_runs=runs,
+            state_text=STATE_TEXT,
+            agent_id=AGENT_ID,
+            goal_id=GOAL_ID,
+            guard_scoped=True,
+            guard_semantic_replan_obligation_id=obligation_id,
+        )
+
+
 def _typed_repeat_runs() -> list[dict]:
     """Two consecutive identical blocked observations (external-wait stall).
 

--- a/tests/control_plane_ts/quota_settlement_readback.test.ts
+++ b/tests/control_plane_ts/quota_settlement_readback.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import { settlementIdentity } from "../../loopx/control_plane/effect_program.ts";
 import {
+  projectSemanticReplanGuard,
   QUOTA_SETTLEMENT_READBACK_REQUEST_SCHEMA,
   readQuotaSettlement,
 } from "../../loopx/control_plane/quota/settlement_readback.ts";
@@ -19,6 +20,32 @@ const identity = settlementIdentity({
   agent_id: agentId,
   todo_id: todoId,
   turn_instance_id: turnId,
+});
+
+test("semantic replan guard distinguishes legacy, none, and exact selection", () => {
+  assert.deepEqual(projectSemanticReplanGuard({}), {
+    schema_version: "semantic_replan_guard_v0",
+    scope: "legacy_unscoped",
+    selected_obligation_id: null,
+  });
+  assert.deepEqual(projectSemanticReplanGuard({
+    semantic_replan_obligation_id: "",
+  }), {
+    schema_version: "semantic_replan_guard_v0",
+    scope: "turn_guard",
+    selected_obligation_id: null,
+  });
+  assert.deepEqual(projectSemanticReplanGuard({
+    semantic_replan_obligation_id: "replan-0000000000000001",
+  }), {
+    schema_version: "semantic_replan_guard_v0",
+    scope: "turn_guard",
+    selected_obligation_id: "replan-0000000000000001",
+  });
+  assert.throws(
+    () => projectSemanticReplanGuard({ semantic_replan_obligation_id: "bad" }),
+    /semantic replan guard is malformed/,
+  );
 });
 
 async function fixture(options: {
@@ -191,6 +218,11 @@ test("reads the complete receipt chain and workspace causality once", async () =
   assert.equal((result.terminal_closeout as any).payload.ok, true);
   assert.equal(result.monitor_phase, "settled");
   assert.equal(result.replay_phase, "settled");
+  assert.deepEqual(result.semantic_replan_guard, {
+    schema_version: "semantic_replan_guard_v0",
+    scope: "legacy_unscoped",
+    selected_obligation_id: null,
+  });
   assert.deepEqual(result.workspace_causality, {
     schema_version: "delivery_workspace_causality_v0",
     todo_id: todoId,


### PR DESCRIPTION
## Summary

- persist the semantic replan target selected by the original quota guard separately from its causal Todo settlement binding
- enforce only that exact replan generation during turn-scoped refresh; preserve later or newly derived obligations for the next Turn
- keep unscoped refreshes and legacy guard receipts fail-closed

## Refined design

The original change fixed a real causal race, but did not distinguish an old receipt with no semantic-replan field from a new guard that explicitly selected no replan. Treating both as “no replan” would silently weaken the gate for an in-flight legacy Turn.

The refined implementation makes receipt interpretation a TypeScript-owned three-state contract:

- `legacy_unscoped`: the receipt predates the field, so current strict behavior is preserved;
- `turn_guard` with no selected obligation: a replan created after admission is deferred to the next Turn;
- `turn_guard` with an exact obligation id: that generation remains strict.

Python now consumes this typed readback instead of reinterpreting raw receipt shape. Malformed persisted ids fail closed.

## Independent review / provenance

No linked issue, review discussion, or originating task/thread was present on the PR. The branch and commit are owner-authored, but the exact generation context could not be reconstructed. The change was therefore rebased onto current `main` and reviewed from the current control-plane invariants rather than relying on its original description or local validation claims.

## Validation

- `LOOPX_PYTHON="$PWD/.venv/bin/python" .venv/bin/python -m pytest -q tests/capabilities/test_benchmark_toolkit.py tests/control_plane/test_refresh_state_replan_gate.py tests/control_plane/test_quota_settlement.py tests/control_plane/test_quota_settlement_cli.py` — 215 passed
- `npm run test:control-plane` — 453 passed, 1 skipped (`LOOPX_TEST_POSTGRES_URL` not configured; unrelated PostgreSQL integration)
- `npm run typecheck:control-plane` — passed
- changed Python compile and Ruff checks — passed
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --format json --no-progress` — passed; 17/17 selected canaries, no failures, warnings, or manual holds
- public/private scan — clean; no private state, raw evidence, credentials, local paths, or generated logs in the diff

## Merge decision

The final diff is cohesive, current-main based, backward-compatible, and covered across the causal race, exact-generation strictness, legacy receipts, malformed state, replay, and the broader quota/settlement surface. Owner authorization for self-review/refine/merge was provided in the current task.
