### PR TITLE
fix(control-plane): project turn-start required reads

### DIFF
--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -24,10 +24,14 @@ contain message content, provider payloads, credentials, destinations, profile
 names, or private cursor values.
 
 The hook is complete only when fresh evidence is routed to Agent reading. A
-result with new observations must set `agent_read_required=true`. The same turn
-then recomputes inbox urgency, selects the inbox work lane ahead of ordinary
-work, and exposes the existing goal-bound private `drain_command`. The Agent
-reads the messages and chooses one typed semantic disposition:
+result with new observations must set `agent_read_required=true`. Its
+registration declares one bounded, public-safe `required_read` descriptor.
+The generic hook kernel validates that descriptor, deduplicates it by command,
+and projects it into both Agent and CLI interaction channels with
+`ordering=before_work`. The selected ordinary Todo and `user_channel.notify`
+remain independent: urgency may still select an inbox lane, but a quiet ordinary
+lane can remain selected while the required read runs first. The Agent reads the
+messages and chooses one typed semantic disposition:
 
 - `steer_current_turn`: update the selected work without changing the durable
   Goal frontier;
@@ -49,8 +53,8 @@ provider-neutral turn_start dispatch
   -> first Agent-read receipt independent of optional provider reaction
   -> retry optional reaction from durable pending reads
   -> fresh status + quota projection
-  -> inbox lane preempts ordinary work when agent_read_required
-  -> private drain into the active Agent turn
+  -> generic kernel projects the registered required read before selected work
+  -> private drain into the active Agent turn (ordinary selection may remain)
   -> semantic disposition + durable settlement
   -> ACK and resume the prior lane when appropriate
 ```

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -357,6 +358,7 @@ def build_lark_turn_start_inbox_hook(
     project: str | Path,
     config_path: str | Path,
     runtime_root_arg: str | Path | None,
+    required_read_command: str,
 ) -> TurnStartHookRegistration:
     """Compose the opt-in provider sync behind the shared turn-start phase."""
 
@@ -427,6 +429,12 @@ def build_lark_turn_start_inbox_hook(
             "provider_message_reaction",
         ),
         producer=produce,
+        required_read={
+            "kind": "operator_inbox",
+            "command": required_read_command,
+            "reason": "turn-start hook synchronized new operator inbox evidence",
+            "ordering": "before_work",
+        },
     )
 
 
@@ -444,12 +452,27 @@ def dispatch_goal_lark_turn_start_hooks(
         goal_id=goal_id,
     )
     config_path = _goal_inbox_config(goal, agent_id=agent_id)
+    control_plane = (
+        goal.get("control_plane") if isinstance(goal.get("control_plane"), dict) else {}
+    )
+    agent_inboxes = (
+        control_plane.get("lark_event_inboxes")
+        if isinstance(control_plane.get("lark_event_inboxes"), dict)
+        else {}
+    )
+    agent_scoped = bool(agent_id and isinstance(agent_inboxes.get(agent_id), dict))
+    drain_parts = ["loopx", "--registry", str(registry_path.expanduser())]
+    drain_parts.extend(["lark-inbox", "drain", "--goal-id", goal_id])
+    if agent_scoped and agent_id:
+        drain_parts.extend(["--agent-id", agent_id])
+    required_read_command = shlex.join(drain_parts)
     registrations = (
         (
             build_lark_turn_start_inbox_hook(
                 project=project,
                 config_path=config_path,
                 runtime_root_arg=runtime_root_arg,
+                required_read_command=required_read_command,
             ),
         )
         if config_path

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -578,6 +578,7 @@ def handle_quota_command(
                 receipt_bound_replan_obligation_id=(receipt_bound_replan_obligation_id),
                 turn_instance_id=heartbeat_turn_id,
                 interaction_projection_hooks=interaction_projection_hooks,
+                turn_start_hook_dispatch=turn_start_hook_dispatch,
             )
             _attach_turn_start_hook_dispatch(payload, turn_start_hook_dispatch)
             _require_requested_quota_action_selection(

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -140,6 +140,7 @@ def handle_turn_command(
                     project_live_explore_composition_frontier
                 ),
                 requested_action_todo_id=requested_action_todo_id,
+                turn_start_hook_dispatch=turn_start_hook_dispatch,
             )
 
         decision = build_turn_decision()

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -23,10 +23,10 @@ INTERACTION_PROJECTION_HOOK_DISPATCH_SCHEMA_VERSION = (
     "loopx_interaction_projection_hook_dispatch_v0"
 )
 TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION = (
-    "loopx_turn_start_capability_hook_registration_v0"
+    "loopx_turn_start_capability_hook_registration_v1"
 )
 TURN_START_HOOK_RESULT_SCHEMA_VERSION = "loopx_turn_start_capability_hook_result_v0"
-TURN_START_HOOK_DISPATCH_SCHEMA_VERSION = "loopx_turn_start_capability_hook_dispatch_v0"
+TURN_START_HOOK_DISPATCH_SCHEMA_VERSION = "loopx_turn_start_capability_hook_dispatch_v1"
 POST_WRITEBACK_HOOK_REGISTRATION_SCHEMA_VERSION = (
     "loopx_post_writeback_capability_hook_registration_v0"
 )
@@ -116,6 +116,7 @@ class TurnStartHookRegistration:
     requested_write_scope: tuple[str, ...]
     producer: TurnStartProducer
     max_result_bytes: int = 16 * 1024
+    required_read: Mapping[str, Any] | None = None
 
     def contract(self) -> dict[str, Any]:
         return {
@@ -130,6 +131,9 @@ class TurnStartHookRegistration:
             "failure_policy": "isolate",
             "requested_read_scope": list(self.requested_read_scope),
             "requested_write_scope": list(self.requested_write_scope),
+            "required_read": (
+                dict(self.required_read) if self.required_read is not None else None
+            ),
         }
 
 
@@ -596,8 +600,10 @@ def dispatch_turn_start_hooks(
     """Run bounded pre-turn observations without exposing provider payloads."""
 
     results: list[dict[str, Any]] = []
+    required_reads: list[dict[str, Any]] = []
     failures: list[dict[str, str]] = []
     seen_hook_ids: set[str] = set()
+    seen_required_read_commands: set[str] = set()
     ordered = sorted(registrations or (), key=lambda item: item.hook_id)
     for registration in ordered:
         if registration.hook_id in seen_hook_ids:
@@ -605,7 +611,7 @@ def dispatch_turn_start_hooks(
             continue
         seen_hook_ids.add(registration.hook_id)
         try:
-            effect_runtime_result(
+            admitted_registration = effect_runtime_result(
                 "capability_hook.turn_start.validate_registration",
                 {"registration": registration.contract()},
             )
@@ -636,12 +642,27 @@ def dispatch_turn_start_hooks(
             )
             continue
         results.append(dict(normalized))
+        if normalized.get("agent_read_required") is True and isinstance(
+            admitted_registration, Mapping
+        ):
+            required_read = admitted_registration.get("required_read")
+            if isinstance(required_read, Mapping):
+                command = str(required_read.get("command") or "").strip()
+                if command and command not in seen_required_read_commands:
+                    required_reads.append(
+                        {
+                            **dict(required_read),
+                            "source": "turn_start_capability_hook",
+                        }
+                    )
+                    seen_required_read_commands.add(command)
     return {
         "schema_version": TURN_START_HOOK_DISPATCH_SCHEMA_VERSION,
         "phase": "turn_start",
         "registered_count": len(registrations or ()),
         "invoked_count": len(results),
         "results": results,
+        "required_reads": required_reads,
         "failures": failures,
     }
 

--- a/loopx/control_plane/capability_hooks.ts
+++ b/loopx/control_plane/capability_hooks.ts
@@ -14,7 +14,7 @@ export const CAPABILITY_HOOK_REGISTRATION_SCHEMA_VERSION =
 export const INTERACTION_PROJECTION_HOOK_RESULT_SCHEMA_VERSION =
   "loopx_interaction_projection_hook_result_v0";
 export const TURN_START_HOOK_REGISTRATION_SCHEMA_VERSION =
-  "loopx_turn_start_capability_hook_registration_v0";
+  "loopx_turn_start_capability_hook_registration_v1";
 export const TURN_START_HOOK_RESULT_SCHEMA_VERSION =
   "loopx_turn_start_capability_hook_result_v0";
 export const POST_WRITEBACK_HOOK_REGISTRATION_SCHEMA_VERSION =
@@ -60,6 +60,13 @@ const TURN_START_REGISTRATION_FIELDS = new Set([
   "failure_policy",
   "requested_read_scope",
   "requested_write_scope",
+  "required_read",
+]);
+const TURN_START_REQUIRED_READ_FIELDS = new Set([
+  "kind",
+  "command",
+  "reason",
+  "ordering",
 ]);
 const TURN_START_RESULT_FIELDS = new Set([
   "schema_version",
@@ -339,6 +346,7 @@ export function validateTurnStartHookRegistration(
   capability_id: string;
   max_result_bytes: number;
   requested_write_scope: string[];
+  required_read: JsonObject | null;
 } {
   const registration = requiredObject(value, "turn-start hook registration");
   requireExactFields(
@@ -387,12 +395,48 @@ export function validateTurnStartHookRegistration(
   if (maxInvocations !== 1 || maxResultBytes < 1024 || maxResultBytes > 65_536) {
     throw new Error("turn-start hook budget is outside the admitted envelope");
   }
+  let requiredRead: JsonObject | null = null;
+  if (registration.required_read !== null) {
+    const candidate = requiredObject(
+      registration.required_read,
+      "turn-start hook required_read",
+    );
+    requireExactFields(
+      candidate,
+      TURN_START_REQUIRED_READ_FIELDS,
+      "turn-start hook required_read",
+    );
+    const kind = requiredString(candidate.kind, "turn-start hook required_read kind");
+    const command = requiredString(
+      candidate.command,
+      "turn-start hook required_read command",
+    ).trim();
+    const reason = requiredString(
+      candidate.reason,
+      "turn-start hook required_read reason",
+    ).trim();
+    const containsControlCharacter = /[\u0000-\u001f\u007f]/;
+    if (
+      !TOKEN_RE.test(kind) ||
+      new TextEncoder().encode(command).byteLength > 360 ||
+      reason.length > 240 ||
+      containsControlCharacter.test(command) ||
+      containsControlCharacter.test(reason)
+    ) {
+      throw new Error("turn-start hook required_read is outside the admitted envelope");
+    }
+    if (candidate.ordering !== "before_work") {
+      throw new Error("turn-start hook required_read ordering is invalid");
+    }
+    requiredRead = { kind, command, reason, ordering: "before_work" };
+  }
   return {
     ...registration,
     hook_id: hookId,
     capability_id: capabilityId,
     max_result_bytes: maxResultBytes,
     requested_write_scope: writeScope,
+    required_read: requiredRead,
   };
 }
 
@@ -491,6 +535,9 @@ export function validateTurnStartHookInvocation(input: {
   }
   if (["unavailable", "failed"].includes(status) && result.agent_read_required) {
     throw new Error("unavailable turn-start hook cannot require unread evidence");
+  }
+  if (result.agent_read_required && registration.required_read === null) {
+    throw new Error("turn-start hook required read route is missing");
   }
   return { ...result };
 }

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -27,6 +27,82 @@ HostObservationResolver = Callable[..., Mapping[str, Any]]
 BoundedResearchFrontierProjector = Callable[..., Mapping[str, Any] | None]
 
 
+def _turn_start_required_reads(
+    dispatch: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Read only the generic, kernel-validated pre-work projection."""
+
+    if not isinstance(dispatch, Mapping):
+        return []
+    reads = dispatch.get("required_reads")
+    if not isinstance(reads, list):
+        return []
+    projected: list[dict[str, Any]] = []
+    seen_commands: set[str] = set()
+    for read in reads:
+        if not isinstance(read, Mapping):
+            continue
+        command = read.get("command")
+        if not isinstance(command, str) or not command.strip():
+            continue
+        normalized = command.strip()
+        if normalized in seen_commands:
+            continue
+        projected.append(
+            {
+                key: read[key]
+                for key in ("kind", "command", "reason", "source", "ordering")
+                if key in read
+            }
+        )
+        seen_commands.add(normalized)
+    return projected
+
+
+def _project_turn_start_required_reads(
+    payload: dict[str, Any],
+    dispatch: Mapping[str, Any] | None,
+    *,
+    available_capabilities: list[str] | None,
+    scheduler_execution_context: (
+        Mapping[str, Any] | SchedulerExecutionContextResolution | None
+    ),
+    turn_instance_id: str | None,
+    runtime_root: Path,
+) -> None:
+    """Order fresh operator evidence before work without changing work selection."""
+
+    projected = _turn_start_required_reads(dispatch)
+    if not projected:
+        return
+    existing = payload.get("required_reads")
+    required_reads = (
+        [dict(item) for item in existing if isinstance(item, Mapping)]
+        if isinstance(existing, list)
+        else []
+    )
+    seen_commands = {
+        str(item.get("command") or "").strip()
+        for item in required_reads
+        if str(item.get("command") or "").strip()
+    }
+    for required_read in projected:
+        command = str(required_read.get("command") or "").strip()
+        if command in seen_commands:
+            continue
+        required_reads.append(required_read)
+        seen_commands.add(command)
+    payload["required_reads"] = required_reads
+    payload["interaction_contract"] = build_interaction_contract(
+        payload,
+        available_capabilities=available_capabilities,
+        scheduler_execution_context=scheduler_execution_context,
+        turn_instance_id=turn_instance_id,
+        runtime_root=str(runtime_root),
+    )
+    payload["protocol_action_packet"] = build_protocol_action_packet(payload)
+
+
 def _apply_pending_capability_intent_precedence(
     payload: dict[str, Any],
     projection: Mapping[str, Any] | None,
@@ -249,6 +325,7 @@ def build_live_quota_should_run_decision(
     turn_instance_id: str | None = None,
     interaction_projection_hooks: Sequence[InteractionProjectionHookRegistration]
     | None = None,
+    turn_start_hook_dispatch: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build one live CLI decision while keeping host observation injectable."""
 
@@ -320,6 +397,14 @@ def build_live_quota_should_run_decision(
     )
     if route_source.startswith("loopx_turn_"):
         payload["runtime_root"] = str(runtime_root)
+    _project_turn_start_required_reads(
+        payload,
+        turn_start_hook_dispatch,
+        available_capabilities=available_capabilities,
+        scheduler_execution_context=resolved_context,
+        turn_instance_id=turn_instance_id,
+        runtime_root=runtime_root,
+    )
     hook_dispatch = dispatch_interaction_projection_hooks(interaction_projection_hooks)
     projections = hook_dispatch["projections"]
     if isinstance(projections, Mapping):

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -53,13 +53,16 @@ turn-start hook
 
 Core owns the provider-neutral hook registration, output budget, allowed
 owner-private write scopes, the narrow `provider_message_reaction` external
-write scope, failure isolation, and `agent_read_required`
-contract. The Lark extension owns history pagination, provider-envelope
-validation, private cursors, and inbox readback. The CLI composition root runs
-the hook before status/quota projection. Raw content remains only in the local
-inbox and appears to the Agent only through the existing goal-bound
-`drain_command`; it never enters the public Goal registry, hook receipt, or
-quota packet.
+write scope, failure isolation, and `agent_read_required` contract. A hook that
+can require Agent reading must also register one bounded public-safe
+`required_read`; the generic kernel validates and deduplicates it, then the live
+decision mirrors it into both interaction channels with `ordering=before_work`.
+The Lark extension owns that drain descriptor, history pagination,
+provider-envelope validation, private cursors, and inbox readback. The CLI
+composition root runs the hook before status/quota projection. Raw content
+remains only in the local inbox and appears to the Agent only through the
+registered drain command; it never enters the public Goal registry, hook
+receipt, or quota packet.
 
 The distinction between `empty`, `provider_contract_error`, permission failure,
 and provider unavailability is mandatory. A success envelope whose message list

--- a/tests/control_plane/test_effect_turn_live_quota_decision.py
+++ b/tests/control_plane/test_effect_turn_live_quota_decision.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from loopx.control_plane.effect_program import (
     interpret_quota_should_run_packet,
 )
+from loopx.control_plane.capability_hooks import (
+    TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+    TurnStartHookRegistration,
+    dispatch_turn_start_hooks,
+)
 from loopx.control_plane.quota.live_decision import (
     bind_action_selection_cli_routes,
     build_live_quota_should_run_decision,
@@ -12,6 +17,73 @@ from loopx.control_plane.quota.live_decision import (
 from loopx.control_plane.testing.quota_fixtures import quota_status_payload
 
 GOAL_ID = "effect-interpreter-fixture"
+
+
+def _turn_start_dispatch(
+    *,
+    required: bool = True,
+    commands: tuple[str, ...] = ("loopx inbox drain --goal-id fixture",),
+) -> dict[str, object]:
+    hooks: list[TurnStartHookRegistration] = []
+    for index, command in enumerate(commands):
+        hook_id = f"operator_inbox.turn_start_sync_{index}"
+
+        def produce(
+            *, hook_id: str = hook_id, required: bool = required
+        ) -> dict[str, object]:
+            return {
+                "schema_version": TURN_START_HOOK_RESULT_SCHEMA_VERSION,
+                "hook_id": hook_id,
+                "capability_id": "operator-inbox",
+                "phase": "turn_start",
+                "status": "observed" if required else "empty",
+                "observation_count": 1 if required else 0,
+                "agent_read_required": required,
+                "external_reads_performed": True,
+                "external_writes_performed": False,
+                "local_private_state_mutated": required,
+                "private_content_returned": False,
+                "provider_payload_returned": False,
+                "error_code": None,
+            }
+
+        hooks.append(
+            TurnStartHookRegistration(
+                hook_id=hook_id,
+                capability_id="operator-inbox",
+                requested_read_scope=("provider_history",),
+                requested_write_scope=("owner_private_inbox",),
+                producer=produce,
+                required_read={
+                    "kind": "operator_inbox",
+                    "command": command,
+                    "reason": "turn-start hook synchronized new operator inbox evidence",
+                    "ordering": "before_work",
+                },
+            )
+        )
+    return dispatch_turn_start_hooks(hooks)
+
+
+def _ordinary_status_payload() -> dict[str, object]:
+    todo_text = "[P1] Keep advancing the selected task."
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        agent_todo_items=[
+            {
+                "todo_id": "todo_ordinary_work",
+                "index": 1,
+                "text": todo_text,
+                "role": "agent",
+                "status": "open",
+                "priority": "P1",
+                "task_class": "advancement_task",
+            }
+        ],
+        recommended_action=todo_text,
+        next_action=todo_text,
+    )
 
 
 def test_live_quota_decision_maps_to_effect_turn(tmp_path: Path) -> None:
@@ -84,3 +156,117 @@ def test_action_selection_route_binding_fails_closed_on_malformed_prefix(
     assert payload["interaction_contract"]["cli_channel"]["selection_command"][
         "route_prefix"
     ] == "loopx --runtime-root /tmp"
+
+
+def test_turn_start_read_is_required_before_ordinary_work(tmp_path: Path) -> None:
+    status = _ordinary_status_payload()
+    baseline = build_live_quota_should_run_decision(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+    )
+    packet = build_live_quota_should_run_decision(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        turn_start_hook_dispatch=_turn_start_dispatch(
+            commands=(
+                f"loopx --registry {tmp_path / 'registry.json'} "
+                f"lark-inbox drain --goal-id {GOAL_ID}",
+            )
+        ),
+    )
+
+    required_reads = packet["interaction_contract"]["agent_channel"]["required_reads"]
+    assert (
+        required_reads
+        == packet["interaction_contract"]["cli_channel"]["required_reads"]
+    )
+    assert required_reads == [
+        {
+            "kind": "operator_inbox",
+            "command": (
+                f"loopx --registry {tmp_path / 'registry.json'} "
+                f"lark-inbox drain --goal-id {GOAL_ID}"
+            ),
+            "reason": "turn-start hook synchronized new operator inbox evidence",
+            "source": "turn_start_capability_hook",
+            "ordering": "before_work",
+        }
+    ]
+    assert packet["interaction_contract"]["user_channel"]["notify"] == "DONT_NOTIFY"
+    assert packet.get("selected_todo") == baseline.get("selected_todo")
+    assert (
+        packet["agent_todo_summary"]["first_executable_items"]
+        == baseline["agent_todo_summary"]["first_executable_items"]
+    )
+    assert packet["recommended_action"] == baseline["recommended_action"]
+    assert packet["effective_action"] == baseline["effective_action"] == "normal_run"
+
+
+def test_turn_start_read_is_not_projected_for_empty_or_failed_dispatch(
+    tmp_path: Path,
+) -> None:
+    status = _ordinary_status_payload()
+    dispatches = [
+        _turn_start_dispatch(required=False),
+        {
+            "registered_count": 1,
+            "invoked_count": 0,
+            "results": [],
+            "failures": [
+                {
+                    "hook_id": "lark.turn_start_inbox_sync",
+                    "capability_id": "lark-event-inbox",
+                    "error_code": "producer_failed",
+                }
+            ],
+        },
+    ]
+
+    for dispatch in dispatches:
+        packet = build_live_quota_should_run_decision(
+            status,
+            goal_id=GOAL_ID,
+            agent_id=None,
+            available_capabilities=["shell"],
+            include_scheduler_detail=False,
+            codex_app_current_rrule=None,
+            registry_path=tmp_path / "registry.json",
+            runtime_root=tmp_path / "runtime",
+            turn_start_hook_dispatch=dispatch,
+        )
+
+        assert "required_reads" not in packet["interaction_contract"]["agent_channel"]
+        assert "required_reads" not in packet["interaction_contract"]["cli_channel"]
+
+
+def test_duplicate_required_inbox_routes_project_one_public_safe_read(
+    tmp_path: Path,
+) -> None:
+    command = "loopx lark-inbox drain --goal-id fixture"
+    dispatch = _turn_start_dispatch(commands=(command, command))
+    packet = build_live_quota_should_run_decision(
+        _ordinary_status_payload(),
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        turn_start_hook_dispatch=dispatch,
+    )
+
+    assert len(packet["required_reads"]) == 1
+    assert packet["required_reads"][0]["command"] == command

--- a/tests/control_plane/test_turn_start_capability_hooks.py
+++ b/tests/control_plane/test_turn_start_capability_hooks.py
@@ -33,6 +33,12 @@ def _hook(producer: object) -> TurnStartHookRegistration:
         requested_read_scope=("provider_history",),
         requested_write_scope=("owner_private_inbox", "owner_private_cursor"),
         producer=producer,  # type: ignore[arg-type]
+        required_read={
+            "kind": "operator_inbox",
+            "command": "loopx inbox drain --goal-id fixture",
+            "reason": "read newly synchronized operator evidence",
+            "ordering": "before_work",
+        },
     )
 
 
@@ -44,6 +50,15 @@ def test_turn_start_hook_returns_only_validated_agent_read_obligation() -> None:
     assert dispatch["results"][0]["agent_read_required"] is True
     assert dispatch["results"][0]["observation_count"] == 1
     assert "content" not in dispatch["results"][0]
+    assert dispatch["required_reads"] == [
+        {
+            "kind": "operator_inbox",
+            "command": "loopx inbox drain --goal-id fixture",
+            "reason": "read newly synchronized operator evidence",
+            "ordering": "before_work",
+            "source": "turn_start_capability_hook",
+        }
+    ]
 
 
 def test_provider_shape_mismatch_is_not_misclassified_as_empty() -> None:
@@ -89,6 +104,12 @@ def test_turn_start_external_write_requires_reaction_scope() -> None:
             "provider_message_reaction",
         ),
         producer=lambda: _result(external_writes_performed=True),
+        required_read={
+            "kind": "operator_inbox",
+            "command": "loopx inbox drain --goal-id fixture",
+            "reason": "read newly synchronized operator evidence",
+            "ordering": "before_work",
+        },
     )
     dispatch = dispatch_turn_start_hooks([admitted])
 

--- a/tests/control_plane_ts/capability_hooks.test.ts
+++ b/tests/control_plane_ts/capability_hooks.test.ts
@@ -426,6 +426,12 @@ function turnStartRegistration(overrides: Record<string, unknown> = {}) {
     failure_policy: "isolate",
     requested_read_scope: ["provider_history"],
     requested_write_scope: ["owner_private_inbox", "owner_private_cursor"],
+    required_read: {
+      kind: "operator_inbox",
+      command: "loopx inbox drain --goal-id fixture",
+      reason: "read newly synchronized operator evidence",
+      ordering: "before_work",
+    },
     ...overrides,
   };
 }
@@ -471,6 +477,28 @@ test("turn-start observations require Agent reading without returning private co
       result: turnStartResult({ private_content_returned: true }),
     }),
     /private provider content/,
+  );
+  assert.throws(
+    () => validateTurnStartHookInvocation({
+      registration: turnStartRegistration({ required_read: null }),
+      result: turnStartResult(),
+    }),
+    /required read route is missing/,
+  );
+  assert.throws(
+    () => validateTurnStartHookInvocation({
+      registration: turnStartRegistration({
+        required_read: {
+          kind: "operator_inbox",
+          command: "loopx inbox drain --goal-id fixture",
+          reason: "read newly synchronized operator evidence",
+          ordering: "before_work",
+          private_message_text: "must-not-enter-the-contract",
+        },
+      }),
+      result: turnStartResult(),
+    }),
+    /required_read fields are invalid/,
   );
 });
 

--- a/tests/extensions/test_lark_turn_start_sync.py
+++ b/tests/extensions/test_lark_turn_start_sync.py
@@ -369,6 +369,7 @@ def test_turn_start_sync_acknowledges_message_previously_captured_by_collector(
                 project=project,
                 config_path=config,
                 runtime_root_arg=None,
+                required_read_command="loopx lark-inbox drain --goal-id fixture",
             )
         ]
     )


### PR DESCRIPTION
## Summary

- extend the provider-neutral turn-start hook contract with one bounded public-safe `required_read` descriptor
- let the generic hook kernel validate and deduplicate required reads, then project them into both interaction channels before selected work
- keep ordinary Todo selection and `DONT_NOTIFY` semantics unchanged while Lark owns only its drain route
- update the RFC/docs to separate pre-work reading from inbox-lane preemption

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` (386 passed, 1 PostgreSQL environment test skipped)
- 66 focused Python tests across hook/live-decision/Lark/quota/Turn paths
- `python -m mypy`
- Ruff on all changed Python files
- `loopx check` on all changed files
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (18 checks passed, 0 holds)
- change-quality receipt `cqr_02e9759a5249048e5a54`

Closes #3844