### PR TITLE
docs(benchmark): standardize metric and effort reporting

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -1005,10 +1005,18 @@ wait `blocked`, and do not use the monitor itself as the runnable successor.
 
 A material user update should include the current countable arm and pair coverage,
 aggregate primary metric by arm, binary outcomes when the benchmark exposes them,
-improved/flat/regressed pair counts, and the new causal insight or next probe. Derive
-these score fields from the experiment board or benchmark-owned scoring projection,
-not from raw private evidence. Do not send a repetitive update when no score,
-coverage, direction, insight, or material runner state changed.
+feature and preservation guardrail totals when the benchmark exposes them,
+improved/flat/regressed pair counts, and the new causal insight or next probe.
+When effort stratification is useful, preregister benchmark-appropriate fixed
+boundaries and assign every matched case from the baseline arm's
+`effort.duration_ms`. Reuse that same case bucket for every candidate arm; candidate
+duration must not define difficulty because it is itself a treatment outcome. Per
+bucket, report pair count, primary/binary/feature/preservation metrics, and
+improved/flat/regressed counts. Treat these strata as descriptive sensitivity
+analysis unless the study preregistered a causal subgroup claim. Derive score fields
+from the experiment board or benchmark-owned scoring projection, not from raw
+private evidence. Do not send a repetitive update when no score, coverage,
+direction, insight, or material runner state changed.
 Only public-safe conclusions from the private post-run insight may enter that user
 update; raw evaluation evidence remains private.
 

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -515,9 +515,32 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "matched_pair_count",
                 "aggregate_primary_metric_by_arm",
                 "binary_outcome_by_arm_when_available",
+                "feature_metric_by_arm_when_available",
+                "preservation_guardrail_by_arm_when_available",
                 "improved_flat_regressed_pair_counts",
+                "baseline_effort_strata_when_available",
                 "new_case_insights_and_next_probe",
             ],
+            "effort_stratification": {
+                "default_reference_arm": "baseline",
+                "default_reference_field": "effort.duration_ms",
+                "candidate_duration_affects_bucket": False,
+                "interpretation": "descriptive_sensitivity_only",
+                "report_per_stratum": [
+                    "matched_pair_count",
+                    "binary_outcome_by_arm_when_available",
+                    "aggregate_primary_metric_by_arm",
+                    "feature_metric_by_arm_when_available",
+                    "preservation_guardrail_by_arm_when_available",
+                    "improved_flat_regressed_pair_counts",
+                ],
+                "boundary_policy": (
+                    "Preregister benchmark-appropriate fixed boundaries before "
+                    "reading candidate durations. Use the same baseline-side case "
+                    "bucket for every arm in a matched comparison; never define "
+                    "difficulty from treatment duration."
+                ),
+            },
             "unchanged_policy": (
                 "Do not send a repetitive user update when no score, coverage, "
                 "direction, insight, or material runner state changed."

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -146,9 +146,21 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         "matched_pair_count",
         "aggregate_primary_metric_by_arm",
         "binary_outcome_by_arm_when_available",
+        "feature_metric_by_arm_when_available",
+        "preservation_guardrail_by_arm_when_available",
         "improved_flat_regressed_pair_counts",
+        "baseline_effort_strata_when_available",
         "new_case_insights_and_next_probe",
     ]
+    effort_stratification = reporting["effort_stratification"]
+    assert effort_stratification["default_reference_arm"] == "baseline"
+    assert effort_stratification["default_reference_field"] == (
+        "effort.duration_ms"
+    )
+    assert effort_stratification["candidate_duration_affects_bucket"] is False
+    assert effort_stratification["interpretation"] == (
+        "descriptive_sensitivity_only"
+    )
     assert "Do not send a repetitive" in reporting["unchanged_policy"]
     active = analysis["active_progress_readback"]
     assert active["workspace_basis"] == [


### PR DESCRIPTION
## Summary

- require material benchmark updates to include feature and preservation guardrail metrics when available
- define provider-neutral effort stratification from preregistered fixed boundaries and the baseline-side `effort.duration_ms`
- explicitly forbid treatment duration from defining case difficulty and mark default strata as descriptive sensitivity analysis

## Validation

- `python -m pytest -q tests/capabilities/test_benchmark_toolkit.py` — 94 passed
- `loopx canary premerge --from-git-diff --format json` — 18/18 checks passed; no failures or warnings
- public/private boundary scan — passed

## Manual hold

The canary correctly requests maintainer review because this updates a benchmark evidence/reporting contract. It does not change runners, scoring, task semantics, or launch jobs.
