### PR TITLE
feat(periodic-report): publish incremental progress deltas

### DIFF
--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -87,6 +87,17 @@ closure, blocker, and manual triggers may bypass that interval. Concurrent
 material facts are coalesced into one report and previously covered trigger
 ids are deduplicated.
 
+Incremental reports advance from an exact, readback-verified publication
+cursor rather than from generated prose. The cursor keeps cumulative trigger
+ids and semantic fingerprints keyed by each fact's stable `source_ref`. A
+later stage includes only new facts and facts whose fingerprint changed;
+changed facts carry their prior status and kind so the editorial step can
+render a transition instead of repeating the old item. If no supplied fact is
+new or changed, the post-writeback producer emits no report intent. Local
+generation, approval, and failed or partial delivery never advance this
+cursor. A successful Goal Channel delivery records the predecessor
+publication identity for the next report.
+
 An enabled custom profile may also declare `trigger_policy.aggregation` with a
 bounded `window_seconds` and `stage_completion_required=true`. Stage completion
 reuses the existing goal-vision, outcome-checkpoint, and frontier-replan facts:

--- a/loopx/capabilities/periodic_report/incremental.py
+++ b/loopx/capabilities/periodic_report/incremental.py
@@ -1,0 +1,504 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ...file_lock import LockAcquisitionPolicy, exclusive_file_lock
+from ...registry import atomic_write_json, read_json
+
+
+PUBLICATION_CANDIDATE_SCHEMA = "periodic_report_publication_candidate_v0"
+PUBLICATION_CURSOR_SCHEMA = "periodic_report_publication_cursor_v0"
+INCREMENTAL_BASELINE_SCHEMA = "periodic_report_incremental_baseline_v0"
+
+_IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$")
+_SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+def _canonical_digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _identity(value: object, *, prefix: str) -> str:
+    return f"{prefix}_{_canonical_digest(value).split(':', 1)[1][:24]}"
+
+
+def _required_text(value: object, label: str, *, maximum: int = 500) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} is required")
+    if len(text) > maximum:
+        raise ValueError(f"{label} exceeds {maximum} characters")
+    return text
+
+
+def _identity_text(value: object, label: str) -> str:
+    text = _required_text(value, label, maximum=160)
+    if not _IDENTITY_RE.fullmatch(text):
+        raise ValueError(f"{label} must be a stable public identity")
+    return text
+
+
+def _timestamp(value: object, label: str) -> str:
+    text = _required_text(value, label, maximum=80)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{label} must include a UTC offset")
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _digest(value: object, label: str) -> str:
+    digest = _required_text(value, label, maximum=80)
+    if not _SHA256_RE.fullmatch(digest):
+        raise ValueError(f"{label} must use sha256")
+    return digest
+
+
+def _fact_state(raw: Mapping[str, Any], *, label: str) -> dict[str, str]:
+    source_ref = _required_text(raw.get("source_ref"), f"{label}.source_ref")
+    status = _required_text(
+        raw.get("status") or _effective_status(raw),
+        f"{label}.status",
+        maximum=80,
+    )
+    fingerprint = _digest(raw.get("fact_fingerprint"), f"{label}.fact_fingerprint")
+    content_kind = _required_text(
+        raw.get("content_kind") or _effective_content_kind(raw),
+        f"{label}.content_kind",
+        maximum=80,
+    )
+    return {
+        "source_ref": source_ref,
+        "status": status,
+        "content_kind": content_kind,
+        "fact_fingerprint": fingerprint,
+    }
+
+
+def _effective_status(item: Mapping[str, Any]) -> str:
+    supplied = str(item.get("status") or "").strip()
+    if supplied:
+        return supplied
+    return "open" if item.get("content_kind") == "next_action" else "done"
+
+
+def _effective_content_kind(item: Mapping[str, Any]) -> str:
+    supplied = str(item.get("content_kind") or "").strip()
+    if supplied:
+        return supplied
+    return "next_action" if _effective_status(item) == "open" else "outcome"
+
+
+def periodic_report_fact_fingerprint(item: Mapping[str, Any]) -> str:
+    """Return the stable semantic identity of one reportable project fact."""
+
+    identity = {
+        key: " ".join(str(item.get(key) or "").split())
+        for key in ("source_ref", "title", "summary", "content_kind", "status")
+    }
+    identity["status"] = _effective_status(item)
+    identity["content_kind"] = _effective_content_kind(item)
+    if not identity["source_ref"]:
+        raise ValueError("periodic-report fact source_ref is required")
+    return _canonical_digest(identity)
+
+
+def _cursor_path(runtime_root: Path, goal_id: str, agent_id: str) -> Path:
+    safe_goal = _identity_text(goal_id, "goal_id")
+    safe_agent = _identity_text(agent_id, "agent_id")
+    return (
+        runtime_root.expanduser().resolve()
+        / "goals"
+        / safe_goal
+        / "periodic_reports"
+        / "publication-cursors"
+        / f"{safe_agent}.json"
+    )
+
+
+def normalize_periodic_report_publication_cursor(
+    raw: Mapping[str, Any],
+) -> dict[str, Any]:
+    if raw.get("schema_version") != PUBLICATION_CURSOR_SCHEMA:
+        raise ValueError(f"publication cursor must use {PUBLICATION_CURSOR_SCHEMA}")
+    goal_id = _identity_text(raw.get("goal_id"), "publication_cursor.goal_id")
+    agent_id = _identity_text(raw.get("agent_id"), "publication_cursor.agent_id")
+    generation_id = _identity_text(
+        raw.get("generation_id"), "publication_cursor.generation_id"
+    )
+    publication_id = _identity_text(
+        raw.get("publication_id"), "publication_cursor.publication_id"
+    )
+    delivered_at = _timestamp(
+        raw.get("delivered_at"), "publication_cursor.delivered_at"
+    )
+    covered_until = _timestamp(
+        raw.get("covered_until"), "publication_cursor.covered_until"
+    )
+    covered = sorted(
+        {
+            _identity_text(value, "publication_cursor.covered_trigger_ids[]")
+            for value in raw.get("covered_trigger_ids") or []
+        }
+    )
+    facts: dict[str, dict[str, str]] = {}
+    raw_facts = raw.get("fact_states")
+    if not isinstance(raw_facts, Sequence) or isinstance(raw_facts, (str, bytes)):
+        raise ValueError("publication_cursor.fact_states must be a list")
+    for index, value in enumerate(raw_facts):
+        if not isinstance(value, Mapping):
+            raise ValueError("publication_cursor.fact_states must contain objects")
+        fact = _fact_state(value, label=f"publication_cursor.fact_states[{index}]")
+        if fact["source_ref"] in facts:
+            raise ValueError("publication_cursor.fact_states contains duplicates")
+        facts[fact["source_ref"]] = fact
+    normalized: dict[str, Any] = {
+        "schema_version": PUBLICATION_CURSOR_SCHEMA,
+        "cursor_id": "",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "generation_id": generation_id,
+        "publication_id": publication_id,
+        "delivered_at": delivered_at,
+        "covered_until": covered_until,
+        "covered_trigger_ids": covered,
+        "fact_states": [facts[key] for key in sorted(facts)],
+    }
+    predecessor = str(raw.get("predecessor_publication_id") or "").strip()
+    if predecessor:
+        normalized["predecessor_publication_id"] = _identity_text(
+            predecessor, "publication_cursor.predecessor_publication_id"
+        )
+    normalized["cursor_id"] = _identity(
+        {key: value for key, value in normalized.items() if key != "cursor_id"},
+        prefix="report_cursor",
+    )
+    if raw.get("cursor_id") != normalized["cursor_id"]:
+        raise ValueError("publication_cursor.cursor_id does not match contents")
+    return normalized
+
+
+def read_periodic_report_publication_cursor(
+    *, runtime_root: Path, goal_id: str, agent_id: str
+) -> dict[str, Any] | None:
+    path = _cursor_path(runtime_root, goal_id, agent_id)
+    return _read_periodic_report_publication_cursor_path(
+        path=path,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+
+
+def _read_periodic_report_publication_cursor_path(
+    *, path: Path, goal_id: str, agent_id: str
+) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    value = read_json(path)
+    if not isinstance(value, Mapping):
+        raise ValueError("periodic-report publication cursor must be an object")
+    cursor = normalize_periodic_report_publication_cursor(value)
+    if cursor["goal_id"] != goal_id or cursor["agent_id"] != agent_id:
+        raise ValueError("periodic-report publication cursor identity changed")
+    return cursor
+
+
+def periodic_report_incremental_baseline(
+    cursor: Mapping[str, Any] | None,
+) -> dict[str, str] | None:
+    if cursor is None:
+        return None
+    normalized = normalize_periodic_report_publication_cursor(cursor)
+    return _normalize_incremental_baseline(
+        {
+            "schema_version": INCREMENTAL_BASELINE_SCHEMA,
+            "cursor_id": normalized["cursor_id"],
+            "predecessor_generation_id": normalized["generation_id"],
+            "predecessor_publication_id": normalized["publication_id"],
+            "delivered_at": normalized["delivered_at"],
+            "covered_until": normalized["covered_until"],
+        }
+    )
+
+
+def _normalize_incremental_baseline(raw: Mapping[str, Any]) -> dict[str, str]:
+    if raw.get("schema_version") != INCREMENTAL_BASELINE_SCHEMA:
+        raise ValueError(f"incremental baseline must use {INCREMENTAL_BASELINE_SCHEMA}")
+    return {
+        "schema_version": INCREMENTAL_BASELINE_SCHEMA,
+        "cursor_id": _identity_text(raw.get("cursor_id"), "baseline.cursor_id"),
+        "predecessor_generation_id": _identity_text(
+            raw.get("predecessor_generation_id"),
+            "baseline.predecessor_generation_id",
+        ),
+        "predecessor_publication_id": _identity_text(
+            raw.get("predecessor_publication_id"),
+            "baseline.predecessor_publication_id",
+        ),
+        "delivered_at": _timestamp(raw.get("delivered_at"), "baseline.delivered_at"),
+        "covered_until": _timestamp(raw.get("covered_until"), "baseline.covered_until"),
+    }
+
+
+def select_incremental_project_progress(
+    snapshot: Mapping[str, Any],
+    *,
+    cursor: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Select only facts absent from, or changed since, a published cursor."""
+
+    items = snapshot.get("items")
+    if not isinstance(items, list):
+        raise ValueError("periodic-report progress snapshot items are invalid")
+    previous = {}
+    baseline = periodic_report_incremental_baseline(cursor)
+    if cursor is not None:
+        normalized = normalize_periodic_report_publication_cursor(cursor)
+        previous = {item["source_ref"]: item for item in normalized["fact_states"]}
+    selected: list[dict[str, Any]] = []
+    for raw in items:
+        if not isinstance(raw, Mapping):
+            raise ValueError("periodic-report progress snapshot item is invalid")
+        item = dict(raw)
+        fingerprint = periodic_report_fact_fingerprint(item)
+        source_ref = str(item.get("source_ref") or "").strip()
+        prior = previous.get(source_ref)
+        if prior and prior["fact_fingerprint"] == fingerprint:
+            continue
+        item["fact_fingerprint"] = fingerprint
+        item["change_kind"] = "changed" if prior else "added"
+        if prior:
+            item["previous_status"] = prior["status"]
+            item["previous_content_kind"] = prior["content_kind"]
+            item["previous_fact_fingerprint"] = prior["fact_fingerprint"]
+        selected.append(item)
+    if not selected:
+        return None
+    result = dict(snapshot)
+    result["items"] = selected
+    if baseline is not None:
+        result["incremental_baseline"] = baseline
+    return result
+
+
+def build_periodic_report_publication_candidate(
+    *,
+    goal_id: str,
+    agent_id: str,
+    generation_id: str,
+    trigger_receipt: Mapping[str, Any],
+    facts: Sequence[Mapping[str, Any]],
+    baseline: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    normalized_facts: dict[str, dict[str, str]] = {}
+    for index, raw in enumerate(facts):
+        item = dict(raw)
+        item.setdefault("fact_fingerprint", periodic_report_fact_fingerprint(item))
+        state = _fact_state(item, label=f"facts[{index}]")
+        normalized_facts[state["source_ref"]] = state
+    covered = sorted(
+        {
+            _identity_text(value, "trigger_receipt.coalesced_trigger_ids[]")
+            for value in trigger_receipt.get("coalesced_trigger_ids") or []
+        }
+    )
+    candidate: dict[str, Any] = {
+        "schema_version": PUBLICATION_CANDIDATE_SCHEMA,
+        "candidate_id": "",
+        "goal_id": _identity_text(goal_id, "goal_id"),
+        "agent_id": _identity_text(agent_id, "agent_id"),
+        "generation_id": _identity_text(generation_id, "generation_id"),
+        "covered_trigger_ids": covered,
+        "fact_states": [normalized_facts[key] for key in sorted(normalized_facts)],
+    }
+    if baseline is not None:
+        candidate["incremental_baseline"] = _normalize_incremental_baseline(baseline)
+    candidate["candidate_id"] = _identity(
+        {key: value for key, value in candidate.items() if key != "candidate_id"},
+        prefix="report_candidate",
+    )
+    return candidate
+
+
+def write_periodic_report_publication_candidate(
+    *, path: Path, candidate: Mapping[str, Any]
+) -> None:
+    if candidate.get("schema_version") != PUBLICATION_CANDIDATE_SCHEMA:
+        raise ValueError(
+            f"publication candidate must use {PUBLICATION_CANDIDATE_SCHEMA}"
+        )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(path, dict(candidate))
+
+
+def find_periodic_report_publication_candidate(
+    *, runtime_root: Path, goal_id: str, generation_id: str
+) -> dict[str, Any] | None:
+    safe_goal = _identity_text(goal_id, "goal_id")
+    safe_generation = _identity_text(generation_id, "generation_id")
+    root = (
+        runtime_root.expanduser().resolve() / "goals" / safe_goal / "periodic_reports"
+    )
+    matches: dict[str, dict[str, Any]] = {}
+    if not root.is_dir():
+        return None
+    for path in root.glob("**/publication-candidate.json"):
+        value = read_json(path)
+        if not isinstance(value, Mapping):
+            raise ValueError("periodic-report publication candidate must be an object")
+        if (
+            value.get("goal_id") != safe_goal
+            or value.get("generation_id") != safe_generation
+        ):
+            continue
+        candidate_id = _identity_text(value.get("candidate_id"), "candidate_id")
+        matches[candidate_id] = dict(value)
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError("generation resolves to conflicting publication candidates")
+    return next(iter(matches.values()))
+
+
+def commit_periodic_report_publication_cursor(
+    *,
+    runtime_root: Path,
+    candidate: Mapping[str, Any],
+    publication_id: str,
+    delivered_at: str,
+    covered_until: str,
+) -> dict[str, Any]:
+    if candidate.get("schema_version") != PUBLICATION_CANDIDATE_SCHEMA:
+        raise ValueError(
+            f"publication candidate must use {PUBLICATION_CANDIDATE_SCHEMA}"
+        )
+    supplied = dict(candidate)
+    candidate_id = _identity_text(
+        supplied.pop("candidate_id", None), "candidate.candidate_id"
+    )
+    allowed_fields = {
+        "schema_version",
+        "goal_id",
+        "agent_id",
+        "generation_id",
+        "covered_trigger_ids",
+        "fact_states",
+        "incremental_baseline",
+    }
+    unknown = sorted(set(supplied) - allowed_fields)
+    if unknown:
+        raise ValueError(
+            "publication candidate contains unsupported fields: " + ", ".join(unknown)
+        )
+    goal_id = _identity_text(candidate.get("goal_id"), "candidate.goal_id")
+    agent_id = _identity_text(candidate.get("agent_id"), "candidate.agent_id")
+    generation_id = _identity_text(
+        candidate.get("generation_id"), "candidate.generation_id"
+    )
+    expected_candidate_id = _identity(supplied, prefix="report_candidate")
+    if candidate_id != expected_candidate_id:
+        raise ValueError("publication candidate identity does not match contents")
+    normalized_publication_id = _identity_text(publication_id, "publication_id")
+    path = _cursor_path(runtime_root, goal_id, agent_id)
+    with exclusive_file_lock(
+        path,
+        policy=LockAcquisitionPolicy.MUTATION,
+        agent_id=agent_id,
+        operation="periodic_report_publication_cursor_commit",
+    ):
+        previous = _read_periodic_report_publication_cursor_path(
+            path=path,
+            goal_id=goal_id,
+            agent_id=agent_id,
+        )
+        if (
+            previous is not None
+            and previous["generation_id"] == generation_id
+            and previous["publication_id"] == normalized_publication_id
+        ):
+            return previous
+        raw_baseline = candidate.get("incremental_baseline")
+        baseline = (
+            _normalize_incremental_baseline(raw_baseline)
+            if isinstance(raw_baseline, Mapping)
+            else None
+        )
+        if previous is None:
+            if raw_baseline is not None:
+                raise ValueError(
+                    "publication candidate baseline does not match an empty cursor"
+                )
+        elif baseline is None or any(
+            baseline.get(key) != previous[expected]
+            for key, expected in (
+                ("cursor_id", "cursor_id"),
+                ("predecessor_generation_id", "generation_id"),
+                ("predecessor_publication_id", "publication_id"),
+                ("covered_until", "covered_until"),
+            )
+        ):
+            raise ValueError(
+                "publication candidate baseline does not match the current cursor"
+            )
+        facts = {
+            item["source_ref"]: item for item in (previous or {}).get("fact_states", [])
+        }
+        for index, raw in enumerate(candidate.get("fact_states") or []):
+            state = _fact_state(raw, label=f"candidate.fact_states[{index}]")
+            facts[state["source_ref"]] = state
+        covered = sorted(
+            set((previous or {}).get("covered_trigger_ids", []))
+            | {
+                _identity_text(value, "candidate.covered_trigger_ids[]")
+                for value in candidate.get("covered_trigger_ids") or []
+            }
+        )
+        cursor: dict[str, Any] = {
+            "schema_version": PUBLICATION_CURSOR_SCHEMA,
+            "cursor_id": "",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "generation_id": generation_id,
+            "publication_id": normalized_publication_id,
+            "delivered_at": _timestamp(delivered_at, "delivered_at"),
+            "covered_until": _timestamp(covered_until, "covered_until"),
+            "covered_trigger_ids": covered,
+            "fact_states": [facts[key] for key in sorted(facts)],
+        }
+        if previous is not None:
+            cursor["predecessor_publication_id"] = previous["publication_id"]
+        cursor["cursor_id"] = _identity(
+            {key: value for key, value in cursor.items() if key != "cursor_id"},
+            prefix="report_cursor",
+        )
+        normalized = normalize_periodic_report_publication_cursor(cursor)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_json(path, normalized)
+        return normalized
+
+
+__all__ = [
+    "INCREMENTAL_BASELINE_SCHEMA",
+    "PUBLICATION_CANDIDATE_SCHEMA",
+    "PUBLICATION_CURSOR_SCHEMA",
+    "build_periodic_report_publication_candidate",
+    "commit_periodic_report_publication_cursor",
+    "find_periodic_report_publication_candidate",
+    "normalize_periodic_report_publication_cursor",
+    "periodic_report_fact_fingerprint",
+    "periodic_report_incremental_baseline",
+    "read_periodic_report_publication_cursor",
+    "select_incremental_project_progress",
+    "write_periodic_report_publication_candidate",
+]

--- a/loopx/capabilities/periodic_report/pending_intent.py
+++ b/loopx/capabilities/periodic_report/pending_intent.py
@@ -37,6 +37,10 @@ from .post_writeback_hook import (
     evaluate_periodic_report_trigger_evaluation_intent,
 )
 from .project_progress_snapshot import build_project_progress_snapshot
+from .incremental import (
+    build_periodic_report_publication_candidate,
+    write_periodic_report_publication_candidate,
+)
 
 
 PENDING_INTENT_SCHEMA = "pending_capability_intent_projection_v0"
@@ -483,6 +487,30 @@ def _progress_facts_from_snapshot(
             "status": status,
             "source_ref": source_ref,
         }
+        change_kind = str(raw_item.get("change_kind") or "").strip()
+        if change_kind:
+            if change_kind not in {"added", "changed"}:
+                raise ValueError(
+                    "periodic-report progress snapshot change_kind is invalid"
+                )
+            fact["change_kind"] = change_kind
+        if change_kind == "changed":
+            previous_status = str(raw_item.get("previous_status") or "").strip()
+            previous_kind = str(raw_item.get("previous_content_kind") or "").strip()
+            previous_fingerprint = str(
+                raw_item.get("previous_fact_fingerprint") or ""
+            ).strip()
+            if not previous_status or not previous_kind or not previous_fingerprint:
+                raise ValueError(
+                    "periodic-report changed fact requires its previous state"
+                )
+            fact.update(
+                {
+                    "previous_status": previous_status,
+                    "previous_content_kind": previous_kind,
+                    "previous_fact_fingerprint": previous_fingerprint,
+                }
+            )
         if completed is not None:
             fact["completed_at"] = completed
         facts.append(fact)
@@ -513,6 +541,7 @@ def _build_editorial_request(
     agent_id: str,
     completed_at: str,
     facts: list[dict[str, Any]],
+    incremental_baseline: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     work_window = _actual_work_window(
         runtime_root=runtime_root,
@@ -520,6 +549,11 @@ def _build_editorial_request(
         agent_id=agent_id,
         facts=facts,
         completed_at=completed_at,
+        publication_boundary=(
+            str(incremental_baseline.get("covered_until") or "")
+            if isinstance(incremental_baseline, Mapping)
+            else None
+        ),
     )
     request: dict[str, Any] = {
         "schema_version": EDITORIAL_REQUEST_SCHEMA,
@@ -538,6 +572,8 @@ def _build_editorial_request(
                 "Separate current-version coverage from historical evidence.",
                 "Keep report-building work out of the analysis mainline.",
                 "Write audience-facing Chinese while preserving necessary technical terms.",
+                "Report only the supplied incremental facts; never restate facts absent from this request.",
+                "Render change_kind=changed as a concise transition from the supplied previous state to the current state.",
             ],
         },
         "completed_at": completed_at,
@@ -549,6 +585,8 @@ def _build_editorial_request(
             "external_writes_performed": False,
         },
     }
+    if isinstance(incremental_baseline, Mapping):
+        request["incremental_baseline"] = dict(incremental_baseline)
     request["request_digest"] = _canonical_digest(request)
     return request
 
@@ -560,9 +598,22 @@ def _actual_work_window(
     agent_id: str,
     facts: list[dict[str, Any]],
     completed_at: str,
+    publication_boundary: str | None = None,
 ) -> dict[str, str]:
     end = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
     observed: list[datetime] = []
+    boundary: datetime | None = None
+    if publication_boundary:
+        try:
+            boundary = datetime.fromisoformat(
+                publication_boundary.replace("Z", "+00:00")
+            )
+        except ValueError as exc:
+            raise ValueError("periodic-report publication boundary is invalid") from exc
+        if boundary.tzinfo is None or boundary >= end:
+            raise ValueError("periodic-report publication boundary is invalid")
+        boundary = boundary.astimezone(end.tzinfo)
+        observed.append(boundary)
     run_index = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
     if run_index.is_file():
         try:
@@ -584,7 +635,7 @@ def _actual_work_window(
             if value.tzinfo is None or end.tzinfo is None:
                 continue
             value = value.astimezone(end.tzinfo)
-            if value <= end:
+            if value <= end and (boundary is None or value >= boundary):
                 observed.append(value)
     for fact in facts:
         raw = str(fact.get("completed_at") or fact.get("updated_at") or "").strip()
@@ -597,7 +648,7 @@ def _actual_work_window(
         if value.tzinfo is None or end.tzinfo is None:
             continue
         value = value.astimezone(end.tzinfo)
-        if value <= end:
+        if value <= end and (boundary is None or value >= boundary):
             observed.append(value)
     start = min(observed, default=end)
     # The document protocol requires a non-empty half-open window. A stage with
@@ -631,12 +682,15 @@ def _actual_work_window(
             f"{display_end:%Y-%m-%d %H:%M}"
             f"（{timezone_label}）"
         )
-    return {
+    window = {
         "start_at": document_start.isoformat(),
         "end_at": end.isoformat(),
         "period_label": period_label,
         "source": "agent_run_history_or_report_facts",
     }
+    if boundary is not None:
+        window["publication_boundary_applied"] = "true"
+    return window
 
 
 def _load_frozen_editorial_request(
@@ -902,6 +956,12 @@ def consume_pending_periodic_report_intent(
         agent_id=agent_id,
         completed_at=completed_at,
         facts=facts,
+        incremental_baseline=(
+            project_progress.get("incremental_baseline")
+            if isinstance(project_progress, Mapping)
+            and isinstance(project_progress.get("incremental_baseline"), Mapping)
+            else None
+        ),
     )
     if not response_path.is_file():
         result = {
@@ -988,9 +1048,28 @@ def consume_pending_periodic_report_intent(
     markdown_path = artifact_dir / "report.md"
     html_path = artifact_dir / "report.html"
     generation_bundle_path = artifact_dir / "generation-bundle.json"
+    publication_candidate_path = artifact_dir / "publication-candidate.json"
     markdown_path.write_text(str(markdown["content"]), encoding="utf-8")
     html_path.write_text(str(html["content"]), encoding="utf-8")
     atomic_write_json(generation_bundle_path, bundle)
+    incremental_baseline = (
+        project_progress.get("incremental_baseline")
+        if isinstance(project_progress, Mapping)
+        and isinstance(project_progress.get("incremental_baseline"), Mapping)
+        else None
+    )
+    publication_candidate = build_periodic_report_publication_candidate(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        generation_id=str(generation["generation_id"]),
+        trigger_receipt=trigger,
+        facts=facts,
+        baseline=incremental_baseline,
+    )
+    write_periodic_report_publication_candidate(
+        path=publication_candidate_path,
+        candidate=publication_candidate,
+    )
     approval_scope = str(result["approval_scope"])
     delivery = add_goal_todo(
         registry_path=registry_path,
@@ -1051,7 +1130,9 @@ def consume_pending_periodic_report_intent(
             "markdown_path": str(markdown_path),
             "markdown_digest": markdown["content_digest"],
             "generation_bundle_path": str(generation_bundle_path),
+            "publication_candidate_path": str(publication_candidate_path),
         },
+        "incremental_baseline": publication_candidate.get("incremental_baseline"),
     }
     atomic_write_json(receipt_path, durable)
     return durable

--- a/loopx/capabilities/periodic_report/post_writeback_hook.py
+++ b/loopx/capabilities/periodic_report/post_writeback_hook.py
@@ -21,13 +21,12 @@ from .stage_completion import STAGE_COMPLETION_RECEIPT_SCHEMA
 from .stage_completion import derive_periodic_report_stage_completion_from_runs
 from .presets import build_periodic_report_preset_activation
 from .project_progress_snapshot import build_project_progress_snapshot_from_state
+from .incremental import read_periodic_report_publication_cursor
 from .triggers import build_periodic_report_trigger_decision
 
 
 PERIODIC_REPORT_POST_WRITEBACK_HOOK_ID = "periodic_report.runtime_trigger"
-PERIODIC_REPORT_TRIGGER_EVALUATION_INTENT = (
-    "periodic_report.trigger_evaluation"
-)
+PERIODIC_REPORT_TRIGGER_EVALUATION_INTENT = "periodic_report.trigger_evaluation"
 
 
 def _result(*, status: str, intent: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -236,6 +235,11 @@ def build_periodic_report_post_writeback_projection(
     if receipt is None:
         return {}
     result: dict[str, object] = {"stage_completion": receipt}
+    publication_cursor = read_periodic_report_publication_cursor(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+        agent_id=normalized_agent_id,
+    )
     project_progress = build_project_progress_snapshot_from_state(
         state_text=state_text,
         goal=goal,
@@ -243,7 +247,15 @@ def build_periodic_report_post_writeback_projection(
         goal_id=goal_id,
         agent_id=normalized_agent_id,
         completed_at=str(receipt["completed_at"]),
+        publication_cursor=publication_cursor,
     )
+    if publication_cursor is not None and project_progress is None:
+        return {}
+    if publication_cursor is not None:
+        result["last_report"] = {
+            "delivered_at": publication_cursor["delivered_at"],
+            "covered_trigger_ids": publication_cursor["covered_trigger_ids"],
+        }
     if project_progress is not None:
         result["project_progress"] = project_progress
     return result
@@ -281,6 +293,9 @@ def periodic_report_post_writeback_hook(
             if isinstance(projection, Mapping)
             else None
         )
+        last_report = (
+            projection.get("last_report") if isinstance(projection, Mapping) else None
+        )
         intent_payload: dict[str, Any] = {
             "schema_version": "periodic_report_trigger_evaluation_intent_v0",
             "stage_completion": dict(stage),
@@ -291,6 +306,8 @@ def periodic_report_post_writeback_hook(
         }
         if isinstance(project_progress, Mapping):
             intent_payload["project_progress"] = dict(project_progress)
+        if isinstance(last_report, Mapping):
+            intent_payload["last_report"] = dict(last_report)
         return _result(
             status="intent",
             intent={
@@ -329,8 +346,7 @@ def evaluate_periodic_report_trigger_evaluation_intent(
     if not isinstance(payload, Mapping):
         raise ValueError("periodic-report trigger intent payload is invalid")
     if (
-        payload.get("schema_version")
-        != "periodic_report_trigger_evaluation_intent_v0"
+        payload.get("schema_version") != "periodic_report_trigger_evaluation_intent_v0"
         or payload.get("generation_authorized") is not False
         or payload.get("external_delivery_authorized") is not False
     ):
@@ -338,7 +354,9 @@ def evaluate_periodic_report_trigger_evaluation_intent(
     stage = payload.get("stage_completion")
     profile_ref = payload.get("profile_ref")
     trigger_policy = payload.get("trigger_policy")
-    if not all(isinstance(value, Mapping) for value in (stage, profile_ref, trigger_policy)):
+    if not all(
+        isinstance(value, Mapping) for value in (stage, profile_ref, trigger_policy)
+    ):
         raise ValueError("periodic-report trigger intent is missing typed facts")
     required_stage_fields = (
         "stage_identity",
@@ -351,49 +369,55 @@ def evaluate_periodic_report_trigger_evaluation_intent(
         stage.get("schema_version") != STAGE_COMPLETION_RECEIPT_SCHEMA
         or stage.get("acceptance") != "validated"
         or stage.get("outcome_checkpoint_satisfied") is not True
-        or any(not str(stage.get(field) or "").strip() for field in required_stage_fields)
+        or any(
+            not str(stage.get(field) or "").strip() for field in required_stage_fields
+        )
     ):
         raise ValueError("periodic-report stage completion receipt is invalid")
     completed_at = str(stage["completed_at"])
     stage_identity = str(stage["stage_identity"])
-    evidence_digest = "sha256:" + hashlib.sha256(
-        json.dumps([stage_identity], separators=(",", ":")).encode()
-    ).hexdigest()
-    return build_periodic_report_trigger_decision(
-        {
-            "schema_version": "periodic_report_trigger_request_v0",
-            "evaluated_at": completed_at,
-            "profile": {
-                "profile_id": profile_ref.get("profile_id"),
-                "profile_version": profile_ref.get("profile_version"),
-            },
-            "trigger_policy": dict(trigger_policy),
-            "candidates": [
-                {
-                    "trigger_kind": "bounded_segment_milestone",
-                    "observed_at": completed_at,
-                    "source_ref": f"stage:{stage_identity}",
-                    "evidence_digest": evidence_digest,
-                    "facts": {
-                        "segment_ref": stage_identity,
-                        "transition": "segment_completed",
-                        "delivered_count": 0,
-                        "remaining_todo_count": 0,
-                        "durable_writeback": True,
-                        "acceptance": "validated",
-                        "completed_at": completed_at,
-                        "completion_receipt_ref": f"stage:{stage_identity}",
-                        "stage_identity": stage_identity,
-                        "closed_vision_revision": stage["closed_vision_revision"],
-                        "frontier_identity": stage["frontier_identity"],
-                        "stage_transition": stage["transition"],
-                        "outcome_checkpoint_satisfied": True,
-                        "status": "completed",
-                    },
-                }
-            ],
-        }
+    evidence_digest = (
+        "sha256:"
+        + hashlib.sha256(
+            json.dumps([stage_identity], separators=(",", ":")).encode()
+        ).hexdigest()
     )
+    request = {
+        "schema_version": "periodic_report_trigger_request_v0",
+        "evaluated_at": completed_at,
+        "profile": {
+            "profile_id": profile_ref.get("profile_id"),
+            "profile_version": profile_ref.get("profile_version"),
+        },
+        "trigger_policy": dict(trigger_policy),
+        "candidates": [
+            {
+                "trigger_kind": "bounded_segment_milestone",
+                "observed_at": completed_at,
+                "source_ref": f"stage:{stage_identity}",
+                "evidence_digest": evidence_digest,
+                "facts": {
+                    "segment_ref": stage_identity,
+                    "transition": "segment_completed",
+                    "delivered_count": 0,
+                    "remaining_todo_count": 0,
+                    "durable_writeback": True,
+                    "acceptance": "validated",
+                    "completed_at": completed_at,
+                    "completion_receipt_ref": f"stage:{stage_identity}",
+                    "stage_identity": stage_identity,
+                    "closed_vision_revision": stage["closed_vision_revision"],
+                    "frontier_identity": stage["frontier_identity"],
+                    "stage_transition": stage["transition"],
+                    "outcome_checkpoint_satisfied": True,
+                    "status": "completed",
+                },
+            }
+        ],
+    }
+    if isinstance(payload.get("last_report"), Mapping):
+        request["last_report"] = dict(payload["last_report"])
+    return build_periodic_report_trigger_decision(request)
 
 
 __all__ = [

--- a/loopx/capabilities/periodic_report/project_progress_snapshot.py
+++ b/loopx/capabilities/periodic_report/project_progress_snapshot.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from ...registry import find_registry_goal, read_json, resolve_state_file
+from .incremental import select_incremental_project_progress
 
 
 _META_ACTION_KINDS = frozenset(
@@ -19,7 +20,12 @@ _META_ACTION_KINDS = frozenset(
 
 
 def build_project_progress_snapshot(
-    *, registry_path: Path, goal_id: str, agent_id: str, completed_at: str
+    *,
+    registry_path: Path,
+    goal_id: str,
+    agent_id: str,
+    completed_at: str,
+    publication_cursor: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Build a bounded public-safe progress snapshot at a stage boundary."""
 
@@ -38,6 +44,7 @@ def build_project_progress_snapshot(
         goal_id=goal_id,
         agent_id=agent_id,
         completed_at=completed_at,
+        publication_cursor=publication_cursor,
     )
 
 
@@ -49,6 +56,7 @@ def build_project_progress_snapshot_from_state(
     goal_id: str,
     agent_id: str,
     completed_at: str,
+    publication_cursor: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     """Build a progress snapshot from one already-read authoritative state."""
 
@@ -82,7 +90,7 @@ def build_project_progress_snapshot_from_state(
     ]
     done.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
     progress_items: list[dict[str, Any]] = []
-    for index, item in enumerate(done[:6]):
+    for index, item in enumerate(done):
         summary = " ".join(
             str(
                 item.get("evidence") or item.get("note") or item.get("text") or ""
@@ -130,13 +138,29 @@ def build_project_progress_snapshot_from_state(
         )
     if not progress_items:
         return None
-    return {
+    snapshot: dict[str, Any] = {
         "schema_version": "periodic_report_project_progress_projection_v0",
         "goal_id": goal_id,
         "observed_at": completed_at,
         "language": "zh-CN",
         "items": progress_items,
     }
+    if publication_cursor is not None:
+        incremental = select_incremental_project_progress(
+            snapshot,
+            cursor=publication_cursor,
+        )
+        if incremental is None:
+            return None
+        snapshot = incremental
+    outcome_items = [
+        item for item in snapshot["items"] if item.get("content_kind") == "outcome"
+    ][:6]
+    next_items = [
+        item for item in snapshot["items"] if item.get("content_kind") == "next_action"
+    ][:1]
+    snapshot["items"] = outcome_items + next_items
+    return snapshot
 
 
 __all__ = [

--- a/loopx/extensions/lark/periodic_report_delivery.py
+++ b/loopx/extensions/lark/periodic_report_delivery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
@@ -13,6 +14,10 @@ from ...capabilities.periodic_report.bindings import (
     build_periodic_report_generation_bundle,
 )
 from ...capabilities.periodic_report.core import _reject_raw_keys
+from ...capabilities.periodic_report.incremental import (
+    commit_periodic_report_publication_cursor,
+    find_periodic_report_publication_candidate,
+)
 from . import LARK_EXTENSION_ID, LARK_GOAL_CHANNEL_PERMISSION
 from .goal_channel_contracts import (
     binding_for_goal,
@@ -573,6 +578,25 @@ def deliver_periodic_report_to_goal_channel(
         ),
         "message_results": message_results,
     }
+    publication_cursor = None
+    if satisfied:
+        generation_id = str(generation["generation_receipt"]["generation_id"])
+        candidate = find_periodic_report_publication_candidate(
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            generation_id=generation_id,
+        )
+        if candidate is not None:
+            publication_cursor = commit_periodic_report_publication_cursor(
+                runtime_root=runtime_root,
+                candidate=candidate,
+                publication_id=(
+                    "goal-channel-"
+                    + hashlib.sha256(idempotency_key.encode()).hexdigest()[:24]
+                ),
+                delivered_at=datetime.now(timezone.utc).isoformat(),
+                covered_until=str(generation["document"]["period_window"]["end_at"]),
+            )
     return {
         "ok": bool(satisfied or not execute),
         "schema_version": GOAL_CHANNEL_DELIVERY_RESULT_SCHEMA,
@@ -580,6 +604,12 @@ def deliver_periodic_report_to_goal_channel(
         "intent_satisfied": satisfied,
         "generation_id": generation["generation_receipt"]["generation_id"],
         "sink_result": sink_result,
+        "publication_cursor": publication_cursor,
+        "incremental_baseline": (
+            candidate.get("incremental_baseline")
+            if satisfied and candidate is not None
+            else None
+        ),
         "boundary": {
             "goal_channel_binding_required": True,
             "project_bot_identity_required": True,

--- a/tests/capabilities/test_periodic_report_incremental.py
+++ b/tests/capabilities/test_periodic_report_incremental.py
@@ -1,0 +1,443 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from copy import deepcopy
+from pathlib import Path
+from threading import Event, Lock
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.periodic_report import incremental
+from loopx.capabilities.periodic_report.incremental import (
+    build_periodic_report_publication_candidate,
+    commit_periodic_report_publication_cursor,
+    periodic_report_incremental_baseline,
+    read_periodic_report_publication_cursor,
+    select_incremental_project_progress,
+)
+from loopx.capabilities.periodic_report.post_writeback_hook import (
+    evaluate_periodic_report_trigger_evaluation_intent,
+    periodic_report_post_writeback_hook,
+)
+from loopx.capabilities.periodic_report.project_progress_snapshot import (
+    build_project_progress_snapshot_from_state,
+)
+
+
+GOAL_ID = "example-goal"
+AGENT_ID = "example-agent"
+
+
+def _item(
+    source_ref: str,
+    *,
+    title: str,
+    summary: str,
+    content_kind: str = "outcome",
+) -> dict[str, object]:
+    return {
+        "item_id": source_ref.replace(":", "_"),
+        "title": title,
+        "summary": summary,
+        "content_kind": content_kind,
+        "source_ref": source_ref,
+        "completed_at": "2026-08-01T08:00:00Z",
+    }
+
+
+def _snapshot(items: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema_version": "periodic_report_project_progress_projection_v0",
+        "goal_id": GOAL_ID,
+        "observed_at": "2026-08-01T08:00:00Z",
+        "language": "zh-CN",
+        "items": items,
+    }
+
+
+def _trigger(trigger_id: str) -> dict[str, object]:
+    return {
+        "coalesced_trigger_ids": [trigger_id],
+    }
+
+
+def test_two_cycle_increment_reports_only_new_and_changed_facts(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    first = select_incremental_project_progress(
+        _snapshot(
+            [
+                _item("todo:a", title="A completed", summary="A is done."),
+                _item(
+                    "todo:b",
+                    title="B started",
+                    summary="B is open.",
+                    content_kind="next_action",
+                ),
+            ]
+        ),
+        cursor=None,
+    )
+    assert first is not None
+    candidate_one = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_first",
+        trigger_receipt=_trigger("trigger_first"),
+        facts=first["items"],
+        baseline=None,
+    )
+    cursor_one = commit_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        candidate=candidate_one,
+        publication_id="goal-channel:first",
+        delivered_at="2026-08-01T09:00:00Z",
+        covered_until="2026-08-01T08:00:00Z",
+    )
+    replayed_cursor_one = commit_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        candidate=candidate_one,
+        publication_id="goal-channel:first",
+        delivered_at="2026-08-01T10:00:00Z",
+        covered_until="2026-08-01T08:00:00Z",
+    )
+    assert replayed_cursor_one == cursor_one
+
+    second = select_incremental_project_progress(
+        _snapshot(
+            [
+                _item("todo:a", title="A completed", summary="A is done."),
+                _item("todo:b", title="B completed", summary="B is now done."),
+                _item("todo:c", title="C completed", summary="C is new."),
+            ]
+        ),
+        cursor=cursor_one,
+    )
+    assert second is not None
+    by_ref = {item["source_ref"]: item for item in second["items"]}
+    assert "todo:a" not in by_ref
+    assert by_ref["todo:b"]["change_kind"] == "changed"
+    assert by_ref["todo:b"]["previous_status"] == "open"
+    assert by_ref["todo:c"]["change_kind"] == "added"
+    assert second["incremental_baseline"] == periodic_report_incremental_baseline(
+        cursor_one
+    )
+
+    candidate_two = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_second",
+        trigger_receipt=_trigger("trigger_second"),
+        facts=second["items"],
+        baseline=second["incremental_baseline"],
+    )
+    cursor_two = commit_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        candidate=candidate_two,
+        publication_id="goal-channel:second",
+        delivered_at="2026-08-08T09:00:00Z",
+        covered_until="2026-08-08T08:00:00Z",
+    )
+    assert cursor_two["predecessor_publication_id"] == "goal-channel:first"
+    assert cursor_two["covered_trigger_ids"] == ["trigger_first", "trigger_second"]
+    assert (
+        select_incremental_project_progress(
+            _snapshot(
+                [
+                    _item("todo:a", title="A completed", summary="A is done."),
+                    _item("todo:b", title="B completed", summary="B is now done."),
+                    _item("todo:c", title="C completed", summary="C is new."),
+                ]
+            ),
+            cursor=cursor_two,
+        )
+        is None
+    )
+
+
+def test_generation_or_failed_delivery_does_not_advance_publication_cursor(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    first = select_incremental_project_progress(
+        _snapshot([_item("todo:a", title="A completed", summary="A is done.")]),
+        cursor=None,
+    )
+    assert first is not None
+    candidate = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_unpublished",
+        trigger_receipt=_trigger("trigger_unpublished"),
+        facts=first["items"],
+        baseline=None,
+    )
+
+    assert candidate["generation_id"] == "report_generation_unpublished"
+    assert (
+        read_periodic_report_publication_cursor(
+            runtime_root=runtime,
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+        )
+        is None
+    )
+    retry = select_incremental_project_progress(
+        deepcopy(_snapshot(first["items"])), cursor=None
+    )
+    assert retry is not None
+    assert [item["source_ref"] for item in retry["items"]] == ["todo:a"]
+
+
+def test_candidate_rejects_an_untyped_incremental_baseline() -> None:
+    with pytest.raises(ValueError, match="incremental baseline must use"):
+        build_periodic_report_publication_candidate(
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            generation_id="report_generation_invalid",
+            trigger_receipt=_trigger("trigger_invalid"),
+            facts=[_item("todo:a", title="A completed", summary="A is done.")],
+            baseline={
+                "cursor_id": "report_cursor_example",
+                "predecessor_generation_id": "report_generation_example",
+                "predecessor_publication_id": "goal-channel:example",
+                "delivered_at": "2026-08-01T09:00:00Z",
+                "covered_until": "2026-08-01T08:00:00Z",
+            },
+        )
+
+
+def test_stale_candidate_cannot_overwrite_a_newer_publication_cursor(
+    tmp_path: Path,
+) -> None:
+    runtime = tmp_path / "runtime"
+    fact = _item("todo:a", title="A completed", summary="A is done.")
+    first = select_incremental_project_progress(_snapshot([fact]), cursor=None)
+    assert first is not None
+    candidate_one = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_first",
+        trigger_receipt=_trigger("trigger_first"),
+        facts=first["items"],
+        baseline=None,
+    )
+    cursor = commit_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        candidate=candidate_one,
+        publication_id="goal-channel:first",
+        delivered_at="2026-08-01T09:00:00Z",
+        covered_until="2026-08-01T08:00:00Z",
+    )
+    stale = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_stale",
+        trigger_receipt=_trigger("trigger_stale"),
+        facts=first["items"],
+        baseline=None,
+    )
+    with pytest.raises(ValueError, match="baseline does not match"):
+        commit_periodic_report_publication_cursor(
+            runtime_root=runtime,
+            candidate=stale,
+            publication_id="goal-channel:stale",
+            delivered_at="2026-08-01T10:00:00Z",
+            covered_until="2026-08-01T08:30:00Z",
+        )
+    assert (
+        read_periodic_report_publication_cursor(
+            runtime_root=runtime,
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+        )
+        == cursor
+    )
+
+
+def test_concurrent_publications_compare_and_swap_under_one_cursor_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = tmp_path / "runtime"
+    fact = _item("todo:a", title="A completed", summary="A is done.")
+    first = select_incremental_project_progress(_snapshot([fact]), cursor=None)
+    assert first is not None
+    candidates = [
+        build_periodic_report_publication_candidate(
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            generation_id=f"report_generation_{suffix}",
+            trigger_receipt=_trigger(f"trigger_{suffix}"),
+            facts=first["items"],
+            baseline=None,
+        )
+        for suffix in ("one", "two")
+    ]
+    first_acquired = Event()
+    second_attempted = Event()
+    counter_lock = Lock()
+    attempts = 0
+    original_lock = incremental.exclusive_file_lock
+
+    @contextmanager
+    def ordered_lock(*args: Any, **kwargs: Any):
+        nonlocal attempts
+        with counter_lock:
+            attempts += 1
+            attempt = attempts
+        if attempt == 1:
+            with original_lock(*args, **kwargs) as lock_path:
+                first_acquired.set()
+                assert second_attempted.wait(timeout=2)
+                yield lock_path
+            return
+        assert first_acquired.wait(timeout=2)
+        second_attempted.set()
+        with original_lock(*args, **kwargs) as lock_path:
+            yield lock_path
+
+    monkeypatch.setattr(incremental, "exclusive_file_lock", ordered_lock)
+
+    def commit(index: int) -> tuple[str, str]:
+        try:
+            cursor = commit_periodic_report_publication_cursor(
+                runtime_root=runtime,
+                candidate=candidates[index],
+                publication_id=f"goal-channel:{index}",
+                delivered_at=f"2026-08-01T{index + 9:02d}:00:00Z",
+                covered_until="2026-08-01T08:00:00Z",
+            )
+        except ValueError as exc:
+            return "rejected", str(exc)
+        return "committed", str(cursor["generation_id"])
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(commit, (0, 1)))
+
+    assert sorted(result[0] for result in results) == ["committed", "rejected"]
+    assert next(value for status, value in results if status == "rejected") == (
+        "publication candidate baseline does not match the current cursor"
+    )
+    cursor = read_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert cursor is not None
+    assert cursor["generation_id"] == next(
+        value for status, value in results if status == "committed"
+    )
+
+
+def test_published_stage_trigger_is_suppressed_until_a_new_stage_exists() -> None:
+    hook = periodic_report_post_writeback_hook(
+        profile_ref={
+            "profile_id": "weekly_progress",
+            "profile_version": "v1",
+        },
+        trigger_policy={
+            "enabled_kinds": ["bounded_segment_milestone"],
+            "minimum_interval_seconds": 0,
+            "aggregation": {
+                "window_seconds": 604800,
+                "stage_completion_required": True,
+            },
+        },
+    )
+    stage = {
+        "schema_version": "periodic_report_stage_completion_receipt_v0",
+        "stage_identity": "stage-first",
+        "agent_id": AGENT_ID,
+        "closed_vision_revision": "vision-first",
+        "frontier_identity": "frontier-first",
+        "transition": "successor_frontier_settled",
+        "completed_at": "2026-08-01T08:00:00Z",
+        "acceptance": "validated",
+        "outcome_checkpoint_satisfied": True,
+        "durable_writeback_required": True,
+    }
+    initial = hook.producer(
+        {
+            "receipt": {"event_id": "event-first"},
+            "projection": {"stage_completion": stage},
+        }
+    )
+    first_decision = evaluate_periodic_report_trigger_evaluation_intent(
+        initial["intent"]
+    )
+    assert first_decision["eligible"] is True
+
+    repeated = hook.producer(
+        {
+            "receipt": {"event_id": "event-replayed"},
+            "projection": {
+                "stage_completion": stage,
+                "last_report": {
+                    "delivered_at": "2026-08-01T09:00:00Z",
+                    "covered_trigger_ids": first_decision["coalesced_trigger_ids"],
+                },
+            },
+        }
+    )
+    repeated_decision = evaluate_periodic_report_trigger_evaluation_intent(
+        repeated["intent"]
+    )
+    assert repeated_decision["eligible"] is False
+    assert repeated_decision["suppressed_triggers"][0]["reason"] == "already_covered"
+
+
+def test_snapshot_applies_cursor_before_the_six_item_report_limit(
+    tmp_path: Path,
+) -> None:
+    state_items = []
+    for index in range(7):
+        state_items.append(
+            "\n".join(
+                [
+                    f"- [x] Completed item {index}.",
+                    "  <!-- loopx:todo "
+                    f"todo_id=todo_{index} status=done task_class=advancement_task "
+                    f"claimed_by={AGENT_ID} updated_at=2026-08-01T0{index}:00:00Z -->",
+                ]
+            )
+        )
+    state = "# Goal\n\n## User Todo\n\n## Agent Todo\n\n" + "\n".join(state_items)
+    first = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T08:00:00Z",
+    )
+    assert first is not None
+    assert len(first["items"]) == 6
+    candidate = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_first_six",
+        trigger_receipt=_trigger("trigger_first_six"),
+        facts=first["items"],
+        baseline=None,
+    )
+    cursor = commit_periodic_report_publication_cursor(
+        runtime_root=tmp_path / "runtime",
+        candidate=candidate,
+        publication_id="goal-channel:first-six",
+        delivered_at="2026-08-01T09:00:00Z",
+        covered_until="2026-08-01T08:00:00Z",
+    )
+    second = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T10:00:00Z",
+        publication_cursor=cursor,
+    )
+    assert second is not None
+    assert len(second["items"]) == 1
+    assert second["items"][0]["title"] == "Completed item 0."

--- a/tests/capabilities/test_periodic_report_pending_intent.py
+++ b/tests/capabilities/test_periodic_report_pending_intent.py
@@ -11,6 +11,11 @@ from loopx.capabilities.periodic_report.pending_intent import (
     pending_periodic_report_intents,
     periodic_report_pending_intent_interaction_hook,
 )
+from loopx.capabilities.periodic_report.incremental import (
+    build_periodic_report_publication_candidate,
+    commit_periodic_report_publication_cursor,
+    periodic_report_incremental_baseline,
+)
 from loopx.capabilities.periodic_report.project_progress_snapshot import (
     build_project_progress_snapshot,
 )
@@ -27,10 +32,15 @@ GOAL_ID = "report-goal"
 AGENT_ID = "report-agent"
 
 
-def test_delivery_binding_ref_is_valid_when_generation_digest_starts_with_digit() -> None:
-    assert _periodic_report_delivery_binding_ref(
-        "report_generation_53429b77872cbe1130a3e2f3"
-    ) == "periodic-report:g53429b77872cbe11"
+def test_delivery_binding_ref_is_valid_when_generation_digest_starts_with_digit() -> (
+    None
+):
+    assert (
+        _periodic_report_delivery_binding_ref(
+            "report_generation_53429b77872cbe1130a3e2f3"
+        )
+        == "periodic-report:g53429b77872cbe11"
+    )
 
 
 def _intent() -> dict[str, object]:
@@ -380,6 +390,7 @@ def test_consumption_is_local_and_exact_replay_does_not_duplicate_gate(
     assert Path(first["artifacts"]["html_path"]).is_file()
     assert Path(first["artifacts"]["markdown_path"]).is_file()
     assert Path(first["artifacts"]["generation_bundle_path"]).is_file()
+    assert Path(first["artifacts"]["publication_candidate_path"]).is_file()
     html = Path(first["artifacts"]["html_path"]).read_text(encoding="utf-8")
     assert "本期结论：阶段分析已经形成完整判断" in html
     assert "当前风险：问题已按影响与证据分层" in html
@@ -500,6 +511,118 @@ def test_consumption_uses_the_stage_progress_snapshot(tmp_path: Path) -> None:
     assert not any(
         "Follow-up work added after stage completion" in fact["title"] for fact in facts
     )
+
+
+def test_publication_candidate_keeps_the_trigger_snapshot_baseline(
+    tmp_path: Path,
+) -> None:
+    registry, runtime = _fixture(tmp_path)
+    first_candidate = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_first",
+        trigger_receipt={"coalesced_trigger_ids": ["trigger_first"]},
+        facts=[
+            {
+                "source_ref": "todo:first",
+                "title": "First outcome",
+                "summary": "The first outcome was published.",
+                "content_kind": "outcome",
+                "status": "done",
+            }
+        ],
+        baseline=None,
+    )
+    cursor_one = commit_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        candidate=first_candidate,
+        publication_id="goal-channel:first",
+        delivered_at="2026-08-30T08:00:00Z",
+        covered_until="2026-08-30T08:00:00Z",
+    )
+    baseline_one = periodic_report_incremental_baseline(cursor_one)
+    sidecar = next(
+        (runtime / "goals" / GOAL_ID / "post_writeback_hooks").glob("*.json")
+    )
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    payload["intent"]["payload"]["project_progress"] = {
+        "schema_version": "periodic_report_project_progress_projection_v0",
+        "goal_id": GOAL_ID,
+        "observed_at": "2026-08-30T09:00:00Z",
+        "language": "zh-CN",
+        "items": [
+            {
+                "item_id": "second",
+                "title": "Second outcome",
+                "summary": "The second outcome belongs to this stage.",
+                "content_kind": "outcome",
+                "status": "done",
+                "source_ref": "todo:second",
+                "completed_at": "2026-08-30T09:00:00Z",
+                "change_kind": "added",
+            }
+        ],
+        "incremental_baseline": baseline_one,
+    }
+    sidecar.write_text(json.dumps(payload), encoding="utf-8")
+
+    required = consume_pending_periodic_report_intent(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        execute=True,
+    )
+    competing_candidate = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        generation_id="report_generation_competing",
+        trigger_receipt={"coalesced_trigger_ids": ["trigger_competing"]},
+        facts=[
+            {
+                "source_ref": "todo:competing",
+                "title": "Competing outcome",
+                "summary": "Another report reached publication first.",
+                "content_kind": "outcome",
+                "status": "done",
+            }
+        ],
+        baseline=baseline_one,
+    )
+    cursor_two = commit_periodic_report_publication_cursor(
+        runtime_root=runtime,
+        candidate=competing_candidate,
+        publication_id="goal-channel:competing",
+        delivered_at="2026-08-30T09:01:00Z",
+        covered_until="2026-08-30T09:00:30Z",
+    )
+    _write_editorial_response(required)
+
+    result = consume_pending_periodic_report_intent(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        execute=True,
+    )
+    frozen_candidate = json.loads(
+        Path(result["artifacts"]["publication_candidate_path"]).read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert frozen_candidate["incremental_baseline"] == baseline_one
+    assert (
+        frozen_candidate["incremental_baseline"]["cursor_id"] != cursor_two["cursor_id"]
+    )
+    with pytest.raises(ValueError, match="baseline does not match"):
+        commit_periodic_report_publication_cursor(
+            runtime_root=runtime,
+            candidate=frozen_candidate,
+            publication_id="goal-channel:second",
+            delivered_at="2026-08-30T09:02:00Z",
+            covered_until="2026-08-30T09:00:00Z",
+        )
 
 
 def test_consumption_rejects_snapshot_outcome_after_stage_completion(

--- a/tests/extensions/test_periodic_report_goal_channel_delivery.py
+++ b/tests/extensions/test_periodic_report_goal_channel_delivery.py
@@ -20,6 +20,11 @@ from loopx.extensions.lark.periodic_report_delivery import (
     GOAL_CHANNEL_DELIVERY_REQUEST_SCHEMA,
     deliver_periodic_report_to_goal_channel,
 )
+from loopx.capabilities.periodic_report.incremental import (
+    build_periodic_report_publication_candidate,
+    read_periodic_report_publication_cursor,
+    write_periodic_report_publication_candidate,
+)
 from loopx.extensions.lark import periodic_report_cli
 from loopx.presentation.renderers.periodic_report_markdown import (
     periodic_report_markdown_renderer_adapter,
@@ -94,6 +99,81 @@ def _extension_activation() -> dict[str, Any]:
     }
 
 
+def _write_publication_candidate(
+    runtime_root: Path, generation_bundle: dict[str, Any]
+) -> None:
+    candidate = build_periodic_report_publication_candidate(
+        goal_id=GOAL_ID,
+        agent_id="example-agent",
+        generation_id=generation_bundle["generation_receipt"]["generation_id"],
+        trigger_receipt={"coalesced_trigger_ids": ["trigger_stage_1"]},
+        facts=[
+            {
+                "source_ref": "todo:stage_1",
+                "title": "Stage 1 completed",
+                "summary": "The stage outcome was validated.",
+                "content_kind": "outcome",
+                "status": "done",
+            }
+        ],
+        baseline=None,
+    )
+    path = (
+        runtime_root
+        / "goals"
+        / GOAL_ID
+        / "periodic_reports"
+        / "fixture"
+        / "publication-candidate.json"
+    )
+    write_periodic_report_publication_candidate(path=path, candidate=candidate)
+
+
+def test_goal_channel_readback_advances_publication_cursor_only_on_success(
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    registry_path.parent.mkdir()
+    registry_path.write_text("{}", encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    _write_binding(registry_path)
+    request = _request()
+    _write_publication_candidate(runtime_root, request["generation_bundle"])
+
+    preview = deliver_periodic_report_to_goal_channel(
+        request,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        extension_activation=_extension_activation(),
+    )
+    assert preview["publication_cursor"] is None
+    assert (
+        read_periodic_report_publication_cursor(
+            runtime_root=runtime_root,
+            goal_id=GOAL_ID,
+            agent_id="example-agent",
+        )
+        is None
+    )
+
+    delivered = deliver_periodic_report_to_goal_channel(
+        request,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        extension_activation=_extension_activation(),
+        execute=True,
+        runner=_runner([]),
+    )
+    cursor = delivered["publication_cursor"]
+    assert (
+        cursor["generation_id"]
+        == request["generation_bundle"]["generation_receipt"]["generation_id"]
+    )
+    assert cursor["covered_trigger_ids"] == ["trigger_stage_1"]
+
+
 def _write_binding(
     registry_path: Path,
     *,
@@ -165,8 +245,7 @@ def _runner(calls: list[list[str]], *, normalized_readback: bool = False):
                 markdown = card["elements"][0]["text"]["content"]
                 footer = card["elements"][2]["elements"][0]["content"]
                 message_content = (
-                    f'<card title="{title}">\n{markdown}\n---\n'
-                    f"📝 {footer}\n</card>"
+                    f'<card title="{title}">\n{markdown}\n---\n📝 {footer}\n</card>'
                 )
             payload = {
                 "ok": True,


### PR DESCRIPTION
## Summary

- persist a per-Goal, per-Agent publication cursor only after exact Goal Channel readback
- select new or semantically changed progress facts before the report item limit, and suppress no-change report intents
- freeze the trigger snapshot baseline with each generation so stale or concurrent publications fail closed
- carry transition metadata into the editorial contract so changed facts render as deltas instead of repeated prose

## Validation

- `uv run ruff format --check` on all changed Python files
- `uv run ruff check` on all changed Python files
- `uv run pytest -q tests/capabilities/test_periodic_report*.py tests/extensions/test_periodic_report*.py tests/presentation/test_periodic_report_html.py tests/control_plane/test_post_writeback_capability_hooks.py` — 181 passed
- `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id ark-4-0-goal` — passed, 14 checks selected, 0 failures, 0 manual holds

## Safety and compatibility

- preview, generation, approval, and failed or partial delivery do not advance the publication cursor
- older frozen generations without a publication candidate remain deliverable, but do not become an inferred incremental baseline
- cursor commit uses a locked compare-and-swap transition; exact delivery replay is idempotent and stale candidates are rejected
- fixtures and documentation are public-safe and synthetic; no private report content, local paths, credentials, or generated lockfile are included

## Future-facing pass

The cursor and publication-candidate ownership stays inside the existing periodic-report capability. Goal Channel remains only the provider boundary that supplies verified delivery evidence; no new generic provider abstraction was added.
