### PR TITLE
fix(desktop): preserve listener self-heal across entrypoints

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -45,6 +45,12 @@ confirmed, startup fails closed without sending a termination signal. Unknown
 services remain a hard error. Windows currently keeps this owner-facing error
 path instead of terminating an existing process automatically.
 
+Release launchers publish a stable process fingerprint that is independent of
+their internal Python entry module. The shell also recognizes the historical
+fixed-CLI and lightweight-entrypoint launcher shapes, so upgrading LoopX can
+replace an already-running older service without asking the operator to find
+and stop it manually.
+
 The WebView is pinned to the loopback Chat origin served by the installed
 LoopX release. Dashboard requests to the status and Chat services remain
 restricted to loopback CORS and the existing preview/apply authority boundary.

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -234,8 +234,15 @@ enum LoopxProcessInvocation {
     ManagedReleaseLauncher,
 }
 
-const MANAGED_RELEASE_LAUNCHER_MARKER: &str =
-    r#"runpy.run_module("loopx.cli", run_name="__main__")"#;
+/// Stable process fingerprint emitted by release launchers. The Desktop must
+/// not couple stale-service recovery to the launcher's current Python module:
+/// changing `loopx.cli` to `loopx.entrypoint` must not strand an older daemon.
+const MANAGED_RELEASE_LAUNCHER_MARKER: &str = "LOOPX_MANAGED_RELEASE_LAUNCHER_V1";
+const LEGACY_CLI_LAUNCHER_MARKER: &str = r#"runpy.run_module("loopx.cli", run_name="__main__")"#;
+const ENTRYPOINT_LAUNCHER_MODULE_MARKER: &str = r#""loopx.entrypoint""#;
+const DYNAMIC_MODULE_LAUNCH_MARKER: &str = r#"runpy.run_module(module, run_name="__main__")"#;
+const RELEASE_ARGV_ZERO_MARKER: &str =
+    r#"sys.argv[0] = os.path.join(release_root, "scripts", "loopx")"#;
 
 fn terminate_stale_listener(
     kind: ServiceKind,
@@ -398,22 +405,36 @@ fn classify_loopx_process_invocation(
     if executable_is_direct {
         return Some(LoopxProcessInvocation::DirectExecutable);
     }
-    if interpreter_is_python && arguments.windows(2).any(|pair| pair == ["-m", "loopx.cli"]) {
+    if interpreter_is_python
+        && arguments
+            .windows(2)
+            .any(|pair| pair == ["-m", "loopx.cli"] || pair == ["-m", "loopx.entrypoint"])
+    {
         return Some(LoopxProcessInvocation::PythonModule);
     }
 
-    // Installed LoopX wrappers intentionally exec Python with a stable `-c`
-    // bootstrap. `ps` exposes that bootstrap instead of the wrapper path, so
-    // the exact module-launch statement and release-root contract are the
-    // durable positive fingerprint for this typed invocation variant.
     if interpreter_is_python
         && arguments.contains(&"-c")
-        && command_line.contains(MANAGED_RELEASE_LAUNCHER_MARKER)
-        && command_line.contains("LOOPX_RELEASE_ROOT")
+        && is_managed_release_launcher(command_line)
     {
         return Some(LoopxProcessInvocation::ManagedReleaseLauncher);
     }
     None
+}
+
+fn is_managed_release_launcher(command_line: &str) -> bool {
+    if !command_line.contains("LOOPX_RELEASE_ROOT") {
+        return false;
+    }
+
+    // New release launchers carry an entrypoint-independent marker. Preserve
+    // both historical templates so an App installed after this fix can still
+    // replace daemons started before the marker existed.
+    command_line.contains(MANAGED_RELEASE_LAUNCHER_MARKER)
+        || command_line.contains(LEGACY_CLI_LAUNCHER_MARKER)
+        || (command_line.contains(ENTRYPOINT_LAUNCHER_MODULE_MARKER)
+            && command_line.contains(DYNAMIC_MODULE_LAUNCH_MARKER)
+            && command_line.contains(RELEASE_ARGV_ZERO_MARKER))
 }
 
 fn paths_refer_to_same_file(candidate: &str, expected: &str) -> bool {

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
@@ -94,6 +94,18 @@ fn stale_listener_process_must_match_loopx_command_and_port() {
         8766,
         r#"/opt/loopx/bin/python -c import os\012import runpy\012release_root = os.environ["LOOPX_RELEASE_ROOT"]\012runpy.run_module("loopx.cli", run_name="__main__")\012 --registry /tmp/registry.json serve-status --global-registry --host 127.0.0.1 --port 8766 --limit 80"#,
     ));
+    assert!(is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        r#"/opt/loopx/bin/python -c import os\012import runpy\012release_root = os.environ["LOOPX_RELEASE_ROOT"]\012sys.argv[0] = os.path.join(release_root, "scripts", "loopx")\012module = (\012    "loopx.entrypoint"\012    if os.path.isfile(os.path.join(release_root, "loopx", "entrypoint.py"))\012    else "loopx.cli"\012)\012runpy.run_module(module, run_name="__main__")\012 --registry /tmp/registry.json serve-status --global-registry --host 127.0.0.1 --port 8766 --limit 80"#,
+    ));
+    assert!(is_expected_loopx_listener_command(
+        ServiceKind::Chat,
+        executable,
+        8767,
+        r#"/opt/loopx/bin/python -c LOOPX_MANAGED_RELEASE_LAUNCHER_V1 = True\012release_root = os.environ["LOOPX_RELEASE_ROOT"]\012runpy.run_module(next_module, run_name="__main__")\012 --registry /tmp/registry.json chat --global-registry --host 127.0.0.1 --port 8767 --no-open"#,
+    ));
     assert!(!is_expected_loopx_listener_command(
         ServiceKind::Status,
         executable,
@@ -130,6 +142,21 @@ fn stale_listener_process_must_match_loopx_command_and_port() {
         8766,
         r#"/opt/loopx/bin/python -c runpy.run_module("other.cli", run_name="__main__") serve-status --port 8766"#,
     ));
+    assert!(!is_expected_loopx_listener_command(
+        ServiceKind::Status,
+        executable,
+        8766,
+        r#"/opt/loopx/bin/python -c release_root = os.environ["LOOPX_RELEASE_ROOT"]\012print("loopx.entrypoint")\012runpy.run_module(module, run_name="__main__") serve-status --port 8766"#,
+    ));
+}
+
+#[test]
+fn release_launchers_publish_the_stable_process_fingerprint() {
+    let posix_launcher = include_str!("../../../../../scripts/loopx");
+    let portable_entry = include_str!("../../../../../scripts/loopx_entry.py");
+
+    assert!(posix_launcher.contains(MANAGED_RELEASE_LAUNCHER_MARKER));
+    assert!(portable_entry.contains(MANAGED_RELEASE_LAUNCHER_MARKER));
 }
 
 #[test]

--- a/scripts/loopx
+++ b/scripts/loopx
@@ -94,6 +94,10 @@ import os
 import runpy
 import sys
 
+# Stable process identity for LoopX Desktop stale-service recovery. Keep this
+# independent from the selected Python entry module.
+LOOPX_MANAGED_RELEASE_LAUNCHER_V1 = True
+
 if sys.version_info < (3, 11):
     print(
         "loopx runtime error: Python 3.11+ is required; "

--- a/scripts/loopx_entry.py
+++ b/scripts/loopx_entry.py
@@ -5,6 +5,10 @@ from pathlib import Path
 import runpy
 import sys
 
+# Stable process identity shared with the POSIX release launcher and LoopX
+# Desktop stale-service recovery. Keep it independent from the entry module.
+LOOPX_MANAGED_RELEASE_LAUNCHER_V1 = True
+
 
 def main() -> int:
     if sys.version_info < (3, 11):

--- a/tests/test_cli_entrypoint.py
+++ b/tests/test_cli_entrypoint.py
@@ -314,6 +314,8 @@ def test_release_launchers_use_lightweight_entrypoint() -> None:
 	posix_launcher = (REPO_ROOT / "scripts" / "loopx").read_text(encoding="utf-8")
 	windows_entry = (REPO_ROOT / "scripts" / "loopx_entry.py").read_text(encoding="utf-8")
 
+	assert "LOOPX_MANAGED_RELEASE_LAUNCHER_V1" in posix_launcher
+	assert "LOOPX_MANAGED_RELEASE_LAUNCHER_V1" in windows_entry
 	assert '"loopx.entrypoint"' in posix_launcher
 	assert '"loopx.entrypoint"' in windows_entry
 	assert 'else "loopx.cli"' in posix_launcher


### PR DESCRIPTION
## Summary

- recognize both historical release-launcher shapes when replacing a stale LoopX status or Chat listener
- add an entrypoint-independent process fingerprint to future POSIX and portable release launchers
- keep unknown processes fail-closed while restoring automatic App startup recovery after CLI upgrades

## Root cause

The Desktop already verified the old service's typed HTTP fingerprint and detected its stale `runtime_identity`. Before terminating it, the process guard still required the historical fixed `runpy.run_module("loopx.cli", ...)` launcher text. The lightweight CLI refactor changed the managed release wrapper to select `loopx.entrypoint` dynamically, so a genuine stale LoopX daemon failed the second ownership check and left the operator with an unrecoverable startup dialog.

## Product and architecture judgment

Known LoopX service replacement remains automatic because it is local, reversible, and already bounded by the service fingerprint, expected command, exact port, and process-shape checks. Foreign or ambiguous listeners remain a hard error and are never terminated. A stable launcher marker decouples future process ownership checks from internal Python entry-module refactors, while explicit legacy recognition lets a newly installed App recover daemons started before the marker existed.

## Validation

- `cargo fmt --check`
- `cargo test` — 11 passed
- `cargo clippy --all-targets -- -D warnings`
- `python -m pytest -q tests/test_cli_entrypoint.py` — 17 passed
- `bash -n scripts/loopx`
- `python3 -m py_compile scripts/loopx_entry.py`
- `LOOPX_PYTHON=<Python 3.11+> ./scripts/loopx canary premerge --from-git-diff --git-diff-base origin/main` — 18/18 selected checks passed, no warnings or manual holds; self-merge allowed

## Boundary

- no arbitrary listener termination or weakened foreign-process guard
- no Goal, Todo, quota, permission, benchmark, or public-evidence semantics changed
- no private runtime state, local process output, credentials, or machine-specific paths committed
