### PR TITLE
docs: repair governance links to project policies

### DIFF
--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -199,6 +199,6 @@ agent trajectories do not belong in that public record.
 
 This charter does not create a legal entity, employment relationship,
 copyright assignment, or trademark registration. See
-[`AUTHORS.md`](../AUTHORS.md) for attribution,
-[`TRADEMARKS.md`](../TRADEMARKS.md) for name and mark usage, and
+[Authors and Contributors](../docs/project/authors.md) for attribution,
+[Name and Marks](../docs/project/trademarks.md) for name and mark usage, and
 [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the contribution workflow.


### PR DESCRIPTION
## Summary

Repair the governance charter's links to contributor attribution and name/mark usage. The root-level AUTHORS.md and TRADEMARKS.md no longer exist; both documents now live under docs/project/.

## Issue Or Task

Small documentation correction under the direct-PR exception in CONTRIBUTING.md.

## Validation

- All five local Markdown links in .github/GOVERNANCE.md resolve to existing files.
- The focused public-boundary scan passed with zero errors. It reports two expected warnings because this fresh checkout has no runtime registry.
- git diff --check passed.

## Type of Change

- [x] Documentation update

## LoopX Area

- [x] Public docs or presentation surface

Target base branch: main. This changes only two link labels and targets; no first-screen layout, runtime behavior, or policy text changes. No related refactor is needed for this link correction.

## Boundary Checklist

- [x] Only the public governance document is included.
- [x] No maintainer-owned benchmark work or private state is included.
- [x] The change is scoped to the two broken links.
- [x] Every commit includes a DCO Signed-off-by trailer.
