### PR TITLE
docs(benchmark): generalize private network examples

### DIFF
--- a/benchmark/swe-marathon/skills/swe-marathon-five-arm/SKILL.md
+++ b/benchmark/swe-marathon/skills/swe-marathon-five-arm/SKILL.md
@@ -228,7 +228,7 @@ Docker compose command failed ... all predefined address pools have been fully s
 
 ### 五、docker 网段池 —— 一次废掉 12 条
 
-默认地址池只支持约 32 个 bridge 网络（172.17.0.0/12 切 /16 得 16 + 192.168.0.0/16 切 /20 得 16）。**机器是共用的**，别人常年占约 15 个，每个 trial 一个 compose 网络。撑爆后新 trial 直接死在环境启动。
+默认地址池只支持约 32 个 bridge 网络（一个 RFC 1918 私网池切成 16 个子网，另一个私网池再切成 16 个子网）。**机器是共用的**，别人常年占约 15 个，每个 trial 一个 compose 网络。撑爆后新 trial 直接死在环境启动。
 
 泄漏源常常是自己：**`docker rm -f` 只删容器，不删 compose 网络**。清理容器时必须连网络一起清。
 

--- a/benchmark/swe-marathon/skills/tb4-five-arm/SKILL.md
+++ b/benchmark/swe-marathon/skills/tb4-five-arm/SKILL.md
@@ -87,7 +87,7 @@ TB4 的 66 个 `task.toml` **一个都没有声明 `network_mode` / `allow_inter
 **另注：`--allow-agent-host` 在 public 下是空操作。** 实测 harbor 会打印
 
 ```
-UserWarning: Run-specific allowlist host(s) ['<model-gateway>', '172.17.0.1'] are
+UserWarning: Run-specific allowlist host(s) ['<model-gateway>', '<container-gateway>'] are
 ignored because the effective network policy is public.
 ```
 


### PR DESCRIPTION
## Summary

- preserve the SWE Marathon Docker network-capacity guidance without publishing literal private network addresses
- replace the run-specific container gateway address in the TB4 warning example with a semantic placeholder
- restore the repository public-boundary check required by latest-main benchmark admission

## Validation

- `git diff --check origin/main...HEAD`
- `scripts/loopx --format json check --scan-root <clean-worktree>` — 3035 files scanned, 0 errors
- `python3 examples/control_plane/control-plane-maintainability-ratchet-smoke.py`
- `python3 examples/benchmark-run-permission-policy-smoke.py`
- `python3 examples/benchmark-candidate-source-boundary-smoke.py`
- `python3 -m compileall -q loopx`

## Premerge review

- changed surfaces: two public benchmark skill documents only
- failures/skips: none
- manual hold: the generic premerge classifier marks every `benchmark/` path as benchmark-sensitive and requests explicit maintainer review
- coverage rationale: this PR changes no runner, scoring, task semantics, permission boundary, or benchmark launch behavior; the exact failing full-repository boundary scan now passes, and benchmark boundary canaries remain green
- merge decision: eligible for maintainer-authorized narrow documentation self-merge after exact-head review
