### PR TITLE
fix(codex): qualify heartbeat transport semantics

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -12,6 +12,8 @@ Runtime status: `codex_provider_routing_runtime_status_v0`
 
 Integration candidate: `codex_provider_integration_candidate_v0`
 
+Heartbeat transport qualification: `codex_app_heartbeat_transport_qualification_v0`
+
 The provider accepts exactly one public-safe operation per invocation and
 returns a deterministic JSON result. An input containing credential-shaped
 keys fails before any operation runs.
@@ -20,6 +22,14 @@ The provider has no Kernel transition authority and no external write
 permission. A qualification result is evidence, not permission to edit a
 Codex home, install CPA, change a model, start a turn, rotate a credential or
 merge an upstream PR.
+
+Heartbeat qualification accepts only symbolic, content-free shape facts. For
+an `automation_heartbeat` carrying a `heartbeat_xml` envelope, the conforming
+delivery is `user_input` with `message_role=user`. A `tool_output` observation
+is non-conforming because it changes the semantic role of the scheduler event;
+the provider reports a stable failure code and never recommends prompt or model
+tuning as remediation. App inspection, binary changes and process lifecycle
+remain outside this read-only extension.
 
 The integration-candidate operation composes with, but does not replace,
 LoopX core `integration-branch`. It accepts only public Git refs, full commit

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -50,6 +50,14 @@ qualification.
   modality-aware affinity, typed route traversal, durable settings revision and
   commit barrier.
 
+`qualify_heartbeat_transport`
+: Checks a content-free host observation for one scheduler-injected heartbeat.
+  A heartbeat envelope must enter the turn as user input with `role=user`.
+  Encoding it as a tool result, especially as an `automation_update` result,
+  fails with a stable code and assigns remediation to the Codex App heartbeat
+  transport rather than to the LoopX prompt or model provider. This operation
+  diagnoses the boundary; it does not patch, restart or modify Codex App.
+
 `project_runtime_status`
 : Joins a stable, route-independent host ChatGPT identity state with a
   content-free CPA execution observation and symbolic A/B quota/activity.
@@ -85,6 +93,10 @@ loopx extension run loopx-codex-provider-routing \
   --format json
 loopx extension run loopx-codex-provider-routing \
   --input-json packages/loopx-codex-provider-routing/examples/normalize-request.json \
+  --execute \
+  --format json
+loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/heartbeat-transport.json \
   --execute \
   --format json
 loopx extension run loopx-codex-provider-routing \

--- a/packages/loopx-codex-provider-routing/examples/heartbeat-transport.json
+++ b/packages/loopx-codex-provider-routing/examples/heartbeat-transport.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "loopx_codex_provider_routing_request_v0",
+  "operation": "qualify_heartbeat_transport",
+  "heartbeat_transport": {
+    "turn_trigger": "automation_heartbeat",
+    "payload_kind": "heartbeat_xml",
+    "delivery_kind": "user_input",
+    "message_role": "user"
+  }
+}

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.4.0"
+version = "0.5.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.4.0"
+version = "0.5.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/schemas/request.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/request.schema.json
@@ -5,8 +5,25 @@
     {
       "properties": {
         "operation": {
+          "const": "qualify_heartbeat_transport"
+        },
+        "integration": false,
+        "normalization": false,
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "upgrade": false
+      },
+      "required": [
+        "heartbeat_transport"
+      ]
+    },
+    {
+      "properties": {
+        "operation": {
           "const": "reconcile_integration_candidate"
         },
+        "heartbeat_transport": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
@@ -22,6 +39,7 @@
         "operation": {
           "const": "project_runtime_status"
         },
+        "heartbeat_transport": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
@@ -37,6 +55,7 @@
         "operation": {
           "const": "compile_catalog"
         },
+        "heartbeat_transport": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
@@ -52,6 +71,7 @@
         "operation": {
           "const": "normalize_selector_request"
         },
+        "heartbeat_transport": false,
         "integration": false,
         "snapshot": false,
         "source": false,
@@ -67,6 +87,7 @@
         "operation": {
           "const": "qualify_snapshot"
         },
+        "heartbeat_transport": false,
         "integration": false,
         "normalization": false,
         "source": false,
@@ -82,6 +103,7 @@
         "operation": {
           "const": "upgrade_plan"
         },
+        "heartbeat_transport": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
@@ -94,11 +116,15 @@
     }
   ],
   "properties": {
+    "heartbeat_transport": {
+      "type": "object"
+    },
     "operation": {
       "enum": [
         "compile_catalog",
         "normalize_selector_request",
         "project_runtime_status",
+        "qualify_heartbeat_transport",
         "qualify_snapshot",
         "reconcile_integration_candidate",
         "upgrade_plan"

--- a/packages/loopx-codex-provider-routing/schemas/response.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/response.schema.json
@@ -45,6 +45,7 @@
         "compile_catalog",
         "normalize_selector_request",
         "project_runtime_status",
+        "qualify_heartbeat_transport",
         "qualify_snapshot",
         "reconcile_integration_candidate",
         "upgrade_plan"

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -21,6 +21,7 @@ build_upgrade_plan = contract.build_upgrade_plan
 compile_catalog = contract.compile_catalog
 normalize_selector_request = contract.normalize_selector_request
 project_runtime_status = contract.project_runtime_status
+qualify_heartbeat_transport = contract.qualify_heartbeat_transport
 qualify_snapshot = contract.qualify_snapshot
 reconcile_integration_candidate = contract.reconcile_integration_candidate
 
@@ -191,6 +192,44 @@ def expect_error(action: Callable[[], Any], message: str) -> None:
 
 
 def main() -> int:
+    heartbeat = qualify_heartbeat_transport(
+        {
+            "turn_trigger": "automation_heartbeat",
+            "payload_kind": "heartbeat_xml",
+            "delivery_kind": "user_input",
+            "message_role": "user",
+        }
+    )
+    assert heartbeat["qualified"] is True
+    assert heartbeat["prompt_or_model_remediation"] is False
+
+    mislabeled_heartbeat = qualify_heartbeat_transport(
+        {
+            "turn_trigger": "automation_heartbeat",
+            "payload_kind": "heartbeat_xml",
+            "delivery_kind": "tool_output",
+            "tool_name": "automation_update",
+        }
+    )
+    assert mislabeled_heartbeat["qualified"] is False
+    assert mislabeled_heartbeat["failure_code"] == (
+        "heartbeat_mislabeled_as_automation_tool_output"
+    )
+    assert mislabeled_heartbeat["responsible_layer"] == (
+        "codex_app_heartbeat_transport"
+    )
+    expect_error(
+        lambda: qualify_heartbeat_transport(
+            {
+                "turn_trigger": "automation_heartbeat",
+                "payload_kind": "heartbeat_xml",
+                "delivery_kind": "user_input",
+                "message_role": "assistant",
+            }
+        ),
+        "heartbeat user input accepted a non-user role",
+    )
+
     catalog = compile_catalog(_source())
     assert catalog["credential_free"] is True
     auto = next(
@@ -607,6 +646,7 @@ def main() -> int:
         "normalize-request.json",
         "runtime-status.json",
         "qualification-snapshot.json",
+        "heartbeat-transport.json",
         "integration-candidate.json",
         "upgrade-request.json",
     ):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -13,6 +13,7 @@ from .contract import (
     compile_catalog,
     normalize_selector_request,
     project_runtime_status,
+    qualify_heartbeat_transport,
     qualify_snapshot,
     reconcile_integration_candidate,
     reject_private_material,
@@ -45,6 +46,7 @@ def _doctor() -> int:
                 "compile_catalog",
                 "normalize_selector_request",
                 "project_runtime_status",
+                "qualify_heartbeat_transport",
                 "qualify_snapshot",
                 "reconcile_integration_candidate",
                 "upgrade_plan",
@@ -66,6 +68,7 @@ def _run_request(request: Any) -> dict[str, Any]:
         "compile_catalog": "source",
         "normalize_selector_request": "normalization",
         "project_runtime_status": "status",
+        "qualify_heartbeat_transport": "heartbeat_transport",
         "qualify_snapshot": "snapshot",
         "reconcile_integration_candidate": "integration",
         "upgrade_plan": "upgrade",
@@ -95,6 +98,13 @@ def _run_request(request: Any) -> dict[str, Any]:
         if not isinstance(status, Mapping):
             raise ValueError("project_runtime_status requires object `status`")
         result = project_runtime_status(status)
+    elif operation == "qualify_heartbeat_transport":
+        heartbeat_transport = request.get("heartbeat_transport")
+        if not isinstance(heartbeat_transport, Mapping):
+            raise ValueError(
+                "qualify_heartbeat_transport requires object `heartbeat_transport`"
+            )
+        result = qualify_heartbeat_transport(heartbeat_transport)
     elif operation == "qualify_snapshot":
         snapshot = request.get("snapshot")
         if not isinstance(snapshot, Mapping):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -10,6 +10,7 @@ RUNTIME_STATUS_SCHEMA_VERSION = "codex_provider_routing_runtime_status_v0"
 REQUEST_SCHEMA_VERSION = "loopx_codex_provider_routing_request_v0"
 RESPONSE_SCHEMA_VERSION = "loopx_codex_provider_routing_response_v0"
 INTEGRATION_CANDIDATE_SCHEMA_VERSION = "codex_provider_integration_candidate_v0"
+HEARTBEAT_TRANSPORT_SCHEMA_VERSION = "codex_app_heartbeat_transport_qualification_v0"
 
 FORBIDDEN_KEYS = {
     "account_id",
@@ -94,6 +95,73 @@ def _boolean(value: Any, field: str, *, default: bool | None = None) -> bool:
     if not isinstance(value, bool):
         raise TypeError(f"{field} must be a boolean")
     return value
+
+
+def qualify_heartbeat_transport(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Check the host boundary used to inject one scheduled heartbeat turn."""
+
+    reject_private_material(observation)
+    _reject_unexpected_keys(
+        observation,
+        {"turn_trigger", "payload_kind", "delivery_kind", "message_role", "tool_name"},
+        "heartbeat_transport",
+    )
+    turn_trigger = _non_empty_string(
+        observation.get("turn_trigger"), "heartbeat_transport.turn_trigger"
+    )
+    if turn_trigger != "automation_heartbeat":
+        raise ValueError(
+            "heartbeat_transport.turn_trigger must be automation_heartbeat"
+        )
+    payload_kind = _non_empty_string(
+        observation.get("payload_kind"), "heartbeat_transport.payload_kind"
+    )
+    if payload_kind != "heartbeat_xml":
+        raise ValueError("heartbeat_transport.payload_kind must be heartbeat_xml")
+    delivery_kind = _non_empty_string(
+        observation.get("delivery_kind"), "heartbeat_transport.delivery_kind"
+    )
+    if delivery_kind not in {"user_input", "tool_output"}:
+        raise ValueError(
+            "heartbeat_transport.delivery_kind must be user_input or tool_output"
+        )
+
+    message_role = observation.get("message_role")
+    tool_name = observation.get("tool_name")
+    if delivery_kind == "user_input":
+        if message_role != "user":
+            raise ValueError("heartbeat user_input must declare message_role=user")
+        if tool_name is not None:
+            raise ValueError("heartbeat user_input must not declare tool_name")
+        qualified = True
+        failure_code = None
+    else:
+        if message_role is not None:
+            raise ValueError("heartbeat tool_output must not declare message_role")
+        tool_name = _non_empty_string(tool_name, "heartbeat_transport.tool_name")
+        qualified = False
+        failure_code = (
+            "heartbeat_mislabeled_as_automation_tool_output"
+            if tool_name == "automation_update"
+            else "heartbeat_injected_as_tool_output"
+        )
+
+    return {
+        "schema_version": HEARTBEAT_TRANSPORT_SCHEMA_VERSION,
+        "qualified": qualified,
+        "failure_code": failure_code,
+        "required_delivery": {
+            "delivery_kind": "user_input",
+            "message_role": "user",
+        },
+        "observed_delivery": {
+            "delivery_kind": delivery_kind,
+            "message_role": message_role,
+            "tool_name": tool_name,
+        },
+        "responsible_layer": "codex_app_heartbeat_transport",
+        "prompt_or_model_remediation": False,
+    }
 
 
 def _reject_unexpected_keys(


### PR DESCRIPTION
## Summary

- add a public-safe Codex App heartbeat transport conformance check
- require scheduled heartbeat envelopes to enter a turn as user input with `role=user`
- classify tool-output injection, including `automation_update`, with stable failure codes and the correct host-transport owner
- keep the extension read-only: no App inspection, binary patching, restart, prompt mutation, or provider credential access

## Validation

- `python packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py`
- `pytest -q tests/extensions/test_colocated_extension_layout.py` (2 passed)
- request/response JSON Schema validation for conforming and failing observations
- Ruff check and format check on touched Python
- `loopx check --scan-path packages/loopx-codex-provider-routing` (public boundary clean; unrelated registry warnings only)
- `loopx canary premerge --from-git-diff` (17 selected checks passed, no failures or manual holds)

## Boundary

No local paths, private rollout evidence, credentials, raw prompts, or proprietary app bundle code are included. This PR productizes diagnosis and conformance only; remediation of the host transport remains owned by Codex App.
