### PR TITLE
fix(control-plane): separate fresh inbox reads from recovery

### DIFF
--- a/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
+++ b/docs/architecture/rfcs/provider-neutral-turn-start-inbox-hook-v0.md
@@ -28,10 +28,12 @@ result with new observations must set `agent_read_required=true`. Its
 registration declares one bounded, public-safe `required_read` descriptor.
 The generic hook kernel validates that descriptor, deduplicates it by command,
 and projects it into both Agent and CLI interaction channels with
-`ordering=before_work`. The selected ordinary Todo and `user_channel.notify`
-remain independent: urgency may still select an inbox lane, but a quiet ordinary
-lane can remain selected while the required read runs first. The Agent reads the
-messages and chooses one typed semantic disposition:
+`ordering=before_work`. A fresh ordinary material read emits a non-blocking user
+notification while preserving the already selected work lane. If the material
+remains durably pending on the next turn, the existing material-review lane
+preempts work for recovery. A direct question or verified reply still preempts
+on its first turn. The Agent reads the messages and chooses one typed semantic
+disposition:
 
 - `steer_current_turn`: update the selected work without changing the durable
   Goal frontier;

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -653,6 +653,8 @@ def dispatch_turn_start_hooks(
                         {
                             **dict(required_read),
                             "source": "turn_start_capability_hook",
+                            "hook_id": registration.hook_id,
+                            "capability_id": registration.capability_id,
                         }
                     )
                     seen_required_read_commands.add(command)

--- a/loopx/control_plane/quota/live_decision.py
+++ b/loopx/control_plane/quota/live_decision.py
@@ -27,6 +27,24 @@ HostObservationResolver = Callable[..., Mapping[str, Any]]
 BoundedResearchFrontierProjector = Callable[..., Mapping[str, Any] | None]
 
 
+def _fresh_read_covers_all_pending_material(
+    dispatch: Mapping[str, Any] | None,
+    projector: Callable[..., dict[str, Any]] | None,
+) -> Callable[..., dict[str, Any]] | None:
+    if projector is None:
+        return None
+    fresh_count = _fresh_operator_inbox_observation_count(dispatch)
+
+    def project(**kwargs: Any) -> dict[str, Any]:
+        urgency = dict(projector(**kwargs))
+        pending_count = max(0, int(urgency.get("pending_count") or 0))
+        if pending_count <= fresh_count:
+            urgency["material_review_due"] = False
+        return urgency
+
+    return project
+
+
 def _turn_start_required_reads(
     dispatch: Mapping[str, Any] | None,
 ) -> list[dict[str, Any]]:
@@ -93,6 +111,18 @@ def _project_turn_start_required_reads(
         required_reads.append(required_read)
         seen_commands.add(command)
     payload["required_reads"] = required_reads
+    if _fresh_operator_inbox_read_required(dispatch):
+        recommendation = (
+            dict(payload.get("heartbeat_recommendation") or {})
+            if isinstance(payload.get("heartbeat_recommendation"), Mapping)
+            else {}
+        )
+        recommendation.update(
+            {
+                "notify": "NOTIFY",
+            }
+        )
+        payload["heartbeat_recommendation"] = recommendation
     payload["interaction_contract"] = build_interaction_contract(
         payload,
         available_capabilities=available_capabilities,
@@ -101,6 +131,37 @@ def _project_turn_start_required_reads(
         runtime_root=str(runtime_root),
     )
     payload["protocol_action_packet"] = build_protocol_action_packet(payload)
+
+
+def _fresh_operator_inbox_observation_count(
+    dispatch: Mapping[str, Any] | None,
+) -> int:
+    if not isinstance(dispatch, Mapping):
+        return 0
+    required_reads = dispatch.get("required_reads")
+    results = dispatch.get("results")
+    if not isinstance(required_reads, list) or not isinstance(results, list):
+        return 0
+    operator_inbox_hook_ids = {
+        str(read.get("hook_id") or "")
+        for read in required_reads
+        if isinstance(read, Mapping)
+        and read.get("kind") == "operator_inbox"
+        and str(read.get("hook_id") or "")
+    }
+    return sum(
+        max(0, int(result.get("observation_count") or 0))
+        for result in results
+        if isinstance(result, Mapping)
+        and result.get("agent_read_required") is True
+        and result.get("hook_id") in operator_inbox_hook_ids
+    )
+
+
+def _fresh_operator_inbox_read_required(
+    dispatch: Mapping[str, Any] | None,
+) -> bool:
+    return _fresh_operator_inbox_observation_count(dispatch) > 0
 
 
 def _apply_pending_capability_intent_precedence(
@@ -376,6 +437,9 @@ def build_live_quota_should_run_decision(
     receipt_bound_replay_phase = (
         settlement_readback.replay_phase if settlement_readback else None
     )
+    fresh_operator_inbox_read = _fresh_operator_inbox_read_required(
+        turn_start_hook_dispatch
+    )
     payload = build_quota_should_run(
         decision_status_payload,
         goal_id=goal_id,
@@ -386,7 +450,14 @@ def build_live_quota_should_run_decision(
         codex_app_current_rrule=observed_rrule,
         codex_app_automation_id=observed_automation_id or None,
         scheduler_execution_context=resolved_context,
-        operator_inbox_urgency_projector=operator_inbox_urgency_projector,
+        operator_inbox_urgency_projector=(
+            _fresh_read_covers_all_pending_material(
+                turn_start_hook_dispatch,
+                operator_inbox_urgency_projector,
+            )
+            if fresh_operator_inbox_read
+            else operator_inbox_urgency_projector
+        ),
         receipt_bound_todo_id=receipt_bound_todo_id,
         requested_action_todo_id=requested_action_todo_id,
         receipt_bound_monitor_phase=receipt_bound_monitor_phase,

--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -57,6 +57,9 @@ write scope, failure isolation, and `agent_read_required` contract. A hook that
 can require Agent reading must also register one bounded public-safe
 `required_read`; the generic kernel validates and deduplicates it, then the live
 decision mirrors it into both interaction channels with `ordering=before_work`.
+Fresh ordinary material notifies without replacing the selected work lane;
+durable material left unsettled preempts on the following turn, while direct
+questions and verified replies retain immediate reply-lane precedence.
 The Lark extension owns that drain descriptor, history pagination,
 provider-envelope validation, private cursors, and inbox readback. The CLI
 composition root runs the hook before status/quota projection. Raw content
@@ -267,7 +270,9 @@ the profile, chat id, message id, reply text, or provider payload.
 
 ## Host collector lifecycle
 
-Keep the collector config ignored and untracked. It references the generic
+In Git projects, keep the collector config ignored and untracked. A non-Git
+project may keep it only below `.loopx/config`; parent Git boundaries and paths
+outside that private root remain rejected. The config references the generic
 inbox config but owns host-only details such as the chat id and supervisor:
 
 ```json

--- a/loopx/extensions/lark/event_collector.py
+++ b/loopx/extensions/lark/event_collector.py
@@ -49,6 +49,21 @@ def _project_config_path(project: str | Path, raw: str | Path) -> Path:
         relative = path.relative_to(root)
     except ValueError as exc:
         raise ValueError("lark collector config must stay inside the project") from exc
+    git_probe = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        check=False,
+    )
+    if git_probe.returncode != 0:
+        has_git_boundary = any(
+            (candidate / ".git").exists() for candidate in (root, *root.parents)
+        )
+        if has_git_boundary or relative.parts[:2] != (".loopx", "config"):
+            raise ValueError(
+                "lark collector config must be ignored and untracked, or stay "
+                "under .loopx/config in a non-Git project"
+            )
+        return path
     tracked = subprocess.run(
         ["git", "-C", str(root), "ls-files", "--error-unmatch", "--", str(relative)],
         capture_output=True,

--- a/tests/control_plane/test_effect_turn_live_quota_decision.py
+++ b/tests/control_plane/test_effect_turn_live_quota_decision.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from loopx.control_plane.effect_program import (
@@ -22,6 +23,7 @@ GOAL_ID = "effect-interpreter-fixture"
 def _turn_start_dispatch(
     *,
     required: bool = True,
+    observation_count: int = 1,
     commands: tuple[str, ...] = ("loopx inbox drain --goal-id fixture",),
 ) -> dict[str, object]:
     hooks: list[TurnStartHookRegistration] = []
@@ -37,7 +39,7 @@ def _turn_start_dispatch(
                 "capability_id": "operator-inbox",
                 "phase": "turn_start",
                 "status": "observed" if required else "empty",
-                "observation_count": 1 if required else 0,
+                "observation_count": observation_count if required else 0,
                 "agent_read_required": required,
                 "external_reads_performed": True,
                 "external_writes_performed": False,
@@ -84,6 +86,50 @@ def _ordinary_status_payload() -> dict[str, object]:
         recommended_action=todo_text,
         next_action=todo_text,
     )
+
+
+def _material_review_urgency(
+    *, reply_due: bool = False, pending_count: int = 1, **_kwargs: object
+) -> dict[str, object]:
+    return {
+        "schema_version": "operator_inbox_urgency_v0",
+        "enabled": True,
+        "pending_count": pending_count,
+        "attention_required_count": int(reply_due),
+        "reply_due": reply_due,
+        "material_review_count": 1,
+        "material_attachment_count": 0,
+        "material_review_due": True,
+        "material_review_drain_limit": 20,
+        "local_private_content_returned": False,
+    }
+
+
+def _inbox_goal(tmp_path: Path) -> dict[str, object]:
+    return {
+        "id": GOAL_ID,
+        "registry_member": True,
+        "status": "active",
+        "adapter_kind": "harness_self_improvement",
+        "adapter_status": "connected-read-only",
+        "repo": str(tmp_path),
+        "quota": {"compute": 1.0, "window_hours": 24},
+        "control_plane": {
+            "lark_event_inbox": {
+                "enabled": True,
+                "config_path": ".loopx/config/lark/inbox.json",
+            }
+        },
+    }
+
+
+def _status_with_inbox(tmp_path: Path) -> dict[str, object]:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps({"goals": [_inbox_goal(tmp_path)]}),
+        encoding="utf-8",
+    )
+    return _ordinary_status_payload() | {"registry": str(registry_path)}
 
 
 def test_live_quota_decision_maps_to_effect_turn(tmp_path: Path) -> None:
@@ -204,7 +250,8 @@ def test_turn_start_read_is_required_before_ordinary_work(tmp_path: Path) -> Non
             "ordering": "before_work",
         }
     ]
-    assert packet["interaction_contract"]["user_channel"]["notify"] == "DONT_NOTIFY"
+    assert packet["interaction_contract"]["user_channel"]["notify"] == "NOTIFY"
+    assert packet["interaction_contract"]["user_channel"]["action_required"] is False
     assert packet.get("selected_todo") == baseline.get("selected_todo")
     assert (
         packet["agent_todo_summary"]["first_executable_items"]
@@ -212,6 +259,197 @@ def test_turn_start_read_is_required_before_ordinary_work(tmp_path: Path) -> Non
     )
     assert packet["recommended_action"] == baseline["recommended_action"]
     assert packet["effective_action"] == baseline["effective_action"] == "normal_run"
+
+
+def test_fresh_turn_start_read_notifies_without_preempting_selected_work(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.goal_boundary.operator_inbox_binding",
+        lambda **_kwargs: {
+            "status": "verified",
+            "attention_required": False,
+        },
+    )
+    status = _status_with_inbox(tmp_path)
+    baseline = build_live_quota_should_run_decision(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+    )
+    packet = build_live_quota_should_run_decision(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        operator_inbox_urgency_projector=_material_review_urgency,
+        turn_start_hook_dispatch=_turn_start_dispatch(),
+    )
+
+    assert packet["effective_action"] == baseline["effective_action"] == "normal_run"
+    assert packet.get("selected_todo") == baseline.get("selected_todo")
+    assert packet["recommended_action"] == baseline["recommended_action"]
+    assert packet["interaction_contract"]["user_channel"]["notify"] == "NOTIFY"
+    assert packet["interaction_contract"]["user_channel"]["action_required"] is False
+    assert packet["interaction_contract"]["agent_channel"]["required_reads"]
+
+
+def test_unsettled_inbox_material_preempts_on_following_turn(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.goal_boundary.operator_inbox_binding",
+        lambda **_kwargs: {
+            "status": "verified",
+            "attention_required": False,
+        },
+    )
+    packet = build_live_quota_should_run_decision(
+        _status_with_inbox(tmp_path),
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        operator_inbox_urgency_projector=_material_review_urgency,
+        turn_start_hook_dispatch=_turn_start_dispatch(required=False),
+    )
+
+    assert packet["effective_action"] == "operator_inbox_material_review_due"
+    assert packet["work_lane_contract"]["priority_preemption"] is True
+    assert "required_reads" not in packet["interaction_contract"]["agent_channel"]
+
+
+def test_fresh_direct_reply_still_preempts_selected_work(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.goal_boundary.operator_inbox_binding",
+        lambda **_kwargs: {
+            "status": "verified",
+            "attention_required": False,
+        },
+    )
+    packet = build_live_quota_should_run_decision(
+        _status_with_inbox(tmp_path),
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        operator_inbox_urgency_projector=(
+            lambda **kwargs: _material_review_urgency(reply_due=True, **kwargs)
+        ),
+        turn_start_hook_dispatch=_turn_start_dispatch(),
+    )
+
+    assert packet["effective_action"] == "lark_inbox_reply_due"
+    assert packet["work_lane_contract"]["priority_preemption"] is True
+    assert packet["interaction_contract"]["agent_channel"]["required_reads"]
+
+
+def test_fresh_read_does_not_hide_older_unsettled_material(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.goal_boundary.operator_inbox_binding",
+        lambda **_kwargs: {
+            "status": "verified",
+            "attention_required": False,
+        },
+    )
+    packet = build_live_quota_should_run_decision(
+        _status_with_inbox(tmp_path),
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        operator_inbox_urgency_projector=(
+            lambda **kwargs: _material_review_urgency(
+                pending_count=2,
+                **kwargs,
+            )
+        ),
+        turn_start_hook_dispatch=_turn_start_dispatch(observation_count=1),
+    )
+
+    assert packet["effective_action"] == "operator_inbox_material_review_due"
+    assert packet["work_lane_contract"]["priority_preemption"] is True
+    assert packet["interaction_contract"]["agent_channel"]["required_reads"]
+
+
+def test_non_inbox_hook_observations_do_not_mask_unsettled_inbox_material(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.quota.goal_boundary.operator_inbox_binding",
+        lambda **_kwargs: {
+            "status": "verified",
+            "attention_required": False,
+        },
+    )
+    dispatch = _turn_start_dispatch(observation_count=1)
+    dispatch["results"].append(
+        {
+            "hook_id": "repository.turn_start_sync",
+            "capability_id": "repository",
+            "agent_read_required": True,
+            "observation_count": 10,
+        }
+    )
+    dispatch["required_reads"].append(
+        {
+            "kind": "repository",
+            "command": "git status --short",
+            "reason": "read repository state",
+            "ordering": "before_work",
+            "source": "turn_start_capability_hook",
+            "hook_id": "repository.turn_start_sync",
+            "capability_id": "repository",
+        }
+    )
+
+    packet = build_live_quota_should_run_decision(
+        _status_with_inbox(tmp_path),
+        goal_id=GOAL_ID,
+        agent_id=None,
+        available_capabilities=["shell"],
+        include_scheduler_detail=False,
+        codex_app_current_rrule=None,
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path / "runtime",
+        operator_inbox_urgency_projector=(
+            lambda **kwargs: _material_review_urgency(
+                pending_count=2,
+                **kwargs,
+            )
+        ),
+        turn_start_hook_dispatch=dispatch,
+    )
+
+    assert packet["effective_action"] == "operator_inbox_material_review_due"
+    assert packet["work_lane_contract"]["priority_preemption"] is True
 
 
 def test_turn_start_read_is_not_projected_for_empty_or_failed_dispatch(

--- a/tests/control_plane/test_turn_start_capability_hooks.py
+++ b/tests/control_plane/test_turn_start_capability_hooks.py
@@ -57,6 +57,8 @@ def test_turn_start_hook_returns_only_validated_agent_read_obligation() -> None:
             "reason": "read newly synchronized operator evidence",
             "ordering": "before_work",
             "source": "turn_start_capability_hook",
+            "hook_id": "operator_inbox.turn_start_sync",
+            "capability_id": "operator-inbox",
         }
     ]
 

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -133,6 +133,46 @@ def _two_route_config(tmp_path: Path) -> tuple[Path, Path, str, str]:
     return project, collector, first_chat, second_chat
 
 
+def test_non_git_project_accepts_private_collector_config(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    first_chat = "oc_public_fixture_alpha"
+    inbox = _write_inbox(project, name="requirements-alpha", chat_id=first_chat)
+    collector = _write_collector(
+        project,
+        routes=[
+            {
+                "route_key": "requirements-alpha",
+                "chat_id": first_chat,
+                "event_inbox_config": inbox,
+            }
+        ],
+    )
+
+    config = load_lark_event_collector_config(
+        project=project,
+        config_path=collector,
+    )
+
+    assert config["project"] == project.resolve()
+    assert config["config_path"] == collector.resolve()
+
+
+def test_non_git_project_rejects_collector_config_outside_private_root(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    collector = project / "collector.json"
+    collector.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="under .loopx/config"):
+        load_lark_event_collector_config(
+            project=project,
+            config_path=collector,
+        )
+
+
 def test_v1_plan_binds_one_profile_to_isolated_multi_chat_routes(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- notify and require a pre-work read when a turn-start hook discovers fresh ordinary inbox material, while preserving the selected Goal/Todo work lane;
- retain immediate preemption for direct replies and recover unresolved ordinary material through the existing material-review lane on a later turn;
- correlate fresh observation counts with the exact operator-inbox hook so unrelated turn-start hooks cannot mask older pending material;
- permit collector configuration below `.loopx/config` for non-Git aggregate project directories while preserving ignored-and-untracked enforcement inside Git projects.

## Product and architecture judgment

This separates two previously coupled concerns: fresh evidence delivery and recovery of evidence that remained unsettled. The implementation reuses the existing turn-start hook dispatch, required-read projection, urgency projector, and reply/material lanes. It adds no text classifier, timer, mode flag, alternate scheduler, or new public protocol. Direct questions retain first-turn precedence, while ordinary fresh material becomes visible without replacing useful work.

The non-Git fallback is deliberately narrow: only the private `.loopx/config` subtree is admitted, and any enclosing Git boundary keeps the existing tracked/ignored policy authoritative.

## Validation

- `72 passed` across focused control-plane and Lark inbox tests;
- Ruff passed for all touched Python source and tests;
- Python compile passed for all touched product modules;
- `npm run typecheck:control-plane` passed;
- `npm run test:control-plane` passed: 394 passed, one PostgreSQL integration skipped because its test URL is not configured;
- strict change-quality receipt `cqr_fe07f1f416b7bd2aa9ff` verified against the exact final diff;
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` passed 16 selected checks with zero failures and zero manual holds;
- public/private boundary scan and `git diff --check` passed.

The PostgreSQL authority-store integration was not run because its test URL is unavailable; this change does not touch that store. Existing repository-wide Mypy debt was not treated as a passing gate. No private inbox content, local state, credentials, local paths, or internal links are included.

## Future-facing pass

A bounded repair associated required reads with their originating hook identity. Broader turn-start scheduling abstractions were unnecessary and intentionally not introduced.
