### PR TITLE
Add SWE-Marathon codex×LoopX evaluation harness

### DIFF
--- a/benchmark/swe-marathon/HARNESS.md
+++ b/benchmark/swe-marathon/HARNESS.md
@@ -1,0 +1,75 @@
+# SWE-Marathon: codex × LoopX evaluation harness
+
+This directory contains the agent adapters, scoring scripts, and skills used to run
+a five-mode comparison of `codex` and LoopX on **SWE-Marathon** (Harbor).
+
+📊 Results, interactive visualization, and per-trial trajectory browser:
+**https://bouwenzhou.github.io/loopx/** (see also the summary in `README.md`).
+
+## The five modes
+
+| mode | role | what it is |
+|---|---|---|
+| `plain` | baseline① | bare codex, objective fixed to `"Finish the task."` |
+| `goal` | baseline② | **codex-native goal** (codex's own goal feature) — not LoopX |
+| `ssh-goal` | LoopX① | codex-native goal + LoopX-rendered goal body / skills, ssh-driven |
+| `codex-cli` | LoopX② | in-container `loopx` CLI renders the goal body (carries claim/lease/peer boilerplate) |
+| `heartbeat` | LoopX③ | heartbeat-driven continuation / unblock + LoopX goal body / skills |
+
+`plain`→`goal` isolates codex-native goal; `goal`→{ssh-goal, codex-cli, heartbeat}
+isolates LoopX's increment on top of codex-native goal.
+
+## Layout
+
+```
+agents/                     # Harbor agent adapters (the treatment definition)
+  codex_loopx_agent.py      #   LoopX treatment: codex-native goal + LoopX skills/CLI/goal-body
+  codex_goal_agent.py       #   codex-native goal baseline
+  native_codex_goal.py      #   codex-native goal turn driver (harness-vendored)
+  codex_offline.py          #   offline/model-only codex runner
+scoring/                    # reporting — reward is binary; partial_score is the main signal
+  _compare.py               #   five-mode comparison table
+  _partial.py               #   continuous-score (partial_score / test pass-rate) table
+  _summarize.py             #   per-mode roll-up
+  _aggregate.py             #   aggregate all trials to a single data.json (feeds the web viz)
+  _extract_traj.py          #   extract per-trial trajectories from codex rollouts
+  _build_viz.py             #   build the self-contained results web page
+skills/                     # the two five-mode benchmark skills (SWE-Marathon, Terminal-Bench 4)
+```
+
+The adapters build on `loopx.capabilities.benchmark_toolkit` and `harbor`. The full run
+orchestration (docker/network/model-gateway wiring) lives in the evaluation harness and
+is environment-specific; it is intentionally **not** included here (it depends on internal
+network topology). These adapters + scoring scripts are the reusable, portable core.
+
+## Scoring conventions (read before interpreting numbers)
+
+- Harbor `reward` is **binary** and mostly 0 under a compressed budget — low signal.
+- Prefer the task-authored **continuous** score `partial_score` (in
+  `/logs/verifier/metrics.json`); `_partial.py` also computes a raw test pass-rate.
+- **Build failures** (Rust-family tasks) zero out `partial_score` at a gate; they are
+  flagged (✗) and **excluded from the reward/partial means** — that is an
+  environment/gate issue, not a capability signal.
+- Per-mode means are computed only over tasks that **all five modes** ran.
+
+These conventions are load-bearing and documented inline in each script (they encode bugs
+that were hit and fixed — e.g. mode-name normalization, job-vs-trial `result.json`,
+half-written `metrics.json` from re-running trials).
+
+## Reproduce the report from a results tree
+
+```bash
+python3 scoring/_aggregate.py    <out_dir> viz/data.json          # aggregate trials
+python3 scoring/_extract_traj.py <out_dir> viz/trajectories       # extract trajectories
+python3 scoring/_build_viz.py    viz/data.json viz/SUMMARY.md viz/index.html
+python3 scoring/_compare.py      <out_dir>                        # terminal comparison table
+```
+
+## Headline finding
+
+Most of the improvement over bare codex (self-completion 0→12/15, partial 0.710→0.767)
+comes from codex's **native goal** feature. The three LoopX modes add only marginal gains
+on top of codex-native goal (partial +0.006 / +0.011 / −0.065) at 30–56% higher cost;
+binary reward moves only for `heartbeat`. A usage-integrity check (in `README.md`)
+separates harness-level LoopX (goal injection + continuation, present in all three LoopX
+modes) from agent-level `loopx` CLI calls (sparse: 1–4 of 15 trials).

--- a/benchmark/swe-marathon/agents/codex_goal_agent.py
+++ b/benchmark/swe-marathon/agents/codex_goal_agent.py
@@ -1,0 +1,487 @@
+"""codex 原生 goal 模式的 harbor agent。
+
+与基线 `CodexOffline` 的**唯一差别**是不用 `codex exec`，改用
+app-server + `thread/goal/set`。其余一切沿用：同一个离线二进制安装、同样的
+provider/auth 配置、同样的 harbor trial 流程、同样的 verifier 调用。
+
+## 为什么必须做成 agent 类而不是脚本
+
+打分要公平，就得走 harbor 原路：同样的 trial 目录结构、同样的
+`continue_until_timeout` 语义、同样的中途/最终 verifier 调用、同样的
+`result.json`。脚本跑出来的东西和基线不可比。
+
+## 为什么不能用 environment.exec
+
+app-server 要持久双向 stdio，而 harbor 的 exec 把 stdin 设成 DEVNULL
+（`docker.py` 里 `stdin=asyncio.subprocess.DEVNULL`）。agent 类本身跑在宿主机，
+所以自己 `docker exec -i` 拿管道，codex 仍然跑在容器内——文件系统语义才对。
+
+## goal 臂相对基线恰好多出三样（不多不少）
+
+  1. 每轮注入的 5338 字符 `<goal_context>`
+  2. `update_goal` 工具
+  3. codex 的自动续跑调度
+
+用法（config.yaml）：
+    agents:
+      - import_path: codex_goal_agent:CodexGoalAgent
+        model_name: openai/gpt-5.5
+        override_timeout_sec: 5400
+        kwargs:
+          reasoning_effort: medium
+"""
+
+import asyncio
+import json
+import os
+import time
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from harbor.agents.installed.codex import EnvironmentPaths
+from harbor.environments.base import BaseEnvironment
+
+from codex_offline import CodexOffline
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from native_codex_goal import (  # noqa: E402
+    NativeGoalConfig,
+    NativeGoalProtocolError,
+    StdioNativeGoalTransport,
+    compact_native_goal_receipt,
+    refresh_native_goal_status,
+    start_native_goal_turn,
+    wait_native_goal_turn,
+)
+
+# objective 用 LoopX 自己的写法（测试夹具与 CLI 测试路径都是这句）。
+#
+# 极简通用、不含任务内容，三条理由：
+#   1. codex 对 objective 有 4000 字符硬上限，46 个任务里 28 个指令超限，
+#      而且超限的恰好是长程硬任务。完整指令走 turn 输入（不受限），一字不删。
+#   2. 逐任务撰写验收标准 = 给 goal 臂一条基线没有的信息通道，
+#      测出来的会是"写标准的水平"而不是 goal 机制的价值。
+#   3. objective 的内容正是 LoopX treatment 臂的变量，基线臂先占了就没得比。
+_OBJECTIVE = "Finish the task."
+
+# goal 的单次时限。harbor 的 agent 基类**没有** _timeout_sec，agent 拿不到自己
+# 的预算，超时是 trial 从外面掐的。所以这里只能给一个略小于 override_timeout_sec
+# (5400) 的值，让内部循环自己抛超时、走到 finally 落 receipt，而不是被外部
+# cancel 掉丢证据。
+#
+# 可用 GOAL_TIMEOUT_SEC 覆盖——冒烟测试要在几分钟内触发超时路径（那条路径正是
+# 之前丢掉 20/27 份 receipt 的地方），不能等 90 分钟。
+#
+# 注意 continue_until_timeout 会多次调 run()，后续阶段的剩余时间递减，这个常量
+# 会大于剩余量——那时仍会被外部掐断，靠 CancelledError 分支兜住。
+_GOAL_TIMEOUT_SEC = float(os.environ.get("GOAL_TIMEOUT_SEC") or 5340.0)
+
+# app-server 读 config.toml，`-c` 那套是给 `codex exec` 的，所以基线用 CLI flag
+# 传的东西这里必须写进文件。内容与基线逐字对应：
+#   web_search="disabled"        基线 build_cli_flags() 里加的
+#   retries 三件套               基线 _RETRY_FLAGS
+# 注意**不写** features.goals——goal 臂就是要它开着。
+#
+# 【踩过的坑】不能像上游那样分两次 `cat >>` 追加。TOML 里 table 头之后的裸键
+# 都归该 table，所以第二段开头的 `web_search = "disabled"` 会变成
+# `model_providers.harbor.web_search`；而再写一次 `[model_providers.harbor]`
+# 是重复声明，直接解析失败。表现是每个 trial 都秒挂在
+# `app_server_request_failed:thread/start`。所以整份文件一次性写出，自己控制顺序。
+_CONFIG_TOML = """\
+web_search = "disabled"
+# 关掉 codex 的**内层**沙箱。容器本身就是隔离边界，再套一层 bubblewrap 只会
+# 在启动时报
+#   Codex's Linux sandbox uses bubblewrap and needs access to create user namespaces.
+# 并让 app-server 的 initialize 握手失败（app_server_request_failed:initialize）。
+# 宿主机 kernel.unprivileged_userns_clone=1，是容器内的 seccomp/apparmor 挡住了
+# user namespace —— 装上 bwrap 二进制并不等于它能用。
+#
+# 这与基线臂的 `codex exec --dangerously-bypass-approvals-and-sandbox` 等价：
+# 两臂都把隔离交给容器，工具面一致。
+sandbox_mode = "danger-full-access"
+# 把任务目录标成受信项目，否则 app-server 启动就报
+#   Project-local config, hooks, and exec policies are disabled ... /app/.codex
+projects."/app" = { trust_level = "trusted" }
+model_provider = "harbor"
+[model_providers.harbor]
+name = "harbor"
+base_url = "${OPENAI_BASE_URL}"
+wire_api = "%(wire_api)s"
+env_key = "OPENAI_API_KEY"
+request_max_retries = 8
+stream_max_retries = 8
+stream_idle_timeout_ms = 300000
+"""
+
+
+class CodexGoalAgent(CodexOffline):
+    # 驱动中的 turn，异常路径也要能落进 receipt（见 _drive 的说明）
+    _turn = None
+
+    @staticmethod
+    def name() -> str:
+        return "codex-goal"
+
+    # ── 容器定位 ──────────────────────────────────────────────────────────
+    def _container_id(self, environment: BaseEnvironment) -> str:
+        """拿到本 trial 的容器 ID。
+
+        harbor 用 docker compose 起容器，project name 是 session_id 消毒后的值、
+        服务名固定 `main`。按 compose 标签查比解析 compose 文件列表稳。
+        """
+        from harbor.environments.docker.docker import (
+            _sanitize_docker_compose_project_name,
+        )
+
+        project = _sanitize_docker_compose_project_name(environment.session_id)
+        out = subprocess.run(
+            ["docker", "ps", "-q",
+             "--filter", f"label=com.docker.compose.project={project}",
+             "--filter", "label=com.docker.compose.service=main"],
+            capture_output=True, text=True, timeout=60,
+        ).stdout.split()
+        if not out:
+            raise RuntimeError(f"找不到 trial 容器（compose project={project}）")
+        return out[0]
+
+    def _container_cwd(self, cid: str) -> str:
+        """任务的工作目录，从容器镜像的 WorkingDir 读。
+
+        【踩过的坑】原来写死 `/app` 兜底。46 个任务镜像里 45 个确实是 /app，
+        但 `tabular-data-feature-covshift` 是 **/workspace**——`docker exec -w /app`
+        直接失败，而且 **docker 把这个错误写到 stdout**：
+
+            OCI runtime exec failed: chdir to cwd ("/app") ... no such file or directory
+
+        于是 stderr 空、stdout 冒出一行非 JSON，撞上 LoopX 的 fail-closed 检查
+        抛 app_server_frame_invalid_json，整个 trial 作废且无从追查（tee 都没
+        执行到，raw stdout 也没有）。基线不受影响，因为上游走 exec_as_agent，
+        用的是容器自己的 WORKDIR。
+        """
+        out = subprocess.run(
+            ["docker", "inspect", "-f", "{{.Config.WorkingDir}}", cid],
+            capture_output=True, text=True, timeout=60,
+        ).stdout.strip()
+        return out or "/app"
+
+    def _user_flag(self, environment: BaseEnvironment) -> list[str]:
+        """任务要求非 root 时，给 `docker exec` 补上 `-u`。
+
+        【公平性缺陷，必须修】上游走 `exec_as_agent`，harbor 会按 task.toml 的
+        `user =` 降权；我这条 `docker exec` 路绕开了它，而 46 个镜像的
+        `Config.User` 全是空 —— 于是**默认以 root 运行**。
+
+        46 个任务里只有 `sudoku-recovery` 设了 `user = "agent"`，它的 task.toml
+        写明这是反作弊基石：非 root 才读不到 /opt/sudoku/private 的 oracle 与
+        密钥、改不了引擎的节奏下限、杀不掉 root daemon。不补这个 flag，
+        goal / LoopX 臂就比基线和 Terminus 多一份权限——本轮审计确认没被利用
+        （敏感路径命中 0），但敞口不能留着。
+        """
+        user = getattr(environment, "default_user", None)
+        return ["-u", str(user)] if user else []
+
+    # ── 环境准备 ──────────────────────────────────────────────────────────
+    async def _prepare(self, environment: BaseEnvironment) -> dict[str, str]:
+        """写 auth.json + config.toml，与上游 Codex.run() 的准备段等价。"""
+        codex_home = self._REMOTE_CODEX_HOME.as_posix()
+        secrets = self._REMOTE_CODEX_SECRETS_DIR.as_posix()
+        auth_path = (self._REMOTE_CODEX_SECRETS_DIR / "auth.json").as_posix()
+        env = {"CODEX_HOME": codex_home}
+
+        await self.exec_as_agent(
+            environment,
+            command=(f'mkdir -p "$CODEX_HOME" {shlex.quote(secrets)} '
+                     f"{shlex.quote(EnvironmentPaths.agent_dir.as_posix())}"),
+            env=env,
+        )
+
+        setup = (
+            f"cat >{shlex.quote(auth_path)} <<EOF\n"
+            '{\n  "OPENAI_API_KEY": "${OPENAI_API_KEY}"\n}\nEOF\n'
+            f'ln -sf {shlex.quote(auth_path)} "$CODEX_HOME/auth.json"\n'
+        )
+        env["OPENAI_API_KEY"] = self._get_env("OPENAI_API_KEY") or ""
+
+        base_url = self._get_env("OPENAI_BASE_URL")
+        if not base_url:
+            raise RuntimeError("OPENAI_BASE_URL 没设，app-server 找不到网关")
+        env["OPENAI_BASE_URL"] = base_url
+        wire_api = self._get_env("CODEX_WIRE_API") or "responses"
+        # `>` 而不是 `>>`：整份一次性写出，避免 table 作用域和重复声明问题
+        setup += (
+            '\ncat >"$CODEX_HOME/config.toml" <<TOML\n'
+            + (_CONFIG_TOML % {"wire_api": wire_api})
+            + "TOML"
+        )
+        await self.exec_as_agent(environment, command=setup, env=env)
+
+        # 前置检查：web_search 没关就中止。信息通道是必须锁死的项，
+        # 静默跑偏比跑失败糟糕得多。
+        check = await self._exec(
+            environment,
+            command=f'grep -c \'^web_search = "disabled"\' "{codex_home}/config.toml"',
+        )
+        if "1" not in (getattr(check, "stdout", "") or ""):
+            raise RuntimeError("config.toml 里 web_search 不是 disabled，中止")
+        return env
+
+    # ── 主流程 ────────────────────────────────────────────────────────────
+    async def run(self, instruction, environment: BaseEnvironment, context) -> None:
+        if not self.model_name:
+            raise ValueError("Model name is required")
+        model = self.model_name.split("/")[-1]
+
+        await self._prepare(environment)
+        cid = self._container_id(environment)
+
+        # 凭证必须在宿主机环境里，才能被 docker exec -e 转发进容器。
+        # 缺了不会报错，只会变成静默空转（见下面 command 里的注释），
+        # 所以在这里硬失败——空转比失败难发现得多。
+        for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
+            if not os.environ.get(key):
+                raise RuntimeError(
+                    f"{key} 不在 harbor 进程的环境里，app-server 拿不到凭证，"
+                    "会静默空转。检查 run_codex.sh 是否 export 了它。"
+                )
+
+        cwd = str(self._resolve_flag_values().get("cwd") or self._container_cwd(cid))
+
+        # treatment 臂（LoopX）在这里装 profile、渲染 goal body。
+        # 基线 goal 臂是空实现，不产生任何行为差异。
+        # instruction 挂到实例上供钩子取用（LoopX 的 --goal-doc 要它）。
+        self._pending_instruction = instruction
+        # 任务要求的运行用户（非 root 时 LoopX 需要把 profile 目录 chown 过去）。
+        self._task_user = getattr(environment, "default_user", None)
+        self._treatment_setup(cid, cwd)
+
+        # app-server 的 stdout 经 tee 留证 + 过滤后才交给 transport。
+        #
+        # 【踩过的坑】LoopX 的 _read_stream 对非 JSON 行是 fail-closed 的：一行
+        # 不合法就抛 app_server_frame_invalid_json，整个 90 分钟的 trial 直接作废
+        # （tabular-data-feature-covshift 就这么丢的，且 stderr 为空、无从还原）。
+        # 协议层严格是对的，但一行杂音不该毁掉一次评测。
+        #
+        # 所以：tee 一份原始 stdout 到容器里留证，再只把 `{` 开头的行喂给
+        # transport。这样既不改 LoopX 的代码，下次出问题也能捞到那行到底是什么。
+        inner = (
+            "codex app-server --listen stdio:// "
+            "--enable goals --enable unified_exec"
+        )
+        piped = (
+            f"{inner} | tee /tmp/goal_raw_stdout.jsonl "
+            "| grep --line-buffered '^{'"
+        )
+        command = [
+            "docker", "exec", "-i",
+            # 【踩过的坑】必须把凭证转发进去。config.toml 里 env_key =
+            # "OPENAI_API_KEY"，基线是靠 exec_as_agent(env=...) 注入的，而
+            # docker exec 这条路绕开了那个机制。漏掉的表现极隐蔽：轮次能起来、
+            # goal_context 能注入，但模型请求根本不发，turn 立刻 complete，
+            # codex 见目标仍 active 又排一轮 —— 每 0.7 秒一圈的死循环，
+            # 1.5 小时空转 17945 轮、0 次 token_count、0 条 error 记录。
+            #
+            # 用裸变量名（不带 =value）让 docker 从宿主机环境转发，
+            # 这样密钥不会出现在进程命令行里被 ps 看到。
+            "-e", "OPENAI_API_KEY",
+            "-e", "OPENAI_BASE_URL",
+            "-e", f"CODEX_HOME={self._REMOTE_CODEX_HOME.as_posix()}",
+        ]
+        # 与基线 exec_as_agent 对齐的降权（详见 _user_flag）。
+        command += self._user_flag(environment)
+        for k, v in self._extra_exec_env().items():
+            command += ["-e", f"{k}={v}"]
+        command += [
+            "-w", cwd,
+            cid,
+            "sh", "-c", piped,
+        ]
+        config = NativeGoalConfig(
+            cwd=cwd,
+            objective=self._objective(),
+            required_skill_ids=self._required_skill_ids(),
+            task_instruction=instruction,   # harbor 已渲染，与基线同一份
+            model=model,
+            effort=str(self._resolve_flag_values().get("reasoning_effort") or "medium"),
+            approval_policy="never",
+            # 基线是 --dangerously-bypass-approvals-and-sandbox，展开就是这个。
+            # 不要用 LoopX 参考实现默认的 workspace-write——那会让 goal 臂弱于基线。
+            sandbox="danger-full-access",
+            token_budget=None,   # 基线没有预算概念，设了就多一个基线没有的机制
+        )
+
+        out_dir = self.logs_dir
+        out_dir.mkdir(parents=True, exist_ok=True)
+        turn = None
+        err_path = out_dir / "goal_app_server.stderr"
+
+        # transport 提到线程外持有：harbor 的超时是从外面掐的（agent 基类没有
+        # _timeout_sec，拿不到自己的预算），被 cancel 时 asyncio.to_thread 里的
+        # 线程不会停，app-server 会一直挂着、receipt 也丢。持有引用才能在
+        # CancelledError 里主动 close()，让线程抛错退出、走到 finally 落 receipt。
+        err = open(err_path, "w")
+        transport = StdioNativeGoalTransport.spawn(
+            command, cwd="/tmp", response_timeout_sec=180, stderr=err
+        )
+        try:
+            turn = await asyncio.to_thread(self._drive, transport, config)
+        # 【踩过的坑】这里**不能**写 `except NativeGoalProtocolError`。
+        # 同名异常类存在两份，来自两个不同模块：
+        #   agents/native_codex_goal.py  ← 符号链接到 wen/loopx 源码树（本文件用）
+        #   loopx.capabilities.benchmark_toolkit.native_codex_goal ← 装在 .venv
+        #     （codex_loopx_agent / codex_plain_appserver 用）
+        # 两者互不为子类。按类捕获的后果是**只对 goal 臂生效**：
+        # goal 臂的超时被吞掉、照常交给 verifier 打分；LoopX 三臂的超时逃到
+        # harbor，被当成基础设施故障 → 重试烧掉 1.5–3 小时 → 最终记成 errored，
+        # 已完成的部分工作全部丢弃、不进评分。
+        # 这是第四次"只打一边"的偏差，方向是压低 treatment 臂。
+        # 超时是长程任务的**正常预算耗尽**，五臂必须一视同仁按部分进度评分。
+        # 改按消息判定：两个类都继承 RuntimeError，消息不匹配的照样重抛。
+        except RuntimeError as exc:
+            if str(exc) != "goal_timeout_before_terminal":
+                raise
+            self.logger.warning("goal 超时终止（预期行为）：%s", exc)
+        except asyncio.CancelledError:
+            self.logger.warning("harbor 掐断了 agent 阶段，关闭 app-server")
+            raise
+        finally:
+            try:
+                transport.close()
+            finally:
+                err.close()
+                self._save_sessions(cid)
+                self._write_receipt(out_dir, self._turn or turn, config)
+                self._assert_not_spinning(self._turn or turn)
+
+    def _drive(self, transport, config):
+        """自己驱动续跑循环，而不是调 run_native_goal_until_terminal。
+
+        【为什么不用现成的】那个函数超时时**抛异常而不返回 turn**，turn 对象
+        在函数内部就丢了。结果是最需要过程证据的场景（长程任务跑满时间）反而
+        什么都留不下——27 个已完成 trial 里 20 个的 receipt 是空壳。
+        这里把 turn 存到 self._turn，异常路径也能落到 receipt 里。
+
+        循环体只有排事件和轮询状态，**不再调 turn/start**——续跑轮次由 codex
+        自己排，这是续跑归属的全部依据，不能自己造轮次。
+        """
+        turn = start_native_goal_turn(transport, config)
+        self._turn = turn
+        deadline = time.monotonic() + _GOAL_TIMEOUT_SEC
+        completed_before = turn.turn_completed_count
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise NativeGoalProtocolError("goal_timeout_before_terminal")
+            try:
+                wait_native_goal_turn(
+                    transport, turn, timeout_sec=remaining,
+                    completed_before=completed_before,
+                )
+            except NativeGoalProtocolError as exc:
+                if str(exc) == "goal_turn_timeout":
+                    raise NativeGoalProtocolError(
+                        "goal_timeout_before_terminal") from exc
+                raise
+            completed_before = turn.turn_completed_count
+            if refresh_native_goal_status(transport, turn) != "active":
+                return turn
+
+    def _save_sessions(self, cid: str) -> None:
+        """把 codex 的 session rollout / goals 库 / 原始 stdout 拷进 /logs/agent。
+
+        上游 Codex.run() 的 finally 里做了拷 sessions 这件事，我覆盖了整个 run()
+        却没带上，导致 46 轮里 27 个已完成 trial 的轨迹**完全没有保存**，
+        而容器随即被删除、永久丢失。
+
+        **故意用同步 subprocess 而不是 await exec_as_agent**：harbor 从外面掐断
+        agent 阶段时（continue_until_timeout 的后续阶段剩余时间 < _GOAL_TIMEOUT_SEC
+        就会发生），finally 里的 await 会在 CancelledError 传播中立刻再次抛出，
+        拷贝根本执行不到——而那恰恰是长程任务最需要留证的场景。
+        同步调用不碰事件循环，取消中照样能跑完。
+        """
+        agent_dir = EnvironmentPaths.agent_dir.as_posix()
+        home = self._REMOTE_CODEX_HOME.as_posix()
+        script = (
+            f'mkdir -p {agent_dir}; '
+            f'if [ -d "{home}/sessions" ]; then '
+            f'  rm -rf {agent_dir}/sessions; cp -R "{home}/sessions" {agent_dir}/sessions; '
+            f'fi; '
+            f'cp "{home}"/goals_1.sqlite* {agent_dir}/ 2>/dev/null; '
+            f'cp /tmp/goal_raw_stdout.jsonl {agent_dir}/ 2>/dev/null; true'
+        )
+        try:
+            subprocess.run(["docker", "exec", cid, "sh", "-c", script],
+                           capture_output=True, timeout=180)
+        except Exception as exc:
+            self.logger.warning("保存 goal 轨迹失败: %s", exc)
+
+    @staticmethod
+    def _assert_not_spinning(turn) -> None:
+        """空转检测：起了很多轮却一个 item 都没产生，说明模型压根没被调到。
+
+        2026-08-23 第二次开跑就栽在这：漏传 OPENAI_API_KEY，轮次能起、
+        goal_context 能注入，但请求不发、turn 立刻 complete、codex 见目标仍
+        active 又排一轮，每 0.7 秒一圈。1.5 小时空转 17945 轮，
+        **没有任何错误记录**，只有会话文件涨到 116MB 才看得出不对。
+
+        与其让它安静地烧满 90 分钟再拿 0 分，不如让这个 trial 明确失败。
+        """
+        if turn is None:
+            return
+        turns = getattr(turn, "turn_started_count", 0) or 0
+        items = getattr(turn, "item_event_count", 0) or 0
+        if turns >= 20 and items == 0:
+            raise RuntimeError(
+                f"goal 空转：起了 {turns} 轮但 item_event_count=0，"
+                "模型未被真正调用（多半是凭证没进到 app-server）"
+            )
+
+    def _write_receipt(self, out_dir: Path, turn, config) -> None:
+        payload = {"objective_source": _OBJECTIVE,
+                   "cwd": config.cwd, "model": config.model,
+                   "effort": config.effort, "sandbox": config.sandbox,
+                   "goal_timeout_sec": _GOAL_TIMEOUT_SEC}
+        if turn is not None:
+            payload.update(compact_native_goal_receipt(turn))
+            # LoopX 臂的解锁次数存在 self._unblock_count 上，compact_native_goal_receipt
+            # 只认 turn 对象、带不出来。不记进 receipt 的话，报分时无法回答
+            # "这个分数用了几次 harness 干预"——那是必须披露的。
+            if getattr(self, "_unblock_count", None) is not None:
+                payload["_unblock_count"] = self._unblock_count
+        else:
+            payload["execution_mode"] = "goal_failed_before_receipt"
+
+        # continue_until_timeout 会多次调 run()，每个阶段一份 receipt。
+        # 只写固定文件名的话后面的阶段会把前面的覆盖掉——实测
+        # langchain-version-migration 跑了 4 个阶段（每阶段模型都宣布 complete，
+        # 前 3 次被中途 verifier 驳回），最后只剩阶段 4 的数据。
+        # 所以逐阶段追加进 jsonl，同时保留 goal_receipt.json 指向最后一个阶段。
+        payload["phase"] = self._phase = getattr(self, "_phase", 0) + 1
+        with (out_dir / "goal_receipts.jsonl").open("a") as fh:
+            fh.write(json.dumps(payload, sort_keys=True, ensure_ascii=False) + "\n")
+        (out_dir / "goal_receipt.json").write_text(
+            json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False)
+        )
+
+    # ── treatment 钩子（基线臂全为空实现，子类覆盖）──────────────────────
+    #
+    # 这四个钩子是 LoopX treatment 臂唯一的接入点。基线 goal 臂走默认实现时
+    # 行为与加钩子之前**逐字节相同**，所以两臂仍然只差 LoopX 那三样东西。
+
+    def _treatment_setup(self, cid: str, cwd: str) -> None:
+        """装 treatment 需要的东西（LoopX profile 等）。基线臂无操作。"""
+        return None
+
+    def _objective(self) -> str:
+        """goal 的 objective。基线臂用 LoopX 夹具的那句极简写法。"""
+        return _OBJECTIVE
+
+    def _required_skill_ids(self) -> tuple:
+        """交给 native_codex_goal 的 skills/list 保真度门禁。基线臂不需要。"""
+        return ()
+
+    def _extra_exec_env(self) -> dict:
+        """追加给 app-server 的环境变量（LoopX 要改 HOME/PATH）。"""
+        return {}

--- a/benchmark/swe-marathon/agents/codex_loopx_agent.py
+++ b/benchmark/swe-marathon/agents/codex_loopx_agent.py
@@ -1,0 +1,595 @@
+"""codex + LoopX treatment 臂的 harbor agent。
+
+继承 `CodexGoalAgent`（codex 原生 goal），在其之上加 LoopX 的三样东西——这正是
+LoopX 自己 `benchmark/deepswe/README.md` 定义的 treatment 与 baseline 的差别：
+
+  1. **skills**：LoopX 的 6 个 skill 装进 app-server 用的 `CODEX_HOME`
+  2. **CLI**：`loopx` 可执行文件进 `PATH`，goal body 里指名的就是它
+  3. **goal body**：objective 从 `"Finish the task."` 换成
+     `loopx heartbeat-prompt --thin` 渲染出的 thin dispatcher
+
+保真度靠 `required_skill_ids` 把关——`native_codex_goal.py` 会在 `thread/start`
+之前发 `skills/list`，codex 没真的发现那些 skill 就直接失败，**一个 token 都不花**。
+README 原话：*"A filesystem check alone is not treatment-fidelity evidence."*
+
+## 为什么 LoopX 要装在容器里
+
+codex 跑在容器内，goal body 让 agent 每轮调 `loopx` CLI 查状态——那个 CLI 必须
+在容器里可执行。所以整个 profile（含 skills、CLI、registry）都装进容器。
+
+## 离线安装怎么做到的
+
+- LoopX `dependencies = []`，零第三方依赖，`install-local.sh` 只拷文件+生成 wrapper，
+  全脚本没有一处网络访问。
+- 但它要求 Python ≥3.11，而 46 个任务镜像里有 5 个是 3.10。所以**统一挂载一份
+  可移植 python**（uv 的 python-build-standalone），46 个容器一视同仁，
+  避免 41/5 两套环境。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+from harbor.environments.base import BaseEnvironment
+
+from codex_goal_agent import CodexGoalAgent, _GOAL_TIMEOUT_SEC
+from loopx.capabilities.benchmark_toolkit.native_codex_goal import (
+    NativeGoalProtocolError,
+)
+
+# 容器内的路径。profile 布局照抄 benchmark_toolkit 的 `_profile_paths()`，
+# 这样 LoopX 自己的 inspect/doctor 逻辑对得上。
+_SRC = "/opt/loopx-src"          # LoopX 源码（docker cp 进去）
+_PY = "/opt/loopx-py"            # 可移植 python
+_NODE = "/opt/loopx-node"        # 可移植 node（doctor 的 TS 运行时必需检查要它）
+_ROOT = "/opt/lxprofile"
+_HOME = f"{_ROOT}/home"
+_CODEX_HOME = f"{_ROOT}/codex-home"
+_BIN = f"{_ROOT}/bin"
+_CLI = f"{_BIN}/loopx"
+_REGISTRY = f"{_ROOT}/registry.json"
+_RUNTIME = f"{_ROOT}/runtime"
+
+_AGENT_ID = "lhtb-agent"
+
+# ── 两个变体开关（env 驱动，同时写进 receipt 以便事后追溯用的是哪一版）────
+#
+# LOOPX_GOAL_DOC=1
+#   bootstrap 时带 --goal-doc <任务原文>。LoopX 文档规定的接入方式是
+#   「--objective 一句话 + --goal-doc 全文」，全文会被登记为 primary
+#   authority source。第一版漏了这个参数，状态文件里明写
+#   "No explicit goal document was provided during bootstrap"，
+#   导致 LoopX 的 Next Action 一直钉在自带的 onboarding 项上、
+#   Progress Ledger 只有 bootstrap 一条，任务进展没沉淀进持久状态。
+#
+#   注意 46 个镜像里只有 6 个自带 /app/instruction.md，所以统一由 agent
+#   把 harbor 传来的 instruction 写进容器，不依赖镜像。
+#
+# LOOPX_GOAL_ID_MODE=task
+#   goal_id 用任务名而不是固定的 lhtb-goal。LoopX 文档只要求 "stable goal id"，
+#   benchmark 相关文档（deepswe README / RFC / 单元测试）**都没有规定**
+#   benchmark 场景该怎么取，所以两种都不违反约定。
+#   固定值的好处是 46 份 goal body 只差 goal-doc 一项；任务名的好处是更贴合
+#   LoopX「一个项目一个持久目标」的语义。
+_GOAL_DOC = bool(os.environ.get("LOOPX_GOAL_DOC"))
+_GOAL_ID_MODE = os.environ.get("LOOPX_GOAL_ID_MODE", "fixed")
+# LOOPX_UNGATED=1 —— 第三版：把前两版自己关掉/卡死的三处打开。
+#
+# 前两版的实测问题（见 LOOPX-DOC-46-RESULTS.md §二之二、§quota 分析）：
+#
+#   ① 待办规划被关掉。bootstrap 带了 `--no-onboarding-scan`，它的 help 原文是
+#      "Skip the fast first-connect repository scan and **todo candidate proposal**"。
+#      于是 LoopX 自己一条候选 todo 都没提，状态文件里那些任务专属 todo 全是模型
+#      运行时自己建的。`terminal_no_followup`（待办队列空）因此成为最大拦截源之一。
+#
+#   ② 人工门禁在无人场景下永不放行。`--codex-app-heartbeat ask` 不预授权；
+#      `coordination.write_scope` 是空的，agent 没有声明过的写权限；实测
+#      `quota should-run` 真实返回里出现 state=operator_gate。
+#
+#   ③ 死锁。goal body 写明第三次相同阻塞轮就 `update_goal status=blocked`，
+#      而「Only user `/goal resume` reactivates it」——benchmark 里没有 user。
+#      v2 有 21/45 个任务、113/417 个阶段（27%）以 blocked 收尾。
+#
+# 三处都用官方 CLI 参数修，不碰 LoopX 渲染出的 goal body，保真度门禁照旧。
+_UNGATED = bool(os.environ.get("LOOPX_UNGATED"))
+
+# ── 三个模式 ────────────────────────────────────────────────────────────────
+# WEN_MODE 选 LoopX README 里 Codex 的哪一行 host（README.md:289-291）。
+# 定义在 wen/modes/profiles.py，这里只取参数，不复制一份枚举。
+import sys as _sys
+_sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from modes.profiles import profile_args as _profile_args, resolve as _resolve_mode  # noqa: E402
+
+_MODE = _resolve_mode(
+    os.environ.get("WEN_MODE", "ssh-goal"),
+    claim_codex_app=bool(os.environ.get("WEN_CLAIM_CODEX_APP")),
+)
+#: 渲染时传给 loopx 的 profile 参数（具名 profile 或 -H/-O/-M 三元组）
+_PROFILE_ARGS = " ".join(_profile_args(_MODE))
+
+_GOAL_DOC_PATH = f"{_ROOT}/goal-doc.md"
+_FIXED_GOAL_ID = "lhtb-goal"
+# 与 benchmark_toolkit 的 NATIVE_CODEX_PROFILE_REQUIRED_SKILL_IDS 对应。
+# 实测 install-local.sh 物化出这 6 个。
+# 技能门禁向上游常量看齐，不写死。
+# 写死过一次 6 个，而 loopx 0.5.3 物化 7 个（多 loopx-benchmark）；
+# 门禁只查那 6 个，于是容器里少装一个技能完全不会被发现。
+# 从 LOOPX_SRC_DIR 读常量，读不到就退回历史的 6 个并在日志里说明。
+def _load_required_skills() -> tuple[str, ...]:
+    src = os.environ.get("LOOPX_SRC_DIR", "")
+    if src and os.path.isdir(src):
+        import sys as _s
+        if src not in _s.path:
+            _s.path.insert(0, src)
+        try:
+            from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
+                NATIVE_CODEX_PROFILE_REQUIRED_SKILL_IDS as _R,
+            )
+            return tuple(_R)
+        except Exception:
+            pass
+    return (
+        "loopx", "loopx-doc-registry", "loopx-pr-program",
+        "loopx-pr-review", "loopx-project", "loopx-self-repair",
+    )
+
+
+_REQUIRED_SKILLS = _load_required_skills()
+
+# `render_native_codex_goal_prompt` 里的同名常量：渲染出的 body 带这个占位符，
+# 必须替换成真实 registry 路径，替换后还要验证占位符确实消失。
+_GLOBAL_REGISTRY_TOKEN = "$HOME/.codex/loopx/registry.global.json"
+
+
+class CodexLoopxAgent(CodexGoalAgent):
+    _loopx_ready = False
+
+    def _bootstrap_gates(self, cwd: str) -> str:
+        """bootstrap 末尾那串门禁/规划相关的参数。
+
+        基准两版（v1/v2）用的是抑制方向的组合，第三版反过来。差别只有这一处，
+        其余（objective、adapter、goal-doc、goal-id）逐字不变。
+        """
+        if not _UNGATED:
+            return "--no-onboarding-scan --codex-app-heartbeat ask"
+        return (
+            # ① 打开 LoopX 自己的首连扫描与候选 todo 提议，并允许自动推进
+            "--accept-onboarding-agent-todos --begin-autonomous-advance "
+            # ② 预授权心跳 + 声明写权限（原来 coordination.write_scope 是空的）
+            f"--codex-app-heartbeat yes --write-scope {cwd}"
+        )
+
+    def _goal_id(self) -> str:
+        """本 trial 的 goal id。
+
+        `LOOPX_GOAL_ID_MODE=task` 时取任务名。trial 目录名形如
+        `<task>__<trialid>`，logs_dir 是 `.../<task>__<trialid>/agent`。
+        LoopX 会把 goal_id 当路径段用，所以只保留安全字符、并保证首字符
+        是字母或数字（`2048` 这类纯数字任务名也合法）。
+        """
+        if _GOAL_ID_MODE != "task":
+            return _FIXED_GOAL_ID
+        raw = self.logs_dir.parent.name.rsplit("__", 1)[0]
+        safe = re.sub(r"[^A-Za-z0-9._-]", "-", raw).strip("-._")
+        return f"{safe}-goal" if safe and safe[0].isalnum() else _FIXED_GOAL_ID
+
+    @staticmethod
+    def name() -> str:
+        return "codex-loopx"
+
+    # ── app-server 要跑在 LoopX profile 的环境里 ──────────────────────────
+    # 覆盖父类的常量，让 config.toml / auth.json 写进 profile 的 CODEX_HOME，
+    # 否则 codex 找不到 skills。
+    @property
+    def _REMOTE_CODEX_HOME(self):  # noqa: N802  (与上游同名)
+        from pathlib import PurePosixPath
+        return PurePosixPath(_CODEX_HOME)
+
+    def _sh(self, cid: str, script: str, env: dict[str, str] | None = None,
+            timeout: int = 600, as_root: bool = False) -> subprocess.CompletedProcess:
+        cmd = ["docker", "exec"]
+        # 默认以任务用户跑，这样 LoopX 写出的 registry / runtime / 状态文件归属
+        # 正确，降权运行的 codex 后续才改得动。只有需要写 /opt 的目录创建和
+        # 权限移交走 as_root=True。
+        if not as_root and getattr(self, "_task_user", None):
+            cmd += ["-u", str(self._task_user)]
+        for k, v in (env or {}).items():
+            cmd += ["-e", f"{k}={v}"]
+        cmd += [cid, "sh", "-c", script]
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+    async def _prepare(self, environment: BaseEnvironment):
+        """先用 root 建好 profile 根目录并移交给任务用户，再走父类准备段。
+
+        【踩过的坑】父类 `_prepare()` 第一件事就是
+        `exec_as_agent('mkdir -p "$CODEX_HOME" ...')`，而我把 CODEX_HOME 挪到了
+        `/opt/lxprofile/codex-home`（codex 必须从 `$CODEX_HOME/skills` 发现那 6 个
+        skill，不放一起过不了保真度门禁）。`/opt` 归 root，于是在
+        `sudoku-recovery`——46 个任务里唯一设 `user = "agent"` 的——直接：
+
+            mkdir: cannot create directory '/opt/lxprofile': Permission denied
+
+        trial 在 setup 阶段就死，一个 token 没花，却被记成 0.000，等于把基础设施
+        失败当成了任务失败（同任务基线 0.429、goal 0.571/0.707）。v1 v2 共用
+        本文件，两轮报错一字不差。
+
+        为什么不把 `_ROOT` 换成 `/tmp`：那会让这一个任务的环境和另外 45 个不同，
+        修公平性的补丁反而制造新的不公平。这里保持路径完全一致，只补权限。
+        """
+        # _drive 破自锁时要用容器 id，但它没有 environment 形参，这里存一份。
+        # 之前直接写 self._environment 导致 'CodexLoopxAgent' object has no
+        # attribute '_environment'，三个 LoopX 臂全挂。
+        self._env_ref = environment
+        self._task_user = getattr(environment, "default_user", None)
+        if self._task_user:
+            cid = self._container_id(environment)
+            r = self._sh(
+                cid,
+                f"mkdir -p {_ROOT} {_SRC} {_PY} {_NODE} && "
+                f"chown -R {self._task_user} {_ROOT} {_SRC} {_PY} {_NODE}",
+                as_root=True, timeout=180,
+            )
+            if r.returncode:
+                raise RuntimeError(
+                    f"以 root 准备 LoopX profile 目录失败: {(r.stderr or r.stdout)[:200]}"
+                )
+            self.logger.info("非 root 任务（user=%s），profile 目录已移交",
+                             self._task_user)
+        return await super()._prepare(environment)
+
+    def _install_env(self) -> dict[str, str]:
+        """照抄 benchmark_toolkit `_formal_install_environment()` 的每一项。
+
+        少一项就可能装成 canary（未验证源码不自动提升为默认），实测过：
+        不设 LOOPX_PROMOTE_DEFAULT=1 就只有 loopx-canary、skills 也不装。
+        """
+        return {
+            "HOME": _HOME, "SHELL": "/bin/sh", "CODEX_HOME": _CODEX_HOME,
+            # node 必须在 PATH 上，doctor 用 shutil.which("node") 找它
+            "PATH": f"{_NODE}/bin:{_BIN}:/usr/local/bin:/usr/bin:/bin",
+            "LOOPX_PYTHON": f"{_PY}/bin/python3",
+            "LOOPX_PROMOTE_DEFAULT": "1",
+            "LOOPX_INSTALL_CANARY": "0",
+            "LOOPX_BIN_DIR": _BIN,
+            "LOOPX_RELEASES_DIR": f"{_ROOT}/releases",
+            "LOOPX_RELEASE_ID": "native-goal-profile",
+            "LOOPX_MAN_ROOT": f"{_ROOT}/man",
+            "LOOPX_MAN_DIR": f"{_ROOT}/man/man1",
+            "LOOPX_SHELL_PROFILE": f"{_HOME}/.profile",
+            "LOOPX_SKILLS_DIR": f"{_CODEX_HOME}/skills",
+            "LOOPX_INSTALL_SLASH_COMMANDS": "0",
+            "LOOPX_INSTALL_OPENCODE": "0",
+            "LOOPX_INSTALL_CLAUDE": "0",
+            "LOOPX_SKILL_DEDUPE_OTHER_ROOT": "0",
+        }
+
+    def _cli_env(self) -> dict[str, str]:
+        return {"HOME": _HOME, "CODEX_HOME": _CODEX_HOME,
+                "PATH": f"{_NODE}/bin:{_BIN}:/usr/local/bin:/usr/bin:/bin"}
+
+    # ── 安装 LoopX profile ────────────────────────────────────────────────
+    def _install_loopx(self, cid: str) -> None:
+        # wen/ 版默认落在本机布局上（原默认是 szh 那台机器的路径）。
+        # env.sh 会显式导出这两个变量，这里的 fallback 只是脱离 env.sh 时的兜底。
+        _wen = Path(__file__).resolve().parent.parent
+        src = os.environ.get("LOOPX_SRC_DIR", str(_wen.parent / "loopx"))
+        py = os.environ.get(
+            "LOOPX_PORTABLE_PYTHON",
+            os.path.expanduser(
+                "~/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu"
+            ),
+        )
+        node = os.environ.get("LOOPX_NODE_DIR", "")
+        if not node or not os.path.isdir(node):
+            raise RuntimeError(
+                "LOOPX_NODE_DIR 没指到可用的 node（>=22.6.0）。0.5.3 的 "
+                "install-local.sh 会跑 doctor --deep，其中 "
+                "typescript_effect_runtime_ready 是必需项，没有 node 就 missing，"
+                "整个 LoopX 安装会中止。"
+            )
+        for host_path, dest in ((src, _SRC), (py, _PY), (node, _NODE)):
+            if not os.path.isdir(host_path):
+                raise RuntimeError(f"LoopX 依赖缺失: {host_path}")
+            r = subprocess.run(["docker", "cp", f"{host_path}/.", f"{cid}:{dest}"],
+                               capture_output=True, text=True, timeout=900)
+            if r.returncode:
+                raise RuntimeError(f"拷贝 {host_path} 失败: {r.stderr[:200]}")
+
+        # `docker cp` 总是以 root 身份写入，非 root 任务上拷完必须再移交一次，
+        # 否则 install-local.sh（降权运行）读不到源码、也写不进 releases。
+        if getattr(self, "_task_user", None):
+            self._sh(cid, f"chown -R {self._task_user} {_SRC} {_PY} {_NODE} {_ROOT}",
+                     as_root=True, timeout=180)
+
+        self._sh(cid, f"mkdir -p {_HOME} {_CODEX_HOME}/skills {_BIN} "
+                      f"{_ROOT}/releases {_ROOT}/man {_RUNTIME}")
+        # 拷进来的源码里可能带着宿主机 pip 留下的 *.egg-info / *.dist-info。
+        # 那是致命污染：0.5.3 的 install-local.sh 会跑一道 RC doctor 深检，
+        # importlib.metadata.distribution("loopx") 会解析到这份树内元数据，
+        # 而 editable/in-tree 构建的 egg-info **不记录 console script**，于是
+        #   distribution_command: {"ok": false, "error": "console_script_not_recorded"}
+        #   loopx installer error: release candidate doctor validation failed
+        # 整个 LoopX 臂装不进去。宿主机上删了 pip 还会再生成，所以在容器侧清，
+        # 不依赖宿主状态。
+        self._sh(cid,
+                 f"find {_SRC} -maxdepth 2 -name '*.egg-info' -o -maxdepth 2 -name '*.dist-info' "
+                 f"| xargs -r rm -rf",
+                 timeout=120)
+
+        r = self._sh(cid, f"bash {_SRC}/scripts/install-local.sh",
+                     env=self._install_env(), timeout=900)
+        if r.returncode:
+            raise RuntimeError(f"LoopX 安装失败: {(r.stderr or r.stdout)[-400:]}")
+
+        # fail-closed：CLI 与 6 个 skill 必须都在，doctor 必须 ok
+        chk = self._sh(cid, f"test -x {_CLI} && ls {_CODEX_HOME}/skills",
+                       env=self._cli_env())
+        missing = [s for s in _REQUIRED_SKILLS if s not in (chk.stdout or "")]
+        if chk.returncode or missing:
+            raise RuntimeError(f"LoopX profile 不完整，缺 skill: {missing}")
+        doc = self._sh(cid, f"{_CLI} --format json doctor --agent-type codex-app-ssh",
+                       env=self._cli_env())
+        try:
+            if not json.loads(doc.stdout).get("ok"):
+                raise ValueError
+        except Exception:
+            raise RuntimeError(f"loopx doctor 未通过: {(doc.stdout or doc.stderr)[:300]}")
+        self.logger.info(f"LoopX profile 就绪（{len(_REQUIRED_SKILLS)} skills + CLI + doctor ok）")
+
+    # ── 注册目标并渲染 goal body ──────────────────────────────────────────
+    def _render_goal_body(self, cid: str, cwd: str, instruction: str = "") -> str:
+        g = (f"{_CLI} --registry {_REGISTRY} --runtime-root {_RUNTIME}")
+        env = self._cli_env()
+        gid = self._goal_id()
+
+        # bootstrap 幂等：registry 已有该目标就跳过。
+        # harbor 的 continue_until_timeout 每阶段都会调 run()，重复 bootstrap
+        # 会被 LoopX 拒绝（它禁止在已有状态上强制 bootstrap）。
+        has = self._sh(cid, f"test -f {_REGISTRY} && grep -q {gid} {_REGISTRY}", env=env)
+        if has.returncode:
+            doc_flag = ""
+            if _GOAL_DOC:
+                # 46 个镜像里只有 6 个自带 instruction.md，所以统一由我们写进去，
+                # 放在 profile 目录而不是任务工作区，避免多给 verifier 一个文件。
+                if not instruction.strip():
+                    raise RuntimeError("LOOPX_GOAL_DOC=1 但 instruction 为空")
+                w = subprocess.run(
+                    ["docker", "exec", "-i", cid, "sh", "-c",
+                     f"cat > {_GOAL_DOC_PATH}"],
+                    input=instruction, text=True, capture_output=True, timeout=120)
+                if w.returncode:
+                    raise RuntimeError(f"写 goal-doc 失败: {w.stderr[:200]}")
+                doc_flag = f" --goal-doc {_GOAL_DOC_PATH}"
+            r = self._sh(cid,
+                         f"cd {cwd} && {g} bootstrap --project . --goal-id {gid} "
+                         f"--objective 'Finish the task.'{doc_flag} "
+                         f"--adapter-kind read_only_project_map_v0 "
+                         f"--adapter-status connected-read-only "
+                         f"{self._bootstrap_gates(cwd)}",
+                         env=env, timeout=300)
+            if r.returncode:
+                raise RuntimeError(f"loopx bootstrap 失败: {(r.stderr or r.stdout)[-300:]}")
+            r = self._sh(cid, f"cd {cwd} && {g} register-agent --goal-id {gid} "
+                              f"--agent-id {_AGENT_ID} --require-new --execute",
+                         env=env, timeout=300)
+            if r.returncode:
+                raise RuntimeError(f"loopx register-agent 失败: {(r.stderr or r.stdout)[-300:]}")
+
+        # ── 每阶段解锁（破死锁）────────────────────────────────────────────
+        # goal body 原文里写着：
+        #   Third identical blocked turn with no progress: call update_goal with
+        #   status=blocked ... **Only user `/goal resume` reactivates it**
+        # benchmark 里没有 user，所以这是个单向阀门。实测 v2 有 21/45 个任务、
+        # 27% 的阶段以 blocked 收尾。这里由 harness 扮演「每阶段来解锁的 operator」，
+        # 用官方 CLI 清掉 waiting_on 并把 agent 置回 active，不碰 goal body。
+        if _UNGATED:
+            self._sh(cid,
+                     f"cd {cwd} && {g} configure-goal --goal-id {gid} "
+                     f"--clear-waiting-on --agent-work-mode {_AGENT_ID}=active --execute",
+                     env=env, timeout=180)
+
+        r = self._sh(cid,
+                     f"cd {cwd} && {g} --format json heartbeat-prompt --thin "
+                     f"--goal-id {gid} --agent-id {_AGENT_ID} "
+                     f"{_PROFILE_ARGS} --cli-bin {_CLI} "
+                     f"--available-capability shell --available-capability filesystem_write",
+                     env=env, timeout=300)
+        # 下面每一条校验都照抄 render_native_codex_goal_prompt()，
+        # 失败码沿用它的命名，方便和 LoopX 自己的实现对照。
+        try:
+            payload = json.loads(r.stdout)
+        except json.JSONDecodeError:
+            raise RuntimeError("goal_prompt_cli_invalid_json")
+        if payload.get("ok") is not True:
+            raise RuntimeError(f"goal_prompt_cli_not_ready: {str(payload.get('error'))[:200]}")
+        if _MODE.runtime_profile and payload.get("runtime_profile") != _MODE.runtime_profile:
+            raise RuntimeError(
+                f"goal_prompt_runtime_profile_mismatch: "
+                f"want={_MODE.runtime_profile} got={payload.get('runtime_profile')}"
+            )
+        budget = payload.get("interface_budget") or {}
+        if budget.get("within_budget") is not True:
+            raise RuntimeError("goal_prompt_interface_budget_invalid")
+        body = payload.get("task_body")
+        if not isinstance(body, str) or not body.strip():
+            raise RuntimeError("goal_prompt_task_body_missing")
+        if _CLI not in body:
+            raise RuntimeError("goal_prompt_installed_cli_not_bound")
+        if _GLOBAL_REGISTRY_TOKEN in body:
+            body = body.replace(_GLOBAL_REGISTRY_TOKEN, _REGISTRY)
+            if _GLOBAL_REGISTRY_TOKEN in body or _REGISTRY not in body:
+                raise RuntimeError("goal_prompt_runtime_registry_not_bound")
+        # codex 的 objective 硬上限 4000；LoopX 的 interface_budget 也按 4000 设计
+        if len(body) > 4000:
+            raise RuntimeError(f"goal body {len(body)} 字符，超过 codex 的 4000 上限")
+        self._goal_body = body
+        self._loopx_variant = {"goal_doc": _GOAL_DOC, "goal_id_mode": _GOAL_ID_MODE,
+                               "goal_id": gid, "ungated": _UNGATED}
+        self.logger.info(
+            "LoopX goal body 已渲染（%d 字符，goal_id=%s，goal_doc=%s，ungated=%s）",
+            len(body), gid, _GOAL_DOC, _UNGATED)
+        return body
+
+    # ── 覆盖父类的四个 treatment 钩子 ─────────────────────────────────────
+    def _treatment_setup(self, cid: str, cwd: str) -> None:
+        # profile 装一次即可；harbor 的 continue_until_timeout 每阶段都会调
+        # run()，但容器不变，所以用实例标志 + 容器内探测双重保险。
+        if not self._loopx_ready:
+            probe = self._sh(cid, f"test -x {_CLI}")
+            if probe.returncode:
+                self._install_loopx(cid)
+            self._loopx_ready = True
+        self._render_goal_body(cid, cwd, self._pending_instruction)
+
+    def _objective(self) -> str:
+        body = getattr(self, "_goal_body", "")
+        if not body:
+            raise RuntimeError("LoopX goal body 未渲染，treatment 未生效")
+        return body
+
+    def _required_skill_ids(self) -> tuple:
+        # 交给 native_codex_goal 的 skills/list 门禁：codex 没真的发现这些
+        # skill 就在 thread/start 之前失败，不花 token。
+        return _REQUIRED_SKILLS
+
+    def _extra_exec_env(self) -> dict:
+        # app-server 必须跑在 profile 的环境里，否则 codex 看不到 skills、
+        # goal body 里指名的 loopx 也不在 PATH 上。
+        return {"HOME": _HOME, "PATH": f"{_BIN}:/usr/local/bin:/usr/bin:/bin"}
+
+
+    # ── 破自锁：blocked 不等于终态 ──────────────────────────────────────────
+    def _restart_turn_same_thread(self, transport, config, turn):
+        """在**已有 thread** 上再起一轮，只发 `turn/start`。
+
+        【为什么不能用 start_native_goal_turn】它内部第一步是 attach_native_goal，
+        而那会重发 `initialize`。同一条 transport 二次 initialize 是协议违规，
+        app-server 直接拒绝：
+
+            Trial ... failed: app_server_request_failed:initialize
+
+        实测代价：kubernetes-rust-rewrite/codex-cli 三次尝试全挂在这里，$0.82 白花。
+        更隐蔽的是**这条路径直到那一刻才第一次被执行到** —— 在此之前 goal 从没
+        真的进过 blocked，receipt 里的解锁数一直是 0，我据此一轮轮报告"自锁未触发、
+        兜底备而未用"。兜底其实是坏的，只是没被叫到。
+
+        turn_params 逐字照抄上游 start_native_goal_turn，只去掉 attach 那一步，
+        保证除"不重新握手"之外语义完全一致。
+        """
+        from loopx.capabilities.benchmark_toolkit.native_codex_goal import (  # noqa: E402
+            NativeGoalProtocolError as _E, _nested,
+        )
+        turn_params = {
+            "threadId": turn.thread_id,
+            "input": [{"type": "text", "text": config.task_instruction}],
+            "cwd": config.cwd,
+            "approvalPolicy": config.approval_policy,
+        }
+        if config.model:
+            turn_params["model"] = config.model
+        if config.effort:
+            turn_params["effort"] = config.effort
+        if config.sandbox_policy is not None:
+            turn_params["sandboxPolicy"] = dict(config.sandbox_policy)
+        turn_result = transport.request("turn/start", turn_params)
+        turn.methods.append("turn/start")
+        rt = _nested(turn_result, "turn")
+        rid = str(rt.get("id") or turn_result.get("turnId") or "")
+        if not rid:
+            raise _E("turn_start_id_missing")
+        turn.turn_id = rid
+        turn.response_turn_id = rid
+        turn.turn_status = str(rt.get("status") or "accepted")
+        return turn
+
+    def _drive(self, transport, config):
+        """在父类续跑循环之上，把 `blocked` 当成可恢复而不是终态。
+
+        父类（codex_goal_agent._drive）的判据是 `status != "active"` 就返回——
+        `blocked` 也满足。而 LoopX 的 goal body 明写：连续三轮相同阻塞就
+        `update_goal status=blocked`，且**只有 user 的 `/goal resume` 能复活它**。
+        benchmark 里没有 user，于是模型一 block，驱动立刻收工。
+
+        实测后果：find-network-alignments/codex-cli 只跑了 7 步、131 个输出 token
+        就以 post_goal_status=blocked、continuation_turn_completed_count=0 结束，
+        而这个 benchmark 单次平均 27.2M token。测到的是自锁，不是 harness 能力。
+
+        LOOPX_UNGATED=1 时由 harness 扮演那个不存在的 operator：清掉 waiting_on、
+        把 agent 置回 active、再起一轮，直到真正终态或预算耗尽。
+        每次解锁都计数并写进 receipt，报分时要能看出用了几次。
+        """
+        from loopx.capabilities.benchmark_toolkit.native_codex_goal import (  # noqa: E402
+            refresh_native_goal_status, start_native_goal_turn, wait_native_goal_turn,
+        )
+        import time as _t
+
+        if not _UNGATED:
+            return super()._drive(transport, config)
+
+        cid = self._container_id(self._env_ref)
+        gid = self._goal_id()
+        env = self._cli_env()
+        cwd = getattr(self, "_workdir", None) or "/app"
+        deadline = _t.monotonic() + _GOAL_TIMEOUT_SEC
+        unblocks = 0
+        max_unblocks = int(os.environ.get("LOOPX_MAX_UNBLOCKS", "8"))
+
+        turn = start_native_goal_turn(transport, config)
+        self._turn = turn
+        completed_before = turn.turn_completed_count
+        while True:
+            remaining = deadline - _t.monotonic()
+            if remaining <= 0:
+                self._unblock_count = unblocks
+                raise NativeGoalProtocolError("goal_timeout_before_terminal")
+            try:
+                wait_native_goal_turn(transport, turn, timeout_sec=remaining,
+                                      completed_before=completed_before)
+            except NativeGoalProtocolError as exc:
+                if str(exc) == "goal_turn_timeout":
+                    self._unblock_count = unblocks
+                    raise NativeGoalProtocolError("goal_timeout_before_terminal") from exc
+                # 【踩过的坑】这条裸 raise 原来不赋值 _unblock_count，于是 receipt 里
+                # 该字段是 None 而不是数字。偏偏这是**最需要证据的**出口：非超时的
+                # 协议错误（实测是 8 次流层重试被 TPM 限流耗尽后抛出的），trial 会
+                # 提前几十分钟死掉。mastodon-clone/ssh-goal 就这么丢了解锁计数，
+                # 排查时只能靠"别的臂都是 0、就它是 -"这个差异反推。
+                # 每条出口都要留下计数，否则出问题的那次恰好没有证据。
+                self._unblock_count = unblocks
+                raise
+            completed_before = turn.turn_completed_count
+            status = refresh_native_goal_status(transport, turn)
+            if status == "active":
+                continue
+            if status != "blocked" or unblocks >= max_unblocks:
+                # 【实测教训】只在循环内判 blocked 是不够的：Goal 常常在 wait 返回、
+                # codex 停止续跑之后才落到 blocked，那时已经走到这个 return。
+                # 实测 ssh-goal cont=3 / codex-cli cont=2 都以 blocked 收尾而
+                # 解锁一次未触发。这里在返回前再兜一次。
+                if status == "blocked" and unblocks < max_unblocks:
+                    unblocks += 1
+                    self.logger.info("收尾时仍 blocked，第 %d 次解锁后重试", unblocks)
+                    self._sh(cid,
+                             f"cd {cwd} && {_CLI} configure-goal --goal-id {gid} "
+                             f"--clear-waiting-on --agent-work-mode {_AGENT_ID}=active "
+                             f"--execute", env=env, timeout=180)
+                    turn = self._restart_turn_same_thread(transport, config, turn)
+                    self._turn = turn
+                    completed_before = turn.turn_completed_count
+                    continue
+                self._unblock_count = unblocks
+                return turn
+            # 扮演 operator：清阻塞、置回 active、再起一轮
+            unblocks += 1
+            self.logger.info("goal 进入 blocked，第 %d 次解锁", unblocks)
+            self._sh(cid,
+                     f"cd {cwd} && {_CLI} configure-goal --goal-id {gid} "
+                     f"--clear-waiting-on --agent-work-mode {_AGENT_ID}=active --execute",
+                     env=env, timeout=180)
+            turn = self._restart_turn_same_thread(transport, config, turn)
+            self._turn = turn
+            completed_before = turn.turn_completed_count

--- a/benchmark/swe-marathon/agents/codex_offline.py
+++ b/benchmark/swe-marathon/agents/codex_offline.py
@@ -1,0 +1,204 @@
+"""离线安装的 Codex agent。
+
+上游 `harbor.agents.installed.codex.Codex.install()` 在容器内 `npm install -g
+@openai/codex`（非 musl 环境还要先装 NVM + Node 22），这需要容器能出公网。
+LHTB 有 22 个任务 `allow_internet=false`，装不上——这正是上一轮 codex-gpt5.5
+只能跑 24 个任务的原因。
+
+但 `@openai/codex` 的 npm 包里带的是一个 **static-pie musl 二进制**，不依赖
+Node、不依赖任何动态库（已在断网容器里验证 `codex --version` 可跑）。所以把
+安装改成"从宿主机拷二进制进去"，就不需要容器出网了。同一个包里还带了 ripgrep，
+一并拷进去（上游 install 也会装 rg）。
+
+除 install() 外一切沿用上游 Codex：同样的 `codex exec` 命令行、同样的
+config.toml / auth.json 处理、同样的轨迹解析。所以这不是另一个 harness，
+只是把"怎么把 codex 放进容器"换了个不需要网的做法。
+
+用法（config.yaml）：
+    agents:
+      - import_path: codex_offline:CodexOffline
+        model_name: openai/gpt-5.5
+需要 PYTHONPATH 指到本文件所在目录，且 CODEX_OFFLINE_DIR 指向存放
+codex / rg 两个二进制的目录（默认见下）。
+"""
+
+import os
+from pathlib import Path
+
+from harbor.agents.installed.base import CliFlag
+from harbor.agents.installed.codex import Codex
+from harbor.environments.base import BaseEnvironment
+
+# wen/ 版默认指向本工作区暂存的二进制（当前 0.151.0）。原值
+# /data/descfly/szh/codex-offline 是 szh 那台机器的路径，本机不存在。
+_DEFAULT_OFFLINE_DIR = str(Path(__file__).resolve().parent.parent / "codex")
+
+# 先落到 /tmp 再 install 到 /usr/local/bin：upload_file 以 root 落盘且不保留
+# 执行位，直接传到 /usr/local/bin 会得到一个不可执行的文件。
+_STAGE_DIR = "/tmp/codex-offline"
+
+# 上游限流会把 agent 打死：2026-08-21 第一次跑 46 全量时，5 个跑完的 trial 里
+# 有 3 个死于
+#   "stream disconnected before completion: Requests have exceeded the throughput
+#    limit on your Provisioned-Managed deployment"
+# nbody 的 todo 只完成 1/5 项就被切断（0.676 vs Terminus 的 0.973）。
+#
+# 【第一次诊断错了，留着当教训】起初以为是"Terminus 配了 num_retries=4 会重试、
+# codex 不重试"，于是把这三个键设成 4。查了才知道 codex 的默认值本来就是
+# request_max_retries=4 / stream_max_retries=5——设成 4 等于没改，stream 那个
+# 还从 5 降到了 4。网关日志也证实 codex 一直在重试：那轮 1721 次调用里 109 次
+# 是 0-token 的失败调用，最惨的一个 session 连续重试 38 次仍然没救回来。
+#
+# 真正的原因是**请求速率**：codex 约 17 次/分（4 路并发），Terminus 只有 2~3 次/分。
+# 同样 4 路并发，codex 的压强是 Terminus 的 5~8 倍，顶穿了 provisioned 部署的吞吐
+# 上限。Terminus 撞不到不是因为它会重试，是因为它根本达不到那个速率。
+#
+# 所以主修法是**降并发**（见 config 里的 n_concurrent_trials），这里只是把重试
+# 抬到默认值以上做兜底——短暂抖动能扛过去，持续超限还是得靠降速率。
+_RETRY_FLAGS = (
+    # codex 0.151.0 起 provider 必须有非空 name，否则起手就是
+    #   Error loading config.toml: model_providers.harbor: provider name must not be empty
+    # harbor 自己生成的 provider 段没写 name（0.147 之前不校验），于是 codex 直接
+    # 退出、连 session 目录都不建，trial 记成 reward=0 —— 看着像模型没做出来，
+    # 其实一个 token 都没花。这一条必须排在其他 harbor provider 覆盖之前。
+    "-c model_providers.harbor.name=harbor"
+    " -c model_providers.harbor.request_max_retries=8"
+    " -c model_providers.harbor.stream_max_retries=8"
+    " -c model_providers.harbor.stream_idle_timeout_ms=300000"
+)
+
+
+class CodexOffline(Codex):
+    # goals 在 0.133.0 里是 stable 且**默认开启**的：模型可以调 create_goal /
+    # get_goal / update_goal，运行时会自动续跑（"Continue working toward the active
+    # thread goal."）直到目标达成或预算耗尽。默认开意味着基线轮不显式关掉的话，
+    # 它自己就带了 goal 模式，三轮就不是三个条件了。
+    # 所以这里做成必须显式声明：基线 goals="false"，goal 轮 goals="true"。
+    CLI_FLAGS = Codex.CLI_FLAGS + [
+        CliFlag(
+            "goals",
+            cli="-c",
+            type="enum",
+            choices=["true", "false"],
+            format="-c features.goals={value}",
+        ),
+        # 模型服务端的 web_search 由**模型侧**执行，不经过容器——internal 网络、
+        # 无默认路由、iptables 对它全部无效。基线轮实测：46 个任务里 6 个用过，
+        # 其中 4 个是断网任务，而 allow_internet=false 是任务作者设的约束。
+        # sokoban 搜关卡答案 22 次、apex-law433 顺着任务反查到 HuggingFace 上的
+        # 源数据集 RUC-AIBOX/Evo-Bench 并试图在里面找答案原文。
+        #
+        # 【键名踩过坑】正确的是 `web_search`，不是 `web_search_mode`。
+        # 后者连同 disabled_tools / tools.web_search / --disable web_search_request
+        # 一共四种写法**codex 都接受但都不生效**——实测同一个必须联网才能答的
+        # 问题，不加开关触发 86 次，四个候选仍触发 46/72/117/52 次。
+        # `web_search="disabled"` 实测触发 0 次，且 agent 会明说
+        # "this session does not have usable web access" 后退回 shell——
+        # **它想用而用不了**，这比计数为 0 更能证明工具真的不在了。
+        CliFlag(
+            "web_search",
+            cli="-c",
+            type="enum",
+            choices=["disabled", "cached", "live"],
+            format='-c web_search="{value}"',
+        ),
+    ]
+
+    @staticmethod
+    def name() -> str:
+        return "codex-offline"
+
+    def version(self) -> str | None:
+        return self._version or "offline"
+
+    def get_version_command(self) -> str | None:
+        # 上游那条命令会先 source nvm；离线安装没有 nvm，直接问二进制。
+        return "/usr/local/bin/codex --version"
+
+    def build_cli_flags(self) -> str:
+        flags = super().build_cli_flags()
+        # 默认关掉模型服务端的 web_search，**对全部 46 个任务一律关闭**。
+        #
+        # 理由是与 Terminus 的信息通道对齐：Terminus 结构上没有这个工具
+        # （46 轮 × 每轮几十个 debug.json 里 `tools` 字段一次都没出现），
+        # 所以留着它就等于给 codex 一条对方没有的信息通道。
+        #
+        # 代价要认：对 24 个 allow_internet=true 的任务，搜索本是正当能力，
+        # 关掉等于让 codex 减配上场——实测 spice-ephemeris 因此从 0.939 掉到 0.030。
+        # 所以这样测出来的是「**限定在 Terminus 同等信息通道下**的对比」，
+        # 而不是「codex 开箱能力」的对比。报告里必须写明这一点。
+        #
+        # 键名是 `web_search` 不是 `web_search_mode`——后者连同 disabled_tools /
+        # tools.web_search / --disable web_search_request 四种写法 codex 都接受
+        # 但都不生效（实测触发 46/72/117/52 次）。只有 web_search="disabled"
+        # 真正关掉：触发 0 次，且 agent 会明说没有可用的 web access 后退回 shell。
+        if "web_search=" not in flags:
+            flags = f'{flags} -c web_search="disabled"'.strip()
+        return f"{flags} {_RETRY_FLAGS}" if flags else _RETRY_FLAGS
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        offline_dir = Path(os.environ.get("CODEX_OFFLINE_DIR", _DEFAULT_OFFLINE_DIR))
+        # wen/codex 顶层的 codex / rg / codex-code-mode-host 都是指向 bin/ 与
+        # codex-path/ 的软链（见 stage_codex_offline.sh）。upload_file 不跟随软链，
+        # 直传会得到 "install: cannot stat ... No such file or directory"，
+        # 所以这里一律 resolve 成真实文件再传。
+        codex_bin = (offline_dir / "codex").resolve()
+        rg_bin = (offline_dir / "rg").resolve()
+        # unified_exec 的 sidecar。**少了它容器里每一次工具调用都失败**，
+        # 而且模型连"把 goal 标成 blocked"都做不到（那也是工具调用），
+        # 结果是跑满预算、零产物、不报错。宿主机上实测空转 47 轮才发现。
+        sidecar_bin = (offline_dir / "codex-code-mode-host").resolve()
+        # 沙箱助手。缺了它 app-server 每次起都报
+        #   "Codex could not find bubblewrap on PATH ... will use the bundled bubblewrap"
+        # 并计入 error_event_count。和当初漏 code-mode sidecar 是同一类错：
+        # vendor 树里有，但上传清单没带上。
+        bwrap_bin = (offline_dir / "codex-resources" / "bwrap")
+        if not codex_bin.is_file():
+            raise FileNotFoundError(
+                f"离线 codex 二进制不存在: {codex_bin}。"
+                " 用 stage_codex_offline.sh 从宿主机的 @openai/codex 包里取出来。"
+            )
+        if not sidecar_bin.is_file():
+            raise FileNotFoundError(
+                f"codex-code-mode-host 不存在: {sidecar_bin}。"
+                " 重跑 stage_codex_offline.sh —— 旧版脚本只抠 codex 和 rg，"
+                " 缺 sidecar 会让容器里的工具面静默全废。"
+            )
+
+        await self.exec_as_root(environment, command=f"mkdir -p {_STAGE_DIR}")
+
+        await environment.upload_file(codex_bin, f"{_STAGE_DIR}/codex")
+        await environment.upload_file(sidecar_bin, f"{_STAGE_DIR}/codex-code-mode-host")
+        if rg_bin.is_file():
+            await environment.upload_file(rg_bin, f"{_STAGE_DIR}/rg")
+        if bwrap_bin.is_file():
+            await environment.upload_file(bwrap_bin, f"{_STAGE_DIR}/bwrap")
+
+        # install 而不是 mv：一步搞定权限位，且目标已存在时直接覆盖。
+        # 顺便把版本和二进制指纹落进 agent 产物目录：上游 codex.py:370 从事件流里
+        # 读 cli_version，但 0.114.0 的 JSON 事件不吐这个字段，harbor 只能记
+        # "unknown"，事后没法从产物反查跑的是哪个版本。
+        await self.exec_as_root(
+            environment,
+            command=(
+                "set -eu; "
+                f"install -m 0755 {_STAGE_DIR}/codex /usr/local/bin/codex; "
+                # sidecar 必须和 codex 同目录：codex 按相对自身的位置找它
+                f"install -m 0755 {_STAGE_DIR}/codex-code-mode-host "
+                "  /usr/local/bin/codex-code-mode-host; "
+                f"if [ -f {_STAGE_DIR}/rg ]; then "
+                f"  install -m 0755 {_STAGE_DIR}/rg /usr/local/bin/rg; "
+                "fi; "
+                f"if [ -f {_STAGE_DIR}/bwrap ]; then "
+                f"  install -m 0755 {_STAGE_DIR}/bwrap /usr/local/bin/bwrap; "
+                "fi; "
+                f"rm -rf {_STAGE_DIR}; "
+                "mkdir -p /logs/agent; "
+                "{ /usr/local/bin/codex --version; "
+                "  md5sum /usr/local/bin/codex /usr/local/bin/codex-code-mode-host; "
+                "} > /logs/agent/codex_version.txt 2>&1; "
+                "cat /logs/agent/codex_version.txt"
+            ),
+        )
+
+        self.logger.info(f"codex 离线安装完成（来源 {offline_dir}，含 code-mode sidecar）")

--- a/benchmark/swe-marathon/agents/native_codex_goal.py
+++ b/benchmark/swe-marathon/agents/native_codex_goal.py
@@ -1,0 +1,740 @@
+"""Reusable Codex app-server Goal runtime for benchmark adapters.
+
+The benchmark harness retains ownership of isolation, environment bridging,
+timeouts, and scoring.  This module owns the native Goal JSON-RPC transaction,
+stdio process transport, event correlation, and public-safe receipts so runner
+implementations do not carry a second copy of that state machine.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import re
+import subprocess
+import threading
+import time
+from collections import Counter, deque
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from hashlib import sha256
+from typing import Any, Protocol, Self, TextIO
+
+
+class NativeGoalProtocolError(RuntimeError):
+    """The app-server exchange did not prove the required Goal transaction."""
+
+
+class NativeGoalTransport(Protocol):
+    def request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def notify(self, method: str, params: Mapping[str, Any]) -> None: ...
+
+
+class NativeGoalEventTransport(NativeGoalTransport, Protocol):
+    def next_event(self, *, timeout_sec: float) -> Mapping[str, Any] | None: ...
+
+
+def _digest(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _nested(value: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    nested = value.get(key)
+    return nested if isinstance(nested, Mapping) else {}
+
+
+def _error_signature(params: Mapping[str, Any]) -> str:
+    error = params.get("error")
+    typed_parts: list[str] = []
+    for container in (params, error):
+        if not isinstance(container, Mapping):
+            continue
+        for key in ("code", "type", "kind"):
+            value = container.get(key)
+            if isinstance(value, (str, int)):
+                normalized = re.sub(r"[^A-Za-z0-9_.:-]", "_", str(value))[:64]
+                typed_parts.append(f"{key}={normalized}")
+    canonical = json.dumps(params, sort_keys=True, default=str)
+    digest = sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    typed = ",".join(dict.fromkeys(typed_parts))
+    return f"{typed},sha256={digest}" if typed else f"sha256={digest}"
+
+
+@dataclass(frozen=True)
+class NativeGoalConfig:
+    cwd: str
+    objective: str
+    task_instruction: str
+    model: str | None = None
+    effort: str | None = None
+    token_budget: int | None = None
+    approval_policy: str = "never"
+    sandbox: str = "workspace-write"
+    sandbox_policy: Mapping[str, Any] | None = None
+    required_skill_ids: tuple[str, ...] = ()
+
+    def validate(self) -> None:
+        if not self.cwd.strip():
+            raise ValueError("cwd must be non-empty")
+        if not self.objective.strip():
+            raise ValueError("objective must be non-empty")
+        if not self.task_instruction.strip():
+            raise ValueError("task_instruction must be non-empty")
+        if self.token_budget is not None and (
+            isinstance(self.token_budget, bool)
+            or not isinstance(self.token_budget, int)
+            or self.token_budget <= 0
+        ):
+            raise ValueError("token_budget must be a positive integer when provided")
+        for skill_id in self.required_skill_ids:
+            if not isinstance(skill_id, str) or not re.fullmatch(
+                r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", skill_id
+            ):
+                raise ValueError("required_skill_ids must contain safe skill ids")
+
+
+@dataclass
+class NativeGoalTurn:
+    thread_id: str
+    turn_id: str
+    response_turn_id: str
+    goal_status: str
+    objective_sha256: str
+    objective_chars: int
+    task_instruction_sha256: str
+    task_instruction_chars: int
+    token_budget_present: bool
+    methods: list[str] = field(default_factory=list)
+    notifications: list[str] = field(default_factory=list)
+    notification_counts: dict[str, int] = field(default_factory=dict)
+    error_signatures: list[str] = field(default_factory=list)
+    event_turn_id_observed: bool = False
+    terminal_event_observed: bool = False
+    turn_status: str = "not_started"
+    post_goal_status: str = ""
+    item_event_count: int = 0
+    error_event_count: int = 0
+    turn_started_count: int = 0
+    turn_completed_count: int = 0
+    goal_status_poll_count: int = 0
+    required_skill_ids: tuple[str, ...] = ()
+    discovered_required_skill_ids: tuple[str, ...] = ()
+    skill_catalog_count: int = 0
+    skill_error_count: int = 0
+
+
+def _read_required_skills(
+    transport: NativeGoalTransport,
+    *,
+    cwd: str,
+    required_skill_ids: tuple[str, ...],
+) -> tuple[tuple[str, ...], int, int]:
+    """Prove required skills through the app-server discovery surface."""
+
+    required = tuple(dict.fromkeys(required_skill_ids))
+    if not required:
+        return (), 0, 0
+    result = transport.request(
+        "skills/list",
+        {"cwds": [cwd], "forceReload": True},
+    )
+    data = result.get("data")
+    if not isinstance(data, list) or not data:
+        raise NativeGoalProtocolError("skills_list_data_missing")
+    matching = [
+        row
+        for row in data
+        if isinstance(row, Mapping) and str(row.get("cwd") or "") == cwd
+    ]
+    if len(matching) != 1:
+        raise NativeGoalProtocolError("skills_list_cwd_mismatch")
+    row = matching[0]
+    errors = row.get("errors")
+    if not isinstance(errors, list):
+        raise NativeGoalProtocolError("skills_list_errors_missing")
+    if errors:
+        raise NativeGoalProtocolError(f"skills_list_errors:{len(errors)}")
+    skills = row.get("skills")
+    if not isinstance(skills, list):
+        raise NativeGoalProtocolError("skills_list_catalog_missing")
+    names = {
+        str(skill.get("name") or "")
+        for skill in skills
+        if isinstance(skill, Mapping) and skill.get("enabled") is not False
+    }
+    missing = [skill_id for skill_id in required if skill_id not in names]
+    if missing:
+        raise NativeGoalProtocolError(
+            "required_skills_missing:" + ",".join(sorted(missing))
+        )
+    return required, len(skills), 0
+
+
+def attach_native_goal(
+    transport: NativeGoalTransport,
+    config: NativeGoalConfig,
+) -> NativeGoalTurn:
+    """Initialize one app-server thread and attach an active native Goal."""
+
+    config.validate()
+    methods: list[str] = []
+
+    transport.request(
+        "initialize",
+        {
+            "clientInfo": {
+                "name": "loopx_benchmark_toolkit",
+                "title": "LoopX Benchmark Toolkit",
+                "version": "0.1.0",
+            },
+            "capabilities": {"experimentalApi": True},
+        },
+    )
+    methods.append("initialize")
+    transport.notify("initialized", {})
+    methods.append("initialized")
+
+    discovered_skills, skill_catalog_count, skill_error_count = _read_required_skills(
+        transport,
+        cwd=config.cwd,
+        required_skill_ids=config.required_skill_ids,
+    )
+    if config.required_skill_ids:
+        methods.append("skills/list")
+
+    thread_params: dict[str, Any] = {
+        "cwd": config.cwd,
+        "sandbox": config.sandbox,
+        "approvalPolicy": config.approval_policy,
+    }
+    if config.model:
+        thread_params["model"] = config.model
+    thread_result = transport.request("thread/start", thread_params)
+    methods.append("thread/start")
+    thread = _nested(thread_result, "thread")
+    thread_id = str(thread.get("id") or thread_result.get("threadId") or "")
+    if not thread_id:
+        raise NativeGoalProtocolError("thread_start_id_missing")
+
+    goal_set: dict[str, Any] = {
+        "threadId": thread_id,
+        "objective": config.objective,
+        "status": "active",
+    }
+    if config.token_budget is not None:
+        goal_set["tokenBudget"] = config.token_budget
+    transport.request("thread/goal/set", goal_set)
+    methods.append("thread/goal/set")
+
+    goal_result = transport.request("thread/goal/get", {"threadId": thread_id})
+    methods.append("thread/goal/get")
+    goal = _nested(goal_result, "goal")
+    if str(goal.get("status") or "") != "active":
+        raise NativeGoalProtocolError("goal_not_active")
+    if str(goal.get("threadId") or "") != thread_id:
+        raise NativeGoalProtocolError("goal_thread_mismatch")
+    if str(goal.get("objective") or "") != config.objective:
+        raise NativeGoalProtocolError("goal_objective_mismatch")
+
+    return NativeGoalTurn(
+        thread_id=thread_id,
+        turn_id="",
+        response_turn_id="",
+        goal_status="active",
+        objective_sha256=_digest(config.objective),
+        objective_chars=len(config.objective),
+        task_instruction_sha256=_digest(config.task_instruction),
+        task_instruction_chars=len(config.task_instruction),
+        token_budget_present=config.token_budget is not None,
+        methods=methods,
+        required_skill_ids=tuple(dict.fromkeys(config.required_skill_ids)),
+        discovered_required_skill_ids=discovered_skills,
+        skill_catalog_count=skill_catalog_count,
+        skill_error_count=skill_error_count,
+    )
+
+
+def start_native_goal_turn(
+    transport: NativeGoalTransport,
+    config: NativeGoalConfig,
+) -> NativeGoalTurn:
+    """Attach an active Goal to a new thread and start one task turn."""
+
+    turn = attach_native_goal(transport, config)
+    turn_params: dict[str, Any] = {
+        "threadId": turn.thread_id,
+        "input": [{"type": "text", "text": config.task_instruction}],
+        "cwd": config.cwd,
+        "approvalPolicy": config.approval_policy,
+    }
+    if config.model:
+        turn_params["model"] = config.model
+    if config.effort:
+        turn_params["effort"] = config.effort
+    if config.sandbox_policy is not None:
+        turn_params["sandboxPolicy"] = dict(config.sandbox_policy)
+    turn_result = transport.request("turn/start", turn_params)
+    turn.methods.append("turn/start")
+    response_turn = _nested(turn_result, "turn")
+    response_turn_id = str(response_turn.get("id") or turn_result.get("turnId") or "")
+    if not response_turn_id:
+        raise NativeGoalProtocolError("turn_start_id_missing")
+    turn.turn_id = response_turn_id
+    turn.response_turn_id = response_turn_id
+    turn.turn_status = str(response_turn.get("status") or "accepted")
+    return turn
+
+
+def observe_native_goal_event(
+    turn: NativeGoalTurn,
+    event: Mapping[str, Any],
+) -> bool:
+    """Apply one app-server notification and return terminal observation state."""
+
+    method = str(event.get("method") or "")
+    params = _nested(event, "params")
+    if not method:
+        event_type = str(event.get("type") or "")
+        payload = _nested(event, "payload")
+        payload_type = str(payload.get("type") or "")
+        method = (
+            f"{event_type}:{payload_type}"
+            if event_type and payload_type
+            else event_type
+        )
+        params = payload
+    if not method:
+        return turn.terminal_event_observed
+
+    turn.notifications.append(method)
+    turn.notification_counts[method] = turn.notification_counts.get(method, 0) + 1
+    event_thread_id = str(params.get("threadId") or "")
+    if event_thread_id and event_thread_id != turn.thread_id:
+        return turn.terminal_event_observed
+    event_turn = _nested(params, "turn")
+    event_turn_id = str(event_turn.get("id") or params.get("turnId") or "")
+
+    if method == "turn/started" and event_turn_id:
+        turn.turn_id = event_turn_id
+        turn.event_turn_id_observed = True
+        turn.turn_status = str(event_turn.get("status") or "inProgress")
+        turn.turn_started_count += 1
+        return False
+    if event_turn_id and event_turn_id != turn.turn_id:
+        return turn.terminal_event_observed
+    if method.startswith(("item/", "response_item:")):
+        turn.item_event_count += 1
+    if method == "error":
+        turn.error_event_count += 1
+        turn.turn_status = "error"
+        if len(turn.error_signatures) < 3:
+            turn.error_signatures.append(_error_signature(params))
+    if method == "turn/completed" or method in {
+        "event_msg:task_complete",
+        "event_msg:task_completed",
+        "event_msg:turn_completed",
+    }:
+        turn.terminal_event_observed = True
+        turn.turn_status = str(event_turn.get("status") or "completed")
+        turn.turn_completed_count += 1
+    return turn.terminal_event_observed
+
+
+def wait_native_goal_turn(
+    transport: NativeGoalEventTransport,
+    turn: NativeGoalTurn,
+    *,
+    timeout_sec: float,
+    completed_before: int | None = None,
+) -> NativeGoalTurn:
+    """Drain events until one more correlated turn reaches a terminal event.
+
+    ``completed_before`` lets a native Goal runtime wait for automatic
+    continuation turns without starting another model turn itself.  Omitting it
+    preserves the single-turn behavior for existing callers.
+    """
+
+    if timeout_sec <= 0:
+        raise ValueError("timeout_sec must be positive")
+    deadline = time.monotonic() + timeout_sec
+    if completed_before is None:
+        if turn.terminal_event_observed:
+            return turn
+        completed_before = turn.turn_completed_count
+    while turn.turn_completed_count <= completed_before:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise NativeGoalProtocolError("goal_turn_timeout")
+        event = transport.next_event(timeout_sec=min(0.25, remaining))
+        if event is not None:
+            observe_native_goal_event(turn, event)
+    return turn
+
+
+def refresh_native_goal_status(
+    transport: NativeGoalTransport,
+    turn: NativeGoalTurn,
+) -> str:
+    """Read the Goal status after a turn and bind it to the same thread."""
+
+    result = transport.request("thread/goal/get", {"threadId": turn.thread_id})
+    turn.methods.append("thread/goal/get")
+    goal = _nested(result, "goal")
+    if str(goal.get("threadId") or "") != turn.thread_id:
+        raise NativeGoalProtocolError("post_goal_thread_mismatch")
+    status = str(goal.get("status") or "")
+    if not status:
+        raise NativeGoalProtocolError("post_goal_status_missing")
+    turn.post_goal_status = status
+    turn.goal_status_poll_count += 1
+    return status
+
+
+def run_native_goal_turn(
+    transport: NativeGoalEventTransport,
+    config: NativeGoalConfig,
+    *,
+    timeout_sec: float,
+) -> NativeGoalTurn:
+    """Execute the complete native Goal transaction over an admitted transport."""
+
+    turn = start_native_goal_turn(transport, config)
+    wait_native_goal_turn(transport, turn, timeout_sec=timeout_sec)
+    refresh_native_goal_status(transport, turn)
+    return turn
+
+
+def run_native_goal_until_terminal(
+    transport: NativeGoalEventTransport,
+    config: NativeGoalConfig,
+    *,
+    timeout_sec: float,
+) -> NativeGoalTurn:
+    """Run one native Goal until its status leaves ``active``.
+
+    Codex may schedule continuation turns while a Goal remains active.  The
+    caller starts exactly one task turn, then keeps draining those correlated
+    continuation events and reading the Goal status under one total timeout.
+    """
+
+    if timeout_sec <= 0:
+        raise ValueError("timeout_sec must be positive")
+    turn = start_native_goal_turn(transport, config)
+    deadline = time.monotonic() + timeout_sec
+    completed_before = turn.turn_completed_count
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise NativeGoalProtocolError("goal_timeout_before_terminal")
+        try:
+            wait_native_goal_turn(
+                transport,
+                turn,
+                timeout_sec=remaining,
+                completed_before=completed_before,
+            )
+        except NativeGoalProtocolError as exc:
+            if str(exc) == "goal_turn_timeout":
+                raise NativeGoalProtocolError("goal_timeout_before_terminal") from exc
+            raise
+        completed_before = turn.turn_completed_count
+        if refresh_native_goal_status(transport, turn) != "active":
+            return turn
+
+
+_StreamItem = Mapping[str, Any] | Exception
+
+
+def _read_stream(stream: TextIO, messages: queue.Queue[_StreamItem]) -> None:
+    try:
+        for line in stream:
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                messages.put(NativeGoalProtocolError("app_server_frame_invalid_json"))
+                continue
+            if not isinstance(message, Mapping):
+                messages.put(NativeGoalProtocolError("app_server_frame_not_object"))
+                continue
+            messages.put(message)
+    finally:
+        messages.put(EOFError("app_server_stream_closed"))
+
+
+class StdioNativeGoalTransport:
+    """Line-delimited JSON-RPC transport backed by a real app-server process."""
+
+    def __init__(
+        self,
+        process: subprocess.Popen[str],
+        *,
+        response_timeout_sec: float = 30,
+    ) -> None:
+        if process.stdin is None or process.stdout is None:
+            raise ValueError("process must expose text stdin and stdout pipes")
+        if response_timeout_sec <= 0:
+            raise ValueError("response_timeout_sec must be positive")
+        self.process = process
+        self.response_timeout_sec = float(response_timeout_sec)
+        self._messages: queue.Queue[_StreamItem] = queue.Queue()
+        self._pending_events: deque[Mapping[str, Any]] = deque()
+        self._next_request_id = 1
+        self._reader = threading.Thread(
+            target=_read_stream,
+            args=(process.stdout, self._messages),
+            daemon=True,
+        )
+        self._reader.start()
+
+    @classmethod
+    def spawn(
+        cls,
+        command: Sequence[str],
+        *,
+        cwd: str,
+        env: Mapping[str, str] | None = None,
+        response_timeout_sec: float = 30,
+        stderr: int | TextIO | None = subprocess.DEVNULL,
+    ) -> StdioNativeGoalTransport:
+        if not command:
+            raise ValueError("command must be non-empty")
+        process = subprocess.Popen(
+            list(command),
+            cwd=cwd,
+            env=dict(env) if env is not None else None,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=stderr,
+            text=True,
+            encoding="utf-8",
+            bufsize=1,
+        )
+        return cls(process, response_timeout_sec=response_timeout_sec)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        self.close()
+
+    def _send(self, message: Mapping[str, Any]) -> None:
+        if self.process.stdin is None or self.process.poll() is not None:
+            raise NativeGoalProtocolError("app_server_stdin_closed")
+        try:
+            self.process.stdin.write(json.dumps(message) + "\n")
+            self.process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise NativeGoalProtocolError("app_server_write_failed") from exc
+
+    def _next_message(self, *, timeout_sec: float) -> Mapping[str, Any] | None:
+        try:
+            message = self._messages.get(timeout=max(0.0, timeout_sec))
+        except queue.Empty:
+            return None
+        if isinstance(message, Exception):
+            raise NativeGoalProtocolError(str(message)) from message
+        return message
+
+    def request(self, method: str, params: Mapping[str, Any]) -> Mapping[str, Any]:
+        request_id = self._next_request_id
+        self._next_request_id += 1
+        self._send({"id": request_id, "method": method, "params": dict(params)})
+        deadline = time.monotonic() + self.response_timeout_sec
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise NativeGoalProtocolError(f"app_server_response_timeout:{method}")
+            message = self._next_message(timeout_sec=remaining)
+            if message is None:
+                if self.process.poll() is not None:
+                    raise NativeGoalProtocolError("app_server_exited_before_response")
+                continue
+            if message.get("id") == request_id:
+                if message.get("error") is not None:
+                    raise NativeGoalProtocolError(f"app_server_request_failed:{method}")
+                result = message.get("result")
+                return result if isinstance(result, Mapping) else {}
+            if message.get("method"):
+                self._pending_events.append(message)
+                continue
+            raise NativeGoalProtocolError("app_server_unexpected_response")
+
+    def notify(self, method: str, params: Mapping[str, Any]) -> None:
+        self._send({"method": method, "params": dict(params)})
+
+    def next_event(self, *, timeout_sec: float) -> Mapping[str, Any] | None:
+        if self._pending_events:
+            return self._pending_events.popleft()
+        message = self._next_message(timeout_sec=timeout_sec)
+        if message is None:
+            if self.process.poll() is not None:
+                raise NativeGoalProtocolError("app_server_exited_before_terminal_event")
+            return None
+        if message.get("method"):
+            return message
+        raise NativeGoalProtocolError("app_server_unexpected_response")
+
+    def close(self) -> None:
+        if self.process.stdin is not None:
+            try:
+                self.process.stdin.close()
+            except OSError:
+                pass
+        if self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=2)
+
+
+def _default_app_server_command(codex_bin: str) -> list[str]:
+    return [
+        codex_bin,
+        "app-server",
+        "--listen",
+        "stdio://",
+        "--enable",
+        "goals",
+    ]
+
+
+def probe_native_goal_process(
+    config: NativeGoalConfig,
+    *,
+    codex_bin: str = "codex",
+    process_command: Sequence[str] | None = None,
+    process_env: Mapping[str, str] | None = None,
+    process_cwd: str | None = None,
+    response_timeout_sec: float = 30,
+) -> NativeGoalTurn:
+    """Exercise a real app-server through Goal attachment without starting a model turn."""
+
+    command = process_command or _default_app_server_command(codex_bin)
+    with StdioNativeGoalTransport.spawn(
+        command,
+        cwd=process_cwd or config.cwd,
+        env=process_env,
+        response_timeout_sec=response_timeout_sec,
+    ) as transport:
+        return attach_native_goal(transport, config)
+
+
+def run_native_goal_process(
+    config: NativeGoalConfig,
+    *,
+    codex_bin: str = "codex",
+    process_command: Sequence[str] | None = None,
+    process_env: Mapping[str, str] | None = None,
+    process_cwd: str | None = None,
+    response_timeout_sec: float = 30,
+    goal_timeout_sec: float = 21_600,
+) -> NativeGoalTurn:
+    """Spawn a real app-server and execute one complete native Goal turn."""
+
+    command = process_command or _default_app_server_command(codex_bin)
+    with StdioNativeGoalTransport.spawn(
+        command,
+        cwd=process_cwd or config.cwd,
+        env=process_env,
+        response_timeout_sec=response_timeout_sec,
+    ) as transport:
+        return run_native_goal_turn(transport, config, timeout_sec=goal_timeout_sec)
+
+
+def run_native_goal_process_until_terminal(
+    config: NativeGoalConfig,
+    *,
+    codex_bin: str = "codex",
+    process_command: Sequence[str] | None = None,
+    process_env: Mapping[str, str] | None = None,
+    process_cwd: str | None = None,
+    response_timeout_sec: float = 30,
+    goal_timeout_sec: float = 21_600,
+) -> NativeGoalTurn:
+    """Spawn app-server and keep the native Goal alive through continuations."""
+
+    command = process_command or _default_app_server_command(codex_bin)
+    with StdioNativeGoalTransport.spawn(
+        command,
+        cwd=process_cwd or config.cwd,
+        env=process_env,
+        response_timeout_sec=response_timeout_sec,
+    ) as transport:
+        return run_native_goal_until_terminal(
+            transport,
+            config,
+            timeout_sec=goal_timeout_sec,
+        )
+
+
+def compact_native_goal_receipt(turn: NativeGoalTurn) -> dict[str, Any]:
+    """Return public-safe transaction evidence without task or response content."""
+
+    counts = turn.notification_counts or dict(Counter(turn.notifications))
+    return {
+        "schema_version": "native_codex_goal_turn_receipt_v0",
+        "thread_id_present": bool(turn.thread_id),
+        "turn_id_present": bool(turn.turn_id),
+        "response_turn_id_present": bool(turn.response_turn_id),
+        "event_turn_id_observed": turn.event_turn_id_observed,
+        "goal_status": turn.goal_status,
+        "post_goal_status": turn.post_goal_status or None,
+        "token_budget_present": turn.token_budget_present,
+        "objective_sha256": turn.objective_sha256,
+        "objective_chars": turn.objective_chars,
+        "task_instruction_sha256": turn.task_instruction_sha256,
+        "task_instruction_chars": turn.task_instruction_chars,
+        "methods": list(turn.methods),
+        "notifications": sorted(set(turn.notifications)),
+        "notification_counts": dict(sorted(counts.items())),
+        "turn_status": turn.turn_status,
+        "terminal_event_observed": turn.terminal_event_observed,
+        "item_event_count": turn.item_event_count,
+        "error_event_count": turn.error_event_count,
+        "turn_started_count": turn.turn_started_count,
+        "turn_completed_count": turn.turn_completed_count,
+        "goal_continuation_turn_completed_count": max(0, turn.turn_completed_count - 1),
+        "goal_status_poll_count": turn.goal_status_poll_count,
+        "required_skill_ids": list(turn.required_skill_ids),
+        "discovered_required_skill_ids": list(turn.discovered_required_skill_ids),
+        "skill_catalog_count": turn.skill_catalog_count,
+        "skill_error_count": turn.skill_error_count,
+        "required_skills_discovered": (
+            turn.discovered_required_skill_ids == turn.required_skill_ids
+            if turn.required_skill_ids
+            else None
+        ),
+        "error_signatures": list(turn.error_signatures),
+        "public_boundary": {
+            "raw_objective_recorded": False,
+            "raw_task_instruction_recorded": False,
+            "raw_assistant_message_recorded": False,
+            "raw_tool_events_recorded": False,
+            "credentials_recorded": False,
+            "local_paths_recorded": False,
+        },
+    }
+
+
+__all__ = [
+    "NativeGoalConfig",
+    "NativeGoalEventTransport",
+    "NativeGoalProtocolError",
+    "NativeGoalTransport",
+    "NativeGoalTurn",
+    "StdioNativeGoalTransport",
+    "attach_native_goal",
+    "compact_native_goal_receipt",
+    "observe_native_goal_event",
+    "probe_native_goal_process",
+    "refresh_native_goal_status",
+    "run_native_goal_process",
+    "run_native_goal_process_until_terminal",
+    "run_native_goal_turn",
+    "run_native_goal_until_terminal",
+    "start_native_goal_turn",
+    "wait_native_goal_turn",
+]

--- a/benchmark/swe-marathon/runtime/RUNTIME.md
+++ b/benchmark/swe-marathon/runtime/RUNTIME.md
@@ -1,0 +1,51 @@
+# SWE-Marathon runtime: mode framework + automation driver
+
+The **automation-driven continuation loop** used by the codex×LoopX comparison. This is
+what makes the `heartbeat` mode the most robust of the LoopX modes: an external driver
+owns the wakeups, so turn boundaries are guaranteed by the driver instead of by a human
+(codex-cli TUI) or by Codex's own visible-Goal loop (ssh-goal).
+
+## Why automation-driven is the stable path
+
+In the eval, `heartbeat` solved tasks that `codex-cli` churned on. Root cause: the
+`codex_cli` profile omits `--begin-turn` (it assumes a human starts each turn in the TUI),
+so run **unattended** its continuation loop degenerates — the agent is re-woken but does
+almost no real work (e.g. 11 wakeups / 13 tool calls, ends `blocked`). The automation
+driver here supplies clean turn boundaries itself (`--turn-instance-id` per turn +
+`quota should-run` guard), so every wakeup does real work.
+
+## Layout
+
+```
+runtime/
+  modes/
+    profiles.py          # declarative Mode table: ssh-goal / codex-cli / heartbeat
+                         #   (runtime_profile, host_surface, continuation owner, guard flags)
+    run_mode.py          # CLI entry: pick a mode, install profile, run a session
+    session.py           # session lifecycle over the mode
+    codex_host.py        # host wiring
+    profile_install.py   # installs the loopx runtime profile / skills into CODEX_HOME
+  turn/
+    loopx_turn_runner.py # THE automation driver: per-turn loop with --turn-instance-id,
+                         #   quota should-run guard, turn timeout, HEAD-moved progress check
+    loopx_native_codex.py# native-codex turn driver
+    goal_codex.py        # visible-Goal turn driver (ssh-goal / codex-cli)
+    codex_nosandbox_wrapper.py
+```
+
+## The three modes (from `modes/profiles.py`)
+
+| mode | runtime_profile | continuation owner | notes |
+|---|---|---|---|
+| `ssh-goal` | `codex_app_ssh_goal` | Codex (visible Goal) | guard carries `--begin-turn`; native unattended path |
+| `codex-cli` | `codex_cli` | Codex (visible Goal) | guard has **no** `--begin-turn` (human-attended TUI by design) |
+| `heartbeat` | `generic_cli` | **driver** (this runtime) | driver owns wakeups via `--turn-instance-id`; **most robust unattended** |
+
+## Dependencies
+
+- `loopx.capabilities.benchmark_toolkit` (native_codex_goal / native_codex_profile) — upstream.
+- The trial/agent framework (`harbor` / `pier`) providing the environment + installed Codex agent.
+- Knobs via env, e.g. `MR_LOOPX_TURN_TIMEOUT` (per-turn timeout seconds, default 1200).
+
+No internal network topology or credentials are embedded; environment-specific wiring
+(gateways, proxies) lives outside this runtime and is supplied via env.

--- a/benchmark/swe-marathon/runtime/modes/codex_host.py
+++ b/benchmark/swe-marathon/runtime/modes/codex_host.py
@@ -1,0 +1,189 @@
+"""用 codex app-server 承载一轮 Goal。
+
+三种模式共用这一个 host：LoopX 渲染出的 task_body 作为 Goal objective 送进
+app-server 的 Goal 事务，Codex 执行。模式差别在于**谁拥有续跑**：
+
+  continuation_owner="codex"   —— visible Goal，起首轮后 Codex 自己续跑到终态，
+                                  驱动只观察（run_until_terminal）。
+  continuation_owner="driver"  —— 心跳，每次唤醒是全新一轮，驱动起完这轮就收，
+                                  下次 tick 用新的 body 再起（run_single_turn）。
+
+Goal 状态机本身不在这里实现：直接用 benchmark_toolkit 里那份安装态运行时，
+上游 benchmark/deepswe/README.md 明确要求适配器 import 它而不是抄第二份。
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loopx.capabilities.benchmark_toolkit.native_codex_goal import (
+    NativeGoalConfig,
+    NativeGoalDeadlineExceeded,
+    NativeGoalProtocolError,
+    StdioNativeGoalTransport,
+    compact_native_goal_receipt,
+    probe_native_goal_process,
+    refresh_native_goal_status,
+    start_native_goal_turn,
+    wait_native_goal_turn,
+)
+
+from .profiles import Mode
+
+
+class HostError(RuntimeError):
+    """app-server 那一侧没能按契约走完。"""
+
+
+def app_server_command(codex_bin: str) -> list[str]:
+    """起 app-server 的 argv。
+
+    两个 feature 都要开：goals 是 Goal 事务本身，unified_exec 是工具面。基线臂
+    也开 unified_exec，两臂工具面必须一致，否则比的是工具不是 harness。
+    """
+
+    return [
+        codex_bin,
+        "app-server",
+        "--listen", "stdio://",
+        "--enable", "goals",
+        "--enable", "unified_exec",
+    ]
+
+
+@dataclass
+class CodexHost:
+    """把一个 task_body 交给 codex 跑。"""
+
+    codex_bin: str
+    mode: Mode
+    model: str | None = None
+    effort: str | None = None
+    """推理档位，进 turn/start 的 turn_params.effort（native_codex_goal.py:277）。"""
+    sandbox: str = "danger-full-access"
+    required_skill_ids: tuple[str, ...] = ()
+    response_timeout_sec: float = 60.0
+    goal_timeout_sec: float = 1800.0
+    process_env: dict[str, str] | None = None
+
+    def _config(self, *, cwd: str, objective: str, task_instruction: str) -> NativeGoalConfig:
+        return NativeGoalConfig(
+            cwd=cwd,
+            objective=objective,
+            task_instruction=task_instruction,
+            model=self.model,
+            effort=self.effort,
+            sandbox=self.sandbox,
+            required_skill_ids=self.required_skill_ids,
+        )
+
+    def _env(self) -> dict[str, str]:
+        """app-server 的环境。
+
+        process_env 里带着 profile 的 CODEX_HOME —— 少了它，codex 的 skills/list
+        找不到装好的技能，required_skill_ids 门禁会以
+        required_skills_missing 失败。preflight 和 run 必须用同一份，否则
+        preflight 过了 run 才炸（或者反过来），白跑。
+        """
+
+        return {**os.environ, **(self.process_env or {})}
+
+    def preflight(self, *, cwd: str, objective: str, task_instruction: str,
+                  process_cwd: str | None = None) -> dict[str, Any]:
+        """只证 initialize / thread / Goal 挂载，不起模型 turn。不烧 token。"""
+
+        turn = probe_native_goal_process(
+            self._config(cwd=cwd, objective=objective, task_instruction=task_instruction),
+            process_command=app_server_command(self.codex_bin),
+            process_env=self._env(),
+            process_cwd=process_cwd,
+            response_timeout_sec=self.response_timeout_sec,
+        )
+        receipt = compact_native_goal_receipt(turn)
+        receipt["execution_mode"] = "goal_attachment_preflight"
+        return receipt
+
+    def run(self, *, cwd: str, objective: str, task_instruction: str,
+            process_cwd: str | None = None) -> dict[str, Any]:
+        """跑一轮，跑到 Goal 离开 active 或预算耗尽为止。
+
+        **不用上游的 run_native_goal_process_until_terminal**：那个函数在预算耗尽时
+        抛 NativeGoalDeadlineExceeded，而异常不携带 turn 对象，于是整份收据全丢。
+        实测后果是——模型已经把任务做完（文件改了、测试建了、跑通了），只因为 Goal
+        还没离开 active 就被记成"彻底失败、零信息"。
+
+        长程任务里预算耗尽是**正常终止**而不是异常：SWE-Marathon 的任务超时上到
+        10 小时，本来就指望跑满预算再交给验证器判分。所以这里照抄上游的循环
+        （native_codex_goal.py:412-449 同样的 start/wait/refresh 三步），只把终止
+        原因作为数据返回，收据一律保留。
+        """
+
+        config = self._config(cwd=cwd, objective=objective,
+                              task_instruction=task_instruction)
+        config.validate()
+        deadline = time.monotonic() + self.goal_timeout_sec
+        stop_reason = "goal_terminal"
+
+        with StdioNativeGoalTransport.spawn(
+            app_server_command(self.codex_bin),
+            env=self._env(),
+            cwd=process_cwd or cwd,   # spawn 的 cwd 是必填
+        ) as transport:
+            turn = start_native_goal_turn(transport, config)
+            completed_before = turn.turn_completed_count
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    stop_reason = "budget_exhausted"
+                    break
+                try:
+                    wait_native_goal_turn(
+                        transport, turn,
+                        timeout_sec=remaining,
+                        completed_before=completed_before,
+                    )
+                except NativeGoalDeadlineExceeded:
+                    stop_reason = "budget_exhausted"
+                    break
+                except NativeGoalProtocolError as exc:
+                    if str(exc) == "goal_turn_timeout":
+                        stop_reason = "budget_exhausted"
+                        break
+                    raise
+                completed_before = turn.turn_completed_count
+                if refresh_native_goal_status(transport, turn) != "active":
+                    break
+                # 心跳模式一次唤醒只做一段：Codex 的续跑归外部调度器管，
+                # 这一轮到此为止，下一 tick 由 LoopX 重新渲染 body 再起。
+                if self.mode.continuation_owner == "driver":
+                    stop_reason = "single_wake_complete"
+                    break
+
+        receipt = compact_native_goal_receipt(turn)
+        receipt["execution_mode"] = (
+            "goal_until_terminal" if self.mode.continuation_owner == "codex"
+            else "goal_single_wake"
+        )
+        receipt["continuation_owner"] = self.mode.continuation_owner
+        receipt["stop_reason"] = stop_reason
+        return receipt
+
+
+def classify(receipt: dict[str, Any]) -> str:
+    """把 Goal 收据折成一个 refresh-state 能吃的分类标签。
+
+    只看运行时自己的 typed 计数，不去解析模型说了什么——模型自称完成不是完成。
+    """
+
+    status = str(receipt.get("post_goal_status") or "")
+    turns = int(receipt.get("turn_completed_count") or 0)
+    if receipt.get("terminal_event_observed") and status and status != "active":
+        return "validated_progress" if turns else "replan_required"
+    # 预算耗尽但确实推进过：算进展，不算需要修复——判分交给 benchmark 的验证器。
+    if turns:
+        return "validated_progress"
+    return "repair_required"

--- a/benchmark/swe-marathon/runtime/modes/profile_install.py
+++ b/benchmark/swe-marathon/runtime/modes/profile_install.py
@@ -1,0 +1,102 @@
+"""安装一份隔离的 LoopX profile，供三种模式共用。
+
+上游 benchmark/deepswe/README.md 要求 treatment 臂有三项独立的产品路径证据：
+
+  1. 该 profile 渲染出的 Goal body；
+  2. LoopX 技能装进 app-server 实际使用的那个 CODEX_HOME；
+  3. body 里点名的那个 release-snapshot CLI 确实存在。
+
+只做第 1 项是不够的——实测过：body 里写着让模型用 `loopx-project` /
+`loopx-self-repair` 技能、跑 `loopx ...` 命令，但技能没装、PATH 上的 `loopx` 还是
+另一个安装，于是模型拿到一份自己无法执行的指令，跑满预算、工作区零改动、
+且不报错。三项必须一起给。
+
+`install_native_codex_profile` 一次把三项都办了，返回的 NativeCodexProfile 里
+codex_home / cli_bin / required_skill_ids 就是那三项证据。
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
+    NativeCodexProfile,
+    NativeCodexProfileError,
+    install_native_codex_profile,
+    native_codex_profile_environment,
+)
+
+
+class ProfileError(RuntimeError):
+    """隔离 profile 没装成。"""
+
+
+@dataclass(frozen=True)
+class InstalledProfile:
+    """装好的 profile + 它的公开身份摘要。"""
+
+    profile: NativeCodexProfile
+
+    @property
+    def cli_bin(self) -> str:
+        return str(self.profile.cli_bin)
+
+    @property
+    def codex_home(self) -> str:
+        return str(self.profile.codex_home)
+
+    @property
+    def required_skill_ids(self) -> tuple[str, ...]:
+        return tuple(self.profile.required_skill_ids)
+
+    def env(self, *, base: dict[str, str] | None = None) -> dict[str, str]:
+        """app-server 该用的环境。
+
+        native_codex_profile_environment 会把 HOME/CODEX_HOME/PATH 指到 profile
+        里，并且是 credential-free 的：模型凭证只通过 provider 网关的 URL 和一个
+        固定的非密 env 哨兵进去，不把宿主机的密钥暴露给 danger-full-access 的
+        agent。
+        """
+
+        return dict(native_codex_profile_environment(
+            self.profile, base_env=base if base is not None else dict(os.environ)
+        ))
+
+    def receipt(self) -> dict[str, Any]:
+        """写进产物的公开身份，只有摘要和 id，不含本地路径。"""
+
+        p = self.profile
+        return {
+            "source_revision": p.source_revision,
+            "source_clean": p.source_clean,
+            "skills_digest": p.skills_digest,
+            "required_skill_ids": list(p.required_skill_ids),
+            "materialized_skill_ids": list(p.materialized_skill_ids),
+        }
+
+
+def install(source_root: str | Path, profile_root: str | Path, *,
+            python_executable: str | None = None,
+            require_clean_source: bool = False) -> InstalledProfile:
+    """装一份 profile。
+
+    profile_root 必须不存在或为空——上游刻意不修复半装的 profile，因为混着两个
+    安装版本会让整个 treatment 失效。所以每次跑用一个新目录。
+
+    require_clean_source 默认放宽：wen 里的 loopx 是带本地改动的工作副本时，
+    严格模式会直接拒装。跑正式对照时应当传 True。
+    """
+
+    try:
+        profile = install_native_codex_profile(
+            source_root,
+            profile_root,
+            python_executable=python_executable,
+            require_clean_source=require_clean_source,
+        )
+    except NativeCodexProfileError as exc:
+        raise ProfileError(f"profile 安装失败: {exc}") from exc
+    return InstalledProfile(profile=profile)

--- a/benchmark/swe-marathon/runtime/modes/profiles.py
+++ b/benchmark/swe-marathon/runtime/modes/profiles.py
@@ -1,0 +1,189 @@
+"""三种 Codex × LoopX 运行模式的声明式定义。
+
+模式取自 LoopX README 的 Codex 三行 host 表（upstream README.md:289-291）。
+三者的差别不是"接法不同"，而是 LoopX 渲染出的 body、闸门命令、结算来源不同——
+这里把差别集中成数据，驱动逻辑（session.py / codex_host.py）对三者一视同仁。
+
+实测三个 profile 在同一个 goal 上渲染出的差别（loopx 0.5.3）：
+
+    codex_app_ssh_goal   body 2720 字符  guard 带 --begin-turn      spend --source visible-goal
+    codex_cli            body 2698 字符  guard 不带 --begin-turn    spend --source visible-goal
+    codex_app_heartbeat  body 1557 字符  guard --codex-app + LOOPX_TURN  spend --source heartbeat
+
+前两者是 visible-Goal 渲染器（body 开头"in this visible Codex `/goal`"），
+Codex 自己拥有续跑；第三个是精简派发器 body，每次唤醒是全新 turn，续跑由外部
+调度器拥有。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class ModeError(RuntimeError):
+    """模式定义或使用方式不成立。"""
+
+
+@dataclass(frozen=True)
+class Mode:
+    """一种运行模式。"""
+
+    name: str
+    """命令行上的短名。"""
+
+    runtime_profile: str
+    """传给 loopx 的 --runtime-profile。"""
+
+    host_surface: str
+    scheduler_owner: str
+    execution_mode: str
+    """profile 展开后的三元组，仅用于自检与记录，不重复传给 CLI。"""
+
+    continuation_owner: str
+    """'codex' = Codex 自己续跑（visible Goal）；'driver' = 本驱动按节拍再唤醒。"""
+
+    needs_turn_instance: bool = False
+    """是否每 tick 需要一个 LOOPX_TURN turn-instance-id。"""
+
+    spend_source: str = "visible-goal"
+
+    notes: str = ""
+    """这个模式在无人值守环境下的真实边界，写进产物收据里。"""
+
+    substitution: str = ""
+    """若本适配器用了替代传输/替代 host_surface，在这里写清楚。空 = 无替代。"""
+
+
+#: `Codex App over SSH` —— LoopX 自己的 benchmark 方法唯一认可的 treatment 臂。
+#: benchmark/deepswe/README.md 要求三项产品路径证据：本 profile 渲染的 Goal body、
+#: 装进 app-server 所用 CODEX_HOME 的 skills、以及 body 里点名的 release CLI。
+SSH_GOAL = Mode(
+    name="ssh-goal",
+    runtime_profile="codex_app_ssh_goal",
+    host_surface="codex_app_ssh",
+    scheduler_owner="agent_cli_loop",
+    execution_mode="interactive",
+    continuation_owner="codex",
+    spend_source="visible-goal",
+    notes=(
+        "LoopX benchmark/deepswe 的官方 treatment 臂。app-server 承载 visible Goal，"
+        "Codex 拥有自动续跑；驱动只起首轮 turn 并观察终态。"
+    ),
+)
+
+#: `Codex CLI` —— 可见 `/goal`。文档（docs/product/runtimes/codex-cli/
+#: codex-cli-tui-loop.md 的 "Headless Disabled Boundary"）明确：这条路默认不提供
+#: headless 回退，连 opt-in 都没有；`codex-cli-exec-handoff` 已从"输出可运行脚本"
+#: 改成"报告禁用边界"。真正的 TUI 注入（Session-Attached Automation）在上游是
+#: 一串 dry-run 诊断，没有任何代码真的往活 TUI 里写。
+#:
+#: 所以本适配器对这个模式做的是**传输替代**：body 仍由 `--runtime-profile codex_cli`
+#: 渲染（渲染器、闸门命令、结算来源都是真的），但承载它的是 app-server 的 Goal
+#: 事务而不是人值守的 TUI。这样模式语义可测，且不假装有人在场。
+CODEX_CLI = Mode(
+    name="codex-cli",
+    runtime_profile="codex_cli",
+    host_surface="codex_cli",
+    scheduler_owner="agent_cli_loop",
+    execution_mode="interactive",
+    continuation_owner="codex",
+    spend_source="visible-goal",
+    notes=(
+        "上游把有人值守的 TUI 当作本模式的定义特征，headless 回退被显式禁用。"
+        "无人值守跑分时 body/闸门/结算是真的，承载传输是替代的。"
+    ),
+    substitution=(
+        "transport: 用 codex app-server 的 Goal 事务承载 codex_cli 渲染的 visible "
+        "body，替代人值守 TUI 里的 `/goal` 粘贴。渲染 profile 未被替换。"
+    ),
+)
+
+#: `Codex App` 心跳 —— host_automation + hosted_automation。
+#:
+#: host_surface=codex_app 在上游是留给真 Codex App 产品的：它会回一套
+#: scheduler_hint.codex_app.stateful_backoff（apply_needed / recommended_rrule /
+#: reset_token / identity_signature），期待宿主去调 App 自己的 automation_update
+#: 改 RRULE 再 ACK。没有真 App 就兑现不了，只会永远悬着或者伪造 ACK。
+#:
+#: 上游为自建定时器指定的对口是 `--runtime-profile generic_cli`：shell_worker
+#: 参考实现 `scripts/external_scheduler_worker.py` 默认就是它，其 help 明写
+#: "Quota runtime profile that emits the local_scheduler hint"。
+#:
+#: 不要直接传 -H local_scheduler：`--turn-instance-id` 只接受 generic_cli 或
+#: codex_app_heartbeat（否则报 "requires runtime-profile generic_cli or
+#: codex_app_heartbeat so quota guard creates a heartbeat receipt"），而没有
+#: turn instance 就拿不到心跳收据。
+HEARTBEAT = Mode(
+    name="heartbeat",
+    runtime_profile="generic_cli",
+    host_surface="generic_cli",
+    scheduler_owner="agent_cli_loop",
+    execution_mode="interactive",
+    continuation_owner="driver",
+    needs_turn_instance=True,
+    spend_source="heartbeat",
+    notes=(
+        "自建定时器拥有唤醒，对应上游 shell_worker 连接器。闸门发 local_scheduler "
+        "提示（初始间隔 + 递进阶梯 + 未变轮询上限），驱动照 external_scheduler_"
+        "worker.py 的做法推进阶梯。"
+    ),
+    substitution=(
+        "host_surface: generic_cli 代替 codex_app —— 这是上游为自建定时器指定的"
+        "对口 profile，不是权宜之计。用 --claim-codex-app 可切到硬声明 codex_app。"
+    ),
+)
+
+#: `--claim-codex-app` 时用的变体：硬声明 codex_app。会拿到 App 形状的
+#: stateful_backoff，但本驱动没有真 App 去 automation_update，apply_needed /
+#: ack_needed 会一直悬着。仅用于观察这套义务在无 App 环境下如何卡住。
+HEARTBEAT_CLAIM_APP = Mode(
+    name="heartbeat-codex-app",
+    runtime_profile="codex_app_heartbeat",
+    host_surface="codex_app",
+    scheduler_owner="host_automation",
+    execution_mode="hosted_automation",
+    continuation_owner="driver",
+    needs_turn_instance=True,
+    spend_source="heartbeat",
+    notes=(
+        "硬声明 codex_app。校验只查枚举组合、不验身份，所以能过；但没有真 App，"
+        "scheduler_hint 的 apply_needed/ack_needed 无法诚实兑现。"
+    ),
+    substitution=(
+        "host_surface: 声明为 codex_app 但没有真 Codex App 支撑。"
+        "属上游文档意义上的误用，只用于观察义务如何悬空。"
+    ),
+)
+
+
+MODES: dict[str, Mode] = {m.name: m for m in (SSH_GOAL, CODEX_CLI, HEARTBEAT)}
+MODES[HEARTBEAT_CLAIM_APP.name] = HEARTBEAT_CLAIM_APP
+
+
+def resolve(name: str, *, claim_codex_app: bool = False) -> Mode:
+    """按短名取模式；heartbeat 可切成硬声明 codex_app 的变体。"""
+
+    if name == HEARTBEAT.name and claim_codex_app:
+        return HEARTBEAT_CLAIM_APP
+    try:
+        return MODES[name]
+    except KeyError:
+        raise ModeError(
+            f"未知模式 {name!r}；可用：{', '.join(sorted(MODES))}"
+        ) from None
+
+
+def profile_args(mode: Mode) -> list[str]:
+    """渲染成 loopx CLI 的 profile 参数。
+
+    有具名 profile 就用 --runtime-profile（上游 round-trip 测试保证它与三元组
+    等价）；没有的（local_scheduler）就显式传 -H/-O/-M。
+    """
+
+    if mode.runtime_profile:
+        return ["--runtime-profile", mode.runtime_profile]
+    return [
+        "-H", mode.host_surface,
+        "-O", mode.scheduler_owner,
+        "-M", mode.execution_mode,
+    ]

--- a/benchmark/swe-marathon/runtime/modes/run_mode.py
+++ b/benchmark/swe-marathon/runtime/modes/run_mode.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""统一驱动 Codex × LoopX 的三种模式。
+
+    python3 -m modes.run_mode --mode ssh-goal   --project <dir> --task-file <f>
+    python3 -m modes.run_mode --mode codex-cli  --project <dir> --task-file <f>
+    python3 -m modes.run_mode --mode heartbeat  --project <dir> --task-file <f> --ticks 4
+
+模式取自 LoopX README 的 Codex 三行 host 表；差别见 profiles.py。
+`--preflight-only` 走通全部 LoopX 侧契约（渲染 + 闸门 + Goal 挂载）但不起模型
+turn，不烧 token，适合当冒烟。
+
+产物是一份 JSON 收据，只含稳定标签、计数、摘要，不含任务原文/轨迹/凭证。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from modes.codex_host import CodexHost, classify  # noqa: E402
+from modes.profile_install import ProfileError, install as install_profile  # noqa: E402
+from modes.profiles import MODES, resolve  # noqa: E402
+from modes.session import LoopxSession, SessionError  # noqa: E402
+
+
+def _default_cli() -> str:
+    here = Path(__file__).resolve().parent.parent
+    venv = here / ".venv" / "bin" / "loopx"
+    return str(venv) if venv.exists() else "loopx"
+
+
+def _default_codex() -> str:
+    here = Path(__file__).resolve().parent.parent
+    staged = here / "codex" / "codex"
+    return str(staged) if staged.exists() else "codex"
+
+
+def _parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--mode", required=True, choices=sorted(MODES),
+                   help="运行模式")
+    p.add_argument("--claim-codex-app", action="store_true",
+                   help="heartbeat 模式下硬声明 host_surface=codex_app（上游文档"
+                        "意义上的误用，只用于观察 RRULE/ACK 义务如何悬空）")
+    p.add_argument("--project", required=True, help="任务工作区（Codex 可见的 cwd）")
+    p.add_argument("--task-file", required=True, help="任务正文文件（UTF-8）")
+    p.add_argument("--goal-id", default="wen-goal")
+    p.add_argument("--agent-id", default="wen-codex")
+    p.add_argument("--objective", default=None,
+                   help="goal 目标；默认取任务正文首行")
+    p.add_argument("--loopx-bin", default=_default_cli())
+    p.add_argument("--codex-bin", default=_default_codex())
+    p.add_argument("--model", default=os.environ.get("MR_MODEL"))
+    p.add_argument("--effort", default=os.environ.get("MR_EFFORT"),
+                   help="推理档位，如 xhigh；进 turn/start 的 turn_params.effort")
+    p.add_argument("--sandbox", default="danger-full-access")
+    p.add_argument("--ticks", type=int, default=1,
+                   help="heartbeat 模式的最大唤醒次数；visible 模式恒为 1")
+    p.add_argument("--tick-seconds", type=float, default=0.0,
+                   help="heartbeat 两次唤醒之间的睡眠秒数")
+    p.add_argument("--turn-timeout", type=float, default=1800.0,
+                   help="单轮 Goal 预算（秒）")
+    p.add_argument("--preflight-only", action="store_true",
+                   help="只证 LoopX 契约与 Goal 挂载，不起模型 turn")
+    p.add_argument("--loopx-src", default=None,
+                   help="LoopX 源码根，用来装隔离 profile；默认 wen/loopx")
+    p.add_argument("--profile-root", default=None,
+                   help="隔离 profile 装到哪；必须是空目录，默认在 --receipt 旁边")
+    p.add_argument("--no-profile", action="store_true",
+                   help="不装隔离 profile（body 会引用裸 loopx、技能不装，"
+                        "模型多半执行不了——只在调试渲染时用）")
+    p.add_argument("--codex-config", default=None,
+                   help="provider 配置（config.toml），装完 profile 后拷进它的 "
+                        "codex-home；不给的话 app-server 不知道往哪调模型")
+    p.add_argument("--require-clean-source", action="store_true",
+                   help="要求 LoopX 源码干净才肯装 profile；正式对照应当开")
+    p.add_argument("--receipt", default=None, help="收据写到这个文件")
+    return p
+
+
+def _one_turn(session: LoopxSession, host: CodexHost, *, task: str,
+              turn_instance: str | None, preflight: bool,
+              project: Path) -> dict[str, Any]:
+    """一轮：渲染 body → 过闸门 → 交给 codex → 结算。"""
+
+    body = session.render_body(turn_instance=turn_instance)
+    objective = body["task_body"]
+
+    decision = session.should_run(turn_instance=turn_instance)
+    obligations = session.scheduler_obligations(decision)
+    turn: dict[str, Any] = {
+        "turn_instance": turn_instance,
+        "objective_chars": len(objective),
+        "should_run": decision.get("should_run"),
+        "effective_action": decision.get("effective_action"),
+        "gate_reason": str(decision.get("reason") or "")[:200],
+        "scheduler_obligations": obligations,
+    }
+
+    if not decision.get("should_run"):
+        turn["outcome"] = "gate_declined"
+        return turn
+
+    if preflight:
+        turn["goal_receipt"] = host.preflight(
+            cwd=str(project), objective=objective, task_instruction=task,
+            process_cwd=str(project),
+        )
+        turn["outcome"] = "preflight_only"
+        return turn
+
+    receipt = host.run(cwd=str(project), objective=objective,
+                       task_instruction=task, process_cwd=str(project))
+    turn["goal_receipt"] = receipt
+    classification = classify(receipt)
+    turn["classification"] = classification
+    turn["settlement"] = _compact_settlement(session.settle(
+        classification=classification,
+        todo_id=session.selected_todo_id(decision),
+    ))
+    turn["outcome"] = "ran"
+    return turn
+
+
+def _compact_settlement(settled: dict[str, Any]) -> dict[str, Any]:
+    """结算结果只留可公开的状态位。"""
+
+    spend = settled.get("spend_slot") or {}
+    refresh = settled.get("refresh_state") or {}
+    before = spend.get("before") or {}
+    quota = before.get("quota") or {}
+    return {
+        "refresh_ok": refresh.get("ok"),
+        "spend_ok": spend.get("ok"),
+        # agent 在 turn 内自己结算过时 spend_ok=false 是正常的，reason 说明原因
+        "spend_reason": str(spend.get("reason") or "")[:160] or None,
+        "spent_slots_total": quota.get("spent_slots"),
+        "quota_state": quota.get("state") or before.get("state"),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    mode = resolve(args.mode, claim_codex_app=args.claim_codex_app)
+    project = Path(args.project).expanduser().resolve()
+    if not project.is_dir():
+        print(f"FATAL: --project 不是目录: {project}", file=sys.stderr)
+        return 2
+    task = Path(args.task_file).read_text(encoding="utf-8").strip()
+    if not task:
+        print("FATAL: --task-file 是空的", file=sys.stderr)
+        return 2
+    objective = args.objective or task.splitlines()[0][:200]
+
+    # ── 隔离 profile：一次给齐上游要求的三项产品路径证据 ──────────────────
+    # 1) 本模式渲染的 Goal body  2) 技能装进 app-server 实际用的 CODEX_HOME
+    # 3) body 里点名的那个 release CLI 真的存在
+    installed = None
+    if not args.no_profile:
+        src = args.loopx_src or str(Path(__file__).resolve().parent.parent / "loopx")
+        root = args.profile_root or str(
+            Path(args.receipt).resolve().parent / f"profile-{mode.name}"
+            if args.receipt else Path(f"/tmp/wen-profile-{mode.name}-{os.getpid()}")
+        )
+        try:
+            installed = install_profile(src, root, python_executable=sys.executable,
+                                        require_clean_source=args.require_clean_source)
+        except ProfileError as exc:
+            print(f"FATAL: {exc}", file=sys.stderr)
+            return 2
+        if args.codex_config:
+            dest = Path(installed.codex_home) / "config.toml"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(Path(args.codex_config).read_text(encoding="utf-8"),
+                            encoding="utf-8")
+
+    cli = installed.cli_bin if installed else args.loopx_bin
+    session = LoopxSession(cli=cli, project=project, goal_id=args.goal_id,
+                           agent_id=args.agent_id, mode=mode,
+                           cli_bin=installed.cli_bin if installed else "",
+                           env=installed.env() if installed else {})
+    host = CodexHost(codex_bin=args.codex_bin, mode=mode, model=args.model,
+                     effort=args.effort, sandbox=args.sandbox,
+                     goal_timeout_sec=args.turn_timeout,
+                     required_skill_ids=installed.required_skill_ids if installed else (),
+                     process_env=installed.env() if installed else None)
+
+    out: dict[str, Any] = {
+        "schema": "wen_mode_run_v0",
+        "mode": mode.name,
+        "runtime_profile": mode.runtime_profile,
+        "scheduler_context": {
+            "host_surface": mode.host_surface,
+            "scheduler_owner": mode.scheduler_owner,
+            "execution_mode": mode.execution_mode,
+        },
+        "continuation_owner": mode.continuation_owner,
+        "substitution": mode.substitution or None,
+        "notes": mode.notes,
+        "model": args.model,
+        "effort": args.effort,
+        "preflight_only": bool(args.preflight_only),
+        "loopx_profile": installed.receipt() if installed else None,
+        "turns": [],
+    }
+
+    try:
+        session.bootstrap(objective)
+        # 任务必须作为 todo 进 goal —— 闸门按 todo 选工作，只放进 turn 输入的话
+        # 模型会去推进 onboarding todo，跑满预算却零产出且不报错。
+        session.add_task_todo(task)
+    except SessionError as exc:
+        out["error"] = f"bootstrap 失败: {exc}"
+        _emit(out, args.receipt)
+        return 1
+
+    # visible Goal 由 Codex 自己续跑，驱动只起一轮；心跳由驱动按节拍唤醒。
+    ticks = args.ticks if mode.continuation_owner == "driver" else 1
+
+    for i in range(ticks):
+        if i and args.tick_seconds:
+            time.sleep(args.tick_seconds)
+        ti = session.new_turn_instance() if mode.needs_turn_instance else None
+        try:
+            turn = _one_turn(session, host, task=task, turn_instance=ti,
+                             preflight=args.preflight_only, project=project)
+        except Exception as exc:  # noqa: BLE001 — 收据要如实记录失败
+            turn = {"turn_instance": ti, "outcome": "error",
+                    "error": f"{type(exc).__name__}: {str(exc)[:300]}"}
+        out["turns"].append(turn)
+        if turn.get("outcome") == "error":
+            break
+        # Goal 已到终态就不用再唤醒
+        receipt = turn.get("goal_receipt") or {}
+        if str(receipt.get("post_goal_status") or "") not in ("", "active"):
+            out["stopped_early"] = "goal_left_active"
+            break
+
+    out["turns_run"] = len(out["turns"])
+    _emit(out, args.receipt)
+    return 0 if out["turns"] and out["turns"][-1].get("outcome") != "error" else 1
+
+
+def _emit(payload: dict[str, Any], path: str | None) -> None:
+    text = json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+    print(text)
+    if path:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text(text + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/runtime/modes/session.py
+++ b/benchmark/swe-marathon/runtime/modes/session.py
@@ -1,0 +1,299 @@
+"""LoopX 侧的一轮：渲染 body → 过闸门 → 结算。
+
+对三种模式一视同仁；模式差别全部来自 profiles.Mode，本模块不写 if mode ==。
+
+刻意不复用 benchmark_toolkit.native_codex_profile.render_native_codex_goal_prompt：
+那个函数把 `codex_app_ssh_goal` 写死在三处（native_codex_profile.py:337-338、366、
+399），换 profile 就会在 `runtime_profile != "codex_app_ssh_goal"` 那道断言上失败。
+这里直接调同一个 CLI 子命令，把 profile 参数化，其余校验照抄它的意图。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .profiles import Mode, profile_args
+
+#: body 里出现这些字样说明 LoopX 认为该模式是 visible Goal 而非心跳自动化。
+_VISIBLE_MARKER = "visible Codex"
+#: 心跳 body 会要求宿主提供 turn instance。
+_TURN_ENV = "LOOPX_TURN"
+
+
+class SessionError(RuntimeError):
+    """LoopX 侧的一轮没能按契约走完。"""
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class LoopxSession:
+    """绑定到一个 goal + agent 的 LoopX 会话。"""
+
+    cli: str
+    """执行用的 loopx 可执行文件路径。"""
+
+    project: Path
+    goal_id: str
+    agent_id: str
+    mode: Mode
+    cli_bin: str = ""
+    """写进 body 的 CLI 路径（--cli-bin）。留空则 body 里渲染成裸 `loopx`。"""
+    timeout_sec: float = 120.0
+    env: dict[str, str] = field(default_factory=dict)
+
+    # ── 底层 ────────────────────────────────────────────────────────────────
+    def _run(self, args: list[str], *, extra_env: dict[str, str] | None = None,
+             expect_ok: bool = True) -> dict[str, Any]:
+        """跑一条 loopx 子命令，要求 --format json 且能解析。
+
+        expect_ok 默认开：loopx 的写命令失败时**照样退出 0**，只在 JSON 里把
+        ok 置 false。不查这一位的话，写不进去的 todo、注册不上的 agent 都会静默
+        通过，一直到几百秒后模型行为不对才发现。
+        """
+
+        argv = [self.cli, "--format", "json", *args]
+        run_env = {**os.environ, **self.env, **(extra_env or {})}
+        proc = subprocess.run(
+            argv,
+            cwd=str(self.project),
+            capture_output=True,
+            text=True,
+            timeout=self.timeout_sec,
+            env=run_env,
+        )
+        text = proc.stdout.strip()
+        # loopx 的 json 输出有时包在 ``` 围栏里
+        if text.startswith("```"):
+            text = text.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+        if not text:
+            raise SessionError(
+                f"loopx {' '.join(args[:2])} 无输出 (exit={proc.returncode}): "
+                f"{proc.stderr.strip()[:300]}"
+            )
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise SessionError(
+                f"loopx {' '.join(args[:2])} 输出不是 JSON: {text[:300]}"
+            ) from exc
+        if expect_ok and isinstance(payload, dict) and payload.get("ok") is False:
+            raise SessionError(
+                f"loopx {' '.join(args[:2])} 失败: "
+                f"{str(payload.get('error'))[:400]}"
+            )
+        return payload
+
+    # ── 一次性准备 ──────────────────────────────────────────────────────────
+    def bootstrap(self, objective: str) -> dict[str, Any]:
+        """建 goal 并把本 agent 注册进 coordination.registered_agents。
+
+        注册这步不能省：不注册的话 heartbeat-prompt 会返回 ok=false，错误信息是
+        "cannot be used because goal has no coordination.registered_agents list"，
+        而它仍然退出 0，很容易被当成渲染成功。
+
+        两个 onboarding 开关也不能省。不加的话闸门会一直回
+        "operator gate blocks gated delivery"，should_run 恒为 false——无人值守
+        环境下没有 operator 去放行，整轮会静默空转出零产物却不报错。
+        """
+
+        boot = self._run([
+            "bootstrap",
+            "--project", ".",
+            "--goal-id", self.goal_id,
+            "--objective", objective,
+            # 把 onboarding 提出的 agent todos 直接写进去，并记录允许自主推进；
+            # 否则等一个永远不会出现的人工放行。
+            "--accept-onboarding-agent-todos",
+            "--begin-autonomous-advance",
+            # 不让 bootstrap 去问要不要建 Codex App 心跳自动化：本工作区没有真 App。
+            "--codex-app-heartbeat", "no",
+        ])
+        self._run([
+            "configure-goal",
+            "--goal-id", self.goal_id,
+            "--registered-agent", self.agent_id,
+            "--execute",
+        ])
+        return boot
+
+    def add_task_todo(self, task_text: str, *, todo_id: str = "wen-task") -> dict[str, Any]:
+        """把任务正文作为一条 P0 agent todo 写进 goal。
+
+        这一步不能省，也不能只靠 turn/start 的输入。实测过：只把任务放进 turn
+        输入、goal 里只有 onboarding todo 时，模型会老老实实按 body 的指示去推进
+        **onboarding todo**，900 秒里只建了 .loopx/ 和 .codex/，任务文件一个字没改，
+        而且不报错——闸门放行、Goal 活着、收据干净，看起来一切正常。
+
+        闸门是按 todo 选工作的，任务不在 todo 里就不会被选中。
+        """
+
+        return self._run([
+            "todo", "add",
+            "--goal-id", self.goal_id,
+            "--role", "agent",
+            "--todo-id", todo_id,
+            "--text", task_text,
+            "--task-class", "advancement_task",
+            "--status", "open",
+            "--execute",
+        ])
+
+    # ── 每轮 ────────────────────────────────────────────────────────────────
+    def render_body(self, *, turn_instance: str | None = None) -> dict[str, Any]:
+        """渲染本模式的 task_body，并校验它确实属于本模式。"""
+
+        args = [
+            "heartbeat-prompt", "--thin",
+            "--goal-id", self.goal_id,
+            "--agent-id", self.agent_id,
+            *profile_args(self.mode),
+        ]
+        # body 里会写"用 `<cli_bin> ...` 跑下一步"。不传的话渲染成裸 `loopx`，
+        # 模型会去 PATH 上找——那多半是另一个安装、另一个 registry。实测这条不传
+        # 的后果是模型拿到一份自己执行不了的指令，跑满预算、零改动、且不报错。
+        if self.cli_bin:
+            args += ["--cli-bin", self.cli_bin]
+
+        if self.mode.needs_turn_instance:
+            if not turn_instance:
+                raise SessionError(
+                    f"{self.mode.name} 每轮需要 turn instance（body 里会引用 "
+                    f"{_TURN_ENV}），调用方没给"
+                )
+            args += ["--turn-instance-id", turn_instance]
+
+        payload = self._run(args, extra_env={_TURN_ENV: turn_instance} if turn_instance else None)
+
+        if not payload.get("ok"):
+            raise SessionError(
+                f"heartbeat-prompt 失败({self.mode.name}): "
+                f"{str(payload.get('error'))[:400]}"
+            )
+        body = (payload.get("task_body") or "").strip()
+        if not body:
+            raise SessionError(f"heartbeat-prompt 没给 task_body({self.mode.name})")
+
+        self._assert_body_matches_mode(body, payload)
+        return payload
+
+    def _assert_body_matches_mode(self, body: str, payload: dict[str, Any]) -> None:
+        """确认渲染出来的确实是本模式的 body，而不是别的模式的。
+
+        这一条是仿 native_codex_profile.py:366 的 runtime_profile 断言。渲染器按
+        profile 分岔（visible-Goal vs 心跳派发器），拿错了不会报错、只会静默测成
+        另一个模式——那种失败最难发现，所以在这里挡住。
+        """
+
+        visible = _VISIBLE_MARKER in body
+        if self.mode.continuation_owner == "codex" and not visible:
+            raise SessionError(
+                f"{self.mode.name} 期望 visible Goal body，实际拿到的不含"
+                f"{_VISIBLE_MARKER!r}——渲染 profile 可能没生效"
+            )
+        if self.mode.continuation_owner == "driver" and visible:
+            raise SessionError(
+                f"{self.mode.name} 期望心跳派发器 body，实际拿到的是 visible Goal body"
+            )
+
+        spend = payload.get("quota_spend_command") or ""
+        want = f"--source {self.mode.spend_source}"
+        if want not in spend:
+            raise SessionError(
+                f"{self.mode.name} 的 spend 命令应含 {want!r}，实际: {spend[:200]}"
+            )
+
+    def should_run(self, *, turn_instance: str | None = None) -> dict[str, Any]:
+        """闸门。返回完整决策，调用方读 should_run / interaction_contract。"""
+
+        args = [
+            "quota", "should-run",
+            "--goal-id", self.goal_id,
+            "--agent-id", self.agent_id,
+            *profile_args(self.mode),
+        ]
+        if self.mode.needs_turn_instance:
+            if not turn_instance:
+                raise SessionError(f"{self.mode.name} 的闸门需要 turn instance")
+            args += ["--turn-instance-id", turn_instance]
+        return self._run(args, extra_env={_TURN_ENV: turn_instance} if turn_instance else None)
+
+    @staticmethod
+    def selected_todo_id(decision: dict[str, Any]) -> str:
+        """闸门这一轮选中的 todo。
+
+        visible Goal 的结算要求绑定恰好一个 todo_id，否则 spend-slot 回
+        "visible Goal settlement requires exactly one todo_id or
+        replan_obligation_id binding"。
+        """
+
+        sel = (decision.get("selected_todo") or {})
+        return str(sel.get("todo_id") or "")
+
+    def settle(self, *, classification: str, todo_id: str = "") -> dict[str, Any]:
+        """一轮做完之后写回状态并花一次配额。
+
+        顺序不能反：LoopX 的契约是 spend_only_after_artifact_validation_writeback，
+        先 refresh-state 再 spend-slot。
+
+        **两步都不强制成功**。visible Goal 模式下 body 本身就要求 agent 在 turn 内
+        自己 refresh + spend，等驱动来收尾时 goal 往往已经是 terminal_no_followup、
+        配额也已经花过（实测 spent_slots=2）。这时再 spend 会返回 ok=false，
+        reason 是"validated closure evidence derives terminal no-follow-up..."——
+        那是**正常的已结算**，不是失败。强行当错误处理会把一次成功的跑判成失败。
+        """
+
+        refresh = self._run([
+            "refresh-state",
+            "--goal-id", self.goal_id,
+            "--agent-id", self.agent_id,
+            "--project", ".",
+            "--classification", classification,
+        ], expect_ok=False)
+        spend_args = [
+            "quota", "spend-slot",
+            "--goal-id", self.goal_id,
+            "--agent-id", self.agent_id,
+            "--slots", "1",
+            "--source", self.mode.spend_source,
+            "--execute",
+        ]
+        if todo_id:
+            spend_args += ["--todo-id", todo_id]
+        spend = self._run(spend_args, expect_ok=False)
+        return {"refresh_state": refresh, "spend_slot": spend}
+
+    # ── 心跳专用 ────────────────────────────────────────────────────────────
+    @staticmethod
+    def new_turn_instance() -> str:
+        """心跳每次唤醒用一个新的 turn instance；重试复用同一个。"""
+
+        return _utc_now_iso()
+
+    @staticmethod
+    def scheduler_obligations(decision: dict[str, Any]) -> dict[str, Any]:
+        """从闸门决策里摘出宿主该兑现的调度义务。
+
+        对 local_scheduler，这里应该是空的（cadence 由宿主自己拥有）。
+        对硬声明 codex_app 的变体，这里会有 apply_needed/ack_needed——本驱动没有
+        真 App 可以 automation_update，所以只记录、不假装兑现。
+        """
+
+        hint = decision.get("scheduler_hint") or {}
+        app = hint.get("codex_app") or {}
+        backoff = app.get("stateful_backoff") or {}
+        return {
+            "applicability": app.get("applicability"),
+            "apply_needed": backoff.get("apply_needed"),
+            "ack_needed": backoff.get("ack_needed"),
+            "recommended_rrule": backoff.get("recommended_rrule"),
+            "host_action": app.get("host_action"),
+        }

--- a/benchmark/swe-marathon/runtime/turn/codex_nosandbox_wrapper.py
+++ b/benchmark/swe-marathon/runtime/turn/codex_nosandbox_wrapper.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""A `codex` stand-in that drops LoopX's sandbox flags before running the real one.
+
+LoopX's codex-cli host is the path that works: driven through it, a Turn loop
+ran four times on one task, committed a 22 KB patch and scored f2p 31/35.  Its
+one problem is the sandbox — it always passes `--sandbox <mode>` (or
+`-c sandbox_mode=...` when resuming), only permits read-only and
+workspace-write, and both need bubblewrap, which needs unprivileged user
+namespaces these containers do not have:
+
+    bwrap: No permissions to create a new namespace
+
+Switching to `--host generic-cli` avoided that but bought a worse problem: the
+generic host carries its own scheduler contract, and eleven of sixteen turns
+died at "LoopX Turn route is not host executable" before any model work, with
+no route recorded to explain why.
+
+So keep the working host and fix the flag instead.  This sits earlier on PATH
+than the real codex, strips the sandbox arguments, and substitutes the same
+`--dangerously-bypass-approvals-and-sandbox` the other two arms already use —
+which is also what keeps the three arms identical in permissions.  LoopX's
+contracts are untouched: it still believes it is driving codex-cli, because it
+is.
+
+Set MR_REAL_CODEX to the real binary; defaults to /usr/local/bin/codex.
+MR_LOOPX_CODEX_LOG names the log file; defaults to /tmp/loopx-goal/codex-wrapper.log.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Resolve the real binary rather than assuming /usr/local/bin/codex.  Codex is
+# installed into the image through nvm, so it lives under the Node version's
+# bin directory and the hardcoded path does not exist — which made the wrapper
+# die before it ever reached Codex, and LoopX report the indistinguishable
+# `codex_cli_exit_nonzero`.  The wrapper is invoked by absolute path through
+# --codex-bin and is not itself on PATH, so a PATH lookup finds the real one.
+REAL = (
+    os.environ.get("MR_REAL_CODEX")
+    or shutil.which("codex")
+    or "/usr/local/bin/codex"
+)
+BYPASS = "--dangerously-bypass-approvals-and-sandbox"
+LOG = Path(
+    os.environ.get("MR_LOOPX_CODEX_LOG", "/tmp/loopx-goal/codex-wrapper.log")
+)
+
+
+def rewrite(argv: list[str]) -> list[str]:
+    out: list[str] = []
+    skip_next = False
+    for i, arg in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
+        # `--sandbox <mode>` — new-session form.
+        if arg == "--sandbox":
+            skip_next = True
+            continue
+        if arg.startswith("--sandbox="):
+            continue
+        # `-c sandbox_mode="..."` — resume form.  The value is a separate argv
+        # item after -c, so both have to go, and only when it is that key: -c
+        # carries every other config override too.
+        if arg == "-c" and i + 1 < len(argv) and argv[i + 1].startswith("sandbox_mode="):
+            skip_next = True
+            continue
+        out.append(arg)
+
+    # Insert the bypass right after the subcommand so it lands before `--`,
+    # which codex treats as the end of flags.
+    if out and out[0] == "exec":
+        out.insert(1, BYPASS)
+    else:
+        out.insert(0, BYPASS)
+    return out
+
+
+def _log(text: str) -> None:
+    try:
+        LOG.parent.mkdir(parents=True, exist_ok=True)
+        with LOG.open("a", encoding="utf-8") as handle:
+            handle.write(text.rstrip("\n") + "\n")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    argv = rewrite(sys.argv[1:])
+    # Run the real codex as a child rather than execv'ing it, so its stderr can
+    # be recorded.  LoopX reports a failed Turn as `codex_cli_exit_nonzero` and
+    # keeps neither the exit code's cause nor any output, and the container is
+    # gone by the time anyone looks — so an execv here means the only evidence
+    # of why Codex refused is destroyed at the moment it is produced.
+    #
+    # stdout stays inherited and untouched: LoopX parses Codex's `--json`
+    # stream off it, so anything written there would corrupt the Turn.
+    _log(f"--- argv in : {sys.argv[1:]}")
+    _log(f"--- argv out: {argv}")
+    _log(f"--- real    : {REAL} (exists={os.path.exists(REAL)})")
+    try:
+        completed = subprocess.run(  # noqa: S603
+            [REAL, *argv], stderr=subprocess.PIPE, check=False
+        )
+    except OSError as exc:
+        # Without this the wrapper's own failure to start Codex is reported by
+        # LoopX as `codex_cli_exit_nonzero`, which reads as "the model refused"
+        # rather than "the binary is not there".
+        _log(f"--- launch failed: {type(exc).__name__}: {exc}")
+        sys.stderr.write(f"codex wrapper could not launch {REAL}: {exc}\n")
+        return 127
+    stderr = completed.stderr.decode("utf-8", "replace") if completed.stderr else ""
+    _log(f"--- exit {completed.returncode}")
+    if stderr:
+        _log(stderr)
+        sys.stderr.write(stderr)
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/runtime/turn/goal_codex.py
+++ b/benchmark/swe-marathon/runtime/turn/goal_codex.py
@@ -1,0 +1,530 @@
+"""Codex driven through its native Goal API, as a Pier agent.
+
+Pier's stock Codex agent runs `codex exec` once.  That is enough to *create* a
+Goal — with `features.goals` on, the model will call `create_goal` when asked —
+but not to exercise one: the process exits after the first turn, so the
+automatic continuation loop that is the entire point of Goal mode never runs.
+Measured that way, Goal mode looks like a no-op, and the experiment would
+conclude the wrong thing for a purely mechanical reason.
+
+So this subclass keeps everything Pier does to stand Codex up — npm install
+through the CN mirror, CODEX_HOME, auth.json, config.toml, skills, MCP, session
+capture — and swaps only the final invocation for the app-server transaction:
+
+    initialize(experimentalApi=true) -> thread/start -> thread/goal/set(active)
+      -> turn/start -> observe continuation turns while the Goal stays active
+
+That transaction is not reimplemented here.  `native_codex_goal.py` from LoopX
+already owns it, is stdlib-only, and is the same code path the LoopX arm will
+use later — sharing it is what keeps the two arms differing in LoopX alone
+rather than in how each one talks to Codex.  It is copied into the container at
+run time rather than baked into the image so that the two arms cannot drift.
+
+The swap is done by intercepting `exec_as_agent` rather than by reimplementing
+`run()`.  Pier's `run()` is one long method whose setup (auth resolution,
+ownership fixes, config blocks) would have to be duplicated and kept in step
+with upstream; intercepting the one command that matters leaves that setup
+untouched.  If Pier ever changes how it invokes Codex, the marker below stops
+matching and this fails loudly instead of silently reverting to plain
+`codex exec` — which would look like a successful Goal run with no Goal in it.
+
+Usage:
+
+    MR_AGENT=goal_codex:GoalCodex MR_MODEL=openai/gpt-5.5 ./run.sh --all -i <task>
+
+Environment:
+
+    MR_GOAL_PREFLIGHT=1        prove Goal attachment and stop before any model
+                               turn — costs nothing, use it first on a new box
+    MR_GOAL_TIMEOUT_SEC        ceiling for the continuation loop (default 5100,
+                               under the 5400 s task budget so the loop stops
+                               itself instead of being killed mid-turn)
+    MR_GOAL_TOKEN_BUDGET       optional Goal token budget
+    MR_NATIVE_GOAL_MODULE      path to LoopX's native_codex_goal.py on the host
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+from pier.agents.installed.codex import Codex
+from pier.models.trial.paths import EnvironmentPaths
+
+# Pier builds exactly one command containing this; see
+# pier/agents/installed/codex.py, Codex.run().
+_CODEX_EXEC_MARKER = "codex exec "
+
+_REMOTE_DIR = "/tmp/loopx-goal"
+_LOOPX_MOUNT = "/opt/loopx"
+_DEFAULT_LOOPX_ROOT = os.path.expanduser("~/szh/loopx")
+_DEFAULT_MODULE = os.path.expanduser(
+    "~/szh/loopx/loopx/capabilities/benchmark_toolkit/native_codex_goal.py"
+)
+
+# The Goal objective is fixed rather than derived from the task text.  A Goal is
+# meant to state the durable intent that survives across continuation turns,
+# while the task file already carries the specifics; restating the task as the
+# objective gave the model two copies of the same thing and nothing to hold on
+# to between turns.  DeepSWE grades a committed patch, so committing belongs in
+# the objective — a run that solves the task and never commits scores zero.
+_OBJECTIVE = (
+    "Complete the software engineering task described in the task file. "
+    "Work in the repository, keep existing behaviour intact, verify the change "
+    "against the repository's own tests, and commit the finished work to a new "
+    "branch off main. The goal is complete only once the change is committed."
+)
+
+# A Goal only continues while it is still active, so an objective that one turn
+# can satisfy never exercises the continuation loop — and the objective above
+# says outright that committing completes it.  Across 53 runs the continuation
+# count was zero every time, which makes the measured "Goal API has no effect"
+# a statement about an objective that never needed the API, not about the API.
+#
+# This variant withholds completion until work that cannot plausibly finish in
+# one turn is done: pass, then re-derive from the tests, then hunt regressions,
+# then edge cases. Whether that actually keeps the Goal active is the thing
+# being tested — if the continuation count is still zero, single-turn
+# termination is Codex's behaviour here rather than an artefact of the wording.
+_OBJECTIVE_STAGED = (
+    "Complete the software engineering task described in the task file, in "
+    "stages, and do not consider the goal complete until every stage is done.\n"
+    "Stage 1: make the target behaviour work and commit it.\n"
+    "Stage 2: re-read the task description and check your implementation "
+    "against every requirement it states, including ones you did not address "
+    "in stage 1. Fix what is missing and commit.\n"
+    "Stage 3: look for behaviour you may have broken elsewhere in the "
+    "repository, run the wider test suite, and fix any regression you find.\n"
+    "Stage 4: consider edge cases the tests may not cover — empty inputs, "
+    "concurrent use, error paths — and handle the ones the task implies.\n"
+    "The goal is complete only after stage 4."
+)
+
+
+def _objective() -> str:
+    return _OBJECTIVE_STAGED if os.environ.get("MR_GOAL_OBJECTIVE") == "staged" else _OBJECTIVE
+
+
+# All three arms keep Pier's own agent name.  Overriding name() per arm looked
+# tidy but fed straight into AgentInstallSpec.fingerprint(), whose first input is
+# agent_name — so each arm produced a different PIER_AGENT_INSTALL_FINGERPRINT,
+# invalidated the Docker layer cache, and rebuilt `nvm install 22` plus the npm
+# install of Codex for every task in every arm: 162 builds where 54 would do.
+# It also removed the only fallback for a network outage, since a cached layer
+# needs no proxy.  The arm is selected by pier_cn.py rebinding AgentName.CODEX,
+# which needs no distinct name.
+
+_WEB_SEARCH_OFF = 'printf "\\nweb_search = \\"disabled\\"\\n" >> "$CODEX_HOME/config.toml"'
+
+
+class PlainCodex(Codex):
+    """The control arm: same everything, no Goal attached.
+
+    Exists so that Goal vs no-Goal differs in the Goal API and nothing else.
+    Two things have to be carried over from GoalCodex or the comparison measures
+    the wrong difference:
+
+    * ``web_search`` off.  Stock Codex leaves it at its default, and it is a
+      hosted tool the container's egress allowlist cannot block, so one arm
+      could look answers up.
+    * the objective text.  A Goal cannot exist without an objective, so the Goal
+      arm is necessarily prompted with those three sentences.  Withholding them
+      here would fold "the effect of that wording" into the measured difference.
+      Appending them leaves the API as the only variable.
+
+    What remains different is intrinsic: `codex exec` runs one turn and exits,
+    while the app-server keeps serving continuations while the Goal stays
+    active.  That *is* the treatment.
+    """
+
+    async def run(self, instruction, environment, context):  # type: ignore[override]
+        return await super().run(
+            f"{instruction}\n\n{_objective()}", environment, context
+        )
+
+    async def exec_as_agent(self, environment, command: str = "", env=None, **kwargs):  # type: ignore[override]
+        if _CODEX_EXEC_MARKER in command:
+            await super().exec_as_agent(environment, command=_WEB_SEARCH_OFF, env=env)
+        return await super().exec_as_agent(
+            environment, command=command, env=env, **kwargs
+        )
+
+
+class LoopxCodex(Codex):
+    """The third arm: Codex driven by LoopX's governed Turn loop.
+
+    The other two arms both stop when the model says it is finished — `codex
+    exec` exits, and the Goal API marked every one of 53 runs complete on the
+    first turn.  LoopX is the only arm where something other than the model
+    decides: it runs one Turn, requires an independent validator to prove the
+    postcondition, and only then commits and spends quota.  Turn two happens
+    because the controller asks for it.
+
+    Everything else is held to the other arms: same model, same disabled
+    web_search, same bypassed sandbox, same task set.  The staged Todo text
+    mirrors the four-stage objective already tested on the Goal arm, where it
+    did not produce a single continuation — so any multi-turn behaviour here is
+    attributable to the loop rather than to the wording.
+
+    LoopX is bind-mounted rather than installed: it declares no runtime
+    dependencies, and a read-only mount cannot drift between tasks the way 54
+    separate installs could.
+
+    Sandbox is ``workspace-write`` rather than the bypass the other two arms
+    use, because LoopX rejects anything else in two places — the argparse
+    choices and again in the driver ("Codex CLI sandbox must be read-only or
+    workspace-write").  Whether Codex can actually execute under it inside
+    these containers is the thing this arm has to establish first: the app-
+    server path could not, but that is a different code path from
+    ``codex exec --sandbox``, and assuming they behave alike is what a smoke
+    test is for.  If it works, the other two arms should move to the same value
+    so permissions stop being a second difference between the arms.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._loopx_instruction: str | None = None
+        self._loopx_swapped = False
+
+    async def run(self, instruction, environment, context):  # type: ignore[override]
+        self._loopx_instruction = instruction
+        self._loopx_swapped = False
+        try:
+            return await super().run(instruction, environment, context)
+        finally:
+            if not self._loopx_swapped:
+                raise RuntimeError(
+                    "LoopxCodex never intercepted a `codex exec` command — this "
+                    "run would have been plain Codex with no LoopX loop."
+                )
+
+    async def exec_as_agent(self, environment, command: str = "", env=None, **kwargs):  # type: ignore[override]
+        if _CODEX_EXEC_MARKER not in command:
+            return await super().exec_as_agent(
+                environment, command=command, env=env, **kwargs
+            )
+
+        self._loopx_swapped = True
+        model = self._command_model_name or (self.model_name or "").split("/")[-1]
+
+        loopx_root = Path(os.environ.get("MR_LOOPX_ROOT", _DEFAULT_LOOPX_ROOT))
+        if not (loopx_root / "loopx" / "__init__.py").is_file():
+            raise FileNotFoundError(f"LoopX package not found under {loopx_root}")
+        runner_src = Path(__file__).resolve().parent / "loopx_turn_runner.py"
+
+        await super().exec_as_agent(
+            environment, command=f"mkdir -p {shlex.quote(_REMOTE_DIR)}", env=env
+        )
+        await super().exec_as_agent(environment, command=_WEB_SEARCH_OFF, env=env)
+
+        # LoopX arrives as one tarball rather than a bind mount: the container is
+        # created by Pier from its own compose file, so an agent cannot add a
+        # mount to it, and uploading 710 files one at a time is not a serious
+        # option.  Packed once per run rather than once per task would be nicer
+        # still, but the tar is ~13 MB and building it is far cheaper than the
+        # model turn that follows.
+        with tempfile.TemporaryDirectory() as tmp:
+            tarball = Path(tmp) / "loopx.tar.gz"
+            subprocess.run(
+                ["tar", "czf", str(tarball), "-C", str(loopx_root), "loopx"],
+                check=True,
+            )
+            task_path = Path(tmp) / "task.txt"
+            task_path.write_text(self._loopx_instruction or "", encoding="utf-8")
+            for local, remote in (
+                (tarball, f"{_REMOTE_DIR}/loopx.tar.gz"),
+                (task_path, f"{_REMOTE_DIR}/task.txt"),
+                (runner_src, f"{_REMOTE_DIR}/loopx_turn_runner.py"),
+                (runner_src.parent / "codex_nosandbox_wrapper.py",
+                 f"{_REMOTE_DIR}/codex_nosandbox_wrapper.py"),
+            ):
+                await environment.upload_file(str(local), remote)
+
+        if environment.default_user is not None:
+            await self.exec_as_root(
+                environment,
+                command=f"chown -R {environment.default_user} {shlex.quote(_REMOTE_DIR)} && chmod +x {shlex.quote(_REMOTE_DIR)}/codex_nosandbox_wrapper.py",
+            )
+        await super().exec_as_agent(
+            environment,
+            command=(
+                f"mkdir -p {shlex.quote(_LOOPX_MOUNT)} && "
+                f"tar xzf {shlex.quote(_REMOTE_DIR)}/loopx.tar.gz "
+                f"-C {shlex.quote(_LOOPX_MOUNT)} && "
+                f"python3 -c 'import sys; sys.path.insert(0, \"{_LOOPX_MOUNT}\"); "
+                "import loopx.cli_commands.turn'"
+            ),
+            env=env,
+        )
+
+        args = [
+            "python3",
+            f"{_REMOTE_DIR}/loopx_turn_runner.py",
+            "--project", "__PWD__",
+            "--task-file", f"{_REMOTE_DIR}/task.txt",
+            "--runtime-root", f"{_REMOTE_DIR}/runtime",
+            "--codex-bin", "codex",
+            "--model", model,
+            "--sandbox", os.environ.get("MR_LOOPX_SANDBOX", "workspace-write"),
+            "--quota", os.environ.get("MR_LOOPX_QUOTA", "4"),
+        ]
+        rendered = shlex.join(args).replace("'__PWD__'", '"$(pwd)"').replace(
+            "__PWD__", '"$(pwd)"'
+        )
+        output = (EnvironmentPaths.agent_dir / "loopx-turns.json").as_posix()
+        return await super().exec_as_agent(
+            environment,
+            command=(
+                "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; "
+                f"PYTHONPATH={shlex.quote(_LOOPX_MOUNT)} {rendered} "
+                f"2>&1 </dev/null | tee {shlex.quote(output)}"
+            ),
+            env=env,
+        )
+
+
+class GoalCodex(Codex):
+    """Codex with its native Goal loop actually running."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._goal_instruction: str | None = None
+        self._goal_swapped = False
+
+    async def run(self, instruction, environment, context):  # type: ignore[override]
+        self._goal_instruction = instruction
+        self._goal_swapped = False
+        try:
+            return await super().run(instruction, environment, context)
+        finally:
+            if not self._goal_swapped:
+                raise RuntimeError(
+                    "GoalCodex never intercepted a `codex exec` command — Pier's "
+                    "Codex.run() no longer matches the expected shape, and this "
+                    "run would have been plain Codex with no Goal attached."
+                )
+
+    async def exec_as_agent(self, environment, command: str = "", env=None, **kwargs):  # type: ignore[override]
+        if _CODEX_EXEC_MARKER not in command:
+            return await super().exec_as_agent(
+                environment, command=command, env=env, **kwargs
+            )
+
+        self._goal_swapped = True
+        instruction = self._goal_instruction or ""
+        model = self._command_model_name or (self.model_name or "").split("/")[-1]
+
+        module_src = Path(os.environ.get("MR_NATIVE_GOAL_MODULE", _DEFAULT_MODULE))
+        if not module_src.is_file():
+            raise FileNotFoundError(
+                f"native_codex_goal.py not found at {module_src}; set "
+                "MR_NATIVE_GOAL_MODULE to LoopX's copy"
+            )
+
+        await super().exec_as_agent(
+            environment, command=f"mkdir -p {shlex.quote(_REMOTE_DIR)}", env=env
+        )
+
+        # Upload rather than heredoc: the instruction is arbitrary user text and
+        # routinely contains quotes, backticks and $ — shell-quoting it into a
+        # container command is how the objective silently loses characters.
+        with tempfile.TemporaryDirectory() as tmp:
+            objective_path = Path(tmp) / "objective.txt"
+            task_path = Path(tmp) / "task.txt"
+            objective_path.write_text(_objective(), encoding="utf-8")
+            task_path.write_text(instruction, encoding="utf-8")
+
+            for local, remote in (
+                (module_src, f"{_REMOTE_DIR}/native_codex_goal.py"),
+                (objective_path, f"{_REMOTE_DIR}/objective.txt"),
+                (task_path, f"{_REMOTE_DIR}/task.txt"),
+            ):
+                await environment.upload_file(str(local), remote)
+
+        # upload_file writes as root; the agent user has to be able to read them.
+        if environment.default_user is not None:
+            await self.exec_as_root(
+                environment,
+                command=f"chown -R {environment.default_user} {shlex.quote(_REMOTE_DIR)} && chmod +x {shlex.quote(_REMOTE_DIR)}/codex_nosandbox_wrapper.py",
+            )
+
+        # Codex ships a `web_search` tool.  It is a hosted tool — the provider
+        # runs the search, so it does not traverse the container's network and
+        # the egress allowlist that blocks apt, pip and the open internet does
+        # not block it.  Left at its default, one arm of this experiment could
+        # look things up while the 113-task mini-swe-agent baseline could not,
+        # and no amount of network isolation would show it.  Disabling it in
+        # config.toml covers both `codex exec` and `codex app-server`; the key
+        # and its values come from the binary's own override message ("live",
+        # "cached", "disabled").  The no-Goal arm needs the same line for the
+        # comparison to hold.
+        await super().exec_as_agent(
+            environment,
+            command=_WEB_SEARCH_OFF,
+            env=env,
+        )
+
+        runner = _RUNNER.format(remote_dir=_REMOTE_DIR)
+        await super().exec_as_agent(
+            environment,
+            command=f"cat > {shlex.quote(_REMOTE_DIR)}/run_goal.py <<'LOOPX_EOF'\n{runner}\nLOOPX_EOF",
+            env=env,
+        )
+
+        timeout = os.environ.get("MR_GOAL_TIMEOUT_SEC", "5100")
+        budget = os.environ.get("MR_GOAL_TOKEN_BUDGET", "")
+        preflight = os.environ.get("MR_GOAL_PREFLIGHT", "") not in ("", "0")
+
+        args = [
+            "python3",
+            f"{_REMOTE_DIR}/run_goal.py",
+            "--cwd",
+            "__PWD__",
+            "--objective-file",
+            # The LoopX arm renders its objective with LoopX's own CLI and
+            # points here; a subclass cannot substitute it by rewriting the
+            # command, because this method calls `super().exec_as_agent` rather
+            # than `self.`, so an override never sees the built command at all.
+            os.environ.get("MR_GOAL_OBJECTIVE_FILE", f"{_REMOTE_DIR}/objective.txt"),
+            "--task-file",
+            f"{_REMOTE_DIR}/task.txt",
+            "--codex-bin",
+            "codex",
+            "--model",
+            model,
+            "--goal-timeout-seconds",
+            timeout,
+            # NativeGoalConfig defaults to sandbox="workspace-write", which on
+            # Linux is enforced with landlock/seccomp and cannot be set up
+            # inside these task containers.  Codex then declines to run
+            # commands: the first attempt produced 431 assistant-message deltas,
+            # zero command_execution events, zero file_change events and an
+            # empty model.patch, which the verifier scored 0/24 — a harness
+            # failure that reads exactly like the model failing the task.
+            # `codex exec` avoids it with --dangerously-bypass-approvals-and-
+            # sandbox; this is the app-server equivalent, so both arms execute
+            # under the same permissions.
+            "--sandbox",
+            os.environ.get("MR_GOAL_SANDBOX", "danger-full-access"),
+        ]
+        if budget:
+            args += ["--token-budget", budget]
+        # Empty on this arm.  The LoopX arm sets it to the skill ids its
+        # installed profile materialized, which arms `skills/list` as a
+        # precondition of thread creation: without it a run in which Codex never
+        # discovered LoopX still finishes and still scores, and is then filed as
+        # a LoopX result.  One such run has already happened.
+        skills = os.environ.get("MR_GOAL_REQUIRED_SKILL_IDS", "").strip()
+        if skills:
+            args += ["--required-skill-ids", skills]
+        if preflight:
+            args.append("--preflight-only")
+
+        # No task declares a working directory, so `codex exec` would have run
+        # in whatever WORKDIR the image sets — different per repository.  Resolve
+        # it in the container instead of guessing.  Both spellings are replaced
+        # because shlex.join only quotes a token that needs it, and this one
+        # (letters and underscores) comes back bare: matching only the quoted
+        # form silently leaves the placeholder in the command, which surfaces as
+        # FileNotFoundError('__PWD__') from inside the runner.
+        rendered = shlex.join(args)
+        rendered = rendered.replace("'__PWD__'", '"$(pwd)"').replace(
+            "__PWD__", '"$(pwd)"'
+        )
+
+        output = (EnvironmentPaths.agent_dir / "codex-goal.json").as_posix()
+        # The LoopX arm points CODEX_HOME at its installed profile so app-server
+        # discovers the LoopX skills; this arm leaves it as Pier set it up.
+        codex_home = os.environ.get("MR_GOAL_CODEX_HOME", "").strip()
+        prefix = f"export CODEX_HOME={shlex.quote(codex_home)}; " if codex_home else ""
+        # The profile's `loopx` launcher was built on the host and records the
+        # host's own Python path, which does not exist in the container.  This
+        # was fixed for the one-shot bootstrap script by exporting the variable
+        # in that command's own shell -- but bootstrap and this long-lived
+        # app-server process are separate `docker exec` invocations, each with
+        # its own shell, so the export did not carry over. Any `loopx` command
+        # Codex itself runs *during* a turn -- todo claim, quota should-run,
+        # heartbeat-prompt -- inherits app-server's process environment, not
+        # bootstrap's, and failed with the same "configured Python executable
+        # not found" every time until this export is repeated here. A session
+        # transcript showed exactly that: two failed `loopx` calls mid-turn.
+        if os.environ.get("MR_GOAL_ARM_LOOPX_PYTHON", "") not in ("", "0"):
+            prefix += 'export LOOPX_PYTHON="$(command -v python3)"; '
+        return await super().exec_as_agent(
+            environment,
+            command=(
+                "if [ -s ~/.nvm/nvm.sh ]; then . ~/.nvm/nvm.sh; fi; "
+                f"{prefix}{rendered} 2>&1 </dev/null | tee {shlex.quote(output)}"
+            ),
+            env=env,
+        )
+
+
+# Written into the container next to the uploaded module.  LoopX's own
+# run_native_codex_goal.py imports through the `loopx` package, which is not
+# installed in a task image; this is the same entry point with the package
+# import removed.
+_RUNNER = '''\
+import argparse, json, sys
+from pathlib import Path
+
+sys.path.insert(0, "{remote_dir}")
+from native_codex_goal import (
+    NativeGoalConfig,
+    compact_native_goal_receipt,
+    probe_native_goal_process,
+    run_native_goal_process_until_terminal,
+)
+
+p = argparse.ArgumentParser()
+p.add_argument("--cwd", required=True)
+p.add_argument("--objective-file", required=True)
+p.add_argument("--task-file", required=True)
+p.add_argument("--codex-bin", default="codex")
+p.add_argument("--model")
+p.add_argument("--effort")
+p.add_argument("--token-budget", type=int)
+p.add_argument("--response-timeout-seconds", type=float, default=30)
+p.add_argument("--goal-timeout-seconds", type=float, default=21600)
+p.add_argument("--sandbox", default="danger-full-access")
+p.add_argument("--required-skill-ids", default="")
+p.add_argument("--preflight-only", action="store_true")
+a = p.parse_args()
+
+config = NativeGoalConfig(
+    cwd=a.cwd,
+    objective=Path(a.objective_file).read_text(encoding="utf-8").strip(),
+    task_instruction=Path(a.task_file).read_text(encoding="utf-8").strip(),
+    model=a.model,
+    effort=a.effort,
+    token_budget=a.token_budget,
+    sandbox=a.sandbox,
+    # Empty on the Goal arm, which has no skills to require.  The LoopX arm
+    # passes the installed skill ids, which makes `skills/list` a precondition
+    # of thread creation: a run where Codex never discovered LoopX then fails
+    # before any model work rather than scoring as a LoopX result.
+    required_skill_ids=tuple(
+        s for s in (x.strip() for x in a.required_skill_ids.split(",")) if s
+    ),
+)
+if a.preflight_only:
+    turn = probe_native_goal_process(
+        config, codex_bin=a.codex_bin, response_timeout_sec=a.response_timeout_seconds
+    )
+    mode = "goal_attachment_preflight"
+else:
+    turn = run_native_goal_process_until_terminal(
+        config,
+        codex_bin=a.codex_bin,
+        response_timeout_sec=a.response_timeout_seconds,
+        goal_timeout_sec=a.goal_timeout_seconds,
+    )
+    mode = "goal_until_terminal"
+
+receipt = compact_native_goal_receipt(turn)
+receipt["execution_mode"] = mode
+print(json.dumps(receipt, indent=2, sort_keys=True))
+'''

--- a/benchmark/swe-marathon/runtime/turn/loopx_native_codex.py
+++ b/benchmark/swe-marathon/runtime/turn/loopx_native_codex.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""The LoopX arm, driven through LoopX's own product path.
+
+The first LoopX arm measured the wrong thing.  It called `loopx turn run-once`
+from an outer loop of my own, four times, against a goal document I hand-wrote
+with four stages in it.  `benchmark/deepswe/README.md` rules that out in as
+many words -- the treatment must not be "an outer polling loop labeled as Goal
+mode" -- and it makes the distinction a formal gate: "a clean run can still be
+uncountable when the treatment did not execute the preregistered LoopX path".
+Under LoopX's own standard those 54 results are uncountable.  They describe my
+wrapper, not this product.
+
+The real path, all of it LoopX's:
+
+    install_native_codex_profile      scripts/install-local.sh builds a release
+                                      snapshot and installs the six LoopX skills
+                                      into a profile-owned CODEX_HOME
+    loopx bootstrap                   LoopX writes .loopx/registry.json and
+                                      .codex/goals/<id>/ACTIVE_GOAL_STATE.md,
+                                      with its own execution profile
+    loopx configure-goal              registers the peer identity
+    render_native_codex_goal_prompt   the installed CLI renders the real Goal
+                                      body -- the thing I used to hand-write
+    run_native_goal_process_until_terminal
+                                      codex app-server owns continuation while
+                                      the Goal stays active; nothing here counts
+                                      turns
+
+`required_skill_ids` makes `skills/list` a precondition of thread creation, so a
+run in which Codex never discovered the LoopX skills fails before model work
+instead of quietly scoring as a LoopX result.
+
+Everything Pier does to stand Codex up is inherited from GoalCodex, which also
+already owns the app-server transaction (it copies LoopX's own
+`native_codex_goal.py` into the container).  Only three things differ from the
+Goal arm: where CODEX_HOME points, who wrote the objective, and whether the
+skills gate is armed.  That is the intended contrast -- the same host, the same
+transaction, LoopX present or absent.
+
+The profile is built on the host and shipped, rather than installed in the
+container: `install-local.sh` is offline (no pip, npm, curl, wget, git clone or
+apt in 872 lines, so the sandbox is not the obstacle), but it verifies that its
+source tree is a clean checkout, and the container receives a tarball of the
+`loopx` package with no `.git` to verify.  Building it once on the host keeps
+`source_clean` a real claim.  Both sides use the same absolute path so the
+release snapshot's symlinks stay valid.
+
+Usage:
+
+    MR_AGENT=loopx_native_codex:LoopxNativeCodex MR_MODEL=openai/gpt-5.5 \
+      ./run.sh --all -i <task>
+
+Environment:
+
+    MR_LOOPX_PREFLIGHT=1     prove skills discovery and Goal attachment, then
+                             stop before any model turn -- costs nothing
+    MR_LOOPX_PROFILE_ROOT    where the profile lives on host and in container
+                             (default /tmp/loopx-profile; must match on both)
+    MR_LOOPX_ROOT            LoopX checkout to install from
+    MR_GOAL_TIMEOUT_SEC      ceiling for the continuation loop
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from goal_codex import GoalCodex, _CODEX_EXEC_MARKER, _REMOTE_DIR
+
+_PROFILE_ROOT = os.environ.get("MR_LOOPX_PROFILE_ROOT", "/tmp/loopx-profile")
+_LOOPX_ROOT = os.path.expanduser(os.environ.get("MR_LOOPX_ROOT", "~/szh/loopx"))
+_GOAL_ID = "deepswe-task"
+_AGENT_ID = "deepswe-codex"
+_PROJECT = "/app"
+# Deliberately not GoalCodex's objective.txt: that file is written after this
+# runs, so sharing the name would let the Goal arm's hand-written objective
+# overwrite the one LoopX rendered.
+_OBJECTIVE_FILE = f"{_REMOTE_DIR}/loopx_objective.txt"
+
+
+def build_host_profile(loopx_root: str = _LOOPX_ROOT,
+                       profile_root: str = _PROFILE_ROOT) -> dict:
+    """Install the formal release snapshot once, on the host.
+
+    Reuses an existing profile: the installer refuses a non-empty target on
+    purpose, because mixing installation revisions would invalidate the
+    treatment, and re-installing per task would repeat that work 54 times.
+    """
+    sys.path.insert(0, loopx_root)
+    from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
+        compact_native_codex_profile_receipt,
+        inspect_native_codex_profile,
+        install_native_codex_profile,
+    )
+
+    target = Path(profile_root)
+    if target.exists() and any(target.iterdir()):
+        profile = inspect_native_codex_profile(target, source_root=loopx_root)
+    else:
+        profile = install_native_codex_profile(loopx_root, target)
+    return compact_native_codex_profile_receipt(profile)
+
+
+class LoopxNativeCodex(GoalCodex):
+    """Codex with LoopX installed, driven by LoopX's rendered Goal."""
+
+    async def exec_as_agent(self, environment, command, env=None, **kwargs):  # noqa: ANN001
+        # Intercept the same marker GoalCodex does, not the command it builds.
+        # GoalCodex reaches the launch through `super().exec_as_agent`, so an
+        # override keyed on `run_goal.py` is never called: the first version of
+        # this arm silently shipped no profile, armed no skills gate, and still
+        # produced a receipt that looked like a LoopX run.  Everything below is
+        # therefore handed over through the environment, which GoalCodex reads
+        # while building its own command.
+        if _CODEX_EXEC_MARKER not in str(command):
+            return await super().exec_as_agent(environment, command, env=env, **kwargs)
+
+        profile_receipt = build_host_profile()
+        parent = str(Path(_PROFILE_ROOT).parent)
+        name = Path(_PROFILE_ROOT).name
+
+        await super().exec_as_agent(
+            environment, command=f"mkdir -p {shlex.quote(_REMOTE_DIR)}", env=env
+        )
+
+        # Ship the installed profile to the identical absolute path: the release
+        # snapshot's `bin/loopx` is a symlink into releases/, so a different path
+        # would leave a dangling CLI and no Goal body could be rendered at all.
+        with tempfile.TemporaryDirectory() as tmp:
+            tarball = Path(tmp) / "profile.tar.gz"
+            subprocess.run(
+                ["tar", "czf", str(tarball), "-C", parent, name], check=True
+            )
+            receipt_path = Path(tmp) / "profile_receipt.json"
+            receipt_path.write_text(
+                json.dumps(profile_receipt, indent=2), encoding="utf-8"
+            )
+            bootstrap_path = Path(tmp) / "loopx_product_bootstrap.py"
+            bootstrap_path.write_text(_BOOTSTRAP, encoding="utf-8")
+            for local, remote in (
+                (tarball, f"{_REMOTE_DIR}/profile.tar.gz"),
+                (receipt_path, f"{_REMOTE_DIR}/profile_receipt.json"),
+                (bootstrap_path, f"{_REMOTE_DIR}/loopx_product_bootstrap.py"),
+            ):
+                await environment.upload_file(str(local), remote)
+
+        await super().exec_as_agent(
+            environment,
+            command=(
+                f"mkdir -p {shlex.quote(parent)} && "
+                f"tar xzf {shlex.quote(_REMOTE_DIR)}/profile.tar.gz "
+                f"-C {shlex.quote(parent)} && "
+                f"test -x {shlex.quote(_PROFILE_ROOT)}/bin/loopx"
+            ),
+            env=env,
+        )
+
+        # LoopX writes its own registry, goal state and Goal body.  Nothing in
+        # this arm authors goal content: the hand-written four-stage document
+        # the previous arm used is exactly what made its results describe a
+        # prompt of mine rather than this product.
+        await super().exec_as_agent(
+            environment,
+            command=(
+                # The profile is installed on the host, so its launcher records
+                # the host's Python path -- a uv-managed interpreter that does
+                # not exist in the task image, which made every CLI call exit 2
+                # with "configured Python executable not found".  LOOPX_PYTHON
+                # redirects the launcher at the container's own interpreter
+                # without reinstalling, so the release snapshot stays the one
+                # whose cleanliness was proven on the host.
+                f"cd {shlex.quote(_PROJECT)} && "
+                "export LOOPX_PYTHON=\"$(command -v python3)\" && "
+                "python3 -c 'import sys; assert sys.version_info >= (3, 11), sys.version' && "
+                f"python3 {shlex.quote(_REMOTE_DIR)}/loopx_product_bootstrap.py "
+                f"--profile-root {shlex.quote(_PROFILE_ROOT)} "
+                f"--project {shlex.quote(_PROJECT)} "
+                f"--goal-id {_GOAL_ID} --agent-id {_AGENT_ID} "
+                f"--objective-out {shlex.quote(_OBJECTIVE_FILE)} "
+                f"--receipt-out {shlex.quote(_REMOTE_DIR)}/loopx_product.json"
+            ),
+            env=env,
+        )
+
+        os.environ["MR_GOAL_OBJECTIVE_FILE"] = _OBJECTIVE_FILE
+        os.environ["MR_GOAL_CODEX_HOME"] = f"{_PROFILE_ROOT}/codex-home"
+        os.environ["MR_GOAL_REQUIRED_SKILL_IDS"] = ",".join(
+            profile_receipt["required_skill_ids"]
+        )
+        # Arm GoalCodex's LOOPX_PYTHON export for the actual app-server process,
+        # not just the earlier bootstrap script -- Codex's own mid-turn `loopx`
+        # calls run inside app-server's environment and hit the same failure
+        # bootstrap did until this is set here too.
+        os.environ["MR_GOAL_ARM_LOOPX_PYTHON"] = "1"
+        if os.environ.get("MR_LOOPX_PREFLIGHT", "") not in ("", "0"):
+            os.environ["MR_GOAL_PREFLIGHT"] = "1"
+
+        # Give the profile's CODEX_HOME the credentials and provider settings
+        # Pier wrote into its own.  Pointing app-server at the formally
+        # installed CODEX_HOME is what makes `skills/list` find LoopX, but that
+        # directory ships only `skills/` -- no auth.json, no config.toml, so no
+        # API key and no gateway base_url.  A run configured that way discovers
+        # every skill, starts, and then waits for a model it has no address
+        # for: one smoke hung for 85 minutes and the gateway's call count never
+        # moved.  The preflight cannot catch it, because Goal attachment stops
+        # before the first model turn and needs no credentials.
+        #
+        # Only top-level files are copied.  `cp -a` of the whole directory
+        # would merge Pier's own skills over the formal install, and which
+        # skills app-server discovers is the one thing this arm must not
+        # improvise.
+        profile_home = f"{_PROFILE_ROOT}/codex-home"
+        await super().exec_as_agent(
+            environment,
+            command=(
+                'for f in "$CODEX_HOME"/*; do '
+                f'[ -f "$f" ] && cp -f "$f" {shlex.quote(profile_home)}/; '
+                "done; "
+                # GoalCodex disables web_search by appending to *its* CODEX_HOME
+                # after this runs, so the copy above would leave the profile
+                # without it and give this arm a hosted search tool the other
+                # two do not have -- an advantage no network isolation would
+                # reveal, since the provider runs the search.
+                f'grep -q "^web_search" {shlex.quote(profile_home)}/config.toml '
+                f'|| printf "\\nweb_search = \\"disabled\\"\\n" '
+                f'>> {shlex.quote(profile_home)}/config.toml; '
+                f'test -s {shlex.quote(profile_home)}/config.toml '
+                '|| { echo "no config.toml reached the LoopX profile" >&2; exit 1; }'
+            ),
+            env=env,
+        )
+
+        # Capture LoopX's own trace before the container is torn down.  Pier's
+        # own teardown copies `$CODEX_HOME/sessions` into the job directory,
+        # but that is Pier's CODEX_HOME -- this arm points app-server at the
+        # profile's instead, so codex writes its session transcript to
+        # `{profile_home}/sessions` and Pier's copy finds nothing.  The first
+        # smoke run's job directory logged "No Codex session directory found"
+        # for exactly this reason: the transcript existed, just one directory
+        # over from where anyone looked for it.
+        #
+        # This has to be a second, separate call rather than the launch command
+        # rewritten to append a capture step.  `command` at this point still
+        # reads "codex exec ..." -- GoalCodex.exec_as_agent below only checks
+        # for that marker's presence and then throws the string away, building
+        # its own `run_goal.py` invocation from internal state.  Appending shell
+        # onto a string GoalCodex never looks at silently does nothing, which is
+        # exactly the bug that made the CODEX_HOME swap above necessary: this
+        # arm keeps stumbling on places where a value must go through GoalCodex
+        # rather than through the string it happens to be holding.
+        capture_dir = "/logs/agent/loopx_trace"
+        try:
+            return await super().exec_as_agent(
+                environment, command=command, env=env, **kwargs
+            )
+        finally:
+            await super().exec_as_agent(
+                environment,
+                command=(
+                    f"mkdir -p {shlex.quote(capture_dir)}; "
+                    f'if [ -d {shlex.quote(profile_home)}/sessions ]; then '
+                    f'cp -R {shlex.quote(profile_home)}/sessions '
+                    f'{shlex.quote(capture_dir)}/sessions; fi; '
+                    f'find /app/.codex/goals -name ACTIVE_GOAL_STATE.md '
+                    f'-exec cp {{}} {shlex.quote(capture_dir)}/ACTIVE_GOAL_STATE.md \\; '
+                    f'2>/dev/null; '
+                    # Same LOOPX_PYTHON fix as the app-server launch above: this
+                    # CLI call is yet another separate shell, and without its own
+                    # export it fails with the same "configured Python
+                    # executable not found" that showed up twice in mid-turn
+                    # calls before the launch-side fix existed.
+                    'export LOOPX_PYTHON="$(command -v python3)"; '
+                    f'{shlex.quote(_PROFILE_ROOT)}/bin/loopx '
+                    f'--registry {shlex.quote(_PROJECT)}/.loopx/registry.json '
+                    f'--runtime-root {shlex.quote(_PROJECT)}/.loopx/runtime '
+                    f'--format json todo list --goal-id {_GOAL_ID} '
+                    f'> {shlex.quote(capture_dir)}/todo_list.json 2>&1; '
+                    "true"
+                ),
+                env=env,
+            )
+
+
+# Runs inside the container: bootstrap, register the peer, render the Goal body.
+_BOOTSTRAP = '''\
+import argparse, json, subprocess, sys
+from pathlib import Path
+
+p = argparse.ArgumentParser()
+p.add_argument("--profile-root", required=True)
+p.add_argument("--project", required=True)
+p.add_argument("--goal-id", required=True)
+p.add_argument("--agent-id", required=True)
+p.add_argument("--objective-out", required=True)
+p.add_argument("--receipt-out", required=True)
+a = p.parse_args()
+
+cli = f"{a.profile_root}/bin/loopx"
+registry = f"{a.project}/.loopx/registry.json"
+runtime = f"{a.project}/.loopx/runtime"
+base = [cli, "--registry", registry, "--runtime-root", runtime, "--format", "json"]
+steps = {}
+
+
+def run(name, args):
+    out = subprocess.run(base + args, capture_output=True, text=True)
+    try:
+        payload = json.loads(out.stdout)
+    except Exception:
+        payload = {}
+    # Keep returncode and both streams for every step.  Pier reports a failed
+    # agent command as "Command failed" and discards its output, so a step that
+    # dies here is otherwise invisible: the first run of this arm failed exactly
+    # once and left nothing but that phrase in the log.
+    steps[name] = {
+        "returncode": out.returncode,
+        "ok": payload.get("ok"),
+        "error": payload.get("error"),
+        "stdout_tail": out.stdout[-400:] if not payload else None,
+        "stderr_tail": out.stderr[-400:],
+    }
+    return payload
+
+
+run("bootstrap", ["bootstrap", "--project", a.project, "--goal-id", a.goal_id,
+                  "--objective", "Complete the software engineering task described "
+                  "in the task file and commit the finished work.",
+                  "--no-onboarding-scan"])
+run("configure_goal", ["configure-goal", "--goal-id", a.goal_id,
+                       "--registered-agent", a.agent_id, "--execute"])
+prompt = run("heartbeat_prompt",
+             ["heartbeat-prompt", "--thin", "--goal-id", a.goal_id,
+              "--agent-id", a.agent_id, "--available-capability", "shell",
+              "--available-capability", "filesystem_write",
+              "--runtime-profile", "codex_app_ssh_goal", "--cli-bin", cli])
+
+body = prompt.get("task_body")
+if body:
+    Path(a.objective_out).write_text(body, encoding="utf-8")
+    steps["goal_body_chars"] = len(body)
+else:
+    steps["fatal"] = "heartbeat-prompt returned no task_body"
+Path(a.receipt_out).write_text(json.dumps(steps, indent=2), encoding="utf-8")
+print(json.dumps(steps, indent=2))
+raise SystemExit(0 if body else 1)
+'''

--- a/benchmark/swe-marathon/runtime/turn/loopx_turn_runner.py
+++ b/benchmark/swe-marathon/runtime/turn/loopx_turn_runner.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""Drive one DeepSWE task through LoopX's governed Turn loop, inside the container.
+
+Run by LoopxCodex after the LoopX package, the Codex profile and the goal state
+have been staged.  Kept as a standalone script for the same reason
+native_codex_goal.py is: it must execute where the repository is, and the
+repository is inside the task container.
+
+Why this calls ``handle_turn_command`` instead of the ``loopx turn run-once``
+CLI: the CLI restricts ``--codex-sandbox`` to read-only and workspace-write,
+and neither can be set up inside these task images — the Linux sandbox needs
+kernel features the container does not grant, and Codex responds by narrating
+instead of executing (measured once: 431 assistant messages, zero command
+executions, an empty patch scored 0/24).  The other two arms run Codex with
+approvals and sandbox bypassed, so the LoopX arm has to as well or the three
+differ in permissions as well as in looping.  Editing LoopX's argparse choices
+would also have made the source tree dirty, and install_native_codex_profile
+refuses an unclean source because mixing revisions invalidates a benchmark
+treatment.  Building the Namespace directly avoids both problems and touches
+no file in the LoopX checkout.
+
+The loop is the point of the arm.  LoopX runs exactly one governed Turn per
+call: it selects a Todo, has the host adapter invoke Codex, requires an
+independent validator to prove the postcondition, and only then commits the
+result and spends quota.  Multi-turn behaviour comes from calling it again --
+which is precisely what the other two arms never do, since `codex exec` and the
+app-server both stop as soon as the model says it is finished.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REMOTE_DIR = Path(__file__).resolve().parent
+DEFAULT_QUOTA = int(os.environ.get("MR_LOOPX_QUOTA", "4"))
+DEFAULT_TURN_TIMEOUT = float(os.environ.get("MR_LOOPX_TURN_TIMEOUT", "1200"))
+
+GOAL_ID = "deepswe-task"
+AGENT_ID = "deepswe-codex"
+TODO_ID = "deepswe-todo-1"
+
+
+def hide_loopx_state_from_git(project: Path) -> None:
+    """Keep LoopX's own files out of git's view.
+
+    The goal document and registry have to live at paths inside the project —
+    LoopX resolves ``state_file`` relative to the repo — but they are control-
+    plane state, not the agent's work.  Left visible they break the run twice:
+    ``git status`` never comes back clean, so the validator rejects every Turn,
+    and they land in ``git diff base..HEAD``, which is exactly the patch the
+    benchmark grades.
+
+    Written to ``.git/info/exclude`` rather than ``.gitignore`` because that
+    file is local to the clone and never becomes part of the diff itself.
+    """
+    exclude = project / ".git" / "info" / "exclude"
+    if not exclude.parent.is_dir():
+        return
+    existing = exclude.read_text(encoding="utf-8") if exclude.exists() else ""
+    additions = [p for p in (".codex/", ".loopx/") if p not in existing]
+    if additions:
+        with exclude.open("a", encoding="utf-8") as fh:
+            fh.write("\n# LoopX control-plane state (benchmark harness)\n")
+            fh.write("\n".join(additions) + "\n")
+
+
+def stage_goal_state(project: Path, instruction: str) -> Path:
+    """Write the goal document LoopX reads Todos from.
+
+    The Todo, not the objective, is what LoopX plans against: it selects one per
+    Turn and asks the host to advance it.  Phrasing it as staged work is what
+    gives the loop somewhere to go on turn two — a Todo that one turn satisfies
+    ends the goal exactly the way the Goal-API arm already ends, and the arm
+    would measure nothing.
+    """
+    state = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(
+        "\n".join(
+            [
+                "---",
+                "status: active",
+                "updated_at: 2026-01-01T00:00:00+00:00",
+                "---",
+                "",
+                "# DeepSWE task",
+                "",
+                "## Agent Todo",
+                "",
+                "- [ ] [P0] Advance the task below by exactly one stage per Turn, "
+                "and report which stage you completed and what remains. "
+                "Stage 1: implement the target behaviour and commit. "
+                "Stage 2: re-check the implementation against every requirement "
+                "in the task text, fix gaps, commit. "
+                "Stage 3: run the wider test suite and repair any regression. "
+                "Stage 4: handle edge cases the tests do not cover.",
+                f"  <!-- loopx:todo todo_id={TODO_ID} status=open "
+                f"task_class=advancement_task action_kind=deepswe_task "
+                f"claimed_by={AGENT_ID} priority=P0 -->",
+                "",
+                "## How to report each Turn",
+                "",
+                # gpt-5.5 reached for path_delta_mode=material_replan on a plain
+                # first implementation Turn, which LoopX rejects four ways at
+                # once: that mode is reserved for Turns that overturn a prior
+                # assumption, and it then demands result_kind=replan_required
+                # plus a goal_path_delta_v0 vision packet the model had not
+                # produced.  Every Turn failed validation, so nothing committed
+                # and the quota bought nothing.  Advancing a stage is routine
+                # continuation, so say so explicitly rather than leaving the
+                # model to pick.
+                "This Todo is routine staged continuation, never a replan. In the",
+                "typed result set `path_delta_mode=unchanged`, leave",
+                "`agent_vision_json` empty, and give a one-line",
+                "`vision_unchanged_reason` such as \"routine stage advance\".",
+                "Set `delivery_batch_scale` to `implementation` when you changed",
+                "source, or `test_only` when you only touched tests.",
+                "Use `result_kind=validated_progress` when the stage advanced and",
+                "`repair_required` when it did not.",
+                "",
+                "## Task",
+                "",
+                instruction,
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return state
+
+
+def stage_registry(project: Path, runtime: Path, state: Path) -> Path:
+    """Write the registry LoopX plans against.
+
+    Shape follows LoopX's own e2e fixture rather than a guess: a goal needs
+    ``state_file`` to find its Todos, ``quota`` for the scheduler to spend
+    against, and a ``coordination`` block with ``registered_agents`` — without
+    the last one every Turn fails at planning with "quota should-run
+    --agent-id requires coordination.registered_agents", before the host is
+    ever invoked.
+
+    ``write_scope`` is the repository rather than the fixture's ``docs/**``:
+    the agent's whole job here is to change source.
+    """
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "deepswe-benchmark",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state.relative_to(project)),
+                        "adapter": {
+                            "kind": "fixture_v0",
+                            "status": "connected-delivery",
+                        },
+                        "quota": {"compute": 1.0, "window_hours": 24},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                            "agent_profiles": {
+                                AGENT_ID: {
+                                    "schema_version": "agent_profile_v1",
+                                    "profile_role": "benchmark",
+                                    "scope": "deepswe task",
+                                }
+                            },
+                            "write_scope": ["**"],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry
+
+
+def validator_command(project: Path, base_sha: str) -> list[str]:
+    """Postcondition: the Turn committed something new and left a clean tree.
+
+    Comparing against the base commit is the whole point.  An earlier version
+    only asked for a clean tree and a non-empty history, which any run
+    satisfies without doing anything at all — four Turns passed validation
+    while producing an empty patch.  A Turn that has not moved HEAD has not
+    advanced the Todo, whatever the model reports.
+
+    Deliberately structural, never the hidden tests: the benchmark's rules put
+    verifier invocation after the run and outside the controller, so that a
+    loop cannot steer on the grade.  What this proves is that the agent really
+    committed work rather than declaring success over an unchanged tree.
+    """
+    program = (
+        "import json,subprocess,sys;"
+        "json.load(sys.stdin);"
+        f"p={str(project)!r};b={base_sha!r};"
+        "st=subprocess.run(['git','-C',p,'status','--porcelain'],"
+        "capture_output=True,text=True);"
+        "hd=subprocess.run(['git','-C',p,'rev-parse','HEAD'],"
+        "capture_output=True,text=True);"
+        "head=hd.stdout.strip();"
+        "clean=st.returncode==0 and not st.stdout.strip();"
+        "raise SystemExit(0 if clean and head and head!=b else 9)"
+    )
+    return [sys.executable, "-c", program]
+
+
+def head_sha(project: Path) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(project), "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    )
+    return out.stdout.strip()
+
+
+def run_turn(*, project: Path, registry: Path, runtime: Path, codex_bin: str,
+             model: str, sandbox: str, turn_index: int, base_sha: str,
+             ) -> dict:
+    from loopx.cli_commands.turn import handle_turn_command, register_turn_commands
+
+    # Build the Namespace from LoopX's own parser rather than by hand.  Hand-
+    # writing it meant discovering missing attributes one failed Turn at a time
+    # (`resume_turn_key` was the third), and every LoopX upgrade would restart
+    # that game.  Parsing real argv fills every default the handler expects and
+    # fails loudly here if an option is ever renamed.
+    #
+    # Host is generic-cli, not codex-cli.  LoopX's built-in Codex host launches
+    # `codex exec --sandbox <mode>`, and both modes it permits need bubblewrap,
+    # which needs unprivileged user namespaces that these containers do not
+    # grant — every Turn came back with "bwrap: No permissions to create a new
+    # namespace" and an empty patch.  The generic-cli seam lets the adapter
+    # launch Codex with the same approvals-and-sandbox bypass the other two
+    # arms use, so the loop stays LoopX's and the permissions stay identical.
+    #
+    # Which adapter is the only thing that differs between the Codex arm and the
+    # Claude Code arm: both go through this same generic-cli seam, the same
+    # validator and the same quota, and only the CLI that executes a Turn
+    # changes.  Defaulting to the Codex one keeps that arm byte-identical to the
+    # runs already recorded against it.
+    wrapper = str(Path(__file__).resolve().parent / "codex_nosandbox_wrapper.py")
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command")
+    register_turn_commands(sub, lambda p: p.add_argument("--format", default="json"))
+    args = parser.parse_args([
+        "turn", "run-once",
+        "--goal-id", GOAL_ID,
+        "--agent-id", AGENT_ID,
+        "--turn-instance-id", f"{GOAL_ID}-turn-{turn_index}",
+        # codex-cli, not generic-cli.  The generic host was an attempt to get
+        # around the sandbox flag, and it cost more than it saved: it carries
+        # its own scheduler contract, and eleven of sixteen turns died at
+        # "LoopX Turn route is not host executable" before any model work, with
+        # no route recorded to say why.  The codex host is the one that
+        # demonstrably works — four turns, a 22 KB patch, f2p 31/35 — so keep it
+        # and neutralise the sandbox at the binary instead, via a wrapper that
+        # strips --sandbox and substitutes the approvals-and-sandbox bypass.
+        "--host", "codex-cli",
+        "--execution-mode", "isolated-headless",
+        "--project", str(project),
+        "--codex-bin", wrapper,
+        # An accepted value that the wrapper then removes; LoopX only permits
+        # read-only and workspace-write, and this argument has to satisfy its
+        # parser rather than the container.
+        "--codex-sandbox", "workspace-write",
+        "--codex-model", model,
+        "--validation-command-json", json.dumps(validator_command(project, base_sha)),
+        "--validation-timeout-seconds", "60",
+        # Without --execute LoopX plans the Turn and stops: every receipt comes
+        # back ok=True with dry_run=True, the host is never invoked, and four
+        # turns of nothing look exactly like four turns of success.
+        "--execute",
+        # Deliberately no --scan-root.  It is not "where the work is"; LoopX
+        # documents it as "public files to scan for obvious private material",
+        # and pointing it at the task repository made LoopX run its public
+        # boundary scanner over the repository's own history.  On the OPA task
+        # that produced
+        #     public_boundary_violation  CHANGELOG.md:3588: private_ip
+        #     public_boundary_violation  CHANGELOG.md:4859: credential
+        # which sets contract health to not-ok, which makes the quota decision
+        # `should_run=false / quota_skip`, which makes the route `wait`, which
+        # is what "LoopX Turn route is not host executable" finally reports —
+        # four layers away from the file it actually objected to.
+        #
+        # It also explains the shape of the failure: any repository whose text
+        # happens to contain something resembling an IP or a credential is
+        # rejected before a model runs, which is most of them, while the odd
+        # clean repository sails through and looks like proof the setup works.
+        # `turn plan` kept answering ready_for_host because the plan probe never
+        # passed --scan-root and so scanned LoopX's own directory instead.
+        #
+        # The default is LoopX's own public root, which is what the scanner is
+        # for.  The task repository reaches the Turn through --project.
+        "--no-global-sync",
+        "--timeout-seconds", str(DEFAULT_TURN_TIMEOUT),
+        "--format", "json",
+    ])
+
+    # PrintPayload is (payload, fmt, renderer) -> None and FormatSelector is
+    # (...) -> str; passing single-argument lambdas made every Turn die with a
+    # TypeError before any model work, which the loop then dutifully repeated
+    # four times.  Capture the payload instead of printing it, so the receipt
+    # survives whatever the CLI would have rendered.
+    captured: list[dict] = []
+
+    def _print_payload(payload, fmt=None, renderer=None):  # noqa: ANN001
+        if isinstance(payload, dict):
+            captured.append(payload)
+
+    # `run-once` decided `route: wait`, which `_typed_route` returns only when
+    # the envelope says should_run is false.  The decision behind it blamed
+    # "status or contract health is not ok" while reporting the quota itself as
+    # eligible with zero slots spent — so the gate is `goal_status_health_ok`,
+    # which reads `contract` and `global_registry` straight off the status
+    # payload.  `turn plan`, run first in this same process, said
+    # ready_for_host, so the two calls are seeing different status.  Spy on
+    # collect_status for both and record what differs; the two subcommands do
+    # not take the same options (`--scan-root` differs, `--no-global-sync` is
+    # run-once only), and that is the remaining candidate.
+    from loopx.cli_commands import turn as _turn_mod
+    _statuses: list[dict] = []
+    _original_collect = _turn_mod.collect_status
+
+    def _spy_collect(*a, **kw):  # noqa: ANN002, ANN003
+        result = _original_collect(*a, **kw)
+        if isinstance(result, dict):
+            contract = (result.get("contract")
+                        if isinstance(result.get("contract"), dict) else {})
+            registry = (result.get("global_registry")
+                        if isinstance(result.get("global_registry"), dict) else {})
+            _statuses.append({
+                "scan_roots": [str(x) for x in (kw.get("scan_roots") or [])],
+                "status_ok": result.get("ok"),
+                "contract_ok": contract.get("ok"),
+                "has_error_diagnostics": "error_diagnostics" in contract,
+                "contract_errors": json.dumps(
+                    contract.get("error_diagnostics"), ensure_ascii=False
+                )[:600],
+                "global_registry_ok": registry.get("ok"),
+                "global_registry_error": json.dumps(
+                    {k: v for k, v in registry.items() if k != "goals"},
+                    ensure_ascii=False,
+                )[:400],
+            })
+        return result
+
+    _turn_mod.collect_status = _spy_collect
+
+    # Plan first, and keep the result whatever happens next.  When the planner
+    # declines to call the host, `run-once` raises "LoopX Turn route is not
+    # host executable" and the receipt it leaves carries only ok and effects —
+    # the route, the selected Todo and the scheduler context all vanish.  Eleven
+    # turns failed exactly that way, and reproducing the call on the host proved
+    # only that the *arguments* were fine, so every explanation stayed a guess.
+    # `turn plan` runs the same decision without invoking a host or spending
+    # quota, so recording it costs nothing and makes the next failure legible.
+    plan_payload: dict = {}
+    try:
+        # Parse `turn plan` argv rather than copying the run-once Namespace and
+        # renaming the subcommand.  The two subparsers do not define the same
+        # options, so the copy was missing `include_transaction_detail` and the
+        # probe failed on its own AttributeError — producing five nulls that
+        # said nothing about the route it was meant to explain.
+        plan_parser = argparse.ArgumentParser()
+        plan_sub = plan_parser.add_subparsers(dest="command")
+        register_turn_commands(
+            plan_sub, lambda p: p.add_argument("--format", default="json")
+        )
+        plan_args = plan_parser.parse_args([
+            "turn", "plan",
+            "--goal-id", GOAL_ID,
+            "--agent-id", AGENT_ID,
+            "--host", "codex-cli",
+            "--execution-mode", "isolated-headless",
+            "--format", "json",
+        ])
+        with redirect_stdout(io.StringIO()):
+            handle_turn_command(
+                plan_args,
+                registry_path=registry,
+                runtime_root_arg=str(runtime),
+                output_format=lambda *_a, **_k: "json",
+                print_payload=_print_payload,
+            )
+        if captured:
+            p = captured.pop()
+            route = p.get("route") or {}
+            ctx = p.get("scheduler_execution_context") or {}
+            plan_payload = {
+                "route_kind": route.get("kind"),
+                "would_invoke_host": route.get("would_invoke_host"),
+                "selected_todo": (route.get("selected_todo") or {}).get("todo_id"),
+                "context_valid": ctx.get("valid"),
+                "context_errors": ctx.get("errors"),
+            }
+            # Keep the raw shape when the expected keys are absent.  Reusing the
+            # run-once Namespace for `plan` produced a payload without `route`
+            # at all, and five nulls said only "not what I expected" — which is
+            # the same dead end as having no diagnostics.
+            if route or ctx:
+                pass
+            else:
+                plan_payload["raw_keys"] = sorted(p)
+                plan_payload["raw"] = json.dumps(p, ensure_ascii=False)[:1200]
+    except Exception as exc:
+        plan_payload = {"plan_error": f"{type(exc).__name__}: {exc}"}
+
+    # Record the plan `run-once` builds and then rejects.  "LoopX Turn route is
+    # not host executable" is raised by build_loopx_turn_host_request after
+    # reading route.would_invoke_host off a payload run-once assembled moments
+    # earlier and never prints, so the one run whose route matters is the one
+    # nobody can see — and `turn plan`, which does print it, keeps answering
+    # ready_for_host.  Both go through build_loopx_turn_plan, so wrapping it
+    # captures run-once's own payload, including the `session` block that only
+    # run-once populates.  Reproducing this on the host was not possible: there
+    # both subcommands succeed, so the difference lives in the container.
+    from loopx.cli_commands import turn as _turn_mod
+    _built: list[dict] = []
+    _original_build = _turn_mod.build_loopx_turn_plan
+
+    def _spy_build(*a, **kw):  # noqa: ANN002, ANN003
+        result = _original_build(*a, **kw)
+        _built.append({"session_binding": kw.get("session_binding"),
+                       "payload": result})
+        return result
+
+    _turn_mod.build_loopx_turn_plan = _spy_build
+
+    # The route came back `wait`, which `_typed_route` only returns when the
+    # envelope says should_run is false and a quiet no-op is allowed — a
+    # scheduling verdict, not a contract error.  `turn plan`, run moments
+    # earlier in this same process against this same registry, said
+    # ready_for_host.  So capture the decision the envelope is projected from:
+    # should_run is set by build_live_quota_should_run_decision, and its
+    # rationale is the only thing that can say why the two disagree.
+    _decisions: list[dict] = []
+    _original_decision = _turn_mod.build_live_quota_should_run_decision
+
+    def _spy_decision(*a, **kw):  # noqa: ANN002, ANN003
+        result = _original_decision(*a, **kw)
+        if isinstance(result, dict):
+            _decisions.append(result)
+        return result
+
+    _turn_mod.build_live_quota_should_run_decision = _spy_decision
+
+    buffer = io.StringIO()
+    try:
+        with redirect_stdout(buffer):
+            code = handle_turn_command(
+                args,
+                registry_path=registry,
+                runtime_root_arg=str(runtime),
+                output_format=lambda *_a, **_k: "json",
+                print_payload=_print_payload,
+            )
+    finally:
+        _turn_mod.build_loopx_turn_plan = _original_build
+        _turn_mod.build_live_quota_should_run_decision = _original_decision
+        _turn_mod.collect_status = _original_collect
+    built_payload: dict = {}
+    if _built:
+        record = _built[-1]
+        built = record["payload"]
+        route = built.get("route") if isinstance(built.get("route"), dict) else {}
+        session = built.get("session") if isinstance(built.get("session"), dict) else {}
+        ctx = built.get("scheduler_execution_context")
+        ctx = ctx if isinstance(ctx, dict) else {}
+        transaction = (built.get("transaction")
+                       if isinstance(built.get("transaction"), dict) else {})
+        built_payload = {
+            "route_kind": route.get("kind"),
+            "would_invoke_host": route.get("would_invoke_host"),
+            "route_reasons": route.get("reasons") or route.get("errors"),
+            "session_action": session.get("action"),
+            "session_binding_status": session.get("binding_status"),
+            "session_binding_arg": record["session_binding"],
+            "context_valid": ctx.get("valid"),
+            "context_errors": ctx.get("errors"),
+            "turn_key": transaction.get("turn_key"),
+            "builds": len(_built),
+        }
+        envelope = (built.get("turn_envelope")
+                    if isinstance(built.get("turn_envelope"), dict) else {})
+        action = (envelope.get("action")
+                  if isinstance(envelope.get("action"), dict) else {})
+        built_payload["envelope"] = {
+            "should_run": envelope.get("should_run"),
+            "effective_action": envelope.get("effective_action"),
+            "delivery_allowed": action.get("delivery_allowed"),
+            "must_attempt": action.get("must_attempt"),
+            "quiet_noop_allowed": action.get("quiet_noop_allowed"),
+        }
+    if _decisions:
+        decision = _decisions[-1]
+        built_payload["decision"] = {
+            key: decision.get(key)
+            for key in ("should_run", "effective_action", "reason", "reasons",
+                        "blocked_reason", "quota", "quota_state", "cadence",
+                        "schedule", "gates")
+            if key in decision
+        }
+        built_payload["decision_keys"] = sorted(decision)[:40]
+        built_payload["decisions"] = len(_decisions)
+    # Two entries: the `plan` probe's status, then run-once's.  Whatever differs
+    # between them is what flipped goal_status_health_ok.
+    built_payload["statuses"] = _statuses[:4]
+    if captured:
+        payload = captured[-1]
+    else:
+        raw = buffer.getvalue().strip()
+        try:
+            payload = json.loads(raw.splitlines()[-1]) if raw else {}
+        except Exception:
+            payload = {"unparsed": raw[-2000:]}
+    payload["_exit_code"] = code
+    payload["_plan"] = plan_payload
+    payload["_built"] = built_payload
+    # Carry the wrapper's log into the receipt.  LoopX reports a failed host as
+    # `codex_cli_exit_nonzero` and keeps nothing else, and the container that
+    # holds the log is deleted as soon as the task ends, so the receipt is the
+    # only artifact that outlives the evidence.
+    codex_log = Path(
+        os.environ.get("MR_LOOPX_CODEX_LOG", "/tmp/loopx-goal/codex-wrapper.log")
+    )
+    try:
+        payload["_codex_log"] = codex_log.read_text(encoding="utf-8")[-4000:]
+        codex_log.unlink()
+    except OSError:
+        payload["_codex_log"] = None
+    return payload
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", required=True)
+    parser.add_argument("--task-file", required=True)
+    parser.add_argument("--runtime-root", required=True)
+    parser.add_argument("--codex-bin", default="codex")
+    parser.add_argument("--adapter", default="loopx_codex_adapter.py",
+                        help="generic-cli host adapter that executes one Turn "
+                             "(loopx_codex_adapter.py | loopx_claude_adapter.py)")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--sandbox", default="danger-full-access")
+    parser.add_argument("--quota", type=int, default=DEFAULT_QUOTA)
+    args = parser.parse_args()
+
+    project = Path(args.project).resolve()
+    runtime = Path(args.runtime_root)
+    runtime.mkdir(parents=True, exist_ok=True)
+    instruction = Path(args.task_file).read_text(encoding="utf-8").strip()
+
+    # The host adapter needs the task text too, and cannot get it from the Turn
+    # envelope: the envelope carries only the selected Todo, and LoopX compacts
+    # that to an 8 KB budget, so the staged Todo's wording survives truncated
+    # ("Advance the task below by exactly one stage per Turn, and report which
+    # s...") while the `## Task` section of the goal document is never included
+    # at all.  An adapter working from the envelope alone therefore sees a
+    # staging meta-instruction with no target behaviour attached, and a
+    # well-behaved model correctly refuses to invent one — four Turns of
+    # `validation_failed` with an empty patch, which reads like a model that
+    # could not do the work rather than a prompt that never described it.
+    # Handing the adapter the same file the goal document was built from keeps
+    # one source of truth for the task text.
+    os.environ["MR_LOOPX_TASK_FILE"] = str(Path(args.task_file).resolve())
+
+    hide_loopx_state_from_git(project)
+    state = stage_goal_state(project, instruction)
+    registry = stage_registry(project, runtime, state)
+    base_sha = head_sha(project)
+
+    receipts = []
+    for turn_index in range(1, args.quota + 1):
+        try:
+            payload = run_turn(
+                project=project, registry=registry, runtime=runtime,
+                codex_bin=args.codex_bin, model=args.model,
+                sandbox=args.sandbox, turn_index=turn_index, base_sha=base_sha,
+
+            )
+        except Exception as exc:  # keep the receipt; a dead turn is evidence too
+            payload = {"error": f"{type(exc).__name__}: {exc}"}
+        receipts.append(payload)
+        # A Turn that never reached the host is a defect in this runner, not a
+        # result: repeating it burns the whole quota on the same traceback, as
+        # four identical TypeErrors once did.  Stop and let the receipt show why.
+        if "error" in payload:
+            break
+        if payload.get("dry_run"):
+            payload["_fatal"] = "dry_run: --execute was not honoured"
+            break
+        status = str(payload.get("status") or payload.get("result_kind") or "")
+        # Stop early only when LoopX says the work is settled; a failed or
+        # repair-required Turn is exactly the case the next Turn exists for.
+        if status in {"completed", "goal_complete", "done"}:
+            break
+
+    print(json.dumps({
+        "schema": "deepswe_loopx_turn_log_v0",
+        "quota": args.quota,
+        "turns_run": len(receipts),
+        "receipts": receipts,
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/scoring/_aggregate.py
+++ b/benchmark/swe-marathon/scoring/_aggregate.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""把 marathon-full 的五模式结果聚合成单一 data.json，供可视化网页与总结 md 使用。
+
+复用 _compare.py / _partial.py 里已经踩过坑的口径，别在这里重造轮子：
+  · 模式名归一化 norm()               —— ssh-goal-1537631 → ssh-goal
+  · 只认 job 级 result.json（有 stats）
+  · 属主必须是当前用户（排除上一轮 root 属主的遗留目录）
+  · partial 半成品（phase=initialized/starting）不算成绩
+  · cost 以 result.json 的 cost_usd 为准（不是 0；上个可视化把它算丢了）
+
+用法：
+    _aggregate.py <out_dir> [data.json]
+    _aggregate.py marathon-full viz/data.json
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+
+ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+# 模式的角色标注，写进 data.json 供前端解释
+ARM_ROLE = {
+    "plain": "baseline①：裸 codex，objective = 'Finish the task.'，无 goal、无 LoopX",
+    "goal": "baseline②：codex 原生 goal（codex 自带的 goal 功能，注入干净 goal，非 LoopX）",
+    "ssh-goal": "LoopX 模式①：codex 原生 goal + LoopX 渲染的 goal body/skills，经 ssh 驱动",
+    "codex-cli": "LoopX 模式②：容器内跑 loopx CLI 现渲 goal body（带 claim/lease/peer 样板）",
+    "heartbeat": "LoopX 模式③：心跳驱动的续跑/解锁 + LoopX goal body/skills",
+}
+
+
+def norm(a: str) -> str:
+    return re.sub(r"-\d{3,}$", "", a)
+
+
+def testrate(d: dict):
+    """测试通过率——比 partial_score 更稳的连续口径（口径同 _partial.py）。"""
+    pt = d.get("pytest")
+    if isinstance(pt, dict) and pt:
+        p = sum((g or {}).get("passed") or 0 for g in pt.values() if isinstance(g, dict))
+        t = sum((g or {}).get("total") or 0 for g in pt.values() if isinstance(g, dict))
+        if t:
+            return p / t
+    p, t, f = d.get("passed"), d.get("total"), d.get("failed")
+    if isinstance(p, (int, float)) and isinstance(t, (int, float)) and t:
+        return p / t
+    if isinstance(p, (int, float)) and isinstance(f, (int, float)) and (p + f):
+        return p / (p + f)
+    gp, gt = d.get("gates_passed"), d.get("gates_total")
+    if isinstance(gp, (int, float)) and isinstance(gt, (int, float)) and gt:
+        return gp / gt
+    return None
+
+
+def collect(root: pathlib.Path) -> dict:
+    out: dict = {}
+    if not root.is_dir():
+        return out
+    for r in root.glob("*/*/*/*/result.json"):
+        rel = r.relative_to(root).parts
+        task, armdir = rel[0], rel[1]
+        if task.startswith("."):
+            continue
+        arm = norm(armdir)
+        if arm not in ARMS:
+            continue
+        try:
+            if (root / rel[0] / rel[1]).stat().st_uid != os.getuid():
+                continue
+        except OSError:
+            continue
+        try:
+            d = json.loads(r.read_text())
+        except Exception:
+            continue
+        s = d.get("stats", {})
+        if not s or int(s.get("n_completed_trials") or 0) < 1:
+            continue
+        rw = [float(k)
+              for ev in (s.get("evals") or {}).values()
+              for k, t in ((ev.get("reward_stats") or {}).get("reward") or {}).items()
+              for _ in t]
+        rec = {
+            "task": task,
+            "arm": arm,
+            "reward": rw[0] if rw else None,
+            "cost": s.get("cost_usd") or 0.0,
+            "tok_in": s.get("n_input_tokens") or 0,
+            "tok_out": s.get("n_output_tokens") or 0,
+            "tok_cache": s.get("n_cache_tokens") or 0,
+            "errors": int(s.get("n_errored_trials") or 0),
+            "partial": None,
+            "testrate": None,
+            "build_failed": False,
+            "passed": None,
+            "failed": None,
+            "status": None,
+            "cont": None,
+            "unblock": None,
+            "err_events": None,
+            "min": None,
+            "run_dir": str(r.parent.relative_to(root)),
+        }
+        try:
+            t0 = datetime.datetime.fromisoformat(d["started_at"])
+            t1 = datetime.datetime.fromisoformat(d["finished_at"])
+            rec["min"] = round((t1 - t0).total_seconds() / 60, 1)
+        except Exception:
+            pass
+        for m in r.parent.glob("*/verifier/metrics.json"):
+            try:
+                mm = json.loads(m.read_text())
+            except Exception:
+                continue
+            ph = str(mm.get("phase") or "")
+            if ph in ("initialized", "starting"):
+                continue
+            rec["partial"] = mm.get("partial_score")
+            rec["testrate"] = testrate(mm)
+            rec["build_failed"] = ph == "build_failed"
+            rec["passed"], rec["failed"] = mm.get("passed"), mm.get("failed")
+        for f in r.parent.glob("*/agent/goal_receipt.json"):
+            try:
+                g = json.loads(f.read_text())
+            except Exception:
+                continue
+            rec["status"] = g.get("post_goal_status")
+            rec["cont"] = g.get("goal_continuation_turn_completed_count")
+            rec["unblock"] = g.get("_unblock_count")
+            rec["err_events"] = g.get("error_event_count")
+        out[(task, arm)] = rec
+    return out
+
+
+def mean(xs):
+    xs = [x for x in xs if x is not None]
+    return sum(xs) / len(xs) if xs else None
+
+
+def main() -> int:
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    outp = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else "viz/data.json")
+    cur = collect(root)
+    if not cur:
+        print("没有结果", file=sys.stderr)
+        return 1
+
+    tasks = sorted({t for t, _ in cur})
+    full = [t for t in tasks if sum(1 for a in ARMS if (t, a) in cur) == 5]
+
+    cells = {}
+    for (task, arm), rec in cur.items():
+        cells.setdefault(task, {})[arm] = rec
+
+    # 模式级汇总（只用五模式齐的任务，口径同 _compare.py）
+    arm_summary = {}
+    for a in ARMS:
+        rs = [cur[(t, a)] for t in full if (t, a) in cur]
+        # reward / partial / testrate 的均值剔除构建失败的 case：构建失败会让 partial
+        # 被门禁直接归零，那是环境/门禁问题不是能力信号，掺进均值会冤枉该模式。
+        # 其余统计（花费、自收工、续跑、解锁）仍按全量。构建失败数单列。
+        scored = [x for x in rs if not x["build_failed"]]
+        arm_summary[a] = {
+            "role": ARM_ROLE[a],
+            "n": len(rs),
+            "n_scored": len(scored),
+            "reward": mean([x["reward"] for x in scored]),
+            "partial": mean([x["partial"] for x in scored]),
+            "testrate": mean([x["testrate"] for x in scored]),
+            "cost": round(sum(x["cost"] for x in rs), 2),
+            "tok_in": sum(x["tok_in"] for x in rs),
+            "tok_out": sum(x["tok_out"] for x in rs),
+            "build_failed": sum(1 for x in rs if x["build_failed"]),
+            "self_complete": sum(1 for x in rs if x.get("status") == "complete"),
+            "cont_total": sum((x.get("cont") or 0) for x in rs),
+            "unblock_total": sum((x.get("unblock") or 0) for x in rs),
+            "wall_min": round(sum((x.get("min") or 0) for x in rs), 1),
+        }
+
+    data = {
+        "generated_at": None,          # 由外部盖时间戳；脚本内不取系统时钟
+        "bench": os.environ.get("WEN_BENCH", "swe-marathon"),
+        "arms": list(ARMS),
+        "arm_role": ARM_ROLE,
+        "tasks_all": tasks,
+        "tasks_full": full,
+        "n_trials": len(cur),
+        "arm_summary": arm_summary,
+        "cells": {t: {a: cells[t].get(a) for a in ARMS if a in cells[t]} for t in tasks},
+    }
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    outp.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    print(f"写出 {outp}：{len(tasks)} 任务，{len(full)} 五模式齐，{len(cur)} trial")
+    for a in ARMS:
+        s = arm_summary[a]
+        print(f"  {a:10} reward={s['reward']!s:>6} partial={s['partial']!s:>7} "
+              f"cost=${s['cost']:<7} 自收工={s['self_complete']}/{s['n']} "
+              f"续跑={s['cont_total']} 解锁={s['unblock_total']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/scoring/_aggregate.py
+++ b/benchmark/swe-marathon/scoring/_aggregate.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 """把 marathon-full 的五模式结果聚合成单一 data.json，供可视化网页与总结 md 使用。
 
-复用 _compare.py / _partial.py 里已经踩过坑的口径，别在这里重造轮子：
-  · 模式名归一化 norm()               —— ssh-goal-1537631 → ssh-goal
-  · 只认 job 级 result.json（有 stats）
-  · 属主必须是当前用户（排除上一轮 root 属主的遗留目录）
-  · partial 半成品（phase=initialized/starting）不算成绩
-  · cost 以 result.json 的 cost_usd 为准（不是 0；上个可视化把它算丢了）
+口径全部走 scripts/_common（模式名归一化、只认 job 级 result.json、属主校验、半成品
+metrics 排除、cost 取 cost_usd）。cost 以 result.json 的 cost_usd 为准（不是 0）。
 
 用法：
     _aggregate.py <out_dir> [data.json]
@@ -15,14 +11,12 @@
 
 from __future__ import annotations
 
-import datetime
 import json
 import os
-import pathlib
-import re
 import sys
 
-ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+from _common import ARMS, collect, mean, safe_path
+
 # 模式的角色标注，写进 data.json 供前端解释
 ARM_ROLE = {
     "plain": "baseline①：裸 codex，objective = 'Finish the task.'，无 goal、无 LoopX",
@@ -33,117 +27,30 @@ ARM_ROLE = {
 }
 
 
-def norm(a: str) -> str:
-    return re.sub(r"-\d{3,}$", "", a)
-
-
-def testrate(d: dict):
-    """测试通过率——比 partial_score 更稳的连续口径（口径同 _partial.py）。"""
-    pt = d.get("pytest")
-    if isinstance(pt, dict) and pt:
-        p = sum((g or {}).get("passed") or 0 for g in pt.values() if isinstance(g, dict))
-        t = sum((g or {}).get("total") or 0 for g in pt.values() if isinstance(g, dict))
-        if t:
-            return p / t
-    p, t, f = d.get("passed"), d.get("total"), d.get("failed")
-    if isinstance(p, (int, float)) and isinstance(t, (int, float)) and t:
-        return p / t
-    if isinstance(p, (int, float)) and isinstance(f, (int, float)) and (p + f):
-        return p / (p + f)
-    gp, gt = d.get("gates_passed"), d.get("gates_total")
-    if isinstance(gp, (int, float)) and isinstance(gt, (int, float)) and gt:
-        return gp / gt
-    return None
-
-
-def collect(root: pathlib.Path) -> dict:
-    out: dict = {}
-    if not root.is_dir():
-        return out
-    for r in root.glob("*/*/*/*/result.json"):
-        rel = r.relative_to(root).parts
-        task, armdir = rel[0], rel[1]
-        if task.startswith("."):
-            continue
-        arm = norm(armdir)
-        if arm not in ARMS:
-            continue
-        try:
-            if (root / rel[0] / rel[1]).stat().st_uid != os.getuid():
-                continue
-        except OSError:
-            continue
-        try:
-            d = json.loads(r.read_text())
-        except Exception:
-            continue
-        s = d.get("stats", {})
-        if not s or int(s.get("n_completed_trials") or 0) < 1:
-            continue
-        rw = [float(k)
-              for ev in (s.get("evals") or {}).values()
-              for k, t in ((ev.get("reward_stats") or {}).get("reward") or {}).items()
-              for _ in t]
-        rec = {
-            "task": task,
-            "arm": arm,
-            "reward": rw[0] if rw else None,
-            "cost": s.get("cost_usd") or 0.0,
-            "tok_in": s.get("n_input_tokens") or 0,
-            "tok_out": s.get("n_output_tokens") or 0,
-            "tok_cache": s.get("n_cache_tokens") or 0,
-            "errors": int(s.get("n_errored_trials") or 0),
-            "partial": None,
-            "testrate": None,
-            "build_failed": False,
-            "passed": None,
-            "failed": None,
-            "status": None,
-            "cont": None,
-            "unblock": None,
-            "err_events": None,
-            "min": None,
-            "run_dir": str(r.parent.relative_to(root)),
-        }
-        try:
-            t0 = datetime.datetime.fromisoformat(d["started_at"])
-            t1 = datetime.datetime.fromisoformat(d["finished_at"])
-            rec["min"] = round((t1 - t0).total_seconds() / 60, 1)
-        except Exception:
-            pass
-        for m in r.parent.glob("*/verifier/metrics.json"):
-            try:
-                mm = json.loads(m.read_text())
-            except Exception:
-                continue
-            ph = str(mm.get("phase") or "")
-            if ph in ("initialized", "starting"):
-                continue
-            rec["partial"] = mm.get("partial_score")
-            rec["testrate"] = testrate(mm)
-            rec["build_failed"] = ph == "build_failed"
-            rec["passed"], rec["failed"] = mm.get("passed"), mm.get("failed")
-        for f in r.parent.glob("*/agent/goal_receipt.json"):
-            try:
-                g = json.loads(f.read_text())
-            except Exception:
-                continue
-            rec["status"] = g.get("post_goal_status")
-            rec["cont"] = g.get("goal_continuation_turn_completed_count")
-            rec["unblock"] = g.get("_unblock_count")
-            rec["err_events"] = g.get("error_event_count")
-        out[(task, arm)] = rec
-    return out
-
-
-def mean(xs):
-    xs = [x for x in xs if x is not None]
-    return sum(xs) / len(xs) if xs else None
+def _mode_summary(rs: list) -> dict:
+    """单个模式的汇总。reward/partial/testrate 剔除构建失败的 case（环境/门禁问题，
+    非能力信号）；花费/自收工/续跑/解锁按全量。"""
+    scored = [x for x in rs if not x["build_failed"]]
+    return {
+        "n": len(rs),
+        "n_scored": len(scored),
+        "reward": mean([x["reward"] for x in scored]),
+        "partial": mean([x["partial"] for x in scored]),
+        "testrate": mean([x["testrate"] for x in scored]),
+        "cost": round(sum(x["cost"] for x in rs), 2),
+        "tok_in": sum(x["tok_in"] for x in rs),
+        "tok_out": sum(x["tok_out"] for x in rs),
+        "build_failed": sum(1 for x in rs if x["build_failed"]),
+        "self_complete": sum(1 for x in rs if x.get("status") == "complete"),
+        "cont_total": sum((x.get("cont") or 0) for x in rs),
+        "unblock_total": sum((x.get("unblock") or 0) for x in rs),
+        "wall_min": round(sum((x.get("min") or 0) for x in rs), 1),
+    }
 
 
 def main() -> int:
-    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
-    outp = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else "viz/data.json")
+    root = safe_path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    outp = safe_path(sys.argv[2] if len(sys.argv) > 2 else "viz/data.json")
     cur = collect(root)
     if not cur:
         print("没有结果", file=sys.stderr)
@@ -152,34 +59,16 @@ def main() -> int:
     tasks = sorted({t for t, _ in cur})
     full = [t for t in tasks if sum(1 for a in ARMS if (t, a) in cur) == 5]
 
-    cells = {}
+    cells: dict = {}
     for (task, arm), rec in cur.items():
         cells.setdefault(task, {})[arm] = rec
 
-    # 模式级汇总（只用五模式齐的任务，口径同 _compare.py）
     arm_summary = {}
     for a in ARMS:
         rs = [cur[(t, a)] for t in full if (t, a) in cur]
-        # reward / partial / testrate 的均值剔除构建失败的 case：构建失败会让 partial
-        # 被门禁直接归零，那是环境/门禁问题不是能力信号，掺进均值会冤枉该模式。
-        # 其余统计（花费、自收工、续跑、解锁）仍按全量。构建失败数单列。
-        scored = [x for x in rs if not x["build_failed"]]
-        arm_summary[a] = {
-            "role": ARM_ROLE[a],
-            "n": len(rs),
-            "n_scored": len(scored),
-            "reward": mean([x["reward"] for x in scored]),
-            "partial": mean([x["partial"] for x in scored]),
-            "testrate": mean([x["testrate"] for x in scored]),
-            "cost": round(sum(x["cost"] for x in rs), 2),
-            "tok_in": sum(x["tok_in"] for x in rs),
-            "tok_out": sum(x["tok_out"] for x in rs),
-            "build_failed": sum(1 for x in rs if x["build_failed"]),
-            "self_complete": sum(1 for x in rs if x.get("status") == "complete"),
-            "cont_total": sum((x.get("cont") or 0) for x in rs),
-            "unblock_total": sum((x.get("unblock") or 0) for x in rs),
-            "wall_min": round(sum((x.get("min") or 0) for x in rs), 1),
-        }
+        summary = _mode_summary(rs)
+        summary["role"] = ARM_ROLE[a]
+        arm_summary[a] = summary
 
     data = {
         "generated_at": None,          # 由外部盖时间戳；脚本内不取系统时钟

--- a/benchmark/swe-marathon/scoring/_build_viz.py
+++ b/benchmark/swe-marathon/scoring/_build_viz.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""从 viz/data.json + viz/SUMMARY.md + viz/trajectories/_index.json 生成 index.html。
+
+指标仪表盘与总结报告内嵌（离线可开）；逐 trial 轨迹按需 fetch
+trajectories/<task>__<arm>.json（在 gh-pages / 本地 http 下可用）。
+
+    _build_viz.py viz/data.json viz/SUMMARY.md viz/index.html
+"""
+from __future__ import annotations
+import json, sys, pathlib
+
+base = pathlib.Path(sys.argv[1]).parent if len(sys.argv) > 1 else pathlib.Path("viz")
+data_path = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "viz/data.json")
+md_path   = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else "viz/SUMMARY.md")
+out_path  = pathlib.Path(sys.argv[3] if len(sys.argv) > 3 else "viz/index.html")
+
+data = json.loads(data_path.read_text())
+md_raw = md_path.read_text()
+idx_path = base / "trajectories" / "_index.json"
+traj_idx = json.loads(idx_path.read_text()) if idx_path.exists() else {}
+
+DATA_JSON = json.dumps(data, ensure_ascii=False)
+MD_JSON   = json.dumps(md_raw, ensure_ascii=False)
+IDX_JSON  = json.dumps(traj_idx, ensure_ascii=False)
+
+HTML = r"""<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SWE-Marathon · codex × LoopX 总结报告</title>
+<style>
+:root{--bg:#0f1117;--card:#181b23;--card2:#1f2430;--fg:#e6e9ef;--mut:#9aa4b2;
+--line:#2a2f3a;--acc:#7aa2f7;--good:#4ec9b0;--warn:#e0af68;--bad:#f7768e;--vio:#bb9af7;}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);
+font:14px/1.55 -apple-system,"Segoe UI",Roboto,"PingFang SC","Microsoft YaHei",sans-serif}
+a{color:var(--acc)}
+.wrap{max-width:1180px;margin:0 auto;padding:28px 20px 80px}
+h1{font-size:26px;margin:0 0 6px}
+.sub{color:var(--mut);margin:0 0 22px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:18px 20px;margin:0 0 20px}
+h2{font-size:18px;margin:2px 0 14px;display:flex;align-items:center;gap:8px}
+table{border-collapse:collapse;width:100%;font-size:13px}
+th,td{padding:8px 10px;text-align:right;border-bottom:1px solid var(--line);white-space:nowrap}
+th:first-child,td:first-child{text-align:left}
+th{color:var(--mut);font-weight:600;position:sticky;top:0;background:var(--card)}
+tbody tr:hover{background:var(--card2)}
+.arm{font-weight:600}
+.bar{position:relative}
+.bar span{position:absolute;left:0;top:0;bottom:0;background:rgba(122,162,247,.16);border-radius:4px;z-index:0}
+.bar b{position:relative;z-index:1;font-weight:600}
+.pill{display:inline-block;padding:1px 7px;border-radius:20px;font-size:11px;font-weight:600}
+.p-good{background:rgba(78,201,176,.18);color:var(--good)}
+.p-warn{background:rgba(224,175,104,.18);color:var(--warn)}
+.p-bad{background:rgba(247,118,142,.18);color:var(--bad)}
+.grid-tbl td{text-align:center;cursor:pointer;font-variant-numeric:tabular-nums}
+.grid-tbl td:first-child{text-align:left;cursor:default;color:var(--fg)}
+.cellv{display:block;font-weight:600}.cellp{display:block;font-size:11px;color:var(--mut)}
+.legend{color:var(--mut);font-size:12px;margin-top:10px}
+.tabs{display:flex;gap:6px;margin:0 0 16px;flex-wrap:wrap}
+.tab{padding:7px 14px;border:1px solid var(--line);border-radius:8px;background:var(--card);
+color:var(--mut);cursor:pointer;font-weight:600}
+.tab.on{background:var(--acc);color:#0f1117;border-color:var(--acc)}
+.hide{display:none}
+.md{font-size:14px}
+.md h1{font-size:22px;border-bottom:1px solid var(--line);padding-bottom:8px}
+.md h2{font-size:17px;margin-top:22px}.md table{margin:12px 0}
+.md code{background:var(--card2);padding:1px 5px;border-radius:4px;font-size:12px}
+.md pre{background:#0b0d12;border:1px solid var(--line);border-radius:8px;padding:12px;overflow:auto}
+.md pre code{background:none;padding:0}
+.md blockquote{border-left:3px solid var(--acc);margin:12px 0;padding:2px 14px;color:var(--mut)}
+.note{color:var(--mut);font-size:12px}
+.dl{display:inline-block;margin-top:8px;padding:6px 12px;border:1px solid var(--line);
+border-radius:8px;color:var(--acc);text-decoration:none;font-weight:600}
+select{background:var(--card2);color:var(--fg);border:1px solid var(--line);border-radius:8px;
+padding:7px 10px;font-size:14px;font-weight:600}
+.ctrl{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:14px}
+.tmeta{color:var(--mut);font-size:12px;margin-left:auto}
+/* 轨迹步骤 */
+.step{border:1px solid var(--line);border-radius:9px;margin:8px 0;overflow:hidden}
+.step .hd{display:flex;gap:8px;align-items:center;padding:7px 12px;cursor:pointer;font-size:12px}
+.step .hd b{font-size:11px;text-transform:uppercase;letter-spacing:.04em}
+.step .bd{padding:0 12px 10px;font-size:12.5px;white-space:pre-wrap;word-break:break-word;
+font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+.step.k-goal{border-color:var(--vio)}.step.k-goal .hd{background:rgba(187,154,247,.14);color:var(--vio)}
+.step.k-exec .hd{background:rgba(122,162,247,.12);color:var(--acc)}
+.step.k-output .hd{background:rgba(154,164,178,.10);color:var(--mut)}
+.step.k-reason .hd{background:transparent;color:var(--mut)}
+.step.k-msg .hd{background:rgba(78,201,176,.10);color:var(--good)}
+.step.k-event .hd{background:rgba(224,175,104,.12);color:var(--warn)}
+.step .n{color:var(--mut);font-weight:600;min-width:34px}
+.role{font-size:11px;color:var(--mut)}
+.hint{color:var(--mut);font-size:12px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>SWE-Marathon · codex × LoopX 总结报告</h1>
+  <p class="sub" id="sub"></p>
+
+  <div class="tabs">
+    <div class="tab on" data-t="overview">总览</div>
+    <div class="tab" data-t="grid">逐任务</div>
+    <div class="tab" data-t="traj">轨迹浏览</div>
+    <div class="tab" data-t="report">总结报告</div>
+  </div>
+
+  <div id="overview">
+    <div class="card"><h2>五模式汇总 <span class="note">（仅 15 个五模式齐任务）</span></h2>
+      <div id="armtbl"></div>
+      <div class="legend">reward = 二值（紧预算下多为 0）；partial_score = 任务连续分（主指标）；
+        "自己收工" = goal receipt 主动 complete 而非撞死线被砍。
+        reward / partial 均值已剔除构建失败的 case（codex-cli 按 14 个任务，其余 15 个）；
+        花费 / 自收工 / 续跑 / 解锁按全量。</div></div>
+    <div class="card"><h2>模式的角色</h2><div id="roles"></div></div>
+  </div>
+
+  <div id="grid" class="hide">
+    <div class="card"><h2>逐任务 × 五模式</h2><div id="gridtbl"></div>
+      <div class="legend">每格上行 = partial_score，下行 = reward；<span class="p-bad">红</span> = 构建失败归零。
+        点任意格 → 跳到该 trial 的轨迹浏览。</div></div>
+  </div>
+
+  <div id="traj" class="hide">
+    <div class="card">
+      <div class="ctrl">
+        <label>任务 <select id="selTask"></select></label>
+        <label>模式 <select id="selArm"></select></label>
+        <span class="tmeta" id="tmeta"></span>
+      </div>
+      <div class="hint" id="thint">选择任务与模式查看该 trial 的完整执行轨迹。plain 模式没有 <b>goal 注入</b>步；
+        goal（codex 原生）与三个 LoopX 模式都有紫色 <b>goal 注入</b>——但只有 LoopX 三模式的 goal body
+        带 claim/lease/peer 样板，goal 模式是干净 goal。</div>
+      <div id="steps"></div>
+    </div>
+  </div>
+
+  <div id="report" class="hide">
+    <div class="card"><a class="dl" id="dlmd" download="codex-loopx-swe-marathon.md">下载 SUMMARY.md</a>
+      <div class="md" id="mdbody"></div></div>
+  </div>
+</div>
+
+<script id="DATA" type="application/json">__DATA__</script>
+<script id="MD" type="application/json">__MD__</script>
+<script id="IDX" type="application/json">__IDX__</script>
+<script>
+const D=JSON.parse(document.getElementById('DATA').textContent);
+const MD=JSON.parse(document.getElementById('MD').textContent);
+const IDX=JSON.parse(document.getElementById('IDX').textContent);
+const ARMS=D.arms;
+const fmt=(v,d=3)=>v==null?'—':(+v).toFixed(d);
+const usd=v=>'$'+Math.round(v);
+const kfmt=n=>n>=1e6?(n/1e6).toFixed(1)+'M':n>=1e3?(n/1e3).toFixed(0)+'k':(''+n);
+const esc=s=>(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+
+document.getElementById('sub').textContent=
+ `${D.bench} · ${D.tasks_full.length} 个五模式齐任务 · ${D.n_trials} trial · 模型 gpt-5.6 · 预算 ~30% · 生成于 ${D.generated_at||''}`;
+
+// 五模式汇总
+function armTable(){const S=D.arm_summary;const maxPart=Math.max(...ARMS.map(a=>S[a].partial||0));
+ let h='<table><thead><tr><th>模式</th><th>reward</th><th>partial</th><th>花费</th><th>自己收工</th>'
+   +'<th>续跑</th><th>解锁</th><th>构建失败</th><th>输出tok</th></tr></thead><tbody>';
+ for(const a of ARMS){const s=S[a];const pw=(100*(s.partial||0)/maxPart).toFixed(0);const best=s.partial===maxPart;
+  h+=`<tr><td class="arm">${a}</td><td>${fmt(s.reward)}</td>`
+   +`<td class="bar"><span style="width:${pw}%"></span><b>${fmt(s.partial)}</b>${best?' <span class="pill p-good">最高</span>':''}</td>`
+   +`<td>${usd(s.cost)}</td><td>${scPill(s.self_complete,s.n)}</td><td>${s.cont_total}</td><td>${s.unblock_total}</td>`
+   +`<td>${s.build_failed?('<span class="pill p-bad">'+s.build_failed+'/'+s.n+'</span>'):'0/'+s.n}</td><td>${kfmt(s.tok_out)}</td></tr>`;}
+ return h+'</tbody></table>';}
+function scPill(x,n){const r=x/n;const c=r>=0.8?'p-good':r>=0.5?'p-warn':'p-bad';return `<span class="pill ${c}">${x}/${n}</span>`;}
+function roles(){let h='<table><tbody>';for(const a of ARMS)h+=`<tr><td class="arm">${a}</td><td style="text-align:left;color:var(--mut)">${D.arm_role[a]}</td></tr>`;return h+'</tbody></table>';}
+
+// 逐任务热力
+function gridTable(){let h='<table class="grid-tbl"><thead><tr><th>任务</th>'+ARMS.map(a=>`<th style="text-align:center">${a}</th>`).join('')+'</tr></thead><tbody>';
+ for(const t of D.tasks_all){h+=`<tr><td>${t}</td>`;
+  for(const a of ARMS){const c=(D.cells[t]||{})[a];if(!c){h+='<td>—</td>';continue;}
+   const p=c.partial;const bg=c.build_failed?'rgba(247,118,142,.22)':heat(p);const rv=c.reward==null?'?':(+c.reward).toFixed(0);
+   h+=`<td style="background:${bg}" data-t="${t}" data-a="${a}"><span class="cellv">${p==null?'—':(+p).toFixed(2)}${c.build_failed?'✗':''}</span><span class="cellp">r=${rv}</span></td>`;}
+  h+='</tr>';}return h+'</tbody></table>';}
+function heat(p){if(p==null)return'transparent';const o=(0.10+0.30*p).toFixed(2);return `rgba(78,201,176,${o})`;}
+
+// ---- 轨迹浏览 ----
+function initTraj(){
+ const st=document.getElementById('selTask'),sa=document.getElementById('selArm');
+ const tasks=Object.keys(IDX).sort();
+ st.innerHTML=tasks.map(t=>`<option>${t}</option>`).join('');
+ function fillArms(){const t=st.value;const arms=ARMS.filter(a=>IDX[t]&&IDX[t][a]);
+   sa.innerHTML=arms.map(a=>`<option>${a}</option>`).join('');}
+ st.onchange=()=>{fillArms();loadTraj();};
+ sa.onchange=loadTraj;
+ fillArms();
+}
+async function loadTraj(){
+ const t=document.getElementById('selTask').value,a=document.getElementById('selArm').value;
+ const box=document.getElementById('steps'),meta=document.getElementById('tmeta');
+ const c=(D.cells[t]||{})[a]||{};
+ meta.innerHTML=`reward=${fmt(c.reward,0)} · partial=${fmt(c.partial)} · $${(c.cost||0).toFixed(2)} · 续跑 ${c.cont==null?'—':c.cont} · 解锁 ${c.unblock==null?'—':c.unblock} · ${IDX[t]&&IDX[t][a]||0} 步`;
+ box.innerHTML='<p class="hint">加载中…</p>';
+ try{
+  const r=await fetch(`trajectories/${t}__${a}.json`);
+  if(!r.ok)throw new Error(r.status);
+  const j=await r.json();
+  box.innerHTML=j.steps.map(renderStep).join('');
+ }catch(e){box.innerHTML=`<p class="hint">无法加载轨迹（${e}）。轨迹需在 http/gh-pages 下浏览（file:// 直接打开会被浏览器拦截 fetch）。</p>`;}
+}
+const KLAB={goal:'goal 注入',exec:'exec',output:'输出',reason:'reasoning',msg:'消息',event:'事件'};
+function renderStep(s,i){
+ const open=(s.kind==='goal'||s.kind==='msg'||s.kind==='event');
+ const label=KLAB[s.kind]||s.kind;
+ const role=s.role?`<span class="role">${s.role}</span>`:'';
+ const body=s.text?`<div class="bd" ${open?'':'style="display:none"'}>${esc(s.text)}</div>`:'';
+ const preview=s.kind==='exec'?esc((s.text||'').split('\n')[0].slice(0,80)):'';
+ return `<div class="step k-${s.kind}"><div class="hd" onclick="this.nextElementSibling&&(this.nextElementSibling.style.display=this.nextElementSibling.style.display==='none'?'block':'none')">`
+  +`<span class="n">${i+1}</span><b>${label}</b>${role}<span style="color:var(--mut);font-weight:400">${preview}</span></div>${body}</div>`;
+}
+
+// 极简 markdown
+function mdRender(src){const inl=s=>esc(s).replace(/`([^`]+)`/g,'<code>$1</code>').replace(/\*\*([^*]+)\*\*/g,'<b>$1</b>').replace(/\[([^\]]+)\]\(([^)]+)\)/g,'<a href="$2">$1</a>');
+ const L=src.split('\n');let o=[],i=0;
+ while(i<L.length){let l=L[i];
+  if(/^```/.test(l)){let b=[];i++;while(i<L.length&&!/^```/.test(L[i])){b.push(esc(L[i]));i++;}i++;o.push('<pre><code>'+b.join('\n')+'</code></pre>');continue;}
+  if(/^\|/.test(l)){let tb=[];while(i<L.length&&/^\|/.test(L[i])){tb.push(L[i]);i++;}o.push(mdTable(tb,inl));continue;}
+  let m;if(m=l.match(/^(#{1,4})\s+(.*)/)){o.push(`<h${m[1].length}>${inl(m[2])}</h${m[1].length}>`);i++;continue;}
+  if(/^>\s?/.test(l)){let b=[];while(i<L.length&&/^>\s?/.test(L[i])){b.push(inl(L[i].replace(/^>\s?/,'')));i++;}o.push('<blockquote>'+b.join('<br>')+'</blockquote>');continue;}
+  if(/^\s*\d+\.\s+/.test(l)){let b=[];while(i<L.length&&/^\s*\d+\.\s+/.test(L[i])){b.push('<li>'+inl(L[i].replace(/^\s*\d+\.\s+/,''))+'</li>');i++;}o.push('<ol>'+b.join('')+'</ol>');continue;}
+  if(/^(\s*)[-*]\s+/.test(l)){let b=[];while(i<L.length&&/^(\s*)[-*]\s+/.test(L[i])){b.push('<li>'+inl(L[i].replace(/^(\s*)[-*]\s+/,''))+'</li>');i++;}o.push('<ul>'+b.join('')+'</ul>');continue;}
+  if(/^(---|\*\*\*)\s*$/.test(l)){o.push('<hr>');i++;continue;}
+  if(l.trim()===''){i++;continue;}o.push('<p>'+inl(l)+'</p>');i++;}
+ return o.join('\n');}
+function mdTable(rows,inl){const cells=r=>r.replace(/^\||\|$/g,'').split('|').map(s=>s.trim());
+ const head=cells(rows[0]);const body=rows.slice(2).map(cells);
+ let h='<table><thead><tr>'+head.map(c=>`<th>${inl(c)}</th>`).join('')+'</tr></thead><tbody>';
+ for(const r of body)h+='<tr>'+r.map(c=>`<td>${inl(c)}</td>`).join('')+'</tr>';return h+'</tbody></table>';}
+
+// 挂载
+document.getElementById('armtbl').innerHTML=armTable();
+document.getElementById('roles').innerHTML=roles();
+document.getElementById('gridtbl').innerHTML=gridTable();
+document.getElementById('mdbody').innerHTML=mdRender(MD);
+document.getElementById('dlmd').href='data:text/markdown;charset=utf-8,'+encodeURIComponent(MD);
+initTraj();loadTraj();
+
+document.getElementById('gridtbl').addEventListener('click',e=>{const td=e.target.closest('td[data-t]');if(!td)return;
+ document.getElementById('selTask').value=td.dataset.t;
+ document.getElementById('selTask').onchange();
+ document.getElementById('selArm').value=td.dataset.a;loadTraj();switchTab('traj');});
+
+function switchTab(name){document.querySelectorAll('.tab').forEach(x=>x.classList.toggle('on',x.dataset.t===name));
+ for(const id of ['overview','grid','traj','report'])document.getElementById(id).classList.toggle('hide',id!==name);}
+document.querySelectorAll('.tab').forEach(tab=>tab.addEventListener('click',()=>switchTab(tab.dataset.t)));
+</script>
+</body>
+</html>
+"""
+
+out = HTML.replace("__DATA__", DATA_JSON).replace("__MD__", MD_JSON).replace("__IDX__", IDX_JSON)
+out_path.write_text(out)
+print(f"写出 {out_path}（{len(out)} 字节）；轨迹索引 {sum(len(v) for v in traj_idx.values())} 条")

--- a/benchmark/swe-marathon/scoring/_build_viz.py
+++ b/benchmark/swe-marathon/scoring/_build_viz.py
@@ -9,10 +9,12 @@ trajectories/<task>__<arm>.json（在 gh-pages / 本地 http 下可用）。
 from __future__ import annotations
 import json, sys, pathlib
 
-base = pathlib.Path(sys.argv[1]).parent if len(sys.argv) > 1 else pathlib.Path("viz")
-data_path = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "viz/data.json")
-md_path   = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else "viz/SUMMARY.md")
-out_path  = pathlib.Path(sys.argv[3] if len(sys.argv) > 3 else "viz/index.html")
+from _common import safe_path
+
+data_path = safe_path(sys.argv[1] if len(sys.argv) > 1 else "viz/data.json")
+md_path   = safe_path(sys.argv[2] if len(sys.argv) > 2 else "viz/SUMMARY.md")
+out_path  = safe_path(sys.argv[3] if len(sys.argv) > 3 else "viz/index.html")
+base = data_path.parent
 
 data = json.loads(data_path.read_text())
 md_raw = md_path.read_text()

--- a/benchmark/swe-marathon/scoring/_common.py
+++ b/benchmark/swe-marathon/scoring/_common.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""五模式评测脚本的公共件：模式名归一化、连续分口径、结果收集、路径校验。
+
+抽出来是为了让 _compare / _partial / _summarize / _aggregate / _extract_traj 复用同一
+份口径（避免同一个 bug 在多个脚本里各修一遍），也消除重复代码。改这里等于同时改所有
+下游报表，动前先想清楚。
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import re
+
+# 五个模式：2 条 baseline（plain=裸 codex、goal=codex 原生 goal）+ 3 个 LoopX 模式
+ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+
+
+def norm(name: str) -> str:
+    """模式名归一化：ssh-goal-1537631 → ssh-goal。
+
+    marathon_run.sh 在原目录不可写时会回退成 `<mode>-<pid>`。不归一化的话这些结果
+    的 key 不在 ARMS 白名单里，下游打印循环会静默跳过——结果存在但表里看不见。
+    """
+    return re.sub(r"-\d{3,}$", "", name)
+
+
+def mean(xs):
+    xs = [x for x in xs if x is not None]
+    return sum(xs) / len(xs) if xs else None
+
+
+def safe_path(arg: str) -> pathlib.Path:
+    """把命令行传入的路径规范化成绝对路径再交给下游访问。
+
+    先 expanduser + resolve 把 `..`、符号链接、`~` 都折叠掉，得到一个确定的规范
+    路径，避免"用未经处理的原始参数直接拼路径去读写文件"。这些脚本本就是对任意
+    结果目录/输出文件工作的 CLI，不额外限制根目录，只保证路径是规范化后的。
+    """
+    return pathlib.Path(arg).expanduser().resolve()
+
+
+def testrate(d: dict):
+    """测试通过率——比 partial_score 更稳的连续口径。
+
+    优先 pytest 分组的 passed/total，其次顶层 passed/total，再次 passed/(passed+failed)
+    （cargo test 只写这俩），最后 gates_passed/gates_total。都没有返回 None。
+    """
+    pt = d.get("pytest")
+    if isinstance(pt, dict) and pt:
+        groups = [g for g in pt.values() if isinstance(g, dict)]
+        p = sum((g.get("passed") or 0) for g in groups)
+        t = sum((g.get("total") or 0) for g in groups)
+        if t:
+            return p / t
+    p, t, f = d.get("passed"), d.get("total"), d.get("failed")
+    if isinstance(p, (int, float)) and isinstance(t, (int, float)) and t:
+        return p / t
+    if isinstance(p, (int, float)) and isinstance(f, (int, float)) and (p + f):
+        return p / (p + f)
+    gp, gt = d.get("gates_passed"), d.get("gates_total")
+    if isinstance(gp, (int, float)) and isinstance(gt, (int, float)) and gt:
+        return gp / gt
+    return None
+
+
+def score(d: dict):
+    """连续分：优先 partial_score，回退 pass_rate。两者都没有返回 None。"""
+    for k in ("partial_score", "pass_rate"):
+        v = d.get(k)
+        if isinstance(v, (int, float)):
+            return float(v)
+    return None
+
+
+def _load(p: pathlib.Path):
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+
+
+def _wall_minutes(d: dict):
+    try:
+        t0 = datetime.datetime.fromisoformat(d["started_at"])
+        t1 = datetime.datetime.fromisoformat(d["finished_at"])
+        return round((t1 - t0).total_seconds() / 60, 1)
+    except Exception:
+        return None
+
+
+def collect(root: pathlib.Path) -> dict:
+    """收集每个 (任务, 模式) 的完整记录，键为 (task, arm)。
+
+    口径（都踩过坑，别退回去）：
+      · 只认 job 级 result.json（有 stats、n_completed_trials≥1）
+      · 属主必须是当前用户（排除上一轮 root 属主的遗留目录）
+      · partial 半成品（phase=initialized/starting）不算成绩
+      · cost 取 stats.cost_usd
+    返回的是超集记录，_compare 与 _aggregate 各取所需字段。
+    """
+    out: dict = {}
+    if not root.is_dir():
+        return out
+    for r in root.glob("*/*/*/*/result.json"):
+        rel = r.relative_to(root).parts
+        task, armdir = rel[0], rel[1]
+        if task.startswith("."):
+            continue
+        arm = norm(armdir)
+        if arm not in ARMS:
+            continue
+        try:
+            if (root / rel[0] / rel[1]).stat().st_uid != os.getuid():
+                continue
+        except OSError:
+            continue
+        d = _load(r)
+        if not d:
+            continue
+        s = d.get("stats", {})
+        if not s or int(s.get("n_completed_trials") or 0) < 1:
+            continue
+        rw = [float(k)
+              for ev in (s.get("evals") or {}).values()
+              for k, tasks in ((ev.get("reward_stats") or {}).get("reward") or {}).items()
+              for _ in tasks]
+        rec = {
+            "task": task, "arm": arm,
+            "reward": rw[0] if rw else None,
+            "cost": s.get("cost_usd") or 0.0,
+            "tok_in": s.get("n_input_tokens") or 0,
+            "tok_out": s.get("n_output_tokens") or 0,
+            "tok_cache": s.get("n_cache_tokens") or 0,
+            "errors": int(s.get("n_errored_trials") or 0),
+            "min": _wall_minutes(d),
+            "partial": None, "testrate": None, "build_failed": False,
+            "passed": None, "failed": None,
+            "status": None, "cont": None, "unblock": None, "err_events": None,
+            "run_dir": str(r.parent.relative_to(root)),
+        }
+        for m in r.parent.glob("*/verifier/metrics.json"):
+            mm = _load(m)
+            if not mm:
+                continue
+            ph = str(mm.get("phase") or "")
+            if ph in ("initialized", "starting"):
+                continue
+            rec["partial"] = mm.get("partial_score")
+            rec["testrate"] = testrate(mm)
+            rec["build_failed"] = ph == "build_failed"
+            rec["passed"], rec["failed"] = mm.get("passed"), mm.get("failed")
+        for f in r.parent.glob("*/agent/goal_receipt.json"):
+            g = _load(f)
+            if not g:
+                continue
+            rec["status"] = g.get("post_goal_status")
+            rec["cont"] = g.get("goal_continuation_turn_completed_count")
+            rec["unblock"] = g.get("_unblock_count")
+            rec["err_events"] = g.get("error_event_count")
+        out[(task, arm)] = rec
+    return out

--- a/benchmark/swe-marathon/scoring/_compare.py
+++ b/benchmark/swe-marathon/scoring/_compare.py
@@ -1,110 +1,29 @@
 #!/usr/bin/env python3
-"""五臂对比报表。可同时读两个跑次做跨预算对照。
+"""五模式对比报表。可同时读两个跑次做跨预算对照。
 
     _compare.py <out_dir> [archive_dir]
 
     _compare.py marathon-full                       # 只看当前跑次
     _compare.py marathon-full marathon-89min-xxx    # 和第一轮对照
 
-【为什么要固定成脚本】
-之前每次出对比都临时手写查询，同一个 bug 犯过两次：
-
-  1. **臂名没归一化** —— marathon_run.sh 在臂目录不可写时会回退成 `<arm>-<pid>`
-     （比如 ssh-goal-1537631）。临时脚本按目录名精确匹配，那一格就查不到，
-     表里显示「—」而实际有数据。_summarize.py / _receipts.py 早就归一化了，
-     临时脚本却没有。
-  2. **半成品 metrics 当成绩** —— 正在重跑的 trial 也留 metrics.json，
-     内容是 phase=initialized、partial=0.0，采信会凭空造出一个 0 分。
-
-【报表的三条原则】
-  · reward 是二值的，在紧预算下几乎全 0，必须同时给 partial_score
-  · 构建失败（Rust 类任务）会让 partial_score 直接归零，要单独标注，
-    不能和「构建通过但测试没全过」混进同一个均值
-  · 臂均值只在**双方都跑过的任务**上算，否则是任务集差异不是能力差异
+口径全部走 scripts/_common（模式名归一化、只认 job 级 result.json、属主校验、半成品
+metrics 排除）。报表三条原则：
+  · reward 是二值的，紧预算下几乎全 0，必须同时给 partial_score
+  · 构建失败（Rust 类任务）会让 partial_score 直接归零，单独标注（✗），不混进均值
+  · 模式均值只在双方都跑过的任务上算，否则是任务集差异不是能力差异
 """
 
 from __future__ import annotations
 
-import datetime
-import json
 import os
-import pathlib
-import re
 import sys
 
-ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+from _common import ARMS, collect, safe_path
 
-# 连续分（partial_score / build_failed）是 SWE-Marathon 任务自己写的约定，
-# 不是 harbor 的。bench profile 说没有时整列不渲染 —— 渲染成一列 0.0 会被
-# 读成"全都没得分"，比不显示更坏。
+# 连续分（partial_score / build_failed）是任务自己写的约定，不是 harbor 的。bench
+# profile 说没有时整列不渲染 —— 渲染成一列 0.0 会被读成"全都没得分"，比不显示更坏。
 BENCH = os.environ.get("WEN_BENCH", "swe-marathon")
 HAS_PARTIAL = os.environ.get("BENCH_HAS_PARTIAL", "1") == "1"
-
-
-def norm(a: str) -> str:
-    """ssh-goal-1537631 → ssh-goal。别删这个函数。"""
-    return re.sub(r"-\d{3,}$", "", a)
-
-
-def collect(root: pathlib.Path) -> dict[tuple[str, str], dict]:
-    out: dict[tuple[str, str], dict] = {}
-    if not root.is_dir():
-        return out
-    for r in root.glob("*/*/*/*/result.json"):
-        task, armdir = r.parts[-5], r.parts[-4]
-        # 跨跑次时 parts 位置会变，用 relative_to 更稳
-        rel = r.relative_to(root).parts
-        task, armdir = rel[0], rel[1]
-        if task.startswith("."):
-            continue          # 有意排除的归档（.excluded-gpu/），不是结果
-        arm = norm(armdir)
-        try:
-            if (root / rel[0] / rel[1]).stat().st_uid != os.getuid():
-                continue          # 遗留的 root 属主目录，是上一轮的产物
-        except OSError:
-            continue
-        try:
-            d = json.loads(r.read_text())
-        except Exception:
-            continue
-        s = d.get("stats", {})
-        if int(s.get("n_completed_trials") or 0) < 1:
-            continue
-        rw = [float(k)
-              for ev in (s.get("evals") or {}).values()
-              for k, t in ((ev.get("reward_stats") or {}).get("reward") or {}).items()
-              for _ in t]
-        rec = {"reward": rw[0] if rw else None,
-               "cost": s.get("cost_usd") or 0,
-               "errors": int(s.get("n_errored_trials") or 0)}
-        try:
-            t0 = datetime.datetime.fromisoformat(d["started_at"])
-            t1 = datetime.datetime.fromisoformat(d["finished_at"])
-            rec["min"] = (t1 - t0).total_seconds() / 60
-        except Exception:
-            rec["min"] = None
-        for m in r.parent.glob("*/verifier/metrics.json"):
-            try:
-                mm = json.loads(m.read_text())
-            except Exception:
-                continue
-            ph = str(mm.get("phase") or "")
-            if ph in ("initialized", "starting"):
-                continue          # 半成品，不是成绩
-            rec["partial"] = mm.get("partial_score")
-            rec["build_failed"] = ph == "build_failed"
-            rec["passed"], rec["failed"] = mm.get("passed"), mm.get("failed")
-        for f in r.parent.glob("*/agent/goal_receipt.json"):
-            try:
-                g = json.loads(f.read_text())
-            except Exception:
-                continue
-            rec["status"] = g.get("post_goal_status")
-            rec["cont"] = g.get("goal_continuation_turn_completed_count")
-            rec["unblock"] = g.get("_unblock_count")     # 带下划线，别写错
-            rec["err_events"] = g.get("error_event_count")
-        out[(task, arm)] = rec
-    return out
 
 
 def cell(rec: dict | None) -> str:
@@ -119,20 +38,10 @@ def cell(rec: dict | None) -> str:
     return f"{rw}|{p}{mark}"
 
 
-def main() -> int:
-    cur = collect(pathlib.Path(sys.argv[1]))
-    old = collect(pathlib.Path(sys.argv[2])) if len(sys.argv) > 2 else {}
-    if not cur:
-        print("  没有结果")
-        return 0
-
-    tasks = sorted({t for t, _ in cur})
-    full = [t for t in tasks if sum(1 for a in ARMS if (t, a) in cur) == 5]
-
+def _print_grid(cur: dict, tasks: list) -> None:
     if HAS_PARTIAL:
-        print(f"格式 reward|partial（✗ = 构建失败，partial 被门禁归零）")
+        print("格式 reward|partial（✗ = 构建失败，partial 被门禁归零）")
     else:
-        # 不渲染成一列 0.0 —— 那会被读成"全都没得分"。整列不出现，并说明原因。
         print(f"格式 reward（二值）。bench={BENCH} 没有连续分约定，partial 列不适用")
     print(f"{'任务':26}" + "".join(f"{a:>12}" for a in ARMS) + "  齐")
     for t in tasks:
@@ -140,55 +49,73 @@ def main() -> int:
         print(f"{t[:26]:26}" + "".join(f"{cell(cur.get((t, a))):>12}" for a in ARMS)
               + f" {n}/5" + ("★" if n == 5 else ""))
 
-    print(f"\n五臂齐 {len(full)} 个任务: {full}")
-    if full:
-        print(f"\n=== 只用五臂齐的任务比较 ===")
-        hdr = f"  {'臂':11}{'reward':>8}"
-        if HAS_PARTIAL:
-            hdr += f"{'partial':>9}{'构建失败':>9}"
-        print(hdr + f"{'花费':>9}{'自己收工':>9}")
-        for a in ARMS:
-            rs = [cur[(t, a)] for t in full]
-            rw = [x["reward"] for x in rs if x.get("reward") is not None]
-            cst = sum(x["cost"] for x in rs)
-            done = sum(1 for x in rs if x.get("status") == "complete")
-            line = f"  {a:11}{(sum(rw)/len(rw) if rw else float('nan')):>8.3f}"
-            if HAS_PARTIAL:
-                ps = [x["partial"] for x in rs if x.get("partial") is not None]
-                bf = sum(1 for x in rs if x.get("build_failed"))
-                line += (f"{(sum(ps)/len(ps) if ps else float('nan')):>9.3f}"
-                         f"{f'{bf}/{len(rs)}':>9}")
-            print(line + f"{'$'+str(round(cst)):>9}{f'{done}/{len(rs)}':>9}")
-        if not HAS_PARTIAL:
-            # 二值 reward 在紧预算下几乎没有区分度，这一行是唯一还能分辨的信号。
-            print("  注: reward 是二值的，紧预算下多为 0；"
-                  "解读要看「自己收工」列（撞死线 vs 自己收尾）。")
 
-    # LoopX 三臂的续跑/解锁——报表必须标注
-    print(f"\n=== LoopX 三臂的续跑与解锁 ===")
+def _print_full_compare(cur: dict, full: list) -> None:
+    print(f"\n五模式齐 {len(full)} 个任务: {full}")
+    if not full:
+        return
+    print("\n=== 只用五模式齐的任务比较 ===")
+    hdr = f"  {'模式':11}{'reward':>8}"
+    if HAS_PARTIAL:
+        hdr += f"{'partial':>9}{'构建失败':>9}"
+    print(hdr + f"{'花费':>9}{'自己收工':>9}")
+    for a in ARMS:
+        rs = [cur[(t, a)] for t in full]
+        rw = [x["reward"] for x in rs if x.get("reward") is not None]
+        cst = sum(x["cost"] for x in rs)
+        done = sum(1 for x in rs if x.get("status") == "complete")
+        line = f"  {a:11}{(sum(rw) / len(rw) if rw else float('nan')):>8.3f}"
+        if HAS_PARTIAL:
+            ps = [x["partial"] for x in rs if x.get("partial") is not None]
+            bf = sum(1 for x in rs if x.get("build_failed"))
+            line += (f"{(sum(ps) / len(ps) if ps else float('nan')):>9.3f}"
+                     f"{f'{bf}/{len(rs)}':>9}")
+        print(line + f"{'$' + str(round(cst)):>9}{f'{done}/{len(rs)}':>9}")
+    if not HAS_PARTIAL:
+        print("  注: reward 是二值的，紧预算下多为 0；"
+              "解读要看「自己收工」列（撞死线 vs 自己收尾）。")
+
+
+def _print_loopx_cont(cur: dict) -> None:
+    print("\n=== LoopX 三模式的续跑与解锁 ===")
     for a in ("ssh-goal", "codex-cli", "heartbeat"):
         rs = [v for (t, x), v in cur.items() if x == a]
         cont = [v.get("cont") for v in rs if v.get("cont") is not None]
         unb = [v.get("unblock") for v in rs if v.get("unblock") is not None]
         print(f"  {a:11} n={len(rs):>2}  续跑合计 {sum(cont)}（{cont}）  解锁合计 {sum(unb)}")
 
+
+def _print_cross_run(cur: dict, old: dict) -> None:
+    print("\n=== 跨跑次对照（只用两轮都有的格）===")
+    common = sorted(set(cur) & set(old))
+    print(f"  共同格 {len(common)} 个")
+    key = "partial" if HAS_PARTIAL else "reward"   # 没有连续分时用 reward 做差
+    for a in ARMS:
+        cs = [(cur[k], old[k]) for k in common if k[1] == a]
+        cs = [(x, y) for x, y in cs
+              if x.get(key) is not None and y.get(key) is not None]
+        if not cs:
+            continue
+        dp = sum(x[key] - y[key] for x, y in cs) / len(cs)
+        dc = sum(x["cost"] - y["cost"] for x, y in cs) / len(cs)
+        cut = sum(1 for x, _ in cs if x.get("status") != "complete")
+        print(f"  {a:11} n={len(cs)}  Δ{key}={dp:+.3f}  Δ花费={dc:+.1f}  "
+              f"本轮被砍 {cut}/{len(cs)}")
+
+
+def main() -> int:
+    cur = collect(safe_path(sys.argv[1]))
+    old = collect(safe_path(sys.argv[2])) if len(sys.argv) > 2 else {}
+    if not cur:
+        print("  没有结果")
+        return 0
+    tasks = sorted({t for t, _ in cur})
+    full = [t for t in tasks if sum(1 for a in ARMS if (t, a) in cur) == 5]
+    _print_grid(cur, tasks)
+    _print_full_compare(cur, full)
+    _print_loopx_cont(cur)
     if old:
-        print(f"\n=== 跨跑次对照（只用两轮都有的格）===")
-        common = sorted(set(cur) & set(old))
-        print(f"  共同格 {len(common)} 个")
-        # 没有连续分时用 reward 做差，指标名跟着变，别让表头骗人。
-        key = "partial" if HAS_PARTIAL else "reward"
-        for a in ARMS:
-            cs = [(cur[k], old[k]) for k in common if k[1] == a]
-            cs = [(x, y) for x, y in cs
-                  if x.get(key) is not None and y.get(key) is not None]
-            if not cs:
-                continue
-            dp = sum(x[key] - y[key] for x, y in cs) / len(cs)
-            dc = sum(x["cost"] - y["cost"] for x, y in cs) / len(cs)
-            cut = sum(1 for x, _ in cs if x.get("status") != "complete")
-            print(f"  {a:11} n={len(cs)}  Δ{key}={dp:+.3f}  Δ花费={dc:+.1f}  "
-                  f"本轮被砍 {cut}/{len(cs)}")
+        _print_cross_run(cur, old)
     return 0
 
 

--- a/benchmark/swe-marathon/scoring/_compare.py
+++ b/benchmark/swe-marathon/scoring/_compare.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""五臂对比报表。可同时读两个跑次做跨预算对照。
+
+    _compare.py <out_dir> [archive_dir]
+
+    _compare.py marathon-full                       # 只看当前跑次
+    _compare.py marathon-full marathon-89min-xxx    # 和第一轮对照
+
+【为什么要固定成脚本】
+之前每次出对比都临时手写查询，同一个 bug 犯过两次：
+
+  1. **臂名没归一化** —— marathon_run.sh 在臂目录不可写时会回退成 `<arm>-<pid>`
+     （比如 ssh-goal-1537631）。临时脚本按目录名精确匹配，那一格就查不到，
+     表里显示「—」而实际有数据。_summarize.py / _receipts.py 早就归一化了，
+     临时脚本却没有。
+  2. **半成品 metrics 当成绩** —— 正在重跑的 trial 也留 metrics.json，
+     内容是 phase=initialized、partial=0.0，采信会凭空造出一个 0 分。
+
+【报表的三条原则】
+  · reward 是二值的，在紧预算下几乎全 0，必须同时给 partial_score
+  · 构建失败（Rust 类任务）会让 partial_score 直接归零，要单独标注，
+    不能和「构建通过但测试没全过」混进同一个均值
+  · 臂均值只在**双方都跑过的任务**上算，否则是任务集差异不是能力差异
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import sys
+
+ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+
+# 连续分（partial_score / build_failed）是 SWE-Marathon 任务自己写的约定，
+# 不是 harbor 的。bench profile 说没有时整列不渲染 —— 渲染成一列 0.0 会被
+# 读成"全都没得分"，比不显示更坏。
+BENCH = os.environ.get("WEN_BENCH", "swe-marathon")
+HAS_PARTIAL = os.environ.get("BENCH_HAS_PARTIAL", "1") == "1"
+
+
+def norm(a: str) -> str:
+    """ssh-goal-1537631 → ssh-goal。别删这个函数。"""
+    return re.sub(r"-\d{3,}$", "", a)
+
+
+def collect(root: pathlib.Path) -> dict[tuple[str, str], dict]:
+    out: dict[tuple[str, str], dict] = {}
+    if not root.is_dir():
+        return out
+    for r in root.glob("*/*/*/*/result.json"):
+        task, armdir = r.parts[-5], r.parts[-4]
+        # 跨跑次时 parts 位置会变，用 relative_to 更稳
+        rel = r.relative_to(root).parts
+        task, armdir = rel[0], rel[1]
+        if task.startswith("."):
+            continue          # 有意排除的归档（.excluded-gpu/），不是结果
+        arm = norm(armdir)
+        try:
+            if (root / rel[0] / rel[1]).stat().st_uid != os.getuid():
+                continue          # 遗留的 root 属主目录，是上一轮的产物
+        except OSError:
+            continue
+        try:
+            d = json.loads(r.read_text())
+        except Exception:
+            continue
+        s = d.get("stats", {})
+        if int(s.get("n_completed_trials") or 0) < 1:
+            continue
+        rw = [float(k)
+              for ev in (s.get("evals") or {}).values()
+              for k, t in ((ev.get("reward_stats") or {}).get("reward") or {}).items()
+              for _ in t]
+        rec = {"reward": rw[0] if rw else None,
+               "cost": s.get("cost_usd") or 0,
+               "errors": int(s.get("n_errored_trials") or 0)}
+        try:
+            t0 = datetime.datetime.fromisoformat(d["started_at"])
+            t1 = datetime.datetime.fromisoformat(d["finished_at"])
+            rec["min"] = (t1 - t0).total_seconds() / 60
+        except Exception:
+            rec["min"] = None
+        for m in r.parent.glob("*/verifier/metrics.json"):
+            try:
+                mm = json.loads(m.read_text())
+            except Exception:
+                continue
+            ph = str(mm.get("phase") or "")
+            if ph in ("initialized", "starting"):
+                continue          # 半成品，不是成绩
+            rec["partial"] = mm.get("partial_score")
+            rec["build_failed"] = ph == "build_failed"
+            rec["passed"], rec["failed"] = mm.get("passed"), mm.get("failed")
+        for f in r.parent.glob("*/agent/goal_receipt.json"):
+            try:
+                g = json.loads(f.read_text())
+            except Exception:
+                continue
+            rec["status"] = g.get("post_goal_status")
+            rec["cont"] = g.get("goal_continuation_turn_completed_count")
+            rec["unblock"] = g.get("_unblock_count")     # 带下划线，别写错
+            rec["err_events"] = g.get("error_event_count")
+        out[(task, arm)] = rec
+    return out
+
+
+def cell(rec: dict | None) -> str:
+    if not rec:
+        return "—"
+    rw = "?" if rec.get("reward") is None else f"{rec['reward']:.0f}"
+    if not HAS_PARTIAL:
+        return rw
+    ps = rec.get("partial")
+    p = "--" if ps is None else f"{ps:.2f}"
+    mark = "✗" if rec.get("build_failed") else ""
+    return f"{rw}|{p}{mark}"
+
+
+def main() -> int:
+    cur = collect(pathlib.Path(sys.argv[1]))
+    old = collect(pathlib.Path(sys.argv[2])) if len(sys.argv) > 2 else {}
+    if not cur:
+        print("  没有结果")
+        return 0
+
+    tasks = sorted({t for t, _ in cur})
+    full = [t for t in tasks if sum(1 for a in ARMS if (t, a) in cur) == 5]
+
+    if HAS_PARTIAL:
+        print(f"格式 reward|partial（✗ = 构建失败，partial 被门禁归零）")
+    else:
+        # 不渲染成一列 0.0 —— 那会被读成"全都没得分"。整列不出现，并说明原因。
+        print(f"格式 reward（二值）。bench={BENCH} 没有连续分约定，partial 列不适用")
+    print(f"{'任务':26}" + "".join(f"{a:>12}" for a in ARMS) + "  齐")
+    for t in tasks:
+        n = sum(1 for a in ARMS if (t, a) in cur)
+        print(f"{t[:26]:26}" + "".join(f"{cell(cur.get((t, a))):>12}" for a in ARMS)
+              + f" {n}/5" + ("★" if n == 5 else ""))
+
+    print(f"\n五臂齐 {len(full)} 个任务: {full}")
+    if full:
+        print(f"\n=== 只用五臂齐的任务比较 ===")
+        hdr = f"  {'臂':11}{'reward':>8}"
+        if HAS_PARTIAL:
+            hdr += f"{'partial':>9}{'构建失败':>9}"
+        print(hdr + f"{'花费':>9}{'自己收工':>9}")
+        for a in ARMS:
+            rs = [cur[(t, a)] for t in full]
+            rw = [x["reward"] for x in rs if x.get("reward") is not None]
+            cst = sum(x["cost"] for x in rs)
+            done = sum(1 for x in rs if x.get("status") == "complete")
+            line = f"  {a:11}{(sum(rw)/len(rw) if rw else float('nan')):>8.3f}"
+            if HAS_PARTIAL:
+                ps = [x["partial"] for x in rs if x.get("partial") is not None]
+                bf = sum(1 for x in rs if x.get("build_failed"))
+                line += (f"{(sum(ps)/len(ps) if ps else float('nan')):>9.3f}"
+                         f"{f'{bf}/{len(rs)}':>9}")
+            print(line + f"{'$'+str(round(cst)):>9}{f'{done}/{len(rs)}':>9}")
+        if not HAS_PARTIAL:
+            # 二值 reward 在紧预算下几乎没有区分度，这一行是唯一还能分辨的信号。
+            print("  注: reward 是二值的，紧预算下多为 0；"
+                  "解读要看「自己收工」列（撞死线 vs 自己收尾）。")
+
+    # LoopX 三臂的续跑/解锁——报表必须标注
+    print(f"\n=== LoopX 三臂的续跑与解锁 ===")
+    for a in ("ssh-goal", "codex-cli", "heartbeat"):
+        rs = [v for (t, x), v in cur.items() if x == a]
+        cont = [v.get("cont") for v in rs if v.get("cont") is not None]
+        unb = [v.get("unblock") for v in rs if v.get("unblock") is not None]
+        print(f"  {a:11} n={len(rs):>2}  续跑合计 {sum(cont)}（{cont}）  解锁合计 {sum(unb)}")
+
+    if old:
+        print(f"\n=== 跨跑次对照（只用两轮都有的格）===")
+        common = sorted(set(cur) & set(old))
+        print(f"  共同格 {len(common)} 个")
+        # 没有连续分时用 reward 做差，指标名跟着变，别让表头骗人。
+        key = "partial" if HAS_PARTIAL else "reward"
+        for a in ARMS:
+            cs = [(cur[k], old[k]) for k in common if k[1] == a]
+            cs = [(x, y) for x, y in cs
+                  if x.get(key) is not None and y.get(key) is not None]
+            if not cs:
+                continue
+            dp = sum(x[key] - y[key] for x, y in cs) / len(cs)
+            dc = sum(x["cost"] - y["cost"] for x, y in cs) / len(cs)
+            cut = sum(1 for x, _ in cs if x.get("status") != "complete")
+            print(f"  {a:11} n={len(cs)}  Δ{key}={dp:+.3f}  Δ花费={dc:+.1f}  "
+                  f"本轮被砍 {cut}/{len(cs)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/scoring/_extract_traj.py
+++ b/benchmark/swe-marathon/scoring/_extract_traj.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""从每个 trial 的 codex rollout 抽出可读轨迹，落成 viz/trajectories/<task>__<arm>.json。
+
+轨迹步骤 kind：
+  goal     首条 developer/user 里的 goal body（plain vs LoopX 的关键差异就在这）
+  msg      assistant/user/developer 文本消息
+  reason   推理（多为加密，仅留标记；有 summary 就带上）
+  exec     工具调用（code-mode 全走 exec，抽出 cmd）
+  output   工具输出（截断）
+  event    task_started / task_complete / goal_updated
+
+用法： _extract_traj.py marathon-full viz/trajectories
+"""
+from __future__ import annotations
+import json, os, re, sys, pathlib
+
+ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+OUT_HEAD, OUT_TAIL = 1000, 240      # 输出保留首尾
+CMD_CAP = 1200
+GOAL_CAP = 6000
+
+
+def norm(a): return re.sub(r"-\d{3,}$", "", a)
+
+
+def clip(s, head, tail=0):
+    s = s or ""
+    if len(s) <= head + tail + 40:
+        return s
+    if tail:
+        return s[:head] + f"\n…(略 {len(s)-head-tail} 字)…\n" + s[-tail:]
+    return s[:head] + f"…(略 {len(s)-head} 字)"
+
+
+def text_of(content):
+    if isinstance(content, str):
+        return content
+    out = []
+    for c in content or []:
+        if isinstance(c, dict):
+            out.append(c.get("text") or c.get("output") or "")
+        else:
+            out.append(str(c))
+    return "".join(out)
+
+
+def extract_cmd(inp: str) -> str:
+    """从 exec 的 JS input 里抽 cmd 字段；抽不出就返回原串截断。"""
+    if not isinstance(inp, str):
+        return json.dumps(inp, ensure_ascii=False)[:CMD_CAP]
+    m = re.search(r'cmd\s*:\s*"((?:[^"\\]|\\.)*)"', inp)
+    if not m:
+        m = re.search(r'cmd\s*:\s*`([^`]*)`', inp)
+    if m:
+        try:
+            return clip(json.loads('"' + m.group(1) + '"') if '\\' in m.group(1) else m.group(1), CMD_CAP)
+        except Exception:
+            return clip(m.group(1), CMD_CAP)
+    return clip(inp, CMD_CAP)
+
+
+def parse_rollout(fp: pathlib.Path):
+    steps = []
+    goal_seen = False
+    for line in fp.read_text(errors="replace").splitlines():
+        try:
+            o = json.loads(line)
+        except Exception:
+            continue
+        t = o.get("type")
+        pl = o.get("payload")
+        if not isinstance(pl, dict):
+            continue
+        if t == "response_item":
+            st = pl.get("type")
+            if st == "message":
+                role = pl.get("role", "?")
+                body = text_of(pl.get("content"))
+                if not body.strip():
+                    continue
+                # LoopX 的关键自变量：注入的 goal 上下文（plain 模式没有这条）
+                if 'codex_internal_context source="goal"' in body or "active thread goal" in body:
+                    steps.append({"kind": "goal", "role": role, "text": clip(body, GOAL_CAP)})
+                    goal_seen = True
+                else:
+                    steps.append({"kind": "msg", "role": role, "text": clip(body, 2500)})
+            elif st == "reasoning":
+                summ = pl.get("summary") or []
+                txt = " ".join(text_of([s]) if isinstance(s, dict) else str(s) for s in summ)
+                steps.append({"kind": "reason", "text": clip(txt, 800) if txt.strip() else ""})
+            elif st in ("custom_tool_call", "function_call"):
+                steps.append({"kind": "exec", "name": pl.get("name", "exec"),
+                              "text": extract_cmd(pl.get("input", ""))})
+            elif st in ("custom_tool_call_output", "function_call_output"):
+                steps.append({"kind": "output", "text": clip(text_of(pl.get("output")), OUT_HEAD, OUT_TAIL)})
+        elif t == "event_msg":
+            et = pl.get("type")
+            if et == "task_started":
+                steps.append({"kind": "event", "text": "task_started"})
+            elif et == "task_complete":
+                steps.append({"kind": "event", "text": "task_complete"})
+            elif et == "thread_goal_updated":
+                steps.append({"kind": "event", "text": "goal_updated（续跑/心跳）"})
+    return steps
+
+
+def main():
+    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    outdir = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else "viz/trajectories")
+    outdir.mkdir(parents=True, exist_ok=True)
+    index = {}
+    for task_dir in sorted(root.glob("*")):
+        if not task_dir.is_dir() or task_dir.name.startswith("."):
+            continue
+        task = task_dir.name
+        for arm_dir in task_dir.glob("*"):
+            arm = norm(arm_dir.name)
+            if arm not in ARMS:
+                continue
+            try:
+                if arm_dir.stat().st_uid != os.getuid():
+                    continue
+            except OSError:
+                continue
+            rolls = sorted(arm_dir.glob("**/agent/sessions/**/rollout-*.jsonl"))
+            if not rolls:
+                continue
+            steps = []
+            for r in rolls:              # 多份则按名字顺序拼（续跑）
+                steps.extend(parse_rollout(r))
+            if not steps:
+                continue
+            key = f"{task}__{arm}"
+            payload = {"task": task, "arm": arm, "n_steps": len(steps), "steps": steps}
+            (outdir / f"{key}.json").write_text(json.dumps(payload, ensure_ascii=False))
+            index.setdefault(task, {})[arm] = len(steps)
+    (outdir / "_index.json").write_text(json.dumps(index, ensure_ascii=False, indent=1))
+    ntot = sum(len(v) for v in index.values())
+    print(f"写出 {ntot} 条轨迹到 {outdir}/（{len(index)} 任务）")
+    # 抽样看大小
+    big = sorted(outdir.glob("*.json"), key=lambda p: p.stat().st_size, reverse=True)[:3]
+    for p in big:
+        print(f"  最大: {p.name} {p.stat().st_size//1024}KB")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/scoring/_extract_traj.py
+++ b/benchmark/swe-marathon/scoring/_extract_traj.py
@@ -14,13 +14,11 @@
 from __future__ import annotations
 import json, os, re, sys, pathlib
 
-ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+from _common import ARMS, norm, safe_path
+
 OUT_HEAD, OUT_TAIL = 1000, 240      # 输出保留首尾
 CMD_CAP = 1200
 GOAL_CAP = 6000
-
-
-def norm(a): return re.sub(r"-\d{3,}$", "", a)
 
 
 def clip(s, head, tail=0):
@@ -61,7 +59,6 @@ def extract_cmd(inp: str) -> str:
 
 def parse_rollout(fp: pathlib.Path):
     steps = []
-    goal_seen = False
     for line in fp.read_text(errors="replace").splitlines():
         try:
             o = json.loads(line)
@@ -81,7 +78,6 @@ def parse_rollout(fp: pathlib.Path):
                 # LoopX 的关键自变量：注入的 goal 上下文（plain 模式没有这条）
                 if 'codex_internal_context source="goal"' in body or "active thread goal" in body:
                     steps.append({"kind": "goal", "role": role, "text": clip(body, GOAL_CAP)})
-                    goal_seen = True
                 else:
                     steps.append({"kind": "msg", "role": role, "text": clip(body, 2500)})
             elif st == "reasoning":
@@ -105,8 +101,8 @@ def parse_rollout(fp: pathlib.Path):
 
 
 def main():
-    root = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
-    outdir = pathlib.Path(sys.argv[2] if len(sys.argv) > 2 else "viz/trajectories")
+    root = safe_path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    outdir = safe_path(sys.argv[2] if len(sys.argv) > 2 else "viz/trajectories")
     outdir.mkdir(parents=True, exist_ok=True)
     index = {}
     for task_dir in sorted(root.glob("*")):

--- a/benchmark/swe-marathon/scoring/_partial.py
+++ b/benchmark/swe-marathon/scoring/_partial.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""连续分（partial credit）对照表。
+
+    _partial.py <out_dir>
+
+【为什么必须有这个】
+harbor 的 `reward` 是**二值**的：SWE-Marathon 多数任务要求全部测试通过才给 1，
+否则 0。而我们把 agent 预算压到了任务声明值的 15–37%，绝大多数任务都做不完，
+于是二值表会是一片 0 —— 五臂看起来毫无差别，实验白跑。
+
+但任务本身就算了连续分，写在 `/logs/verifier/metrics.json`：
+    embedding-eval:  "partial_score is the canonical partial-credit number in [0, 1]"
+    rust-java-lsp:   reward = 1.0 if passed == total else 0.0；pass_rate = passed/total
+    vliw:            partial_score = (BASELINE - cycles) / (BASELINE - CYCLE_TARGET)
+
+实测差异有多大（biofabric-rust-rewrite，408 个测试）：
+    二值 reward   四臂全是 0
+    连续分        goal 0.973 / heartbeat 0.973 / ssh-goal 0.971 / plain 0.924
+                  （失败数 11 / 11 / 12 / 31）
+find-network 更悬殊：goal 0.667、ssh-goal 0.512、plain 0.000。
+
+所以最终报表必须以连续分为主、二值 reward 为辅。
+
+两个坑：
+  1. 字段名不统一 —— 有的任务只写 `pass_rate`，没有 `partial_score`（rust-java-lsp）。
+  2. 正在重跑的 trial 也会留下 metrics.json，但内容是 `phase: initialized`、
+     passed=0、partial_score=0.0。把它当成绩会**凭空造出一个 0 分**，
+     而那条臂其实还在跑。必须按 phase / 是否有完成的 result.json 排除。
+
+【这套约定不是 harbor 的，是 SWE-Marathon 任务自己写的】
+partial_score / pass_rate / pytest / gates_* / phase=build_failed 全都由任务的
+verifier 脚本产出，harbor 只负责那个二值 reward。换 benchmark 时不能假设还在：
+Terminal-Bench 4.0 的 66 个任务根本不写 /logs/verifier/metrics.json。
+所以本模块由 bench profile 的 BENCH_HAS_PARTIAL 控制，为 0 时**整体跳过并说明
+原因**，不做静默兜底 —— 静默兜底会渲染出一整列 0.0，被读成"全都没得分"，
+比没有这一列更坏。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+if os.environ.get("BENCH_HAS_PARTIAL", "1") != "1":
+    bench = os.environ.get("WEN_BENCH", "?")
+    print(f"  （跳过：bench={bench} 的任务不写 /logs/verifier/metrics.json，"
+          f"没有连续分约定。分数以二值 reward 为准。）")
+    raise SystemExit(0)
+
+ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+
+
+def norm(a: str) -> str:
+    return re.sub(r"-\d{3,}$", "", a)
+
+
+def score(d: dict) -> float | None:
+    """连续分：优先 partial_score，回退 pass_rate。两者都没有就返回 None。"""
+    for k in ("partial_score", "pass_rate"):
+        v = d.get(k)
+        if isinstance(v, (int, float)):
+            return float(v)
+    return None
+
+
+def testrate(d: dict) -> float | None:
+    """测试通过率——比 partial_score 更稳的连续口径。
+
+    【为什么需要第二个口径】s3-clone 这类"多阶段 + CUA 评审"的任务，
+    `partial_score` 被后一个阶段按 `0.5*unit_tests_score + 0.5*cua_rubric_score`
+    改写，而两个子分各自是**二值**的（scoring_mode=binary）。实测 s3-clone/codex-cli
+    22 个 gate 过了 16 个、pytest 大部分通过，`partial_score` 仍然是 0.0——
+    它那句 stage_note 自己写着"partial_score is gates_passed/gates_total"，
+    和实际写入的值互相矛盾。
+
+    所以再算一个纯粹的测试通过率：
+      - `pytest` 字段（各分组 passed/total）优先
+      - 其次 passed/total 顶层字段
+      - 再次 gates_passed/gates_total
+    报表里两列并排给出，哪个都不单独下结论。
+    """
+    pt = d.get("pytest")
+    if isinstance(pt, dict) and pt:
+        p = sum((g or {}).get("passed") or 0 for g in pt.values() if isinstance(g, dict))
+        t = sum((g or {}).get("total") or 0 for g in pt.values() if isinstance(g, dict))
+        if t:
+            return p / t
+    p, t, f = d.get("passed"), d.get("total"), d.get("failed")
+    if isinstance(p, (int, float)) and isinstance(t, (int, float)) and t:
+        return p / t
+    # cargo test 类任务只写 passed/failed，没有 total
+    if isinstance(p, (int, float)) and isinstance(f, (int, float)) and (p + f):
+        return p / (p + f)
+    gp, gt = d.get("gates_passed"), d.get("gates_total")
+    if isinstance(gp, (int, float)) and isinstance(gt, (int, float)) and gt:
+        return gp / gt
+    return None
+
+
+def usable(m: pathlib.Path, d: dict) -> bool:
+    """排除还没跑完的 trial 留下的半成品 metrics。"""
+    if str(d.get("phase") or "").lower() in ("initialized", "starting", ""):
+        # phase 缺失时不能一概排除（多数任务不写 phase），只在明确是初始态时排除
+        if "phase" in d:
+            return False
+    # 该 job 必须有 completed 的 result.json
+    job = m.parent.parent.parent            # <task>/<arm>/<stamp>/<arm>
+    for r in job.glob("result.json"):
+        try:
+            s = json.loads(r.read_text()).get("stats", {})
+        except Exception:
+            continue
+        if int(s.get("n_completed_trials") or 0) >= 1:
+            return True
+    return False
+
+
+def main() -> int:
+    out = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    cell: dict[tuple[str, str], float] = {}
+    skipped = 0
+    for m in sorted(out.glob("*/*/*/*/*/verifier/metrics.json")):
+        # 【坑】必须 relative_to(out) 再取 parts。直接用 m.parts[1] 只在 out 是
+        # 相对路径时碰巧对；progress.sh 传的是绝对路径，那时 parts[1] 是 "mnt"，
+        # 后面 stat() 抛 FileNotFoundError，而调用方 2>/dev/null 把 traceback
+        # 吞掉了 —— 整段连续分静默消失，看起来像"还没有数据"。
+        rel = m.relative_to(out).parts
+        task, arm = rel[0], norm(rel[1])
+        if (out / rel[0] / rel[1]).stat().st_uid != os.getuid():
+            continue
+        try:
+            d = json.loads(m.read_text())
+        except Exception:
+            continue
+        if not usable(m, d):
+            skipped += 1
+            continue
+        s, tr = score(d), testrate(d)
+        if s is not None or tr is not None:
+            cell[(task, arm)] = (s, tr)
+
+    if not cell:
+        print("  还没有可用的 metrics.json")
+        return 0
+
+    print("  每格 = partial_score / 测试通过率")
+    print(f"  {'任务':26}" + "".join(f"{a:>13}" for a in ARMS))
+    for t in sorted({t for t, _ in cell}):
+        line = f"  {t[:26]:26}"
+        for a in ARMS:
+            v = cell.get((t, a))
+            if v is None:
+                line += f"{'—':>13}"
+            else:
+                ps, tr = v
+                a1 = f"{ps:.3f}" if ps is not None else "?"
+                a2 = f"{tr:.3f}" if tr is not None else "?"
+                line += f"{a1+'/'+a2:>13}"
+        print(line)
+
+    print(f"  {'臂均值':26}", end="")
+    for a in ARMS:
+        vs = [v[0] for (t, x), v in cell.items() if x == a and v[0] is not None]
+        ts = [v[1] for (t, x), v in cell.items() if x == a and v[1] is not None]
+        m1 = f"{sum(vs)/len(vs):.3f}" if vs else "—"
+        m2 = f"{sum(ts)/len(ts):.3f}" if ts else "—"
+        print(f"{m1+'/'+m2:>13}", end="")
+    print()
+    print(f"  {'(n)':26}", end="")
+    for a in ARMS:
+        vs = [v for (t, x), v in cell.items() if x == a]
+        print(f"{f'(n={len(vs)})':>13}", end="")
+    print()
+
+    # 只在**同任务都有数据**的格子上比较，避免任务集偏差
+    common = [t for t in {t for t, _ in cell}
+              if sum(1 for a in ARMS if (t, a) in cell) >= 2]
+    if common:
+        print(f"  —— 仅用两臂以上都跑过的 {len(common)} 个任务配对比较 ——")
+        for a in ARMS:
+            vs = [cell[(t, a)][0] for t in common if (t, a) in cell and cell[(t, a)][0] is not None]
+            ts = [cell[(t, a)][1] for t in common if (t, a) in cell and cell[(t, a)][1] is not None]
+            if vs or ts:
+                m1 = f"{sum(vs)/len(vs):.3f}" if vs else "—"
+                m2 = f"{sum(ts)/len(ts):.3f}" if ts else "—"
+                print(f"    {a:10} partial={m1} 测试通过率={m2}  (n={len(vs)}/{len(ts)})")
+    if skipped:
+        print(f"  （跳过 {skipped} 份未完成 trial 的半成品 metrics）")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/scoring/_partial.py
+++ b/benchmark/swe-marathon/scoring/_partial.py
@@ -3,46 +3,22 @@
 
     _partial.py <out_dir>
 
-【为什么必须有这个】
-harbor 的 `reward` 是**二值**的：SWE-Marathon 多数任务要求全部测试通过才给 1，
-否则 0。而我们把 agent 预算压到了任务声明值的 15–37%，绝大多数任务都做不完，
-于是二值表会是一片 0 —— 五臂看起来毫无差别，实验白跑。
+harbor 的 reward 是二值的：多数任务要求全部测试通过才给 1。我们把预算压到任务声明值的
+15–37%，绝大多数做不完，二值表会是一片 0。但任务本身算了连续分，写在
+/logs/verifier/metrics.json（partial_score / pass_rate / pytest / gates_*）。所以最终
+报表以连续分为主、二值 reward 为辅。
 
-但任务本身就算了连续分，写在 `/logs/verifier/metrics.json`：
-    embedding-eval:  "partial_score is the canonical partial-credit number in [0, 1]"
-    rust-java-lsp:   reward = 1.0 if passed == total else 0.0；pass_rate = passed/total
-    vliw:            partial_score = (BASELINE - cycles) / (BASELINE - CYCLE_TARGET)
-
-实测差异有多大（biofabric-rust-rewrite，408 个测试）：
-    二值 reward   四臂全是 0
-    连续分        goal 0.973 / heartbeat 0.973 / ssh-goal 0.971 / plain 0.924
-                  （失败数 11 / 11 / 12 / 31）
-find-network 更悬殊：goal 0.667、ssh-goal 0.512、plain 0.000。
-
-所以最终报表必须以连续分为主、二值 reward 为辅。
-
-两个坑：
-  1. 字段名不统一 —— 有的任务只写 `pass_rate`，没有 `partial_score`（rust-java-lsp）。
-  2. 正在重跑的 trial 也会留下 metrics.json，但内容是 `phase: initialized`、
-     passed=0、partial_score=0.0。把它当成绩会**凭空造出一个 0 分**，
-     而那条臂其实还在跑。必须按 phase / 是否有完成的 result.json 排除。
-
-【这套约定不是 harbor 的，是 SWE-Marathon 任务自己写的】
-partial_score / pass_rate / pytest / gates_* / phase=build_failed 全都由任务的
-verifier 脚本产出，harbor 只负责那个二值 reward。换 benchmark 时不能假设还在：
-Terminal-Bench 4.0 的 66 个任务根本不写 /logs/verifier/metrics.json。
-所以本模块由 bench profile 的 BENCH_HAS_PARTIAL 控制，为 0 时**整体跳过并说明
-原因**，不做静默兜底 —— 静默兜底会渲染出一整列 0.0，被读成"全都没得分"，
-比没有这一列更坏。
+口径（score/testrate/norm/ARMS）走 scripts/_common。本模块由 bench profile 的
+BENCH_HAS_PARTIAL 控制，为 0 时整体跳过并说明原因，不做静默兜底。
 """
 
 from __future__ import annotations
 
 import json
 import os
-import pathlib
-import re
 import sys
+
+from _common import ARMS, norm, safe_path, score, testrate
 
 if os.environ.get("BENCH_HAS_PARTIAL", "1") != "1":
     bench = os.environ.get("WEN_BENCH", "?")
@@ -50,64 +26,12 @@ if os.environ.get("BENCH_HAS_PARTIAL", "1") != "1":
           f"没有连续分约定。分数以二值 reward 为准。）")
     raise SystemExit(0)
 
-ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
 
-
-def norm(a: str) -> str:
-    return re.sub(r"-\d{3,}$", "", a)
-
-
-def score(d: dict) -> float | None:
-    """连续分：优先 partial_score，回退 pass_rate。两者都没有就返回 None。"""
-    for k in ("partial_score", "pass_rate"):
-        v = d.get(k)
-        if isinstance(v, (int, float)):
-            return float(v)
-    return None
-
-
-def testrate(d: dict) -> float | None:
-    """测试通过率——比 partial_score 更稳的连续口径。
-
-    【为什么需要第二个口径】s3-clone 这类"多阶段 + CUA 评审"的任务，
-    `partial_score` 被后一个阶段按 `0.5*unit_tests_score + 0.5*cua_rubric_score`
-    改写，而两个子分各自是**二值**的（scoring_mode=binary）。实测 s3-clone/codex-cli
-    22 个 gate 过了 16 个、pytest 大部分通过，`partial_score` 仍然是 0.0——
-    它那句 stage_note 自己写着"partial_score is gates_passed/gates_total"，
-    和实际写入的值互相矛盾。
-
-    所以再算一个纯粹的测试通过率：
-      - `pytest` 字段（各分组 passed/total）优先
-      - 其次 passed/total 顶层字段
-      - 再次 gates_passed/gates_total
-    报表里两列并排给出，哪个都不单独下结论。
-    """
-    pt = d.get("pytest")
-    if isinstance(pt, dict) and pt:
-        p = sum((g or {}).get("passed") or 0 for g in pt.values() if isinstance(g, dict))
-        t = sum((g or {}).get("total") or 0 for g in pt.values() if isinstance(g, dict))
-        if t:
-            return p / t
-    p, t, f = d.get("passed"), d.get("total"), d.get("failed")
-    if isinstance(p, (int, float)) and isinstance(t, (int, float)) and t:
-        return p / t
-    # cargo test 类任务只写 passed/failed，没有 total
-    if isinstance(p, (int, float)) and isinstance(f, (int, float)) and (p + f):
-        return p / (p + f)
-    gp, gt = d.get("gates_passed"), d.get("gates_total")
-    if isinstance(gp, (int, float)) and isinstance(gt, (int, float)) and gt:
-        return gp / gt
-    return None
-
-
-def usable(m: pathlib.Path, d: dict) -> bool:
+def usable(m, d: dict) -> bool:
     """排除还没跑完的 trial 留下的半成品 metrics。"""
-    if str(d.get("phase") or "").lower() in ("initialized", "starting", ""):
-        # phase 缺失时不能一概排除（多数任务不写 phase），只在明确是初始态时排除
-        if "phase" in d:
-            return False
-    # 该 job 必须有 completed 的 result.json
-    job = m.parent.parent.parent            # <task>/<arm>/<stamp>/<arm>
+    if "phase" in d and str(d.get("phase") or "").lower() in ("initialized", "starting", ""):
+        return False
+    job = m.parent.parent.parent            # <task>/<mode>/<stamp>/<mode>
     for r in job.glob("result.json"):
         try:
             s = json.loads(r.read_text()).get("stats", {})
@@ -118,15 +42,11 @@ def usable(m: pathlib.Path, d: dict) -> bool:
     return False
 
 
-def main() -> int:
-    out = pathlib.Path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
-    cell: dict[tuple[str, str], float] = {}
+def collect_partial(out) -> dict:
+    """扫 metrics.json，返回 {(task, mode): (partial_score, testrate)}。"""
+    cell: dict = {}
     skipped = 0
     for m in sorted(out.glob("*/*/*/*/*/verifier/metrics.json")):
-        # 【坑】必须 relative_to(out) 再取 parts。直接用 m.parts[1] 只在 out 是
-        # 相对路径时碰巧对；progress.sh 传的是绝对路径，那时 parts[1] 是 "mnt"，
-        # 后面 stat() 抛 FileNotFoundError，而调用方 2>/dev/null 把 traceback
-        # 吞掉了 —— 整段连续分静默消失，看起来像"还没有数据"。
         rel = m.relative_to(out).parts
         task, arm = rel[0], norm(rel[1])
         if (out / rel[0] / rel[1]).stat().st_uid != os.getuid():
@@ -141,54 +61,70 @@ def main() -> int:
         s, tr = score(d), testrate(d)
         if s is not None or tr is not None:
             cell[(task, arm)] = (s, tr)
+    if skipped:
+        print(f"  （跳过 {skipped} 份未完成 trial 的半成品 metrics）")
+    return cell
 
-    if not cell:
-        print("  还没有可用的 metrics.json")
-        return 0
 
+def _fmt(v) -> str:
+    if v is None:
+        return "—"
+    ps, tr = v
+    a1 = f"{ps:.3f}" if ps is not None else "?"
+    a2 = f"{tr:.3f}" if tr is not None else "?"
+    return f"{a1}/{a2}"
+
+
+def _print_rows(cell: dict) -> None:
     print("  每格 = partial_score / 测试通过率")
     print(f"  {'任务':26}" + "".join(f"{a:>13}" for a in ARMS))
     for t in sorted({t for t, _ in cell}):
-        line = f"  {t[:26]:26}"
-        for a in ARMS:
-            v = cell.get((t, a))
-            if v is None:
-                line += f"{'—':>13}"
-            else:
-                ps, tr = v
-                a1 = f"{ps:.3f}" if ps is not None else "?"
-                a2 = f"{tr:.3f}" if tr is not None else "?"
-                line += f"{a1+'/'+a2:>13}"
+        line = f"  {t[:26]:26}" + "".join(f"{_fmt(cell.get((t, a))):>13}" for a in ARMS)
         print(line)
 
-    print(f"  {'臂均值':26}", end="")
+
+def _col_means(cell: dict, tasks=None):
+    """每个模式的 (partial 均值, testrate 均值, n)。tasks 限定任务集。"""
     for a in ARMS:
-        vs = [v[0] for (t, x), v in cell.items() if x == a and v[0] is not None]
-        ts = [v[1] for (t, x), v in cell.items() if x == a and v[1] is not None]
-        m1 = f"{sum(vs)/len(vs):.3f}" if vs else "—"
-        m2 = f"{sum(ts)/len(ts):.3f}" if ts else "—"
-        print(f"{m1+'/'+m2:>13}", end="")
+        items = [(k, v) for k, v in cell.items() if k[1] == a and (tasks is None or k[0] in tasks)]
+        vs = [v[0] for _, v in items if v[0] is not None]
+        ts = [v[1] for _, v in items if v[1] is not None]
+        m1 = f"{sum(vs) / len(vs):.3f}" if vs else "—"
+        m2 = f"{sum(ts) / len(ts):.3f}" if ts else "—"
+        yield a, m1, m2, len(items), len(vs), len(ts)
+
+
+def _print_means(cell: dict) -> None:
+    print(f"  {'模式均值':26}", end="")
+    for _, m1, m2, *_ in _col_means(cell):
+        print(f"{m1 + '/' + m2:>13}", end="")
     print()
     print(f"  {'(n)':26}", end="")
-    for a in ARMS:
-        vs = [v for (t, x), v in cell.items() if x == a]
-        print(f"{f'(n={len(vs)})':>13}", end="")
+    for _, _m1, _m2, n, *_ in _col_means(cell):
+        print(f"{f'(n={n})':>13}", end="")
     print()
 
-    # 只在**同任务都有数据**的格子上比较，避免任务集偏差
+
+def _print_paired(cell: dict) -> None:
     common = [t for t in {t for t, _ in cell}
               if sum(1 for a in ARMS if (t, a) in cell) >= 2]
-    if common:
-        print(f"  —— 仅用两臂以上都跑过的 {len(common)} 个任务配对比较 ——")
-        for a in ARMS:
-            vs = [cell[(t, a)][0] for t in common if (t, a) in cell and cell[(t, a)][0] is not None]
-            ts = [cell[(t, a)][1] for t in common if (t, a) in cell and cell[(t, a)][1] is not None]
-            if vs or ts:
-                m1 = f"{sum(vs)/len(vs):.3f}" if vs else "—"
-                m2 = f"{sum(ts)/len(ts):.3f}" if ts else "—"
-                print(f"    {a:10} partial={m1} 测试通过率={m2}  (n={len(vs)}/{len(ts)})")
-    if skipped:
-        print(f"  （跳过 {skipped} 份未完成 trial 的半成品 metrics）")
+    if not common:
+        return
+    print(f"  —— 仅用两模式以上都跑过的 {len(common)} 个任务配对比较 ——")
+    for a, m1, m2, _n, nv, nt in _col_means(cell, set(common)):
+        if nv or nt:
+            print(f"    {a:10} partial={m1} 测试通过率={m2}  (n={nv}/{nt})")
+
+
+def main() -> int:
+    out = safe_path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    cell = collect_partial(out)
+    if not cell:
+        print("  还没有可用的 metrics.json")
+        return 0
+    _print_rows(cell)
+    _print_means(cell)
+    _print_paired(cell)
     return 0
 
 

--- a/benchmark/swe-marathon/scoring/_summarize.py
+++ b/benchmark/swe-marathon/scoring/_summarize.py
@@ -1,84 +1,51 @@
 #!/usr/bin/env python3
-"""把 marathon-full 下的结果汇总成逐臂表格。
+"""把 marathon-full 下的结果汇总成逐模式表格。
 
-【踩过的坑，别改回去】
-原来的做法是：先按目录 mtime 排序取"最新的 <stamp> 目录"，再在其下找 result.json。
-两处都错——
+递归找所有 job 级 result.json，按文件自身 mtime 给每个 (任务, 模式) 取最新一份，
+再按模式累加完成/错误/reward。归一化与 ARMS 走 scripts/_common。
 
-  1. 目录的 mtime 会随子目录写入不断变化，排序不稳定；
-  2. 实际层级是 <task>/<arm>/<stamp>/<arm>/<trial>/result.json，
-     而当时用的 glob("*/*") 只够到两层，根本扫不到。
-
-后果是**已完成和已失败的 trial 全被漏掉**，进度恒显示「0 完成 0 错误」。
-这比 trial 本身失败更危险：整轮监控都会误判成一切正常。实际当时
-biofabric-rust-rewrite/codex-cli 已经以 errors=1 收尾了。
-
-现在直接递归找所有 result.json，按文件自身的 mtime 给每个 (任务, 臂) 取最新一份。
+【别退回去的坑】
+  · 不能按目录 mtime 取"最新 stamp 目录"——目录 mtime 会随子写入变化，排序不稳。
+  · glob 要够深：<task>/<mode>/<stamp>/<mode>/<trial>/result.json。
+  · 只认有 stats 的 job 级 result.json（trial 级没有 stats）。
+  · phase=initialized/starting 的半成品不算。
+  · "一个 trial 都没起来"的格（completed=0/errored=0/pending=1）要单独报，
+    否则两边都加 0，表里完全看不见它——沉默的失败比响亮的失败危险。
 """
 
 from __future__ import annotations
 
 import json
 import pathlib
-import re
 import sys
 from collections import defaultdict
 
-ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+from _common import ARMS, norm, safe_path
 
 
-def norm_arm(name: str) -> str:
-    """臂名归一化：ssh-goal-1537631 → ssh-goal。
-
-    marathon_run.sh 在原目录不可写时会回退成 `<arm>-<pid>`。不归一化的话，
-    这些结果的 key 不在 ARMS 白名单里，下面的打印循环直接跳过它们——
-    **结果存在但表格里看不见**，和之前 glob 太浅漏掉全部结果是同一类事故。
-    """
-    return re.sub(r"-\d{3,}$", "", name)
-
-
-def main() -> int:
-    out = pathlib.Path(sys.argv[1])
-    latest: dict[tuple[str, str], tuple[float, pathlib.Path]] = {}
+def _latest_job_results(out: pathlib.Path) -> dict:
+    """{(task, mode): result.json 路径}，每格取 mtime 最新的 job 级文件。"""
+    latest: dict = {}
     for res in out.glob("*/*/**/result.json"):
         parts = res.relative_to(out).parts
-        if len(parts) < 2:
+        if len(parts) < 2 or parts[0].startswith("."):
             continue
-        # 【跳过点目录】被有意排除的任务挪进 .excluded-gpu/ 归档，不能再当成结果扫。
-        # 不跳的话，它下面每个任务目录会被当成"臂"，而那些格子恰好是
-        # completed=0/errored=0/pending=1，正好触发上面"一个 trial 都没起来"的告警——
-        # 于是**已经处理掉的问题会永远报警**，把真出问题时的同一条告警淹掉。
-        if parts[0].startswith("."):
-            continue
-        # 【只认 job 级】这个 glob 同时会匹配到 trial 级的 result.json
-        # （<task>/<arm>/<stamp>/<arm>/<trial>/result.json），而 trial 级是
-        # TrialResult 结构、**没有 stats 字段**。下面按 mtime 取最新，一旦某个
-        # trial 级文件比 job 级新，这一格的 stats 就是空 → 完成数/错误数静默记 0，
-        # 看着像"这条臂什么都没跑出来"。实测目前 harbor 总是最后写 job 级文件，
-        # 所以还没踩到，但那是时序巧合、不是保证。这里显式按 stats 在不在过滤。
         try:
             if not json.loads(res.read_text()).get("stats"):
-                continue
+                continue                     # trial 级没有 stats
         except Exception:
             continue
-        key = (parts[0], norm_arm(parts[1]))          # (任务, 臂)
+        key = (parts[0], norm(parts[1]))
         m = res.stat().st_mtime
         if key not in latest or m > latest[key][0]:
             latest[key] = (m, res)
+    return {k: v[1] for k, v in latest.items()}
 
-    agg: dict[str, dict] = defaultdict(lambda: {"n": 0, "err": 0, "reward": []})
-    failures: list[tuple[str, str]] = []
-    # 【别删】"一个 trial 都没起来"的格子。签名是
-    #   n_completed=0, n_errored=0, n_pending=1
-    # 也就是 harbor 在**构造环境阶段**就抛了，还没轮到 trial。这种格子在下面的
-    # 累加里两边都加 0 —— 完成数不涨、错误数也不涨，于是整张表**完全看不见它**，
-    # 汇总还照样打印"无错误"。
-    # 实际踩到：三个 GPU 任务的 15 个格子全是这样（task.toml 声明 gpus=1，而
-    # harbor 的 docker 环境 capabilities.gpus 恒为 False，_validate_gpu_support
-    # 直接 RuntimeError）。连着几轮监控都报"全臂 0 错误"，而那 15 格一直是空的。
-    # 和 glob 太浅漏掉全部结果是同一类事故：**沉默的失败比响亮的失败危险**。
-    never_started: list[tuple[str, str]] = []
-    for (task, arm), (_, res) in sorted(latest.items()):
+
+def _aggregate(results: dict):
+    agg = defaultdict(lambda: {"n": 0, "err": 0, "reward": []})
+    failures, never_started = [], []
+    for (task, arm), res in sorted(results.items()):
         try:
             st = json.loads(res.read_text()).get("stats", {})
         except Exception:
@@ -98,12 +65,11 @@ def main() -> int:
                     a["reward"] += [float(k)] * len(tasks)
                 except ValueError:
                     pass
+    return agg, failures, never_started
 
-    if not agg:
-        print("  还没有任何 result.json")
-        return 0
 
-    print(f"  {'臂':12} {'完成':>4} {'错误':>4} {'平均reward':>10}")
+def _print(agg: dict, failures: list, never_started: list) -> None:
+    print(f"  {'模式':12} {'完成':>4} {'错误':>4} {'平均reward':>10}")
     for arm in ARMS:
         a = agg.get(arm)
         if not a:
@@ -111,16 +77,23 @@ def main() -> int:
         r = sum(a["reward"]) / len(a["reward"]) if a["reward"] else None
         print(f"  {arm:12} {a['n']:>4} {a['err']:>4} "
               f"{(f'{r:.3f}' if r is not None else '—'):>10}")
-
     if failures:
-        print(f"  有错误的 (任务,臂)：{', '.join(f'{t}/{a}' for t, a in failures[:6])}")
+        print(f"  有错误的 (任务,模式)：{', '.join(f'{t}/{a}' for t, a in failures[:6])}")
     if never_started:
         tasks = sorted({t for t, _ in never_started})
         print(f"  ⚠ 一个 trial 都没起来的格 {len(never_started)} 个"
-              f"（环境构造阶段就失败，完成/错误两边都不计）："
-              f"{', '.join(tasks[:6])}")
-    return 0
+              f"（环境构造阶段就失败，完成/错误两边都不计）：{', '.join(tasks[:6])}")
+
+
+def main() -> None:
+    out = safe_path(sys.argv[1] if len(sys.argv) > 1 else "marathon-full")
+    results = _latest_job_results(out)
+    if not results:
+        print("  还没有任何 result.json")
+        return
+    agg, failures, never_started = _aggregate(results)
+    _print(agg, failures, never_started)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    main()

--- a/benchmark/swe-marathon/scoring/_summarize.py
+++ b/benchmark/swe-marathon/scoring/_summarize.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""把 marathon-full 下的结果汇总成逐臂表格。
+
+【踩过的坑，别改回去】
+原来的做法是：先按目录 mtime 排序取"最新的 <stamp> 目录"，再在其下找 result.json。
+两处都错——
+
+  1. 目录的 mtime 会随子目录写入不断变化，排序不稳定；
+  2. 实际层级是 <task>/<arm>/<stamp>/<arm>/<trial>/result.json，
+     而当时用的 glob("*/*") 只够到两层，根本扫不到。
+
+后果是**已完成和已失败的 trial 全被漏掉**，进度恒显示「0 完成 0 错误」。
+这比 trial 本身失败更危险：整轮监控都会误判成一切正常。实际当时
+biofabric-rust-rewrite/codex-cli 已经以 errors=1 收尾了。
+
+现在直接递归找所有 result.json，按文件自身的 mtime 给每个 (任务, 臂) 取最新一份。
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+from collections import defaultdict
+
+ARMS = ("plain", "goal", "ssh-goal", "codex-cli", "heartbeat")
+
+
+def norm_arm(name: str) -> str:
+    """臂名归一化：ssh-goal-1537631 → ssh-goal。
+
+    marathon_run.sh 在原目录不可写时会回退成 `<arm>-<pid>`。不归一化的话，
+    这些结果的 key 不在 ARMS 白名单里，下面的打印循环直接跳过它们——
+    **结果存在但表格里看不见**，和之前 glob 太浅漏掉全部结果是同一类事故。
+    """
+    return re.sub(r"-\d{3,}$", "", name)
+
+
+def main() -> int:
+    out = pathlib.Path(sys.argv[1])
+    latest: dict[tuple[str, str], tuple[float, pathlib.Path]] = {}
+    for res in out.glob("*/*/**/result.json"):
+        parts = res.relative_to(out).parts
+        if len(parts) < 2:
+            continue
+        # 【跳过点目录】被有意排除的任务挪进 .excluded-gpu/ 归档，不能再当成结果扫。
+        # 不跳的话，它下面每个任务目录会被当成"臂"，而那些格子恰好是
+        # completed=0/errored=0/pending=1，正好触发上面"一个 trial 都没起来"的告警——
+        # 于是**已经处理掉的问题会永远报警**，把真出问题时的同一条告警淹掉。
+        if parts[0].startswith("."):
+            continue
+        # 【只认 job 级】这个 glob 同时会匹配到 trial 级的 result.json
+        # （<task>/<arm>/<stamp>/<arm>/<trial>/result.json），而 trial 级是
+        # TrialResult 结构、**没有 stats 字段**。下面按 mtime 取最新，一旦某个
+        # trial 级文件比 job 级新，这一格的 stats 就是空 → 完成数/错误数静默记 0，
+        # 看着像"这条臂什么都没跑出来"。实测目前 harbor 总是最后写 job 级文件，
+        # 所以还没踩到，但那是时序巧合、不是保证。这里显式按 stats 在不在过滤。
+        try:
+            if not json.loads(res.read_text()).get("stats"):
+                continue
+        except Exception:
+            continue
+        key = (parts[0], norm_arm(parts[1]))          # (任务, 臂)
+        m = res.stat().st_mtime
+        if key not in latest or m > latest[key][0]:
+            latest[key] = (m, res)
+
+    agg: dict[str, dict] = defaultdict(lambda: {"n": 0, "err": 0, "reward": []})
+    failures: list[tuple[str, str]] = []
+    # 【别删】"一个 trial 都没起来"的格子。签名是
+    #   n_completed=0, n_errored=0, n_pending=1
+    # 也就是 harbor 在**构造环境阶段**就抛了，还没轮到 trial。这种格子在下面的
+    # 累加里两边都加 0 —— 完成数不涨、错误数也不涨，于是整张表**完全看不见它**，
+    # 汇总还照样打印"无错误"。
+    # 实际踩到：三个 GPU 任务的 15 个格子全是这样（task.toml 声明 gpus=1，而
+    # harbor 的 docker 环境 capabilities.gpus 恒为 False，_validate_gpu_support
+    # 直接 RuntimeError）。连着几轮监控都报"全臂 0 错误"，而那 15 格一直是空的。
+    # 和 glob 太浅漏掉全部结果是同一类事故：**沉默的失败比响亮的失败危险**。
+    never_started: list[tuple[str, str]] = []
+    for (task, arm), (_, res) in sorted(latest.items()):
+        try:
+            st = json.loads(res.read_text()).get("stats", {})
+        except Exception:
+            continue
+        a = agg[arm]
+        n_ok = int(st.get("n_completed_trials") or 0)
+        err = int(st.get("n_errored_trials") or 0)
+        if n_ok == 0 and err == 0 and int(st.get("n_pending_trials") or 0) > 0:
+            never_started.append((task, arm))
+        a["n"] += n_ok
+        a["err"] += err
+        if err:
+            failures.append((task, arm))
+        for ev in (st.get("evals") or {}).values():
+            for k, tasks in ((ev.get("reward_stats") or {}).get("reward") or {}).items():
+                try:
+                    a["reward"] += [float(k)] * len(tasks)
+                except ValueError:
+                    pass
+
+    if not agg:
+        print("  还没有任何 result.json")
+        return 0
+
+    print(f"  {'臂':12} {'完成':>4} {'错误':>4} {'平均reward':>10}")
+    for arm in ARMS:
+        a = agg.get(arm)
+        if not a:
+            continue
+        r = sum(a["reward"]) / len(a["reward"]) if a["reward"] else None
+        print(f"  {arm:12} {a['n']:>4} {a['err']:>4} "
+              f"{(f'{r:.3f}' if r is not None else '—'):>10}")
+
+    if failures:
+        print(f"  有错误的 (任务,臂)：{', '.join(f'{t}/{a}' for t, a in failures[:6])}")
+    if never_started:
+        tasks = sorted({t for t, _ in never_started})
+        print(f"  ⚠ 一个 trial 都没起来的格 {len(never_started)} 个"
+              f"（环境构造阶段就失败，完成/错误两边都不计）："
+              f"{', '.join(tasks[:6])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/skills/swe-marathon-five-arm/SKILL.md
+++ b/benchmark/swe-marathon/skills/swe-marathon-five-arm/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: swe-marathon-five-arm
+description: 在 SWE-Marathon 上做 codex harness 五臂对照（裸 codex / 原生 /goal / LoopX 三模式）。包含 agent 适配、跑法、监控，以及一整天踩出来的坑——这些坑的共同特征是**退出码 0、日志干净、结果看着正常**，不看这份文档几乎必然重踩。
+---
+
+# SWE-Marathon 五臂对照
+
+对照维度是 **harness**，不是模型。五条臂的模型、effort、工具面、沙箱、容器完全一致，唯一变量是"怎么驱动 codex"。
+
+## 五条臂
+
+| 臂 | agent 类 | 是什么 | runtime profile |
+|---|---|---|---|
+| `plain` | `codex_plain_appserver:CodexPlainAppServer` | 裸 codex，不挂 Goal、不装 LoopX | — |
+| `goal` | `codex_goal_agent:CodexGoalAgent` | codex 原生 `/goal`，不装 LoopX | — |
+| `ssh-goal` | `codex_loopx_agent:CodexLoopxAgent` | LoopX 模式二：Codex App over SSH | `codex_app_ssh_goal --begin-turn` |
+| `codex-cli` | 同上，`WEN_MODE=codex-cli` | LoopX 模式三：Codex CLI 可见 `/goal` | `codex_cli` |
+| `heartbeat` | 同上，`WEN_MODE=heartbeat` | LoopX 模式一：心跳自动化 | `generic_cli --turn-instance-id` |
+
+三个 LoopX 臂共用一个 agent 类，靠 `WEN_MODE` 选 `modes/profiles.py` 里的 Mode。**模式差异是数据不是分支**——body 文本、runtime profile、是否需要 turn instance 都写在 Mode 里。
+
+`ssh-goal` 与 `codex-cli` 的 goal body 逐字只差一行（runtime profile 那行），这符合上游设计：分流发生在 LoopX CLI 的闸门里，不在 body 文本里。
+
+## 必须披露的两处偏离
+
+1. **`plain` 走 app-server，不是论文的 `codex exec`。** 原因见下面「只杀对照组」那节。
+2. **`heartbeat` 用 `generic_cli` 代替 `codex_app`。** 上游 `host_surface=codex_app` 是留给真 Codex App 的：它回一套 `stateful_backoff`，期待宿主调 App 的 `automation_update` 改 RRULE 再 ACK；没有真 App 就永远悬着。上游给自建定时器指定的对口就是 `generic_cli`（参考实现 `scripts/external_scheduler_worker.py` 的默认值）。这个替换写在 `profiles.py` 的 `substitution` 字段里，**但不会自动进产物，报表时要手工带上**。
+
+## 跑法
+
+```bash
+# 环境验收（install-only，不烧 token）
+./scripts/verify_envs.sh
+
+# 超时路径冒烟（~10 分钟跑完五臂，验证预算耗尽后能正常收尾评分）
+./scripts/canary_timeout.sh
+
+# 全量
+MARATHON_CONCURRENCY=12 GOAL_TIMEOUT_SEC=21600 MARATHON_AGENT_TIMEOUT_MULT=1.0 \
+  setsid nohup ./scripts/marathon_all.sh >> marathon-full.log 2>&1 < /dev/null &
+
+# 监控（进度 + 逐臂 reward + receipt 的续跑/解锁/错误事件 + 连续分）
+./scripts/progress.sh
+./scripts/health_check.sh [--fix]
+```
+
+常用旋钮（都可放进 `marathon-full/.driver_env`，`health_check --fix` 重新拉起时会读）：
+
+| 变量 | 作用 |
+|---|---|
+| `GOAL_TIMEOUT_SEC` | **我们自己的死线**，默认 5340（89 分钟）。多数任务是它先到，不是 harbor |
+| `MARATHON_AGENT_TIMEOUT_MULT` | harbor 侧 = 任务声明预算 × 它 |
+| `MARATHON_VERIFIER_MULT` | verifier 超时倍率，默认 4 |
+| `MARATHON_CONCURRENCY` | 跨 (任务,臂) 的并发 |
+| `MARATHON_ARM_MAJOR` | 1=按臂分组，0=按任务分组 |
+| `MARATHON_TASKS` / `MARATHON_ARMS` | 覆盖任务集/臂集与顺序 |
+| `MARATHON_NET_CAP` / `NET_MARGIN` | docker 网段池闸门 |
+| `MARATHON_MAX_PASSES` | 多趟扫描次数，捡漏延迟失败 |
+
+## 环境准备（跑之前必须做完的三步）
+
+### 1. `stage_codex_offline.sh` —— 搬 codex 运行时
+
+`@openai/codex-linux-x64` 这个 npm 包里 vendor 的是 **static-pie musl 静态可执行文件**，不需要 Node 运行时，断网空白容器里直接能跑。
+
+**必须整棵拷,不能只抠 `codex` 和 `rg`**：0.151 的 `unified_exec` 需要 `codex-code-mode-host` 这个 sidecar。缺了它容器里**每次工具调用都失败,而且不报错**——表现是 47 轮什么都没干成、零错误上报。
+
+### 2. `stage_local.sh` —— 把重资产搬到本地 NVMe
+
+`wen/` 在 NFS 上（`192.168.7.8:/volume1`，nfs v3）。docker 数据根在本地 NVMe，所以**镜像层不慢**，慢的是每个 trial 往容器里搬的东西：
+
+```
+codex 二进制    331M   NFS 读
+LoopX 源码      178M   NFS 读（整个 git checkout）
+node（整个 nvm）721M   本地，但含 npm/lib/include，其实只要 bin/node
+可移植 python   109M   本地
+                ─────
+LoopX 臂每次   ~1.3G，其中 ~509M 走 NFS —— 12 路并发时这是主要瓶颈
+```
+
+预装到 `$HOME/wen-cache` 后全部本地，node 裁到只剩二进制（721M→119M），每 trial 降到约 400M。
+
+**只搬 agent 自己的依赖，`swe-marathon/tasks` 一个字节不动**——那是 benchmark 数据，`dataset.toml` 里有 sha256 digest，改了就不是这个 benchmark。
+
+### 3. `prebuild_images.sh` —— 预构建任务镜像
+
+任务 Dockerfile 里有 `apt-get update && install`，构建要出网。本机出网必须过 `<host-proxy>`，而 **dockerd 自己钉的代理 `<dead-dockerd-proxy>` 是死的**，症状：
+
+```
+W: Failed to fetch http://deb.debian.org/... connection timed out
+failed to solve: process "/bin/sh -c apt-get update ..." did not complete
+```
+
+**不能用 `~/.docker/config.json` 的 proxies 段**：它会把 `HTTP_PROXY` **同时注入运行时容器**，等于给 `no-network` 任务开了出口，公平性直接没了。
+
+正确做法是只在**构建**时经 `--build-arg` 给代理 + `--network host`。BuildKit 层缓存按内容寻址，预构建产生的层 harbor 之后照样命中，而 harbor 自己那次构建不带代理、运行时容器干净。
+
+`wen/.venv` 里改过 harbor 两个文件（自己的副本，允许改）：
+
+- `harbor/environments/docker/docker-compose-build.yaml` —— 加 `network: host` + proxy build-args。**两边 build-arg 必须一致**，不一致会导致缓存不命中、白构建一遍
+- `.../harbor-docker-egress-control-sidecar/Dockerfile` —— 去掉 digest pin
+
+## LoopX profile 怎么装进容器
+
+布局**照抄 `benchmark_toolkit` 的 `_profile_paths()`**，这样 LoopX 自己的 `inspect` / `doctor` 逻辑才对得上：
+
+```
+/opt/loopx-src      LoopX 源码（docker cp 进去）
+/opt/loopx-py       可移植 python
+/opt/loopx-node     可移植 node
+/opt/lxprofile/     profile 根
+    bin/loopx       install-local.sh 生成的 wrapper
+    codex-home/     CODEX_HOME（config.toml、skills/）
+    registry.json
+    runtime/
+```
+
+LoopX `dependencies = []`，零第三方依赖，`install-local.sh` 只拷文件 + 生成 wrapper，所以断网容器里装得起来。
+
+**node 必须在 PATH 上**：`doctor` 用 `shutil.which("node")` 找它，TS control plane 要 node ≥ 22.6。装配和后续所有 CLI 调用都用这套环境：
+
+```
+PATH=/opt/loopx-node/bin:/opt/lxprofile/bin:/usr/local/bin:/usr/bin:/bin
+HOME=/opt/lxprofile/home   CODEX_HOME=/opt/lxprofile/codex-home
+LOOPX_PYTHON=/opt/loopx-py/bin/python3
+```
+
+（**查容器内状态时也要用这套**，否则 `loopx status` 会报 `status_collection_failed`，看着像 LoopX 坏了，其实是你没给 PATH。）
+
+### 三道门禁，任何一道不过就硬失败
+
+1. **技能齐全**：`_REQUIRED_SKILLS` 从上游常量 `NATIVE_CODEX_PROFILE_REQUIRED_SKILL_IDS` 读，**不要硬编码**——0.5.3 是 7 个，历史值是 6 个，硬编码会漏掉 `loopx-benchmark`
+2. **`doctor` 通过**：`loopx --format json doctor --agent-type codex-app-ssh`
+3. **`skills/list` 发现**：`native_codex_goal` 在 `thread/start` **之前**发 `skills/list`，codex 没真的发现那些 skill 就直接失败，**一个 token 都不花**——这是最省钱的门禁
+
+装配成功的日志长这样：`LoopX profile 就绪（7 skills + CLI + doctor ok）`
+
+### goal body 渲染
+
+`render_native_codex_goal_prompt` 产出的 body 里带 `$HOME/.codex/loopx/registry.global.json` 占位符，**必须替换成真实 registry 路径，替换后还要验证占位符确实消失**。
+
+日志：`LoopX goal body 已渲染（2953 字符，goal_id=lhtb-goal，ungated=True）`。字符数按模式不同（heartbeat 1682 / codex-cli 2931 / ssh-goal 2953），这是模式确实分开渲染的证据。
+
+### 运行期状态写在仓库里
+
+`/app/.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md`，Agent Todo 带完整元数据：
+
+```markdown
+- [x] [P1] Identify the fastest validation command from Cargo.toml ...
+  <!-- loopx:todo todo_id=todo_d657c9f294e2 status=done
+       successor_todo_ids=todo_909ae1136cbc completion_continuation=successor
+       evidence=cargo check -p rusternetes-common exited 0 in 48.88s; ...
+       completed_at=2026-09-01T05:46:28 -->
+```
+
+这是 LoopX "跨 turn 不丢上下文"的落地形式：自举出候选待办 → 带证据完成 → 派生后继。实测 LoopX CLI 调用占工具调用的 12–37%。
+
+**注意**：`agent/` 目录保存了 sessions / goals sqlite / trajectory，但**没有保存 `registry.json`**，所以已完成 trial 的最终 todo 状态查不到，只能对在跑的容器采样。要在报表里给这个，得把 registry 加进 `_save_sessions` 的拷贝清单。
+
+### 一个装配期的坑
+
+`pip install -e` 会在源码树里留下 `loopx.egg-info`，`docker cp` 时被一起带进容器，污染 profile。改用非编辑安装 + 容器侧清理。
+
+## 坑（按危险程度排）
+
+### 一、"只杀对照组"的偏向性 —— 会得出**反向结论**
+
+同一个故障如果只打某一条臂，最终会显示"另一条臂更强"，而那是基础设施差异。已发现四次：
+
+1. **TPM 限流**只杀 `plain`（裸 codex 上下文线性膨胀，单请求 116k token）→ 降并发 + 压预算
+2. **HTTP 400 `internal_chat_message_metadata_passthrough`** 只打 `plain`（只在 `codex exec` 路径出现）→ `scripts/param_strip_proxy.py` 剥字段
+3. **传输通道不同**：`plain` 走 SSE，其余四臂走 app-server，SSE 在 routify 上 2/2 全错 → 新增 `codex_plain_appserver.py`，plain 也走 app-server
+4. **异常类分裂**（下条单列）
+
+**判据**：任何时候看到某条臂的失败率显著高于其他臂，先假设是基础设施，不要先假设是能力。
+
+### 二、同名异常类分裂 —— 整晚三条臂颗粒无收
+
+`NativeGoalProtocolError` 存在两份：
+
+```
+agents/native_codex_goal.py                            ← 符号链接到 wen/loopx 源码树
+loopx.capabilities.benchmark_toolkit.native_codex_goal ← 装在 .venv
+```
+
+互不为子类。`run()` 里按**类**捕获 `goal_timeout_before_terminal` 的后果：只有 `goal` 臂的超时被吞掉并正常评分，LoopX 三臂的超时逃到 harbor 被当基础设施故障 → 重试 → 记 errored，几小时的真实进度全丢。
+
+**修法**：按**消息**判定（两个类都继承 `RuntimeError`）。
+
+```python
+except RuntimeError as exc:
+    if str(exc) != "goal_timeout_before_terminal":
+        raise
+```
+
+超时是长程任务的**正常预算耗尽**，五臂必须一视同仁按部分进度评分。
+
+### 三、二值 reward 在紧预算下没有区分度
+
+SWE-Marathon 的 `reward` 是二值的（全部测试通过才给 1）。实测：**撞死线的 23 条 trial 无一得分，自己收尾的 14 条中 11 条得分**——决定分数的是"任务能不能在预算内做完"，不是哪条臂。
+
+连续分在 `metrics.json` 的 `partial_score`（任务官方定义，[0,1]）。用 `scripts/_partial.py` 提取。两个坑：
+
+- **字段名不统一**：有的任务只写 `pass_rate`
+- **不是所有任务都真连续**：`s3-clone` 有 correctness+ux 两阶段，后一阶段按 `0.5×unit + 0.5×cua` 改写 `partial_score`，而两个子分各自二值 → 22 个 gate 过 16 个、pytest 87.7%，`partial_score` 仍是 0.0
+- **Rust 任务有构建门禁**：`BUILD FAILED` → `partial_score` 直接归零。同一条臂早一分钟或晚一分钟被切断，分数可能在 0 和 0.98 之间跳变
+
+所以报表要**两个口径并排**（partial_score + 测试通过率），且把 `build_failed` 单独标注。
+
+### 四、`BUILD FAILED` 不是环境故障
+
+它发生在 **verifier 阶段**（agent 早跑完了），是 `cargo` 编译 **agent 写的代码**。典型报错是"缺东西"而不是"写错了"：
+
+```
+can't find lib `xxx` at path `src/lib.rs`        Cargo.toml 声明了但没建文件
+error[E0432]: unresolved imports ...              import 了还没定义的类型
+couldn't read `src/client.rs`: No such file       测试引用的源文件不存在
+```
+
+排除环境嫌疑的三个交叉验证：同环境下别的臂构建成功；四条臂报错在四个不同 crate；网络类关键词（`failed to download` / `registry` / `no matching package`）命中 0 次。
+
+harbor 记 `n_errored_trials=0`，**不作废**。对比真正的环境故障：
+
+```
+Docker compose command failed ... all predefined address pools have been fully subnetted
+```
+那种记 `n_errored_trials=1`，**要作废重跑**。
+
+### 五、docker 网段池 —— 一次废掉 12 条
+
+默认地址池只支持约 32 个 bridge 网络（172.17.0.0/12 切 /16 得 16 + 192.168.0.0/16 切 /20 得 16）。**机器是共用的**，别人常年占约 15 个，每个 trial 一个 compose 网络。撑爆后新 trial 直接死在环境启动。
+
+泄漏源常常是自己：**`docker rm -f` 只删容器，不删 compose 网络**。清理容器时必须连网络一起清。
+
+`marathon_all.sh` 有起跑前闸门（`MARATHON_NET_CAP/NET_MARGIN`），等待时顺手回收空网络。扩池要改 `daemon.json` + 重启 dockerd，**会杀掉别人所有容器**，需要本人操作并先打招呼。
+
+### 六、清理进程：绝不用模糊匹配（已犯五次）
+
+`pkill -f` / `pgrep -f` / `case` 匹配 `/proc/cmdline` 都会命中**调用者自己的 shell**——因为命令文本里就含那些字样。第五次的表现是 TERM 发给自己、shell 在清容器之前就死（退出码 144）。
+
+正确写法：模式用字符串拼接构造，让命令行里不出现完整字面量，再显式排除 `$$` 和 `$PPID`：
+
+```bash
+PAT=$'marathon''_all.sh'; ME=$$; PA=$PPID
+for p in /proc/[0-9]*; do pid=${p#/proc/}
+  [ "$pid" = "$ME" ] && continue; [ "$pid" = "$PA" ] && continue
+  cl=$(tr '\0' ' ' < "$p/cmdline" 2>/dev/null) || continue
+  case "$cl" in *"$PAT"*) echo "$pid" >> /tmp/kill.txt;; esac
+done
+xargs -r kill -TERM < /tmp/kill.txt
+```
+
+另：`ps -eo` 里的 `-e` 会**覆盖** `-p`，`ps -eo pid= -p 123` 会列出全机进程。
+
+### 七、监控工具本身出错比 trial 失败更危险
+
+一天里监控工具错了七次，每次都表现为"看起来一切正常"：
+
+| 错误 | 后果 |
+|---|---|
+| `health_check.sh` 扫 `marathon-jobs*` 而产物在 `marathon-full` | 整晚报 OK，实际三条臂全挂 |
+| `find -mindepth 4` 而 job 级 `result.json` 在深度 5 | 永远查不到错误跑次 |
+| `_summarize.py` 用 `glob("*/*")` 太浅 + 目录 mtime 排序 | 「0 完成 0 错误」而实际已有失败 |
+| `_partial.py` 用 `m.parts[1]`，绝对路径下是 `mnt` | 异常被 `2>/dev/null` 吞掉，整段连续分静默消失 |
+| `grep -c` 计数为 0 时退出码 1，`\|\| echo 0` 追加第二个 0 | 变量含换行，监控输出被拆成三行 |
+| 计数不按「本次跑次」切分 | 跨重启累加，显示 37/90 而当次只排了 10 |
+| `_receipts.py` 读 `unblock_count`（真名 `_unblock_count`，带下划线） | 五臂全返回 None，会永远报"解锁 0 次" |
+
+**教训**：监控工具要和被测对象一样对待——先验证它真能看见东西。路径写错的监控比没有监控更坏，因为它每轮都报"正常"。
+
+### 八、别拿环境不同的数据下结论
+
+- **臂均值不可比**：各臂跑过的任务集不同。`ssh-goal` 均值低是因为它多跑了几个难任务。只用**双方都跑过的格**做配对比较
+- **遗留目录要排除**：root 属主的旧跑次目录（`marathon_run.sh` 写不进去会另起 `<arm>-<pid>`），里面的 receipt 是上一轮的。`_receipts.py` 按臂目录属主排除
+- **半成品 metrics 要排除**：正在重跑的 trial 也留 `metrics.json`，内容是 `phase: initialized`、partial 0.0，采信会**凭空造出一个 0 分**
+- **查容器内状态要复现 agent 的环境**：`docker exec` 裸奔没有 PATH，`loopx doctor` 找不到 node 会报 `status_collection_failed`，看着像 LoopX 坏了。正确环境是
+  `PATH=/opt/loopx-node/bin:/opt/lxprofile/bin:...  HOME=/opt/lxprofile/home  CODEX_HOME=/opt/lxprofile/codex-home`
+
+### 九、其他单点
+
+- **codex 缺 `codex-code-mode-host` sidecar**：容器里每次工具调用都失败，不报错、只是零产出。`stage_codex_offline.sh` 要镜像整个 vendor 树
+- **app-server 需要 `sandbox_mode = "danger-full-access"` + `projects."/app" = { trust_level = "trusted" }"`**，否则 bwrap 缺用户命名空间，`initialize` 握手就失败
+- **`config.toml` 必须一次性写完**：TOML 里 table 头之后的裸键都归该 table，分两次 `cat >>` 会让 `web_search` 变成 `model_providers.harbor.web_search`
+- **LoopX 自锁**：goal body 规定连续三轮相同阻塞就 `update_goal status=blocked`，只有 user `/goal resume` 能复活——benchmark 里没有 user。`LOOPX_UNGATED=1` 让 harness 扮演 operator，解锁次数记进 receipt 的 `_unblock_count`
+- **NAS 输出盘的 mtime 比宿主机慢约 2 分钟**，别用宿主机时间 `find -newermt` 筛产物
+- **`$$` 在 bash 子 shell 里是父进程 PID**，认领文件要用 `$BASHPID`
+
+## 产物与判据
+
+```
+marathon-full/<task>/<arm>/<stamp>/<arm>/result.json          job 级，含 stats
+                                       /<trial>/verifier/     reward.txt / metrics.json / test-stdout.txt
+                                                /agent/       trajectory.json / goal_receipt.json / sessions/
+marathon-full/.claims/<task>__<arm>.claim                     在跑认领（内容是 BASHPID）
+marathon-full/.driver_env                                     驱动参数，health_check --fix 会读
+marathon-voided/                                              作废的 trial，带 README 说明原因
+```
+
+"成功"的统一判据（`scripts/_is_done.py`，断点续跑和监控共用，避免两处判据打架）：
+
+```
+n_completed_trials >= 1 且 n_errored_trials == 0
+```
+
+`errors > 0` **不算跑过**，必须重跑——那多半是基础设施故障。

--- a/benchmark/swe-marathon/skills/tb4-five-arm/SKILL.md
+++ b/benchmark/swe-marathon/skills/tb4-five-arm/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: tb4-five-arm
+description: 在 Terminal-Bench 4.0 上做 codex harness 五臂对照（裸 codex / 原生 /goal / LoopX 三模式）。复用 SWE-Marathon 那套驱动，靠 WEN_BENCH 切换。重点是 TB4 相对 SWE-Marathon 的四处结构性差异——每一处踩错都**退出码 0、有轨迹、有分数**，只是分数不对。
+---
+
+# Terminal-Bench 4.0 五臂对照
+
+五臂定义、LoopX profile 装配、agent 类、监控工具全部与
+[[swe-marathon-five-arm]] 相同，**先读那一份**。这里只写 TB4 特有的部分。
+
+对照维度仍是 **harness 不是模型**：五臂的模型、effort、工具面、沙箱、容器一致。
+
+## 切换方式
+
+```bash
+export WEN_BENCH=tb4      # 必须 export，见下面「最毒的一个坑」
+source env.sh
+
+./scripts/prebuild_images.sh music-harmony   # 应建 2 个镜像，不是 1 个
+./scripts/verify_envs.sh music-harmony       # install-only，不烧 token
+./scripts/canary_timeout.sh                  # 五臂 × 短死线
+./scripts/marathon_all.sh --dry              # 63 任务 × 5 臂 = 315 trial
+```
+
+benchmark 相关的量全在 `scripts/bench/tb4.sh`，驱动脚本里没有任何 TB4 常量。
+`WEN_BENCH` 不设时默认 `swe-marathon`，行为与引入 bench 层之前逐字一致
+（已用 `bash -x` 逐参数 diff 验证过）。
+
+## 数据来源
+
+`terminal-bench/` 是 `harbor-framework/terminal-bench` 的 **tag v4.0.0**
+（commit `452bf305c6`），66 个任务，见 `terminal-bench/VERSION`。
+
+- **不能用 `harbor run -d terminal-bench@4.0`**：harbor 的注册表（Supabase
+  `dataset` 表）里只有 `terminal-bench@2.0`，实测查 4.0 返回 `null`。
+- **不要跟 main**：上游 README 明说 "will be continuously updated"，
+  跟 main 跑出来的结果不可复现。
+- `tasks/dataset.toml` 里每个任务有 sha256 digest，`task.toml` 与 `tests/`
+  一个字节都不能改。要注入环境变量走 harbor 的 `--ve` / `--ae`。
+
+## TB4 vs SWE-Marathon：四处结构性差异
+
+| 项 | SWE-Marathon | TB4.0 |
+|---|---|---|
+| `agent.timeout_sec` | 3600–36000 各异 | **全部 28800（统一 8h）** |
+| `verifier.environment_mode` | 无（shared） | **全部 `separate`** |
+| `network_mode` | 三态，逐任务 | **一个都没声明** → harbor 默认 public |
+| 每任务镜像数 | 1（`environment/`） | **2（`environment/` + `tests/`）** |
+| 连续分 | `metrics.json` 有 | **没有**，只有二值 reward |
+
+排除 3 个要 H100 的任务（`fp8-rmsnorm-gemm` / `jax-speedrun-gpu` /
+`math-eval-grader`），本机是 4090D。剩 63 个，其中 11 个是多容器
+（`environment/docker-compose.yaml`），1 个（`medical-claims-processing`）
+还要 MCP server（playwright，sse `http://playwright-mcp:3080/sse`）。
+
+## 坑（都会静默通过）
+
+### 一、最毒的一个：`WEN_BENCH` 用前缀赋值
+
+```bash
+WEN_BENCH=tb4 source env.sh      # ✗ 错
+export WEN_BENCH=tb4; source env.sh   # ✓ 对
+```
+
+bash 在 `source` 返回后会把前缀赋值的变量**还原成未设置**，但 `WEN_TASKS_DIR`
+是 export 的、留了下来。于是后续任何脚本自己 source env.sh 时：`WEN_BENCH` 空 →
+回退 swe-marathon profile，却继承着 TB4 的任务目录 —— 拿 **TB4 的任务**、套
+**marathon 的网络策略**（`from-task` 找不到 `network_mode` 就断网）、
+开着判官注入、写进 `marathon-full/`。退出码 0，全程无警告。
+
+`env.sh` 里有个一致性闸门专门拦这个（`WEN_TASKS_DIR_BENCH` 与当前 bench 不符
+就丢弃继承值），但闸门只保证**状态自洽**，不保证是你想要的那个 bench。
+开跑前看一眼各脚本打印的 `bench:` 那一行。
+
+### 二、网络策略反了 → 66 个任务全跑成断网
+
+TB4 的 66 个 `task.toml` **一个都没有声明 `network_mode` / `allow_internet`**，
+而 harbor 0.20.0 的 `NetworkPolicy.network_mode` 默认是 `PUBLIC` ——
+上游的标定条件是联网。
+
+而 `marathon_run.sh` 原本的做法是 grep `task.toml` 的 `network_mode`、
+**找不到就回退 `no-network`**。直接套用会把 66 个任务全跑成断网：
+退出码 0、有轨迹、有分数，只是分数偏低，看着像"模型不行"。
+
+`bench/tb4.sh` 里 `BENCH_NET_POLICY=public` 显式钉死，不走那条 grep。
+
+**另注：`--allow-agent-host` 在 public 下是空操作。** 实测 harbor 会打印
+
+```
+UserWarning: Run-specific allowlist host(s) ['<model-gateway>', '172.17.0.1'] are
+ignored because the effective network policy is public.
+```
+
+模型端点的可达性靠代理环境变量和宿主机路由，不靠这个参数，别以为加了就生效。
+
+**再注：本机实测容器不穿代理也能出网**（`docker run` 里直连 pypi.org 得 200）。
+代理注入是沿用 marathon 对 public 任务的既有做法、属冗余保险；
+`no_proxy` 已包含模型网关，不会劫持 codex 的调用。
+
+### 三、`environment_mode = "separate"`：两个镜像、两个环境
+
+全部 66 个任务都是 separate。harbor 0.20.0 的实际时序
+（`harbor/trial/single_step.py:38-55`、`trial/trial.py:610-680`）：
+
+```
+跑 agent → 上传 agent 日志 → 收 artifacts → **停掉 agent 环境**
+        → 起一个从 tests/ 构建的独立 verifier 环境 → 验证 → 停
+```
+
+三个后果：
+
+1. **每个任务两个镜像**（66 × 2 = 132）。`prebuild_images.sh` 原来只扫
+   `environment/`，漏掉 `tests/`。漏了的话 verifier 镜像会在**运行期**首次构建，
+   而运行期没有代理（那是刻意的，代理进运行时容器会破坏隔离），dockerd 自己钉的
+   `<dead-dockerd-proxy>` 又是死的 → `apt-get` 超时 → verifier 起不来记 errored。
+   **症状极像"任务没做出来"**：agent 阶段完全正常、有轨迹、有 token 消耗。
+   现在由 `BENCH_IMAGE_DIRS=(environment tests)` 覆盖，且跳过会计数。
+
+2. **只有声明在 `artifacts` 里的文件能跨到 verifier**（66 个全声明了）。
+   agent 把活干在别处、没写到声明路径 → verifier 看到空目录 → reward 0，
+   而 agent 轨迹完全正常。这是 shared 模式下不存在的失败模式。
+
+3. 串行，所以每 trial 的容器/网段**峰值**不翻倍，但多一次构建、
+   多一个 compose project。
+
+### 四、二值 reward 在紧预算下没有区分度，而 TB4 没有连续分
+
+SWE-Marathon 靠任务自写的 `metrics.json`（`partial_score` / `pass_rate` /
+`pytest` / `gates_*`）补救；**TB4 不写这个文件**，只有 harbor 的二值 reward。
+
+`bench/tb4.sh` 设 `BENCH_HAS_PARTIAL=0`，于是：
+- `_partial.py` 整体跳过并打印原因，不静默兜底
+- `_compare.py` **整列不渲染** partial，而不是渲染成一列 0.0
+  （一列 0.0 会被读成"全都没得分"，比不显示更坏）
+- `_compare.py` 的跨跑次对照自动改用 `reward` 做差，表头跟着变
+
+marathon 那轮实测：撞死线的 23 条 trial 无一得分，自己收尾的 14 条中 11 条得分
+——决定分数的是"能不能在预算内做完"。TB4 统一 8h 预算而我们的死线远短于此，
+这个问题只会更严重。**唯一还能分辨的信号是终止原因**（自己收工 vs 撞死线），
+`_receipts.py` 有这个数据，报表必须并排给出。
+
+### 五、超时倍率不要照抄 marathon
+
+marathon 用的是 build 6× / setup 3× / verifier 4×，那是为**未做资源标定**的
+Dockerfile 定的。TB 4.0 的卖点恰恰是"重新标定了 time/CPU/memory"
+（`build_timeout_sec` 中位数 900、`verifier.timeout_sec` 中位数 600），
+照抄 6× 等于把上游的标定压掉。`bench/tb4.sh` 用 4 / 3 / 2。
+
+### 六、canary 的预算比例要重算
+
+`canary_timeout.sh` 的 `CANARY_TIMEOUT_MULT=0.05` 是按 8h 声明预算定的
+（8h × 0.05 = 24 分钟 > `GOAL_TIMEOUT_SEC` 5 分钟，保证**我们先到**）。
+TB4 恰好也统一 8h，所以同一个值仍成立。换到声明预算短的 benchmark 上，
+harbor 侧可能反而先到，冒烟就白做了 —— 而那是**静默**的：
+五臂照样出 result.json，只是走的是另一条超时路径。
+
+### 七、全量的量级要先量再定
+
+63 任务 × 5 臂 = **315 trial**，外加 126 个镜像构建。
+`MARATHON_AGENT_TIMEOUT_MULT` 沿用 marathon 的 0.3 得 8640s（2.4h）/trial。
+**先拿冒烟的真实单 trial 墙钟再算总时长**，别直接开全量。
+
+网段池是硬约束：默认约 32 个 bridge 网络，机器共用。起跑前确认池子有余量
+（`marathon_all.sh` 有 `MARATHON_NET_CAP` 闸门），清理容器时**连 compose 网络
+一起清**（`docker rm -f` 不删网络）。
+
+### 八、11 个多容器 + 1 个 MCP 任务未验证
+
+冒烟只覆盖单容器路径。`ctr-optimization` `cumulative-layout-shift`
+`freight-dispatch-shift` `heat-pump-warranty` `intrastat-meldung`
+`kv-live-surgery` `legacy-utility-triage` `live-database-cutover`
+`medical-claims-processing` `nextjs-performance` `payments-pipeline-fix`
+容器数与内存压力显著更高；`medical-claims-processing` 还要
+MCP server 起得来。全量前单独验这 11 个。
+
+## 产物
+
+```
+tb4-full/<task>/<arm>/<stamp>/<arm>/result.json          job 级，含 stats
+                                   /<trial>/verifier/    reward.txt
+                                            /agent/      trajectory.json / goal_receipt.json
+tb4-full/.claims/<task>__<arm>.claim
+tb4-jobs/                                                marathon_run.sh 单独跑的落脚点
+verify-envs-tb4/  canary-timeout-tb4/
+```
+
+成功判据与 marathon 相同（`scripts/_is_done.py`，驱动与监控共用）：
+
+```
+n_completed_trials >= 1 且 n_errored_trials == 0
+```


### PR DESCRIPTION
Companion to the results summary PR. Adds `benchmark/swe-marathon/` with the **agent adapters** (LoopX treatment + codex-native goal baselines), **scoring/aggregation/visualization** scripts, and the two **five-mode benchmark skills**.

Five modes: bare `codex`, codex-native `goal`, and three LoopX modes (`ssh-goal`, `codex-cli`, `heartbeat`).

- Builds on `loopx.capabilities.benchmark_toolkit` + `harbor`.
- Internal network topology scrubbed to placeholders; environment-specific run orchestration is intentionally omitted.
- Scoring conventions (binary reward vs task `partial_score`, build-failure exclusion, five-mode-common averaging) are documented inline and in `HARNESS.md`.

Results + interactive per-trial trajectory browser: https://bouwenzhou.github.io/loopx/
