### PR TITLE
fix: reconcile agent-scoped cadence advisory

### DIFF
--- a/docs/operations/long-task-cadence-policy.md
+++ b/docs/operations/long-task-cadence-policy.md
@@ -2,8 +2,8 @@
 
 LoopX should not let a recurring heartbeat turn long-running agent work into
 tiny status-only turns. The cadence hint is a small, derived signal that tells a
-host or controller whether recent work looks blocked, thin, material, or
-unknown.
+host or controller whether recent work looks blocked, actively runnable, thin,
+material, or unknown.
 
 It is intentionally not a scheduler policy. Quota, gates, goal boundaries,
 permissions, public/private scans, and user/controller decisions remain the
@@ -45,9 +45,11 @@ Stable fields:
 | Field | Values | Meaning |
 | --- | --- | --- |
 | `schema_version` | `cadence_hint_v0` | The public projection shape. |
-| `signal` | `blocked`, `thin_progress`, `material_progress`, `unknown` | What the recent control-plane evidence suggests. |
+| `signal` | `blocked`, `active_work`, `thin_progress`, `material_progress`, `unknown` | What the recent control-plane evidence suggests. |
 | `recommendation` | `wait`, `widen`, `keep` | A lightweight host/controller hint. |
 | `reason_codes` | compact strings | Machine-readable explanation for the signal. |
+| `authority` | compact string, optional | The final authority that reconciled an earlier compatibility advisory. |
+| `superseded` | compact advisory, optional | The earlier signal, recommendation, and reason codes retained for diagnosis. |
 
 Typical examples:
 
@@ -57,6 +59,21 @@ Typical examples:
   "signal": "blocked",
   "recommendation": "wait",
   "reason_codes": ["quota_state_operator_gate", "open_user_todos_visible"]
+}
+```
+
+```json
+{
+  "schema_version": "cadence_hint_v0",
+  "signal": "active_work",
+  "recommendation": "keep",
+  "reason_codes": ["final_agent_scoped_active_work"],
+  "authority": "final_agent_scoped_interaction_and_scheduler",
+  "superseded": {
+    "signal": "blocked",
+    "recommendation": "wait",
+    "reason_codes": ["quota_state_operator_gate"]
+  }
 }
 ```
 
@@ -88,6 +105,14 @@ The hint is derived from existing public-safe control-plane metadata:
 - quota state;
 - whether open user todos are already visible.
 
+The status projection can be computed before final agent-scoped arbitration.
+If that early compatibility advisory says `wait`, but the final agent channel
+requires an attempt, disallows a quiet no-op, and the final scheduler selects
+`run_now` / `active_work`, quota reconciles the advisory to `active_work` +
+`keep`. The final interaction contract and scheduler are named as the authority,
+while the earlier signal and reason codes remain under `superseded`. This exact
+reconciliation does not apply to a genuine blocking user gate.
+
 The current "thin progress" detector is deliberately conservative. It is based
 on agent writeback metadata, not a perfect measure of actual agent-loop runtime.
 Elapsed wall time may become an optional future input, but it should not be the
@@ -97,6 +122,8 @@ be stuck.
 ## Controller Use
 
 - `blocked` + `wait`: do not widen; show the concrete gate or blocker.
+- `active_work` + `keep`: follow the final agent-scoped interaction and
+  scheduler decision; use `superseded` only for diagnosis.
 - `thin_progress` + `widen`: the next eligible turn should try for a coherent
   artifact plus validation/writeback, or write a blocker explaining why widening
   is unsafe.

--- a/examples/long-task-cadence-policy-smoke.py
+++ b/examples/long-task-cadence-policy-smoke.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(REPO_ROOT))
 from loopx.long_task_cadence import (  # noqa: E402
     LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
     build_long_task_cadence_hint,
+    reconcile_long_task_cadence_hint,
 )
 from loopx.quota import build_quota_should_run  # noqa: E402
 
@@ -118,6 +119,47 @@ def assert_runtime_hint() -> None:
         "recommendation": "keep",
         "reason_codes": ["missing_recent_runs"],
     }, unknown
+
+    reconciled = reconcile_long_task_cadence_hint(
+        gated,
+        interaction_contract={
+            "agent_channel": {
+                "must_attempt": True,
+                "quiet_noop_allowed": False,
+            }
+        },
+        scheduler_hint={"action": "run_now", "cadence_class": "active_work"},
+    )
+    assert reconciled == {
+        "schema_version": LONG_TASK_CADENCE_HINT_SCHEMA_VERSION,
+        "signal": "active_work",
+        "recommendation": "keep",
+        "reason_codes": ["final_agent_scoped_active_work"],
+        "authority": "final_agent_scoped_interaction_and_scheduler",
+        "superseded": {
+            "signal": "blocked",
+            "recommendation": "wait",
+            "reason_codes": [
+                "quota_state_operator_gate",
+                "open_user_todos_visible",
+            ],
+        },
+    }, reconciled
+
+    still_gated = reconcile_long_task_cadence_hint(
+        gated,
+        interaction_contract={
+            "agent_channel": {
+                "must_attempt": False,
+                "quiet_noop_allowed": False,
+            }
+        },
+        scheduler_hint={
+            "action": "backoff_waiting_for_user",
+            "cadence_class": "human_gate",
+        },
+    )
+    assert still_gated == gated, still_gated
 
 
 def assert_status_and_quota_projection() -> None:
@@ -229,8 +271,10 @@ def main() -> int:
         "Long-Task Cadence Hint",
         "not a scheduler policy",
         "`cadence_hint_v0`",
-        "`blocked`, `thin_progress`, `material_progress`, `unknown`",
+        "`blocked`, `active_work`, `thin_progress`, `material_progress`, `unknown`",
         "`wait`, `widen`, `keep`",
+        "final agent channel",
+        "`superseded`",
         "not a perfect measure of actual agent-loop runtime",
         "conversation transcripts",
         "raw local logs",

--- a/loopx/control_plane/quota/should_run_packet.py
+++ b/loopx/control_plane/quota/should_run_packet.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ...long_task_cadence import reconcile_long_task_cadence_hint
 from ...state_projection import (
     next_action_projection_warning,
 )
@@ -1480,6 +1481,11 @@ def _build_quota_should_run_payload(
         scheduler_execution_context=prepared.resolved_scheduler_context,
         turn_instance_id=turn_instance_id,
         runtime_root=_interaction_runtime_root(runtime_root, prepared.status_payload),
+    )
+    payload["long_task_cadence_hint"] = reconcile_long_task_cadence_hint(
+        payload.get("long_task_cadence_hint"),
+        interaction_contract=payload.get("interaction_contract"),
+        scheduler_hint=payload.get("scheduler_hint"),
     )
     payload["protocol_action_packet"] = build_protocol_action_packet(payload)
     return payload

--- a/loopx/long_task_cadence.py
+++ b/loopx/long_task_cadence.py
@@ -17,6 +17,9 @@ from .execution_profile import (
 
 
 LONG_TASK_CADENCE_HINT_SCHEMA_VERSION = "cadence_hint_v0"
+FINAL_AGENT_SCOPED_CADENCE_AUTHORITY = (
+    "final_agent_scoped_interaction_and_scheduler"
+)
 
 BLOCKED_QUOTA_STATES = frozenset(
     {
@@ -187,6 +190,56 @@ def build_long_task_cadence_policy(**kwargs: Any) -> dict[str, Any]:
     """Compatibility wrapper for older callers while this projection rolls out."""
 
     return build_long_task_cadence_hint(**kwargs)
+
+
+def reconcile_long_task_cadence_hint(
+    value: Any,
+    *,
+    interaction_contract: Any,
+    scheduler_hint: Any,
+) -> dict[str, Any] | None:
+    """Align a legacy wait advisory with final agent-scoped run authority."""
+
+    if not isinstance(value, dict):
+        return None
+    hint = dict(value)
+    if hint.get("recommendation") != "wait":
+        return hint
+
+    contract = interaction_contract if isinstance(interaction_contract, dict) else {}
+    agent_channel = (
+        contract.get("agent_channel")
+        if isinstance(contract.get("agent_channel"), dict)
+        else {}
+    )
+    scheduler = scheduler_hint if isinstance(scheduler_hint, dict) else {}
+    final_authority_requires_work = (
+        agent_channel.get("must_attempt") is True
+        and agent_channel.get("quiet_noop_allowed") is False
+        and scheduler.get("action") == "run_now"
+        and scheduler.get("cadence_class") == "active_work"
+    )
+    if not final_authority_requires_work:
+        return hint
+
+    prior_reason_codes = hint.get("reason_codes")
+    superseded = {
+        "signal": hint.get("signal"),
+        "recommendation": hint.get("recommendation"),
+        "reason_codes": (
+            list(prior_reason_codes) if isinstance(prior_reason_codes, list) else []
+        ),
+    }
+    return {
+        "schema_version": hint.get(
+            "schema_version", LONG_TASK_CADENCE_HINT_SCHEMA_VERSION
+        ),
+        "signal": "active_work",
+        "recommendation": "keep",
+        "reason_codes": ["final_agent_scoped_active_work"],
+        "authority": FINAL_AGENT_SCOPED_CADENCE_AUTHORITY,
+        "superseded": superseded,
+    }
 
 
 def long_task_cadence_hint_summary(value: Any) -> str:

--- a/tests/control_plane/test_user_gate_lane_progress.py
+++ b/tests/control_plane/test_user_gate_lane_progress.py
@@ -74,6 +74,17 @@ def _status_payload(*, gate_action_kind: str) -> dict:
             "agent_model": "peer_v1",
             "registered_agents": [AGENT_ID],
         },
+        item_extra={
+            "long_task_cadence_hint": {
+                "schema_version": "cadence_hint_v0",
+                "signal": "blocked",
+                "recommendation": "wait",
+                "reason_codes": [
+                    "quota_state_operator_gate",
+                    "open_user_todos_visible",
+                ],
+            }
+        },
     )
 
 
@@ -119,6 +130,21 @@ def test_unrelated_user_gate_allows_ready_deferred_successor_replan() -> None:
         "agent_channel"
     ]["primary_action"]
     assert payload["scheduler_hint"]["cadence_class"] == "active_work"
+    assert payload["long_task_cadence_hint"] == {
+        "schema_version": "cadence_hint_v0",
+        "signal": "active_work",
+        "recommendation": "keep",
+        "reason_codes": ["final_agent_scoped_active_work"],
+        "authority": "final_agent_scoped_interaction_and_scheduler",
+        "superseded": {
+            "signal": "blocked",
+            "recommendation": "wait",
+            "reason_codes": [
+                "quota_state_operator_gate",
+                "open_user_todos_visible",
+            ],
+        },
+    }
 
 
 def test_consumed_review_gate_exposes_quality_vision_replan() -> None:
@@ -202,6 +228,15 @@ def test_blocking_user_gate_backs_off_instead_of_polling_as_active_work() -> Non
     )
     assert payload["scheduler_hint"]["cadence_class"] == "human_gate"
     assert payload["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 30
+    assert payload["long_task_cadence_hint"] == {
+        "schema_version": "cadence_hint_v0",
+        "signal": "blocked",
+        "recommendation": "wait",
+        "reason_codes": [
+            "quota_state_operator_gate",
+            "open_user_todos_visible",
+        ],
+    }
 
     initial_backoff = payload["scheduler_hint"]["codex_app"]["stateful_backoff"]
     next_hint = build_scheduler_hint(


### PR DESCRIPTION
## Summary

- reconcile a legacy `blocked` / `wait` cadence advisory only when the final agent channel requires work and the final scheduler selects `run_now` / `active_work`
- retain the superseded goal-level signal, recommendation, and reason codes for diagnosis while naming the final agent-scoped authority
- preserve genuine blocking user-gate backoff, and document the additive compatibility projection

Fixes #3830.

## Validation

- `python3 -m pytest tests/control_plane/test_user_gate_lane_progress.py tests/control_plane/test_fine_grained_turn_mode.py -q` — 16 passed
- `python3 examples/long-task-cadence-policy-smoke.py` — passed
- changed Python modules compile successfully
- `git diff --check origin/main...HEAD` — passed
- `loopx canary premerge --from-git-diff` — 18 selected checks passed, 0 failures, 0 warnings, 0 manual holds

## Scope and safety

- no scheduler state machine or authority rule was added; reconciliation occurs once after the existing final interaction and scheduler projections
- unchanged hints and genuine human-gate waits retain their existing shape and behavior
- public/private boundary validation passed; no runtime state, credentials, local paths, raw logs, trajectories, or verifier output are included

## Future-facing pass

Applied narrowly: the compatibility rule lives in the existing `long_task_cadence` owner and the quota packet only invokes it after final arbitration. No broader scheduler refactor is needed for this fix.
