### PR TITLE
fix(benchmark): preserve study upload authority

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -1219,7 +1219,9 @@ loopx benchmark upload-readback \
 Retries using the same producer, benchmark, study, and idempotency key are accepted
 only when the payload digest is unchanged. A corrected record uses a new idempotency
 key and explicitly names `--supersedes-record-id`; experiment-board corrections must
-also obey existing legal run-state transitions.
+also obey existing legal run-state transitions. A study manifest is immutable
+comparison intent: change its design under a new `study_id` instead of superseding it.
+Supersession also stays within the producer that authored the prior record.
 
 Finally, derive a read-only `benchmark_study_dashboard_v0` packet. It exposes
 campaign, arm, case, and run projections with explicit denominators and provisional

--- a/loopx/capabilities/benchmark_toolkit/study_projection.py
+++ b/loopx/capabilities/benchmark_toolkit/study_projection.py
@@ -646,9 +646,13 @@ def _validate_supersession(
         raise ValueError("upload must supersede the current active record")
     if prior is not None:
         old = prior["envelope"]
-        for field in ("benchmark_id", "study_id", "record_kind"):
+        for field in ("producer_id", "benchmark_id", "study_id", "record_kind"):
             if old[field] != envelope[field]:
                 raise ValueError("supersession identity does not match prior record")
+        if envelope["record_kind"] == "study_manifest":
+            raise ValueError(
+                "study manifest comparison intent is immutable; use a new study_id"
+            )
         if envelope["record_kind"] == "experiment_board_row":
             if not _same_board_row(old["payload"], envelope["payload"]):
                 raise ValueError("board-row supersession must preserve run identity")

--- a/tests/capabilities/test_benchmark_study_projection.py
+++ b/tests/capabilities/test_benchmark_study_projection.py
@@ -399,6 +399,44 @@ def test_case_insight_supersession_preserves_run_identity(tmp_path: Path) -> Non
         simulate_benchmark_upload(store, replacement, execute=True)
 
 
+def test_supersession_preserves_producer_and_immutable_study_identity(
+    tmp_path: Path,
+) -> None:
+    store = tmp_path / "simulated-upload.jsonl"
+    first = _envelope(_manifest(), record_kind="study_manifest", key="manifest-v1")
+    simulate_benchmark_upload(store, first, execute=True)
+
+    changed = _manifest()
+    changed["labels"] = {"title": "Changed public title"}
+    replacement = _envelope(
+        changed,
+        record_kind="study_manifest",
+        key="manifest-v2",
+        supersedes=first["record_id"],
+    )
+    with pytest.raises(ValueError, match="immutable"):
+        simulate_benchmark_upload(store, replacement, execute=True)
+
+    insight = _envelope(
+        _insight(), record_kind="case_insight_projection", key="insight-v1"
+    )
+    simulate_benchmark_upload(store, insight, execute=True)
+    other_producer = build_benchmark_upload_envelope(
+        _insight(),
+        record_kind="case_insight_projection",
+        producer_id="another-adapter",
+        producer_version="1.0.0",
+        benchmark_id="fixture-swe@1",
+        study_id="paired-v1",
+        idempotency_key="insight-v2",
+        observed_at="2026-09-02T12:00:00+00:00",
+        source_revision="0123456789abcdef",
+        supersedes_record_id=insight["record_id"],
+    )
+    with pytest.raises(ValueError, match="identity"):
+        simulate_benchmark_upload(store, other_producer, execute=True)
+
+
 def test_redacted_insight_rejects_raw_fields_and_path_references() -> None:
     insight = _insight()
     insight["raw_trajectory"] = "private solver text"


### PR DESCRIPTION
## Summary

- keep study manifests immutable under a declared `study_id`
- require supersession to remain within the producer that authored the prior record
- document both rules and add focused negative coverage

This is a narrow follow-up to #3846 and RFC #3812. It changes no scoring, runner, remote provider, upload authority, or benchmark result data.

## Validation

- `/usr/bin/python3 -m ruff check loopx/capabilities/benchmark_toolkit/study_projection.py tests/capabilities/test_benchmark_study_projection.py`
- `/usr/bin/python3 -m pytest -q tests/capabilities/test_benchmark_study_projection.py tests/capabilities/test_benchmark_toolkit.py` — 111 passed
- `git diff --check`
- public/private boundary scan — clean

## Review focus

Please verify the typed supersession authority: experiment design changes require a new study identity, while run and insight corrections remain explicit same-producer supersessions.
