### PR TITLE
fix(benchmark): reject duplicate study manifests

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/study_projection.py
+++ b/loopx/capabilities/benchmark_toolkit/study_projection.py
@@ -633,6 +633,16 @@ def _validate_supersession(
     by_id = {row["envelope"]["record_id"]: row for row in records}
     supersedes = envelope.get("supersedes_record_id")
     prior = by_id.get(supersedes) if supersedes else None
+    if envelope["record_kind"] == "study_manifest" and any(
+        row["envelope"]["record_kind"] == "study_manifest"
+        and row["envelope"]["benchmark_id"] == envelope["benchmark_id"]
+        and row["envelope"]["study_id"] == envelope["study_id"]
+        and row["envelope"]["record_id"] != envelope["record_id"]
+        for row in records
+    ):
+        raise ValueError(
+            "study manifest comparison intent is immutable; use a new study_id"
+        )
     if supersedes and prior is None:
         raise ValueError("superseded upload record does not exist")
     if supersedes == envelope["record_id"]:
@@ -649,10 +659,6 @@ def _validate_supersession(
         for field in ("producer_id", "benchmark_id", "study_id", "record_kind"):
             if old[field] != envelope[field]:
                 raise ValueError("supersession identity does not match prior record")
-        if envelope["record_kind"] == "study_manifest":
-            raise ValueError(
-                "study manifest comparison intent is immutable; use a new study_id"
-            )
         if envelope["record_kind"] == "experiment_board_row":
             if not _same_board_row(old["payload"], envelope["payload"]):
                 raise ValueError("board-row supersession must preserve run identity")

--- a/tests/capabilities/test_benchmark_study_projection.py
+++ b/tests/capabilities/test_benchmark_study_projection.py
@@ -416,6 +416,11 @@ def test_supersession_preserves_producer_and_immutable_study_identity(
     )
     with pytest.raises(ValueError, match="immutable"):
         simulate_benchmark_upload(store, replacement, execute=True)
+    duplicate_identity = _envelope(
+        _manifest(), record_kind="study_manifest", key="manifest-v3"
+    )
+    with pytest.raises(ValueError, match="immutable"):
+        simulate_benchmark_upload(store, duplicate_identity, execute=True)
 
     insight = _envelope(
         _insight(), record_kind="case_insight_projection", key="insight-v1"


### PR DESCRIPTION
## Summary

- reject a second manifest for the same benchmark/study identity at the local-provider write boundary
- preserve idempotent replay of the original manifest
- require changed experiment design to use a new `study_id`

This is the final narrow authority follow-up to #3846 and #3849. It changes no scoring, runner, external provider, or benchmark data.

## Validation

- `/usr/bin/python3 -m ruff check loopx/capabilities/benchmark_toolkit/study_projection.py tests/capabilities/test_benchmark_study_projection.py`
- `/usr/bin/python3 -m pytest -q tests/capabilities/test_benchmark_study_projection.py tests/capabilities/test_benchmark_toolkit.py` — 111 passed
- `git diff --check`
- public/private boundary scan — clean

## Review focus

Verify that a same-record retry still replays before this rule runs, while a different idempotency key for the same study manifest fails closed before corrupting local provider state.
