### PR TITLE
fix(ci): repair public smoke regressions

### DIFF
--- a/examples/project/next-action-projection-contract-smoke.py
+++ b/examples/project/next-action-projection-contract-smoke.py
@@ -27,6 +27,7 @@ from loopx.status import collect_status
 
 GOAL_ID = "next-action-projection-goal"
 ACTIVE_NEXT_ACTION = "Keep the durable route on the broad public PoC lane."
+PRIMARY_AGENT_ACTION = "Validate the primary public PoC control-plane lane."
 RUN_RECOMMENDATION = "Inspect the vliw suite result before changing the durable route."
 UPDATED_NEXT_ACTION = "Promote the vliw repair slice as the durable next action."
 UPDATED_RUN_RECOMMENDATION = "Validate the vliw repair slice and then write compact evidence."
@@ -221,9 +222,13 @@ def main() -> None:
                 dry_run=True,
                 sync_global=False,
             )
-            assert implicit_payload["recommended_action"] == ACTIVE_NEXT_ACTION, implicit_payload
             assert (
-                implicit_payload["recommended_action_source"] == "active_state_next_action"
+                implicit_payload["recommended_action"]
+                == f"[P0] {PRIMARY_AGENT_ACTION}"
+            ), implicit_payload
+            assert (
+                implicit_payload["recommended_action_source"]
+                == "agent_lane_selected_todo"
             ), implicit_payload
             assert implicit_payload.get("active_state_next_action_update") is None, implicit_payload
 
@@ -425,10 +430,11 @@ def main() -> None:
             )
             assert (
                 fallback_payload["recommended_action"]
-                == "[P0] Validate the primary public PoC control-plane lane."
+                == f"[P0] {PRIMARY_AGENT_ACTION}"
             ), fallback_payload
             assert (
-                fallback_payload["recommended_action_source"] == "agent_todo_fallback"
+                fallback_payload["recommended_action_source"]
+                == "agent_lane_selected_todo"
             ), fallback_payload
     finally:
         state_refresh.now_local = original_now_local

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -53,6 +53,7 @@ from .lark_inbox import (
     build_lark_operator_inbox_urgency_projector,
     dispatch_goal_lark_turn_start_hooks,
 )
+from .turn_dsh_host import build_dsh_host_runner
 from .turn_registration import register_turn_commands as register_turn_commands
 from .turn_inspection import handle_turn_journal_inspection
 from .turn_rendering import (
@@ -902,7 +903,7 @@ def handle_turn_command(
                     }
                 )
 
-            host_runner = None
+            host_runner: Callable[[Mapping[str, Any]], dict[str, Any]] | None = None
             session_binding_resolver = None
             if args.host == "codex-cli":
 
@@ -928,41 +929,10 @@ def handle_turn_command(
 
                 session_binding_resolver = resolve_built_in_session_binding
             elif args.host == "dsh":
-                from ..dsh_goal_mode.turn_host_adapter import (
-                    DshHostConfig,
-                    run_dsh_host,
-                )
-
-                dsh_config = DshHostConfig(
+                host_runner = build_dsh_host_runner(
+                    args,
                     workspace=project,
-                    **{
-                        key: value
-                        for key, value in {
-                            "provider": args.dsh_provider,
-                            "model": args.dsh_model,
-                            "max_tokens": args.dsh_max_tokens,
-                            "dsh_home": (
-                                Path(args.dsh_home) if args.dsh_home else None
-                            ),
-                            "cordis": Path(args.dsh_cordis) if args.dsh_cordis else None,
-                            "runtime_bin": args.dsh_runtime_bin,
-                            "request_timeout_seconds": max(
-                                1.0, args.timeout_seconds - 5.0
-                            ),
-                            "dsh_runner": (
-                                Path(args.dsh_runner) if args.dsh_runner else None
-                            ),
-                        }.items()
-                        if value is not None
-                    },
                 )
-
-                def run_dsh_built_in_host(
-                    request: Mapping[str, Any],
-                ) -> dict[str, Any]:
-                    return run_dsh_host(request, config=dsh_config)
-
-                host_runner = run_dsh_built_in_host
 
             payload = run_loopx_turn_once(
                 payload,

--- a/loopx/cli_commands/turn_dsh_host.py
+++ b/loopx/cli_commands/turn_dsh_host.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping
+from pathlib import Path
+from typing import Any
+
+from ..dsh_goal_mode.turn_host_adapter import DshHostConfig, run_dsh_host
+
+
+DshHostRunner = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+def build_dsh_host_runner(
+    args: argparse.Namespace,
+    *,
+    workspace: Path,
+) -> DshHostRunner:
+    """Bind CLI-owned DSH options to the in-process Turn host adapter."""
+    config = DshHostConfig(
+        workspace=workspace,
+        **{
+            key: value
+            for key, value in {
+                "provider": args.dsh_provider,
+                "model": args.dsh_model,
+                "max_tokens": args.dsh_max_tokens,
+                "dsh_home": Path(args.dsh_home) if args.dsh_home else None,
+                "cordis": Path(args.dsh_cordis) if args.dsh_cordis else None,
+                "runtime_bin": args.dsh_runtime_bin,
+                "request_timeout_seconds": max(1.0, args.timeout_seconds - 5.0),
+                "dsh_runner": Path(args.dsh_runner) if args.dsh_runner else None,
+            }.items()
+            if value is not None
+        },
+    )
+
+    def run(request: Mapping[str, Any]) -> dict[str, Any]:
+        return run_dsh_host(request, config=config)
+
+    return run


### PR DESCRIPTION
## Summary

- keep `loopx/cli_commands/turn.py` within the public CLI line budget by moving DSH option binding into an owner-local helper
- update the next-action projection smoke to assert the agent-lane selected Todo introduced by the current routing contract

Fixes the two actionable failures from public-smoke run [33661571065](https://github.com/huangruiteng/loopx/actions/runs/33661571065).

## Validation

- `python -m mypy`
- `npm run typecheck:control-plane`
- `npm run test:control-plane` (453 passed, 1 environment-gated skip)
- focused Python Turn suite (169 passed)
- changed-file Ruff
- next-action projection and CLI output-budget smokes
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (16/16)
- public/private boundary scan and `git diff --check`

Change-quality receipt: `cqr_ff239c7088056e4b07d5`.