### PR TITLE
feat(machine-config): add typed durable machine policy

### DIFF
--- a/loopx/capabilities/machine_configuration/__init__.py
+++ b/loopx/capabilities/machine_configuration/__init__.py
@@ -1,0 +1,19 @@
+"""Typed, provider-neutral machine configuration contracts."""
+
+from .contract import (
+    MACHINE_CONFIGURATION_SCHEMA,
+    MachineConfigurationNamespace,
+    MachineConfigurationRegistry,
+    machine_configuration_revision,
+    normalize_machine_configuration,
+    project_machine_configuration,
+)
+
+__all__ = [
+    "MACHINE_CONFIGURATION_SCHEMA",
+    "MachineConfigurationNamespace",
+    "MachineConfigurationRegistry",
+    "machine_configuration_revision",
+    "normalize_machine_configuration",
+    "project_machine_configuration",
+]

--- a/loopx/capabilities/machine_configuration/__init__.py
+++ b/loopx/capabilities/machine_configuration/__init__.py
@@ -7,6 +7,7 @@ from .contract import (
     machine_configuration_revision,
     normalize_machine_configuration,
     project_machine_configuration,
+    remove_machine_configuration_namespace,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "machine_configuration_revision",
     "normalize_machine_configuration",
     "project_machine_configuration",
+    "remove_machine_configuration_namespace",
 ]

--- a/loopx/capabilities/machine_configuration/builtins.py
+++ b/loopx/capabilities/machine_configuration/builtins.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .contract import MachineConfigurationRegistry
+
+
+def build_builtin_machine_configuration_registry() -> MachineConfigurationRegistry:
+    # Imports stay at the composition boundary: the generic contract does not
+    # depend on any consumer capability.
+    from ..periodic_report.machine_defaults import (
+        periodic_report_machine_configuration_namespace,
+    )
+
+    return MachineConfigurationRegistry().register(
+        periodic_report_machine_configuration_namespace()
+    )
+
+
+__all__ = ["build_builtin_machine_configuration_registry"]

--- a/loopx/capabilities/machine_configuration/cli.py
+++ b/loopx/capabilities/machine_configuration/cli.py
@@ -10,9 +10,11 @@ from typing import Any
 from ...paths import resolve_runtime_root
 from ...registry import read_json
 from .builtins import build_builtin_machine_configuration_registry
+from .contract import remove_machine_configuration_namespace
 from .store import (
     configure_machine_configuration,
     inspect_machine_configuration,
+    read_machine_configuration,
     rollback_machine_configuration,
 )
 
@@ -68,6 +70,13 @@ def register_machine_configuration_commands(
     apply.add_argument("--execute", action="store_true", required=True)
     inspect = commands.add_parser("inspect")
     add_subcommand_format(inspect)
+    remove = commands.add_parser(
+        "remove", help="Preview or remove one machine-configuration namespace."
+    )
+    add_subcommand_format(remove)
+    remove.add_argument("--namespace", required=True)
+    remove.add_argument("--expected-plan-revision")
+    remove.add_argument("--execute", action="store_true")
     rollback = commands.add_parser("rollback")
     add_subcommand_format(rollback)
     rollback.add_argument("--transaction-id", required=True)
@@ -110,6 +119,18 @@ def handle_machine_configuration_command(
             )
         elif args.machine_config_command == "inspect":
             payload = inspect_machine_configuration(runtime_root, registry=registry)
+        elif args.machine_config_command == "remove":
+            payload = configure_machine_configuration(
+                runtime_root=runtime_root,
+                configuration=remove_machine_configuration_namespace(
+                    read_machine_configuration(runtime_root, registry=registry),
+                    namespace=args.namespace,
+                    registry=registry,
+                ),
+                registry=registry,
+                execute=args.execute,
+                expected_plan_revision=args.expected_plan_revision,
+            )
         else:
             payload = rollback_machine_configuration(
                 runtime_root=runtime_root,

--- a/loopx/capabilities/machine_configuration/cli.py
+++ b/loopx/capabilities/machine_configuration/cli.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ...paths import resolve_runtime_root
+from ...registry import read_json
+from .builtins import build_builtin_machine_configuration_registry
+from .store import (
+    configure_machine_configuration,
+    inspect_machine_configuration,
+    rollback_machine_configuration,
+)
+
+
+def _load_json_object(path_text: str) -> dict[str, Any]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path_text} must contain a JSON object")
+    return payload
+
+
+def _render(payload: dict[str, object]) -> str:
+    lines = ["# Machine Configuration", ""]
+    for key in (
+        "status",
+        "action",
+        "revision",
+        "current_revision",
+        "desired_revision",
+        "transaction_id",
+        "rollback_id",
+        "error",
+    ):
+        if key in payload:
+            lines.append(f"- {key}: `{payload.get(key)}`")
+    namespaces = payload.get("changed_namespaces")
+    if isinstance(namespaces, list):
+        lines.append(
+            f"- changed_namespaces: `{', '.join(map(str, namespaces)) or 'none'}`"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def register_machine_configuration_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "machine-config",
+        help="Inspect, preview, apply, or roll back typed machine configuration.",
+    )
+    commands = parser.add_subparsers(dest="machine_config_command", required=True)
+    preview = commands.add_parser("preview")
+    add_subcommand_format(preview)
+    preview.add_argument("--config-json", required=True)
+    apply = commands.add_parser("apply")
+    add_subcommand_format(apply)
+    apply.add_argument("--config-json", required=True)
+    apply.add_argument("--expected-plan-revision", required=True)
+    apply.add_argument("--execute", action="store_true", required=True)
+    inspect = commands.add_parser("inspect")
+    add_subcommand_format(inspect)
+    rollback = commands.add_parser("rollback")
+    add_subcommand_format(rollback)
+    rollback.add_argument("--transaction-id", required=True)
+    rollback.add_argument("--expected-plan-revision")
+    rollback.add_argument("--execute", action="store_true")
+
+
+def handle_machine_configuration_command(
+    args: argparse.Namespace,
+    *,
+    runtime_root_arg: str | None,
+    registry_path: Path,
+    output_format: Callable[..., str],
+    print_payload: Callable[
+        [dict[str, object], str, Callable[[dict[str, object]], str]], None
+    ],
+) -> int | None:
+    if args.command != "machine-config":
+        return None
+    registry = build_builtin_machine_configuration_registry()
+    runtime_root = resolve_runtime_root(
+        read_json(registry_path),
+        runtime_root_arg,
+        registry_path=registry_path,
+    )
+    try:
+        if args.machine_config_command == "preview":
+            payload = configure_machine_configuration(
+                runtime_root=runtime_root,
+                configuration=_load_json_object(args.config_json),
+                registry=registry,
+            )
+        elif args.machine_config_command == "apply":
+            payload = configure_machine_configuration(
+                runtime_root=runtime_root,
+                configuration=_load_json_object(args.config_json),
+                registry=registry,
+                execute=args.execute,
+                expected_plan_revision=args.expected_plan_revision,
+            )
+        elif args.machine_config_command == "inspect":
+            payload = inspect_machine_configuration(runtime_root, registry=registry)
+        else:
+            payload = rollback_machine_configuration(
+                runtime_root=runtime_root,
+                transaction_id=args.transaction_id,
+                registry=registry,
+                execute=args.execute,
+                expected_plan_revision=args.expected_plan_revision,
+            )
+    except (OSError, TypeError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "machine_configuration_error_v0",
+            "status": "invalid_request",
+            "error": str(exc),
+        }
+        print_payload(payload, output_format(args), _render)
+        return 2
+    print_payload(payload, output_format(args), _render)
+    return 0
+
+
+__all__ = [
+    "handle_machine_configuration_command",
+    "register_machine_configuration_commands",
+]

--- a/loopx/capabilities/machine_configuration/cli.py
+++ b/loopx/capabilities/machine_configuration/cli.py
@@ -37,6 +37,7 @@ def _render(payload: dict[str, object]) -> str:
         "revision",
         "current_revision",
         "desired_revision",
+        "plan_revision",
         "transaction_id",
         "rollback_id",
         "error",
@@ -60,13 +61,23 @@ def register_machine_configuration_commands(
         help="Inspect, preview, apply, or roll back typed machine configuration.",
     )
     commands = parser.add_subparsers(dest="machine_config_command", required=True)
-    preview = commands.add_parser("preview")
+    preview = commands.add_parser(
+        "preview",
+        help="Preview an exact change and return the plan revision required by apply.",
+    )
     add_subcommand_format(preview)
     preview.add_argument("--config-json", required=True)
-    apply = commands.add_parser("apply")
+    apply = commands.add_parser(
+        "apply",
+        help="Apply an exact preview using its returned plan revision.",
+    )
     add_subcommand_format(apply)
     apply.add_argument("--config-json", required=True)
-    apply.add_argument("--expected-plan-revision", required=True)
+    apply.add_argument(
+        "--expected-plan-revision",
+        required=True,
+        help="Exact plan_revision returned by machine-config preview.",
+    )
     apply.add_argument("--execute", action="store_true", required=True)
     inspect = commands.add_parser("inspect")
     add_subcommand_format(inspect)
@@ -75,12 +86,21 @@ def register_machine_configuration_commands(
     )
     add_subcommand_format(remove)
     remove.add_argument("--namespace", required=True)
-    remove.add_argument("--expected-plan-revision")
+    remove.add_argument(
+        "--expected-plan-revision",
+        help="Exact plan_revision returned by the preceding removal preview.",
+    )
     remove.add_argument("--execute", action="store_true")
-    rollback = commands.add_parser("rollback")
+    rollback = commands.add_parser(
+        "rollback",
+        help="Preview a rollback, then apply it with the returned plan revision.",
+    )
     add_subcommand_format(rollback)
     rollback.add_argument("--transaction-id", required=True)
-    rollback.add_argument("--expected-plan-revision")
+    rollback.add_argument(
+        "--expected-plan-revision",
+        help="Exact plan_revision returned by the preceding rollback preview.",
+    )
     rollback.add_argument("--execute", action="store_true")
 
 

--- a/loopx/capabilities/machine_configuration/contract.py
+++ b/loopx/capabilities/machine_configuration/contract.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+MACHINE_CONFIGURATION_SCHEMA = "loopx_machine_configuration_v0"
+_NAMESPACE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+Normalizer = Callable[[Mapping[str, Any]], dict[str, Any]]
+Projector = Callable[[Mapping[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class MachineConfigurationNamespace:
+    """One typed owner of a machine-configuration namespace."""
+
+    namespace: str
+    schema_versions: frozenset[str]
+    normalize: Normalizer
+    project_public: Projector
+
+    def __post_init__(self) -> None:
+        if not _NAMESPACE_RE.fullmatch(self.namespace):
+            raise ValueError("machine-configuration namespace is invalid")
+        if not self.schema_versions or any(
+            not str(version).strip() for version in self.schema_versions
+        ):
+            raise ValueError("machine-configuration schema versions are required")
+
+
+class MachineConfigurationRegistry:
+    """Fail-closed registry shared by CLI, Dashboard, and other effect owners."""
+
+    def __init__(self) -> None:
+        self._namespaces: dict[str, MachineConfigurationNamespace] = {}
+
+    def register(
+        self, contract: MachineConfigurationNamespace
+    ) -> MachineConfigurationRegistry:
+        if contract.namespace in self._namespaces:
+            raise ValueError(
+                "machine-configuration namespace is already registered: "
+                + contract.namespace
+            )
+        self._namespaces[contract.namespace] = contract
+        return self
+
+    def resolve(self, namespace: str) -> MachineConfigurationNamespace:
+        try:
+            return self._namespaces[namespace]
+        except KeyError as exc:
+            raise ValueError(
+                f"unsupported machine-configuration namespace: {namespace}"
+            ) from exc
+
+    @property
+    def namespace_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._namespaces))
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def normalize_machine_configuration(
+    raw: object, *, registry: MachineConfigurationRegistry
+) -> dict[str, Any]:
+    payload = _mapping(raw, "machine_configuration")
+    unknown = sorted(set(payload) - {"schema_version", "namespaces"})
+    if unknown:
+        raise ValueError(
+            "machine_configuration contains unsupported fields: " + ", ".join(unknown)
+        )
+    if payload.get("schema_version") != MACHINE_CONFIGURATION_SCHEMA:
+        raise ValueError(
+            f"machine_configuration must use {MACHINE_CONFIGURATION_SCHEMA}"
+        )
+    namespaces = _mapping(payload.get("namespaces"), "machine_configuration.namespaces")
+    if not namespaces:
+        raise ValueError("machine_configuration.namespaces must not be empty")
+    normalized: dict[str, Any] = {}
+    for namespace in sorted(namespaces):
+        contract = registry.resolve(namespace)
+        candidate = _mapping(
+            namespaces[namespace], f"machine_configuration.namespaces.{namespace}"
+        )
+        schema_version = str(candidate.get("schema_version") or "").strip()
+        if schema_version not in contract.schema_versions:
+            raise ValueError(
+                f"machine_configuration namespace {namespace} has unsupported "
+                f"schema_version: {schema_version or 'missing'}"
+            )
+        value = contract.normalize(candidate)
+        if value.get("schema_version") != schema_version:
+            raise ValueError(
+                f"machine-configuration normalizer changed {namespace} schema_version"
+            )
+        normalized[namespace] = value
+    return {
+        "schema_version": MACHINE_CONFIGURATION_SCHEMA,
+        "namespaces": normalized,
+    }
+
+
+def machine_configuration_revision(configuration: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        configuration, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def project_machine_configuration(
+    configuration: object, *, registry: MachineConfigurationRegistry
+) -> dict[str, Any]:
+    normalized = normalize_machine_configuration(configuration, registry=registry)
+    projected: dict[str, Any] = {}
+    for namespace, value in normalized["namespaces"].items():
+        contract = registry.resolve(namespace)
+        public_value = contract.project_public(value)
+        if public_value.get("schema_version") != value.get("schema_version"):
+            raise ValueError(
+                f"machine-configuration public projection changed {namespace} schema_version"
+            )
+        projected[namespace] = public_value
+    return {
+        "schema_version": MACHINE_CONFIGURATION_SCHEMA,
+        "namespaces": projected,
+    }
+
+
+__all__ = [
+    "MACHINE_CONFIGURATION_SCHEMA",
+    "MachineConfigurationNamespace",
+    "MachineConfigurationRegistry",
+    "machine_configuration_revision",
+    "normalize_machine_configuration",
+    "project_machine_configuration",
+]

--- a/loopx/capabilities/machine_configuration/contract.py
+++ b/loopx/capabilities/machine_configuration/contract.py
@@ -134,6 +134,31 @@ def project_machine_configuration(
     }
 
 
+def remove_machine_configuration_namespace(
+    current: Mapping[str, Any] | None,
+    *,
+    namespace: str,
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any] | None:
+    """Remove one typed namespace, returning absence for an empty document."""
+
+    registry.resolve(namespace)
+    if current is None:
+        return None
+    normalized = normalize_machine_configuration(current, registry=registry)
+    namespaces = dict(normalized["namespaces"])
+    namespaces.pop(namespace, None)
+    if not namespaces:
+        return None
+    return normalize_machine_configuration(
+        {
+            "schema_version": MACHINE_CONFIGURATION_SCHEMA,
+            "namespaces": namespaces,
+        },
+        registry=registry,
+    )
+
+
 __all__ = [
     "MACHINE_CONFIGURATION_SCHEMA",
     "MachineConfigurationNamespace",
@@ -141,4 +166,5 @@ __all__ = [
     "machine_configuration_revision",
     "normalize_machine_configuration",
     "project_machine_configuration",
+    "remove_machine_configuration_namespace",
 ]

--- a/loopx/capabilities/machine_configuration/store.py
+++ b/loopx/capabilities/machine_configuration/store.py
@@ -137,10 +137,14 @@ def inspect_machine_configuration(
 def _update_plan(
     *,
     current: Mapping[str, Any] | None,
-    desired: Mapping[str, Any],
+    desired: Mapping[str, Any] | None,
     registry: MachineConfigurationRegistry,
 ) -> dict[str, Any]:
-    normalized_desired = normalize_machine_configuration(desired, registry=registry)
+    normalized_desired = (
+        normalize_machine_configuration(desired, registry=registry)
+        if desired is not None
+        else None
+    )
     normalized_current = (
         normalize_machine_configuration(current, registry=registry)
         if current is not None
@@ -151,12 +155,18 @@ def _update_plan(
         if normalized_current is not None
         else _MISSING_REVISION
     )
-    desired_revision = machine_configuration_revision(normalized_desired)
+    desired_revision = (
+        machine_configuration_revision(normalized_desired)
+        if normalized_desired is not None
+        else _MISSING_REVISION
+    )
     action = (
         "create"
-        if normalized_current is None
+        if normalized_current is None and normalized_desired is not None
         else "unchanged"
         if current_revision == desired_revision
+        else "delete"
+        if normalized_desired is None
         else "update"
     )
     identity = {
@@ -166,10 +176,10 @@ def _update_plan(
         "action": action,
         "changed_namespaces": sorted(
             namespace
-            for namespace in set(normalized_desired["namespaces"])
+            for namespace in set((normalized_desired or {}).get("namespaces", {}))
             | set((normalized_current or {}).get("namespaces", {}))
             if (normalized_current or {}).get("namespaces", {}).get(namespace)
-            != normalized_desired["namespaces"].get(namespace)
+            != (normalized_desired or {}).get("namespaces", {}).get(namespace)
         ),
     }
     return {
@@ -179,8 +189,10 @@ def _update_plan(
         **identity,
         "plan_revision": _digest(identity),
         "writes_required": int(action != "unchanged"),
-        "machine_configuration": project_machine_configuration(
-            normalized_desired, registry=registry
+        "machine_configuration": (
+            project_machine_configuration(normalized_desired, registry=registry)
+            if normalized_desired is not None
+            else None
         ),
     }
 
@@ -188,7 +200,7 @@ def _update_plan(
 def plan_machine_configuration_update(
     *,
     runtime_root: Path,
-    configuration: Mapping[str, Any],
+    configuration: Mapping[str, Any] | None,
     registry: MachineConfigurationRegistry,
 ) -> dict[str, Any]:
     return _update_plan(
@@ -213,7 +225,7 @@ def _restore_prior_state(
 def configure_machine_configuration(
     *,
     runtime_root: Path,
-    configuration: Mapping[str, Any],
+    configuration: Mapping[str, Any] | None,
     registry: MachineConfigurationRegistry,
     execute: bool = False,
     expected_plan_revision: str | None = None,
@@ -263,10 +275,17 @@ def configure_machine_configuration(
             "prior_revision": prior_revision,
             "prior_machine_configuration": current,
         }
-        desired = normalize_machine_configuration(configuration, registry=registry)
+        desired = (
+            normalize_machine_configuration(configuration, registry=registry)
+            if configuration is not None
+            else None
+        )
         try:
             _secure_write(backup_path, backup, writer=writer)
-            _secure_write(store_path, desired, writer=writer)
+            if desired is None:
+                store_path.unlink(missing_ok=True)
+            else:
+                _secure_write(store_path, desired, writer=writer)
             readback = read_machine_configuration(runtime_root, registry=registry)
             if readback != desired:
                 raise RuntimeError(
@@ -287,8 +306,10 @@ def configure_machine_configuration(
                 "readback_verified": True,
                 "rollback_available": True,
                 "changed_namespaces": plan["changed_namespaces"],
-                "machine_configuration": project_machine_configuration(
-                    readback, registry=registry
+                "machine_configuration": (
+                    project_machine_configuration(readback, registry=registry)
+                    if readback is not None
+                    else None
                 ),
             }
             receipt["receipt_revision"] = _digest(receipt)
@@ -327,7 +348,9 @@ def _read_transaction(runtime_root: Path, transaction_id: str) -> dict[str, Any]
         raise ValueError("machine-configuration transaction receipt is invalid")
     receipt["receipt_revision"] = receipt_revision
     applied_revision = str(receipt.get("applied_revision") or "")
-    if not re.fullmatch(r"sha256:[0-9a-f]{64}", applied_revision):
+    if applied_revision != _MISSING_REVISION and not re.fullmatch(
+        r"sha256:[0-9a-f]{64}", applied_revision
+    ):
         raise ValueError("machine-configuration transaction revision is invalid")
     return receipt
 

--- a/loopx/capabilities/machine_configuration/store.py
+++ b/loopx/capabilities/machine_configuration/store.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ...file_lock import exclusive_file_lock
+from ...registry import atomic_write_json, read_json
+from .contract import (
+    MachineConfigurationRegistry,
+    machine_configuration_revision,
+    normalize_machine_configuration,
+    project_machine_configuration,
+)
+
+
+MACHINE_CONFIGURATION_UPDATE_PLAN_SCHEMA = "machine_configuration_update_plan_v0"
+MACHINE_CONFIGURATION_TRANSACTION_SCHEMA = "machine_configuration_transaction_v0"
+MACHINE_CONFIGURATION_BACKUP_SCHEMA = "machine_configuration_backup_v0"
+MACHINE_CONFIGURATION_INSPECTION_SCHEMA = "machine_configuration_inspection_v0"
+MACHINE_CONFIGURATION_ROLLBACK_PLAN_SCHEMA = "machine_configuration_rollback_plan_v0"
+MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA = (
+    "machine_configuration_rollback_receipt_v0"
+)
+
+_MISSING_REVISION = "absent"
+_TRANSACTION_ID_RE = re.compile(r"^machine_configuration_[0-9a-f]{24}$")
+JsonWriter = Callable[[Path, dict[str, Any]], None]
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _now_iso(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    return current.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _runtime_root(runtime_root: Path) -> Path:
+    return runtime_root.expanduser().resolve()
+
+
+def machine_configuration_store_path(runtime_root: Path) -> Path:
+    return _runtime_root(runtime_root) / "machine" / "configuration.json"
+
+
+def _store_ref() -> str:
+    return "machine/configuration.json"
+
+
+def _transaction_ref(transaction_id: str) -> str:
+    return f"machine/configuration/transactions/{transaction_id}.json"
+
+
+def _backup_ref(transaction_id: str) -> str:
+    return f"machine/configuration/backups/{transaction_id}.json"
+
+
+def _transaction_path(runtime_root: Path, transaction_id: str) -> Path:
+    return _runtime_root(runtime_root) / _transaction_ref(transaction_id)
+
+
+def _backup_path(runtime_root: Path, transaction_id: str) -> Path:
+    return _runtime_root(runtime_root) / _backup_ref(transaction_id)
+
+
+def _safe_transaction_id(value: str) -> str:
+    transaction_id = str(value or "").strip()
+    if not _TRANSACTION_ID_RE.fullmatch(transaction_id):
+        raise ValueError("transaction_id is invalid")
+    return transaction_id
+
+
+def _new_transaction_id() -> str:
+    return f"machine_configuration_{uuid4().hex[:24]}"
+
+
+def _new_rollback_id() -> str:
+    return f"machine_configuration_rollback_{uuid4().hex[:24]}"
+
+
+def _secure_write(
+    path: Path, payload: dict[str, Any], *, writer: JsonWriter = atomic_write_json
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    writer(path, payload)
+    path.chmod(0o600)
+
+
+def read_machine_configuration(
+    runtime_root: Path, *, registry: MachineConfigurationRegistry
+) -> dict[str, Any] | None:
+    path = machine_configuration_store_path(runtime_root)
+    if not path.is_file():
+        return None
+    normalized: dict[str, Any] = normalize_machine_configuration(
+        read_json(path), registry=registry
+    )
+    return normalized
+
+
+def inspect_machine_configuration(
+    runtime_root: Path, *, registry: MachineConfigurationRegistry
+) -> dict[str, Any]:
+    current = read_machine_configuration(runtime_root, registry=registry)
+    return {
+        "ok": True,
+        "schema_version": MACHINE_CONFIGURATION_INSPECTION_SCHEMA,
+        "status": "configured" if current is not None else "absent",
+        "defaults_ref": _store_ref(),
+        "revision": (
+            machine_configuration_revision(current)
+            if current is not None
+            else _MISSING_REVISION
+        ),
+        "changed_namespaces": [],
+        "machine_configuration": (
+            project_machine_configuration(current, registry=registry)
+            if current is not None
+            else None
+        ),
+    }
+
+
+def _update_plan(
+    *,
+    current: Mapping[str, Any] | None,
+    desired: Mapping[str, Any],
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    normalized_desired = normalize_machine_configuration(desired, registry=registry)
+    normalized_current = (
+        normalize_machine_configuration(current, registry=registry)
+        if current is not None
+        else None
+    )
+    current_revision = (
+        machine_configuration_revision(normalized_current)
+        if normalized_current is not None
+        else _MISSING_REVISION
+    )
+    desired_revision = machine_configuration_revision(normalized_desired)
+    action = (
+        "create"
+        if normalized_current is None
+        else "unchanged"
+        if current_revision == desired_revision
+        else "update"
+    )
+    identity = {
+        "current_revision": current_revision,
+        "desired_revision": desired_revision,
+        "defaults_ref": _store_ref(),
+        "action": action,
+        "changed_namespaces": sorted(
+            namespace
+            for namespace in set(normalized_desired["namespaces"])
+            | set((normalized_current or {}).get("namespaces", {}))
+            if (normalized_current or {}).get("namespaces", {}).get(namespace)
+            != normalized_desired["namespaces"].get(namespace)
+        ),
+    }
+    return {
+        "ok": True,
+        "schema_version": MACHINE_CONFIGURATION_UPDATE_PLAN_SCHEMA,
+        "status": "preview",
+        **identity,
+        "plan_revision": _digest(identity),
+        "writes_required": int(action != "unchanged"),
+        "machine_configuration": project_machine_configuration(
+            normalized_desired, registry=registry
+        ),
+    }
+
+
+def plan_machine_configuration_update(
+    *,
+    runtime_root: Path,
+    configuration: Mapping[str, Any],
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    return _update_plan(
+        current=read_machine_configuration(runtime_root, registry=registry),
+        desired=configuration,
+        registry=registry,
+    )
+
+
+def _restore_prior_state(
+    *,
+    store_path: Path,
+    prior: Mapping[str, Any] | None,
+    writer: JsonWriter,
+) -> None:
+    if prior is None:
+        store_path.unlink(missing_ok=True)
+        return
+    _secure_write(store_path, dict(prior), writer=writer)
+
+
+def configure_machine_configuration(
+    *,
+    runtime_root: Path,
+    configuration: Mapping[str, Any],
+    registry: MachineConfigurationRegistry,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    """Preview or atomically apply one machine policy with a rollback receipt."""
+
+    preview = plan_machine_configuration_update(
+        runtime_root=runtime_root,
+        configuration=configuration,
+        registry=registry,
+    )
+    if not execute:
+        return preview
+    expected = str(expected_plan_revision or "").strip()
+    if not expected:
+        raise ValueError("expected_plan_revision is required when execute is true")
+
+    store_path = machine_configuration_store_path(runtime_root)
+    with exclusive_file_lock(store_path, operation="configure_machine_configuration"):
+        current = read_machine_configuration(runtime_root, registry=registry)
+        plan = _update_plan(current=current, desired=configuration, registry=registry)
+        if plan["plan_revision"] != expected:
+            raise ValueError(
+                "machine-configuration plan revision changed; preview again"
+            )
+        if plan["action"] == "unchanged":
+            return {
+                **plan,
+                "schema_version": MACHINE_CONFIGURATION_TRANSACTION_SCHEMA,
+                "status": "unchanged",
+                "transaction_id": None,
+                "transaction_ref": None,
+                "backup_ref": None,
+                "readback_verified": True,
+                "rollback_available": False,
+            }
+
+        transaction_id = _new_transaction_id()
+        backup_path = _backup_path(runtime_root, transaction_id)
+        receipt_path = _transaction_path(runtime_root, transaction_id)
+        prior_revision = str(plan["current_revision"])
+        backup = {
+            "schema_version": MACHINE_CONFIGURATION_BACKUP_SCHEMA,
+            "transaction_id": transaction_id,
+            "prior_revision": prior_revision,
+            "prior_machine_configuration": current,
+        }
+        desired = normalize_machine_configuration(configuration, registry=registry)
+        try:
+            _secure_write(backup_path, backup, writer=writer)
+            _secure_write(store_path, desired, writer=writer)
+            readback = read_machine_configuration(runtime_root, registry=registry)
+            if readback != desired:
+                raise RuntimeError(
+                    "machine-configuration readback did not match the requested policy"
+                )
+            receipt = {
+                "ok": True,
+                "schema_version": MACHINE_CONFIGURATION_TRANSACTION_SCHEMA,
+                "status": "applied",
+                "transaction_id": transaction_id,
+                "transaction_ref": _transaction_ref(transaction_id),
+                "backup_ref": _backup_ref(transaction_id),
+                "defaults_ref": _store_ref(),
+                "plan_revision": plan["plan_revision"],
+                "prior_revision": prior_revision,
+                "applied_revision": plan["desired_revision"],
+                "applied_at": _now_iso(now),
+                "readback_verified": True,
+                "rollback_available": True,
+                "changed_namespaces": plan["changed_namespaces"],
+                "machine_configuration": project_machine_configuration(
+                    readback, registry=registry
+                ),
+            }
+            receipt["receipt_revision"] = _digest(receipt)
+            _secure_write(receipt_path, receipt, writer=writer)
+            return receipt
+        except Exception as exc:
+            try:
+                _restore_prior_state(
+                    store_path=store_path, prior=current, writer=writer
+                )
+            except Exception as rollback_exc:
+                raise RuntimeError(
+                    "machine-configuration apply failed and automatic rollback also failed"
+                ) from rollback_exc
+            raise RuntimeError(
+                "machine-configuration apply failed; prior state was restored"
+            ) from exc
+
+
+def _read_transaction(runtime_root: Path, transaction_id: str) -> dict[str, Any]:
+    safe_id = _safe_transaction_id(transaction_id)
+    path = _transaction_path(runtime_root, safe_id)
+    if not path.is_file():
+        raise ValueError(f"machine-configuration transaction not found: {safe_id}")
+    receipt: dict[str, Any] = read_json(path)
+    if (
+        receipt.get("schema_version") != MACHINE_CONFIGURATION_TRANSACTION_SCHEMA
+        or receipt.get("transaction_id") != safe_id
+        or receipt.get("status") != "applied"
+        or receipt.get("transaction_ref") != _transaction_ref(safe_id)
+        or receipt.get("defaults_ref") != _store_ref()
+    ):
+        raise ValueError("machine-configuration transaction receipt is invalid")
+    receipt_revision = str(receipt.pop("receipt_revision", ""))
+    if receipt_revision != _digest(receipt):
+        raise ValueError("machine-configuration transaction receipt is invalid")
+    receipt["receipt_revision"] = receipt_revision
+    applied_revision = str(receipt.get("applied_revision") or "")
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", applied_revision):
+        raise ValueError("machine-configuration transaction revision is invalid")
+    return receipt
+
+
+def _read_backup(
+    runtime_root: Path,
+    transaction_id: str,
+    receipt: Mapping[str, Any],
+    *,
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    path = _backup_path(runtime_root, transaction_id)
+    if receipt.get("backup_ref") != _backup_ref(transaction_id) or not path.is_file():
+        raise ValueError("machine-configuration transaction backup is unavailable")
+    backup = read_json(path)
+    if (
+        backup.get("schema_version") != MACHINE_CONFIGURATION_BACKUP_SCHEMA
+        or backup.get("transaction_id") != transaction_id
+    ):
+        raise ValueError("machine-configuration transaction backup is invalid")
+    prior = backup.get("prior_machine_configuration")
+    normalized_prior = (
+        normalize_machine_configuration(prior, registry=registry)
+        if prior is not None
+        else None
+    )
+    prior_revision = (
+        machine_configuration_revision(normalized_prior)
+        if normalized_prior is not None
+        else _MISSING_REVISION
+    )
+    if prior_revision != backup.get("prior_revision") or prior_revision != receipt.get(
+        "prior_revision"
+    ):
+        raise ValueError(
+            "machine-configuration backup revision does not match its receipt"
+        )
+    return {**backup, "prior_machine_configuration": normalized_prior}
+
+
+def _rollback_plan(
+    *,
+    transaction_id: str,
+    receipt: Mapping[str, Any],
+    backup: Mapping[str, Any],
+    current: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    current_revision = (
+        machine_configuration_revision(current)
+        if current is not None
+        else _MISSING_REVISION
+    )
+    applied_revision = str(receipt.get("applied_revision") or "")
+    target_revision = str(backup.get("prior_revision") or "")
+    if current_revision == target_revision:
+        action, allowed, reason = "unchanged", True, "already_rolled_back"
+    elif current_revision != applied_revision:
+        action, allowed, reason = "blocked", False, "current_revision_changed"
+    else:
+        action = "delete" if target_revision == _MISSING_REVISION else "restore"
+        allowed, reason = True, "exact_applied_revision_matches"
+    identity = {
+        "transaction_id": transaction_id,
+        "current_revision": current_revision,
+        "applied_revision": applied_revision,
+        "target_revision": target_revision,
+        "action": action,
+    }
+    return {
+        "ok": True,
+        "schema_version": MACHINE_CONFIGURATION_ROLLBACK_PLAN_SCHEMA,
+        "status": "preview",
+        **identity,
+        "reason": reason,
+        "rollback_allowed": allowed,
+        "writes_required": int(action in {"delete", "restore"}),
+        "plan_revision": _digest(identity),
+    }
+
+
+def plan_machine_configuration_rollback(
+    *,
+    runtime_root: Path,
+    transaction_id: str,
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    safe_id = _safe_transaction_id(transaction_id)
+    receipt = _read_transaction(runtime_root, safe_id)
+    backup = _read_backup(runtime_root, safe_id, receipt, registry=registry)
+    current = read_machine_configuration(runtime_root, registry=registry)
+    return _rollback_plan(
+        transaction_id=safe_id,
+        receipt=receipt,
+        backup=backup,
+        current=current,
+    )
+
+
+def rollback_machine_configuration(
+    *,
+    runtime_root: Path,
+    transaction_id: str,
+    registry: MachineConfigurationRegistry,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    preview = plan_machine_configuration_rollback(
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+        registry=registry,
+    )
+    if not execute:
+        return preview
+    expected = str(expected_plan_revision or "").strip()
+    if not expected:
+        raise ValueError("expected_plan_revision is required when execute is true")
+
+    safe_id = _safe_transaction_id(transaction_id)
+    store_path = machine_configuration_store_path(runtime_root)
+    with exclusive_file_lock(store_path, operation="rollback_machine_configuration"):
+        receipt = _read_transaction(runtime_root, safe_id)
+        backup = _read_backup(runtime_root, safe_id, receipt, registry=registry)
+        current = read_machine_configuration(runtime_root, registry=registry)
+        plan = _rollback_plan(
+            transaction_id=safe_id,
+            receipt=receipt,
+            backup=backup,
+            current=current,
+        )
+        if plan["plan_revision"] != expected:
+            raise ValueError(
+                "machine-configuration rollback plan changed; preview again"
+            )
+        if not plan["rollback_allowed"]:
+            raise ValueError(
+                "machine-configuration rollback is blocked by a newer revision"
+            )
+        if plan["action"] == "unchanged":
+            return {
+                **plan,
+                "schema_version": MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA,
+                "status": "unchanged",
+                "rollback_id": None,
+                "readback_verified": True,
+            }
+
+        prior = backup.get("prior_machine_configuration")
+        rollback_id = _new_rollback_id()
+        rollback_path = _runtime_root(runtime_root) / _transaction_ref(rollback_id)
+        try:
+            _restore_prior_state(store_path=store_path, prior=prior, writer=writer)
+            readback = read_machine_configuration(runtime_root, registry=registry)
+            if readback != prior:
+                raise RuntimeError(
+                    "machine-configuration rollback readback did not match backup"
+                )
+            result = {
+                "ok": True,
+                "schema_version": MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA,
+                "status": "rolled_back",
+                "rollback_id": rollback_id,
+                "rollback_ref": _transaction_ref(rollback_id),
+                "transaction_id": safe_id,
+                "plan_revision": plan["plan_revision"],
+                "restored_revision": plan["target_revision"],
+                "rolled_back_at": _now_iso(now),
+                "readback_verified": True,
+            }
+            _secure_write(rollback_path, result, writer=writer)
+            return result
+        except Exception as exc:
+            try:
+                _restore_prior_state(
+                    store_path=store_path, prior=current, writer=writer
+                )
+            except Exception as restore_exc:
+                raise RuntimeError(
+                    "machine-configuration rollback failed and applied state could not be restored"
+                ) from restore_exc
+            raise RuntimeError(
+                "machine-configuration rollback failed; applied state was restored"
+            ) from exc
+
+
+__all__ = [
+    "MACHINE_CONFIGURATION_BACKUP_SCHEMA",
+    "MACHINE_CONFIGURATION_INSPECTION_SCHEMA",
+    "MACHINE_CONFIGURATION_ROLLBACK_PLAN_SCHEMA",
+    "MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA",
+    "MACHINE_CONFIGURATION_TRANSACTION_SCHEMA",
+    "MACHINE_CONFIGURATION_UPDATE_PLAN_SCHEMA",
+    "configure_machine_configuration",
+    "inspect_machine_configuration",
+    "machine_configuration_store_path",
+    "plan_machine_configuration_rollback",
+    "plan_machine_configuration_update",
+    "read_machine_configuration",
+    "rollback_machine_configuration",
+]

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -24,6 +24,16 @@ from .bindings import (
     normalize_periodic_report_sink_bindings,
 )
 from .core import build_periodic_report_run
+from .machine_defaults import (
+    build_goal_periodic_report_delivery_identity,
+    build_goal_periodic_report_delivery_plan,
+    normalize_loopx_machine_defaults,
+    normalize_periodic_report_machine_defaults,
+    periodic_report_machine_configuration_namespace,
+    plan_periodic_report_machine_default_backfill,
+    resolve_goal_periodic_report_subscription,
+    select_goal_periodic_report_executor,
+)
 from .presets import (
     PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
     PERIODIC_REPORT_PROFILE_PRESET_IDS,
@@ -64,14 +74,22 @@ __all__ = [
     "build_periodic_report_preset_activation",
     "build_project_progress_periodic_report_source",
     "build_periodic_report_archive_bundle",
+    "build_goal_periodic_report_delivery_identity",
+    "build_goal_periodic_report_delivery_plan",
     "build_periodic_report_run",
     "build_periodic_report_source_result",
     "build_periodic_report_trigger_decision",
     "normalize_periodic_report_profile",
+    "normalize_loopx_machine_defaults",
+    "normalize_periodic_report_machine_defaults",
+    "periodic_report_machine_configuration_namespace",
+    "plan_periodic_report_machine_default_backfill",
     "normalize_periodic_report_audience_policy",
     "normalize_periodic_report_sink_bindings",
     "normalize_periodic_report_trigger_policy",
     "project_progress_periodic_report_source_adapter",
     "resolve_periodic_report_profile_preset",
+    "resolve_goal_periodic_report_subscription",
+    "select_goal_periodic_report_executor",
     "verify_periodic_report_archive_receipts",
 ]

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -30,7 +30,6 @@ from .machine_defaults import (
     normalize_loopx_machine_defaults,
     normalize_periodic_report_machine_defaults,
     periodic_report_machine_configuration_namespace,
-    plan_periodic_report_machine_default_backfill,
     resolve_goal_periodic_report_subscription,
     select_goal_periodic_report_executor,
 )
@@ -83,7 +82,6 @@ __all__ = [
     "normalize_loopx_machine_defaults",
     "normalize_periodic_report_machine_defaults",
     "periodic_report_machine_configuration_namespace",
-    "plan_periodic_report_machine_default_backfill",
     "normalize_periodic_report_audience_policy",
     "normalize_periodic_report_sink_bindings",
     "normalize_periodic_report_trigger_policy",

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -13,6 +13,10 @@ from ...extensions.runtime import (
 )
 from ...rollout_event_log import iter_rollout_events
 from .core import build_periodic_report_run
+from .machine_defaults import (
+    build_goal_periodic_report_delivery_plan,
+    plan_periodic_report_machine_default_backfill,
+)
 from .extension_envelope import build_openviking_archive_execution_envelope
 from .presets import (
     PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
@@ -100,6 +104,26 @@ def register_periodic_report_commands(
     consume_pending.add_argument("--goal-id", required=True)
     consume_pending.add_argument("--agent-id", required=True)
     consume_pending.add_argument("--execute", action="store_true")
+    plan_machine_defaults = commands.add_parser(
+        "plan-machine-defaults",
+        help="Preview per-Goal weekly-report inheritance without writing registries.",
+    )
+    add_subcommand_format(plan_machine_defaults)
+    plan_machine_defaults.add_argument(
+        "--config-json",
+        required=True,
+        help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
+    )
+    plan_goal_delivery = commands.add_parser(
+        "plan-goal-delivery",
+        help="Preview Goal-owned delivery identity and preferred Agent execution.",
+    )
+    add_subcommand_format(plan_goal_delivery)
+    plan_goal_delivery.add_argument(
+        "--request-json",
+        required=True,
+        help="Path to periodic_report_goal_delivery_plan_request_v0 JSON.",
+    )
     evaluate_runtime.add_argument(
         "--rollout-events-jsonl",
         required=True,
@@ -276,6 +300,20 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
                 "",
             ]
         )
+    if payload.get("schema_version") in {
+        "periodic_report_machine_default_backfill_plan_v0",
+        "periodic_report_goal_delivery_plan_v0",
+    }:
+        return "\n".join(
+            [
+                "# Periodic Report Goal Plan",
+                "",
+                f"- schema: `{payload.get('schema_version')}`",
+                f"- status: `{payload.get('status', 'preview')}`",
+                f"- writes_required: `{payload.get('writes_required', 0)}`",
+                "",
+            ]
+        )
     run_state = payload.get("run_state")
     retry = payload.get("retry")
     state = run_state if isinstance(run_state, dict) else {}
@@ -350,6 +388,16 @@ def handle_periodic_report_command(
                 goal_id=args.goal_id,
                 agent_id=args.agent_id,
                 execute=bool(args.execute),
+            )
+        elif args.periodic_report_command == "plan-machine-defaults":
+            payload = plan_periodic_report_machine_default_backfill(
+                read_json(registry_path),
+                _load_json_object(args.config_json),
+            )
+            payload["ok"] = True
+        elif args.periodic_report_command == "plan-goal-delivery":
+            payload = build_goal_periodic_report_delivery_plan(
+                _load_json_object(args.request_json)
             )
         else:
             request = _load_json_object(args.request_json)

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -331,20 +331,28 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
             ]
         )
     if payload.get("schema_version") in {
+        "machine_configuration_update_plan_v0",
+        "machine_configuration_transaction_v0",
+        "machine_configuration_inspection_v0",
+        "machine_configuration_rollback_plan_v0",
+        "machine_configuration_rollback_receipt_v0",
         "periodic_report_machine_default_backfill_plan_v0",
-        "periodic_report_machine_default_update_plan_v0",
-        "periodic_report_machine_default_transaction_v0",
-        "periodic_report_machine_default_inspection_v0",
-        "periodic_report_machine_default_rollback_plan_v0",
-        "periodic_report_machine_default_rollback_receipt_v0",
         "periodic_report_goal_delivery_plan_v0",
     }:
+        machine_configuration = str(payload.get("schema_version") or "").startswith(
+            "machine_configuration_"
+        )
         return "\n".join(
             [
-                "# Periodic Report Goal Plan",
+                (
+                    "# Machine Configuration"
+                    if machine_configuration
+                    else "# Periodic Report Goal Plan"
+                ),
                 "",
                 f"- schema: `{payload.get('schema_version')}`",
                 f"- status: `{payload.get('status', 'preview')}`",
+                f"- action: `{payload.get('action', 'none')}`",
                 f"- writes_required: `{payload.get('writes_required', 0)}`",
                 "",
             ]

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -17,6 +17,11 @@ from .machine_defaults import (
     build_goal_periodic_report_delivery_plan,
     plan_periodic_report_machine_default_backfill,
 )
+from .machine_store import (
+    configure_periodic_report_machine_defaults,
+    inspect_periodic_report_machine_defaults,
+    rollback_periodic_report_machine_defaults,
+)
 from .extension_envelope import build_openviking_archive_execution_envelope
 from .presets import (
     PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
@@ -114,6 +119,31 @@ def register_periodic_report_commands(
         required=True,
         help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
     )
+    configure_machine_defaults = commands.add_parser(
+        "configure-machine-defaults",
+        help="Preview or apply the runtime-root machine periodic-report policy.",
+    )
+    add_subcommand_format(configure_machine_defaults)
+    configure_machine_defaults.add_argument(
+        "--config-json",
+        required=True,
+        help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
+    )
+    configure_machine_defaults.add_argument("--execute", action="store_true")
+    configure_machine_defaults.add_argument("--expected-plan-revision")
+    inspect_machine_defaults = commands.add_parser(
+        "inspect-machine-defaults",
+        help="Read back the runtime-root machine periodic-report policy.",
+    )
+    add_subcommand_format(inspect_machine_defaults)
+    rollback_machine_defaults = commands.add_parser(
+        "rollback-machine-defaults",
+        help="Preview or execute rollback of one exact machine-policy transaction.",
+    )
+    add_subcommand_format(rollback_machine_defaults)
+    rollback_machine_defaults.add_argument("--transaction-id", required=True)
+    rollback_machine_defaults.add_argument("--execute", action="store_true")
+    rollback_machine_defaults.add_argument("--expected-plan-revision")
     plan_goal_delivery = commands.add_parser(
         "plan-goal-delivery",
         help="Preview Goal-owned delivery identity and preferred Agent execution.",
@@ -302,6 +332,11 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
         )
     if payload.get("schema_version") in {
         "periodic_report_machine_default_backfill_plan_v0",
+        "periodic_report_machine_default_update_plan_v0",
+        "periodic_report_machine_default_transaction_v0",
+        "periodic_report_machine_default_inspection_v0",
+        "periodic_report_machine_default_rollback_plan_v0",
+        "periodic_report_machine_default_rollback_receipt_v0",
         "periodic_report_goal_delivery_plan_v0",
     }:
         return "\n".join(
@@ -395,6 +430,31 @@ def handle_periodic_report_command(
                 _load_json_object(args.config_json),
             )
             payload["ok"] = True
+        elif args.periodic_report_command in {
+            "configure-machine-defaults",
+            "inspect-machine-defaults",
+            "rollback-machine-defaults",
+        }:
+            registry = read_json(registry_path)
+            runtime_root = resolve_runtime_root(
+                registry, runtime_root_arg, registry_path=registry_path
+            )
+            if args.periodic_report_command == "configure-machine-defaults":
+                payload = configure_periodic_report_machine_defaults(
+                    runtime_root=runtime_root,
+                    machine_defaults=_load_json_object(args.config_json),
+                    execute=bool(args.execute),
+                    expected_plan_revision=args.expected_plan_revision,
+                )
+            elif args.periodic_report_command == "inspect-machine-defaults":
+                payload = inspect_periodic_report_machine_defaults(runtime_root)
+            else:
+                payload = rollback_periodic_report_machine_defaults(
+                    runtime_root=runtime_root,
+                    transaction_id=args.transaction_id,
+                    execute=bool(args.execute),
+                    expected_plan_revision=args.expected_plan_revision,
+                )
         elif args.periodic_report_command == "plan-goal-delivery":
             payload = build_goal_periodic_report_delivery_plan(
                 _load_json_object(args.request_json)

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -19,6 +19,7 @@ from .machine_defaults import (
 from .machine_store import (
     configure_periodic_report_machine_defaults,
     inspect_periodic_report_machine_defaults,
+    read_periodic_report_machine_defaults,
     rollback_periodic_report_machine_defaults,
 )
 from .extension_envelope import build_openviking_archive_execution_envelope
@@ -119,7 +120,10 @@ def register_periodic_report_commands(
         help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
     )
     configure_machine_defaults.add_argument("--execute", action="store_true")
-    configure_machine_defaults.add_argument("--expected-plan-revision")
+    configure_machine_defaults.add_argument(
+        "--expected-plan-revision",
+        help="Exact plan_revision returned by the preceding configuration preview.",
+    )
     inspect_machine_defaults = commands.add_parser(
         "inspect-machine-defaults",
         help="Read back the runtime-root machine periodic-report policy.",
@@ -132,10 +136,16 @@ def register_periodic_report_commands(
     add_subcommand_format(rollback_machine_defaults)
     rollback_machine_defaults.add_argument("--transaction-id", required=True)
     rollback_machine_defaults.add_argument("--execute", action="store_true")
-    rollback_machine_defaults.add_argument("--expected-plan-revision")
+    rollback_machine_defaults.add_argument(
+        "--expected-plan-revision",
+        help="Exact plan_revision returned by the preceding rollback preview.",
+    )
     plan_goal_delivery = commands.add_parser(
         "plan-goal-delivery",
-        help="Preview Goal-owned delivery identity and preferred Agent execution.",
+        help=(
+            "Preview delivery from a Goal override or the current machine default, "
+            "then select the preferred Agent executor."
+        ),
     )
     add_subcommand_format(plan_goal_delivery)
     plan_goal_delivery.add_argument(
@@ -342,6 +352,11 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
                 f"- status: `{payload.get('status', 'preview')}`",
                 f"- action: `{payload.get('action', 'none')}`",
                 f"- writes_required: `{payload.get('writes_required', 0)}`",
+                *(
+                    [f"- plan_revision: `{payload.get('plan_revision')}`"]
+                    if payload.get("plan_revision")
+                    else []
+                ),
                 "",
             ]
         )
@@ -446,8 +461,13 @@ def handle_periodic_report_command(
                     expected_plan_revision=args.expected_plan_revision,
                 )
         elif args.periodic_report_command == "plan-goal-delivery":
+            registry = read_json(registry_path)
+            runtime_root = resolve_runtime_root(
+                registry, runtime_root_arg, registry_path=registry_path
+            )
             payload = build_goal_periodic_report_delivery_plan(
-                _load_json_object(args.request_json)
+                _load_json_object(args.request_json),
+                machine_defaults=read_periodic_report_machine_defaults(runtime_root),
             )
         else:
             request = _load_json_object(args.request_json)

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -15,7 +15,6 @@ from ...rollout_event_log import iter_rollout_events
 from .core import build_periodic_report_run
 from .machine_defaults import (
     build_goal_periodic_report_delivery_plan,
-    plan_periodic_report_machine_default_backfill,
 )
 from .machine_store import (
     configure_periodic_report_machine_defaults,
@@ -109,16 +108,6 @@ def register_periodic_report_commands(
     consume_pending.add_argument("--goal-id", required=True)
     consume_pending.add_argument("--agent-id", required=True)
     consume_pending.add_argument("--execute", action="store_true")
-    plan_machine_defaults = commands.add_parser(
-        "plan-machine-defaults",
-        help="Preview per-Goal weekly-report inheritance without writing registries.",
-    )
-    add_subcommand_format(plan_machine_defaults)
-    plan_machine_defaults.add_argument(
-        "--config-json",
-        required=True,
-        help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
-    )
     configure_machine_defaults = commands.add_parser(
         "configure-machine-defaults",
         help="Preview or apply the runtime-root machine periodic-report policy.",
@@ -336,7 +325,6 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
         "machine_configuration_inspection_v0",
         "machine_configuration_rollback_plan_v0",
         "machine_configuration_rollback_receipt_v0",
-        "periodic_report_machine_default_backfill_plan_v0",
         "periodic_report_goal_delivery_plan_v0",
     }:
         machine_configuration = str(payload.get("schema_version") or "").startswith(
@@ -432,12 +420,6 @@ def handle_periodic_report_command(
                 agent_id=args.agent_id,
                 execute=bool(args.execute),
             )
-        elif args.periodic_report_command == "plan-machine-defaults":
-            payload = plan_periodic_report_machine_default_backfill(
-                read_json(registry_path),
-                _load_json_object(args.config_json),
-            )
-            payload["ok"] = True
         elif args.periodic_report_command in {
             "configure-machine-defaults",
             "inspect-machine-defaults",

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -161,9 +161,41 @@ def loopx_machine_defaults_revision(raw: object) -> str:
     return machine_configuration_revision(normalize_loopx_machine_defaults(raw))
 
 
-def _periodic_report_defaults(machine_defaults: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = normalize_loopx_machine_defaults(machine_defaults)
-    return dict(normalized["namespaces"]["periodic_report"])
+def _periodic_report_defaults(
+    machine_configuration: Mapping[str, Any],
+) -> tuple[dict[str, Any], str] | None:
+    """Read only this capability's namespace from a generic machine document."""
+
+    payload = _mapping(machine_configuration, "machine_configuration")
+    _reject_unknown(
+        payload,
+        allowed={"schema_version", "namespaces"},
+        label="machine_configuration",
+    )
+    if payload.get("schema_version") != MACHINE_CONFIGURATION_SCHEMA:
+        raise ValueError(
+            f"machine_configuration must use {MACHINE_CONFIGURATION_SCHEMA}"
+        )
+    namespaces = _mapping(
+        payload.get("namespaces"),
+        "machine_configuration.namespaces",
+    )
+    raw_periodic = namespaces.get("periodic_report")
+    if raw_periodic is None:
+        return None
+    periodic = normalize_periodic_report_machine_defaults(
+        _mapping(
+            raw_periodic,
+            "machine_configuration.namespaces.periodic_report",
+        )
+    )
+    source_revision = _digest(
+        {
+            "namespace": "periodic_report",
+            "configuration": periodic,
+        }
+    )
+    return periodic, source_revision
 
 
 def _goal_periodic_report(goal: Mapping[str, Any]) -> dict[str, Any] | None:
@@ -234,12 +266,20 @@ def resolve_goal_periodic_report_subscription(
             source="not_configured",
             source_revision=None,
         )
-    normalized_defaults = normalize_loopx_machine_defaults(machine_defaults)
+    resolved_default = _periodic_report_defaults(machine_defaults)
+    if resolved_default is None:
+        return _normalized_goal_subscription(
+            goal_id=goal_id,
+            config={"enabled": False, "timezone": "UTC"},
+            source="not_configured",
+            source_revision=None,
+        )
+    periodic_defaults, source_revision = resolved_default
     return _normalized_goal_subscription(
         goal_id=goal_id,
-        config=_periodic_report_defaults(normalized_defaults),
+        config=periodic_defaults,
         source="machine_default",
-        source_revision=machine_configuration_revision(normalized_defaults),
+        source_revision=source_revision,
     )
 
 

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -21,21 +20,11 @@ from ..machine_configuration.contract import (
 MACHINE_DEFAULTS_SCHEMA = MACHINE_CONFIGURATION_SCHEMA
 PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA = "periodic_report_machine_defaults_v0"
 GOAL_SUBSCRIPTION_SCHEMA = "periodic_report_goal_subscription_v0"
-BACKFILL_PLAN_SCHEMA = "periodic_report_machine_default_backfill_plan_v0"
 DELIVERY_IDENTITY_SCHEMA = "periodic_report_goal_delivery_identity_v0"
 DELIVERY_PLAN_REQUEST_SCHEMA = "periodic_report_goal_delivery_plan_request_v0"
 DELIVERY_PLAN_SCHEMA = "periodic_report_goal_delivery_plan_v0"
 
-_INHERITANCE_MODE = "materialize_on_goal_connect"
-_TERMINAL_GOAL_STATUSES = {
-    "archived",
-    "canceled",
-    "cancelled",
-    "completed",
-    "disconnected",
-    "retired",
-    "stopped",
-}
+_INHERITANCE_MODE = "live_machine_default"
 
 
 def _mapping(value: object, label: str) -> dict[str, Any]:
@@ -108,9 +97,7 @@ def normalize_periodic_report_machine_defaults(
         "periodic_report.inheritance",
     )
     if inheritance != _INHERITANCE_MODE:
-        raise ValueError(
-            "periodic_report.inheritance must be materialize_on_goal_connect"
-        )
+        raise ValueError("periodic_report.inheritance must be live_machine_default")
     timezone = _text(
         periodic.get("timezone", "UTC"),
         "periodic_report.timezone",
@@ -188,7 +175,11 @@ def _goal_periodic_report(goal: Mapping[str, Any]) -> dict[str, Any] | None:
 
 
 def _normalized_goal_subscription(
-    *, goal_id: str, config: Mapping[str, Any], source: str
+    *,
+    goal_id: str,
+    config: Mapping[str, Any],
+    source: str,
+    source_revision: str | None,
 ) -> dict[str, Any]:
     enabled = config.get("enabled")
     if not isinstance(enabled, bool):
@@ -212,6 +203,7 @@ def _normalized_goal_subscription(
         "goal_id": goal_id,
         "enabled": enabled,
         "source": source,
+        "source_revision": source_revision,
         "profile_preset": profile_preset,
         "route_ref": route_ref,
         "timezone": timezone_name,
@@ -222,109 +214,33 @@ def _normalized_goal_subscription(
 
 def resolve_goal_periodic_report_subscription(
     goal: Mapping[str, Any],
+    machine_defaults: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Resolve the runtime subscription from Goal-owned state only.
+    """Resolve one live machine default beneath a complete Goal override."""
 
-    Machine configuration is a connection and explicit-migration input. It is
-    deliberately absent here so changing machine policy cannot silently alter
-    an already-running Goal.
-    """
     goal_id = _text(goal.get("id"), "goal.id")
     existing = _goal_periodic_report(goal)
-    if existing is None:
+    if existing is not None:
+        return _normalized_goal_subscription(
+            goal_id=goal_id,
+            config=existing,
+            source="goal_override",
+            source_revision=None,
+        )
+    if machine_defaults is None:
         return _normalized_goal_subscription(
             goal_id=goal_id,
             config={"enabled": False, "timezone": "UTC"},
             source="not_configured",
+            source_revision=None,
         )
-    source = (
-        "machine_default"
-        if existing.get("source") == "machine_default"
-        else "goal_override"
-    )
+    normalized_defaults = normalize_loopx_machine_defaults(machine_defaults)
     return _normalized_goal_subscription(
         goal_id=goal_id,
-        config=existing,
-        source=source,
+        config=_periodic_report_defaults(normalized_defaults),
+        source="machine_default",
+        source_revision=machine_configuration_revision(normalized_defaults),
     )
-
-
-def _materialized_periodic_config(
-    machine_defaults: Mapping[str, Any],
-) -> dict[str, Any]:
-    normalized = normalize_loopx_machine_defaults(machine_defaults)
-    periodic = dict(normalized["namespaces"]["periodic_report"])
-    periodic.pop("schema_version", None)
-    periodic.pop("inheritance", None)
-    periodic["source"] = "machine_default"
-    periodic["source_revision"] = machine_configuration_revision(normalized)
-    return periodic
-
-
-def _state_path(goal: Mapping[str, Any]) -> Path | None:
-    state_file = str(goal.get("state_file") or "").strip()
-    repo = str(goal.get("repo") or "").strip()
-    if not state_file or not repo:
-        return None
-    path = Path(state_file).expanduser()
-    return path if path.is_absolute() else Path(repo).expanduser() / path
-
-
-def plan_periodic_report_machine_default_backfill(
-    registry: Mapping[str, Any],
-    machine_defaults: Mapping[str, Any],
-    *,
-    state_file_exists: Callable[[Path], bool] = Path.is_file,
-) -> dict[str, Any]:
-    """Build a path-free per-Goal migration ledger before any registry write."""
-
-    normalized_defaults = normalize_loopx_machine_defaults(machine_defaults)
-    intended = _materialized_periodic_config(normalized_defaults)
-    rows: list[dict[str, Any]] = []
-    goals = registry.get("goals")
-    for raw_goal in goals if isinstance(goals, list) else []:
-        if not isinstance(raw_goal, Mapping):
-            continue
-        goal_id = str(raw_goal.get("id") or "").strip()
-        if not goal_id:
-            continue
-        existing = _goal_periodic_report(raw_goal)
-        status = str(raw_goal.get("status") or "active").strip().lower()
-        state_path = _state_path(raw_goal)
-        if status in _TERMINAL_GOAL_STATUSES:
-            action, reason = "excluded", "goal_not_active"
-        elif state_path is None or not state_file_exists(state_path):
-            action, reason = "excluded", "authoritative_state_unavailable"
-        elif existing is not None and existing.get("source") != "machine_default":
-            action, reason = "preserve", "goal_override"
-        elif existing == intended:
-            action, reason = "unchanged", "already_materialized"
-        elif existing is None:
-            action, reason = "materialize", "machine_default_missing"
-        else:
-            action, reason = "update", "inherited_default_revision_changed"
-        rows.append(
-            {
-                "goal_id": goal_id,
-                "action": action,
-                "reason": reason,
-            }
-        )
-    counts = {
-        action: sum(row["action"] == action for row in rows)
-        for action in ("materialize", "update", "unchanged", "preserve", "excluded")
-    }
-    plan: dict[str, Any] = {
-        "schema_version": BACKFILL_PLAN_SCHEMA,
-        "machine_defaults_revision": machine_configuration_revision(
-            normalized_defaults
-        ),
-        "rows": rows,
-        "counts": counts,
-        "writes_required": counts["materialize"] + counts["update"],
-    }
-    plan["plan_revision"] = _digest(plan)
-    return plan
 
 
 def build_goal_periodic_report_delivery_identity(
@@ -395,6 +311,8 @@ def select_goal_periodic_report_executor(
 
 def build_goal_periodic_report_delivery_plan(
     request: Mapping[str, Any],
+    *,
+    machine_defaults: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Arbitrate one effect-free Goal delivery plan from a reporting Agent event."""
 
@@ -417,7 +335,10 @@ def build_goal_periodic_report_delivery_plan(
     eligible_raw = payload.get("eligible_agent_ids")
     if not isinstance(eligible_raw, list):
         raise TypeError("request.eligible_agent_ids must be a list")
-    subscription = resolve_goal_periodic_report_subscription(goal)
+    subscription = resolve_goal_periodic_report_subscription(
+        goal,
+        machine_defaults,
+    )
     if subscription["enabled"] is not True:
         return {
             "ok": True,
@@ -449,7 +370,6 @@ def build_goal_periodic_report_delivery_plan(
 
 
 __all__ = [
-    "BACKFILL_PLAN_SCHEMA",
     "DELIVERY_IDENTITY_SCHEMA",
     "DELIVERY_PLAN_REQUEST_SCHEMA",
     "DELIVERY_PLAN_SCHEMA",
@@ -462,7 +382,6 @@ __all__ = [
     "normalize_loopx_machine_defaults",
     "normalize_periodic_report_machine_defaults",
     "periodic_report_machine_configuration_namespace",
-    "plan_periodic_report_machine_default_backfill",
     "resolve_goal_periodic_report_subscription",
     "select_goal_periodic_report_executor",
 ]

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+from ...control_plane.todos.contract import normalize_todo_claimed_by
 from ..machine_configuration.contract import (
     MACHINE_CONFIGURATION_SCHEMA,
     MachineConfigurationNamespace,
@@ -56,6 +57,15 @@ def _text(value: object, label: str, *, maximum: int = 160) -> str:
     if len(text) > maximum:
         raise ValueError(f"{label} exceeds {maximum} characters")
     return text
+
+
+def _agent_id(value: object, label: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{label} must be a string")
+    normalized = normalize_todo_claimed_by(value)
+    if normalized is None:
+        raise ValueError(f"{label} must be a public-safe Agent id")
+    return normalized
 
 
 def _digest(value: object) -> str:
@@ -180,48 +190,62 @@ def _goal_periodic_report(goal: Mapping[str, Any]) -> dict[str, Any] | None:
 def _normalized_goal_subscription(
     *, goal_id: str, config: Mapping[str, Any], source: str
 ) -> dict[str, Any]:
-    enabled = config.get("enabled") is True
+    enabled = config.get("enabled")
+    if not isinstance(enabled, bool):
+        raise TypeError("goal periodic_report.enabled must be a boolean")
+    timezone_name = _text(
+        config.get("timezone", "UTC"), "goal periodic_report.timezone"
+    )
+    try:
+        ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("goal periodic_report.timezone is unknown") from exc
+    profile_preset = str(config.get("profile_preset") or "").strip() or None
+    route_ref = str(config.get("route_ref") or "").strip() or None
+    if enabled:
+        profile_preset = _text(
+            profile_preset, "goal periodic_report.profile_preset"
+        )
+        route_ref = _text(route_ref, "goal periodic_report.route_ref")
     subscription: dict[str, Any] = {
         "schema_version": GOAL_SUBSCRIPTION_SCHEMA,
         "goal_id": goal_id,
         "enabled": enabled,
         "source": source,
-        "profile_preset": str(config.get("profile_preset") or "").strip() or None,
-        "route_ref": str(config.get("route_ref") or "").strip() or None,
-        "timezone": str(config.get("timezone") or "UTC").strip(),
+        "profile_preset": profile_preset,
+        "route_ref": route_ref,
+        "timezone": timezone_name,
     }
     subscription["effective_revision"] = _digest(subscription)
     return subscription
 
 
 def resolve_goal_periodic_report_subscription(
-    goal: Mapping[str, Any], machine_defaults: Mapping[str, Any]
+    goal: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Resolve ownership without making the executing Agent part of identity."""
+    """Resolve the runtime subscription from Goal-owned state only.
 
+    Machine configuration is a connection and explicit-migration input. It is
+    deliberately absent here so changing machine policy cannot silently alter
+    an already-running Goal.
+    """
     goal_id = _text(goal.get("id"), "goal.id")
-    periodic_defaults = _periodic_report_defaults(machine_defaults)
     existing = _goal_periodic_report(goal)
-    if existing is not None:
-        effective = {
-            **periodic_defaults,
-            **existing,
-        }
-        effective.pop("inheritance", None)
-        source = (
-            "machine_default"
-            if existing.get("source") == "machine_default"
-            else "goal_override"
-        )
+    if existing is None:
         return _normalized_goal_subscription(
             goal_id=goal_id,
-            config=effective,
-            source=source,
+            config={"enabled": False, "timezone": "UTC"},
+            source="not_configured",
         )
+    source = (
+        "machine_default"
+        if existing.get("source") == "machine_default"
+        else "goal_override"
+    )
     return _normalized_goal_subscription(
         goal_id=goal_id,
-        config=periodic_defaults,
-        source="machine_default_preview",
+        config=existing,
+        source=source,
     )
 
 
@@ -341,16 +365,15 @@ def build_goal_periodic_report_delivery_identity(
 
 
 def select_goal_periodic_report_executor(
-    *, reporting_agent_id: str, eligible_agent_ids: list[str]
+    *, reporting_agent_id: object, eligible_agent_ids: list[object]
 ) -> dict[str, Any]:
     """Prefer the selected candidate's reporter while keeping Goal-owned failover."""
 
-    reporter = _text(reporting_agent_id, "reporting_agent_id")
+    reporter = _agent_id(reporting_agent_id, "reporting_agent_id")
     eligible = sorted(
         {
-            str(agent_id).strip()
-            for agent_id in eligible_agent_ids
-            if str(agent_id).strip()
+            _agent_id(agent_id, f"eligible_agent_ids[{index}]")
+            for index, agent_id in enumerate(eligible_agent_ids)
         }
     )
     if reporter in eligible:
@@ -381,7 +404,6 @@ def build_goal_periodic_report_delivery_plan(
         allowed={
             "schema_version",
             "goal",
-            "machine_defaults",
             "period_window",
             "reporting_agent_id",
             "eligible_agent_ids",
@@ -391,14 +413,11 @@ def build_goal_periodic_report_delivery_plan(
     if payload.get("schema_version") != DELIVERY_PLAN_REQUEST_SCHEMA:
         raise ValueError(f"request must use {DELIVERY_PLAN_REQUEST_SCHEMA}")
     goal = _mapping(payload.get("goal"), "request.goal")
-    machine_defaults = _mapping(
-        payload.get("machine_defaults"), "request.machine_defaults"
-    )
     period = _mapping(payload.get("period_window"), "request.period_window")
     eligible_raw = payload.get("eligible_agent_ids")
     if not isinstance(eligible_raw, list):
         raise TypeError("request.eligible_agent_ids must be a list")
-    subscription = resolve_goal_periodic_report_subscription(goal, machine_defaults)
+    subscription = resolve_goal_periodic_report_subscription(goal)
     if subscription["enabled"] is not True:
         return {
             "ok": True,
@@ -416,10 +435,8 @@ def build_goal_periodic_report_delivery_plan(
         route_id=route_ref,
     )
     executor = select_goal_periodic_report_executor(
-        reporting_agent_id=_text(
-            payload.get("reporting_agent_id"), "request.reporting_agent_id"
-        ),
-        eligible_agent_ids=[str(agent_id) for agent_id in eligible_raw],
+        reporting_agent_id=payload.get("reporting_agent_id"),
+        eligible_agent_ids=eligible_raw,
     )
     return {
         "ok": True,

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from ..machine_configuration.contract import (
+    MACHINE_CONFIGURATION_SCHEMA,
+    MachineConfigurationNamespace,
+    MachineConfigurationRegistry,
+    machine_configuration_revision,
+    normalize_machine_configuration,
+)
+
+
+MACHINE_DEFAULTS_SCHEMA = MACHINE_CONFIGURATION_SCHEMA
+PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA = "periodic_report_machine_defaults_v0"
+GOAL_SUBSCRIPTION_SCHEMA = "periodic_report_goal_subscription_v0"
+BACKFILL_PLAN_SCHEMA = "periodic_report_machine_default_backfill_plan_v0"
+DELIVERY_IDENTITY_SCHEMA = "periodic_report_goal_delivery_identity_v0"
+DELIVERY_PLAN_REQUEST_SCHEMA = "periodic_report_goal_delivery_plan_request_v0"
+DELIVERY_PLAN_SCHEMA = "periodic_report_goal_delivery_plan_v0"
+
+_INHERITANCE_MODE = "materialize_on_goal_connect"
+_TERMINAL_GOAL_STATUSES = {
+    "archived",
+    "canceled",
+    "cancelled",
+    "completed",
+    "disconnected",
+    "retired",
+    "stopped",
+}
+
+
+def _mapping(value: object, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{label} must be an object")
+    return {str(key): item for key, item in value.items()}
+
+
+def _reject_unknown(value: Mapping[str, Any], *, allowed: set[str], label: str) -> None:
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError(f"{label} contains unsupported fields: {', '.join(unknown)}")
+
+
+def _text(value: object, label: str, *, maximum: int = 160) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{label} is required")
+    if len(text) > maximum:
+        raise ValueError(f"{label} exceeds {maximum} characters")
+    return text
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def normalize_periodic_report_machine_defaults(
+    raw: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Validate the periodic-report-owned machine configuration namespace."""
+
+    periodic = _mapping(raw, "periodic_report")
+    _reject_unknown(
+        periodic,
+        allowed={
+            "schema_version",
+            "enabled",
+            "inheritance",
+            "profile_preset",
+            "route_ref",
+            "timezone",
+        },
+        label="periodic_report",
+    )
+    if periodic.get("schema_version") != PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA:
+        raise ValueError(
+            "periodic_report must use " + PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA
+        )
+    enabled = periodic.get("enabled")
+    if not isinstance(enabled, bool):
+        raise TypeError("periodic_report.enabled must be a boolean")
+    inheritance = _text(
+        periodic.get("inheritance", _INHERITANCE_MODE),
+        "periodic_report.inheritance",
+    )
+    if inheritance != _INHERITANCE_MODE:
+        raise ValueError(
+            "periodic_report.inheritance must be materialize_on_goal_connect"
+        )
+    timezone = _text(
+        periodic.get("timezone", "UTC"),
+        "periodic_report.timezone",
+    )
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError("periodic_report.timezone is unknown") from exc
+    normalized_periodic: dict[str, Any] = {
+        "schema_version": PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA,
+        "enabled": enabled,
+        "inheritance": inheritance,
+        "timezone": timezone,
+    }
+    if enabled:
+        normalized_periodic["profile_preset"] = _text(
+            periodic.get("profile_preset"),
+            "periodic_report.profile_preset",
+        )
+        normalized_periodic["route_ref"] = _text(
+            periodic.get("route_ref"),
+            "periodic_report.route_ref",
+        )
+    else:
+        for field in ("profile_preset", "route_ref"):
+            value = str(periodic.get(field) or "").strip()
+            if value:
+                normalized_periodic[field] = _text(
+                    value,
+                    f"periodic_report.{field}",
+                )
+    return normalized_periodic
+
+
+def periodic_report_machine_configuration_namespace() -> MachineConfigurationNamespace:
+    return MachineConfigurationNamespace(
+        namespace="periodic_report",
+        schema_versions=frozenset({PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA}),
+        normalize=normalize_periodic_report_machine_defaults,
+        project_public=lambda value: dict(value),
+    )
+
+
+def _machine_configuration_registry() -> MachineConfigurationRegistry:
+    return MachineConfigurationRegistry().register(
+        periodic_report_machine_configuration_namespace()
+    )
+
+
+def normalize_loopx_machine_defaults(raw: object) -> dict[str, Any]:
+    """Compatibility name for the generic typed machine configuration envelope."""
+
+    return normalize_machine_configuration(
+        raw, registry=_machine_configuration_registry()
+    )
+
+
+def _periodic_report_defaults(machine_defaults: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = normalize_loopx_machine_defaults(machine_defaults)
+    return dict(normalized["namespaces"]["periodic_report"])
+
+
+def _goal_periodic_report(goal: Mapping[str, Any]) -> dict[str, Any] | None:
+    control_plane = goal.get("control_plane")
+    if not isinstance(control_plane, Mapping):
+        return None
+    periodic = control_plane.get("periodic_report")
+    return dict(periodic) if isinstance(periodic, Mapping) else None
+
+
+def _normalized_goal_subscription(
+    *, goal_id: str, config: Mapping[str, Any], source: str
+) -> dict[str, Any]:
+    enabled = config.get("enabled") is True
+    subscription: dict[str, Any] = {
+        "schema_version": GOAL_SUBSCRIPTION_SCHEMA,
+        "goal_id": goal_id,
+        "enabled": enabled,
+        "source": source,
+        "profile_preset": str(config.get("profile_preset") or "").strip() or None,
+        "route_ref": str(config.get("route_ref") or "").strip() or None,
+        "timezone": str(config.get("timezone") or "UTC").strip(),
+    }
+    subscription["effective_revision"] = _digest(subscription)
+    return subscription
+
+
+def resolve_goal_periodic_report_subscription(
+    goal: Mapping[str, Any], machine_defaults: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Resolve ownership without making the executing Agent part of identity."""
+
+    goal_id = _text(goal.get("id"), "goal.id")
+    periodic_defaults = _periodic_report_defaults(machine_defaults)
+    existing = _goal_periodic_report(goal)
+    if existing is not None:
+        effective = {
+            **periodic_defaults,
+            **existing,
+        }
+        effective.pop("inheritance", None)
+        source = (
+            "machine_default"
+            if existing.get("source") == "machine_default"
+            else "goal_override"
+        )
+        return _normalized_goal_subscription(
+            goal_id=goal_id,
+            config=effective,
+            source=source,
+        )
+    return _normalized_goal_subscription(
+        goal_id=goal_id,
+        config=periodic_defaults,
+        source="machine_default_preview",
+    )
+
+
+def _materialized_periodic_config(
+    machine_defaults: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized = normalize_loopx_machine_defaults(machine_defaults)
+    periodic = dict(normalized["namespaces"]["periodic_report"])
+    periodic.pop("schema_version", None)
+    periodic.pop("inheritance", None)
+    periodic["source"] = "machine_default"
+    periodic["source_revision"] = machine_configuration_revision(normalized)
+    return periodic
+
+
+def _state_path(goal: Mapping[str, Any]) -> Path | None:
+    state_file = str(goal.get("state_file") or "").strip()
+    repo = str(goal.get("repo") or "").strip()
+    if not state_file or not repo:
+        return None
+    path = Path(state_file).expanduser()
+    return path if path.is_absolute() else Path(repo).expanduser() / path
+
+
+def plan_periodic_report_machine_default_backfill(
+    registry: Mapping[str, Any],
+    machine_defaults: Mapping[str, Any],
+    *,
+    state_file_exists: Callable[[Path], bool] = Path.is_file,
+) -> dict[str, Any]:
+    """Build a path-free per-Goal migration ledger before any registry write."""
+
+    normalized_defaults = normalize_loopx_machine_defaults(machine_defaults)
+    intended = _materialized_periodic_config(normalized_defaults)
+    rows: list[dict[str, Any]] = []
+    goals = registry.get("goals")
+    for raw_goal in goals if isinstance(goals, list) else []:
+        if not isinstance(raw_goal, Mapping):
+            continue
+        goal_id = str(raw_goal.get("id") or "").strip()
+        if not goal_id:
+            continue
+        existing = _goal_periodic_report(raw_goal)
+        status = str(raw_goal.get("status") or "active").strip().lower()
+        state_path = _state_path(raw_goal)
+        if status in _TERMINAL_GOAL_STATUSES:
+            action, reason = "excluded", "goal_not_active"
+        elif state_path is None or not state_file_exists(state_path):
+            action, reason = "excluded", "authoritative_state_unavailable"
+        elif existing is not None and existing.get("source") != "machine_default":
+            action, reason = "preserve", "goal_override"
+        elif existing == intended:
+            action, reason = "unchanged", "already_materialized"
+        elif existing is None:
+            action, reason = "materialize", "machine_default_missing"
+        else:
+            action, reason = "update", "inherited_default_revision_changed"
+        rows.append(
+            {
+                "goal_id": goal_id,
+                "action": action,
+                "reason": reason,
+            }
+        )
+    counts = {
+        action: sum(row["action"] == action for row in rows)
+        for action in ("materialize", "update", "unchanged", "preserve", "excluded")
+    }
+    plan: dict[str, Any] = {
+        "schema_version": BACKFILL_PLAN_SCHEMA,
+        "machine_defaults_revision": machine_configuration_revision(
+            normalized_defaults
+        ),
+        "rows": rows,
+        "counts": counts,
+        "writes_required": counts["materialize"] + counts["update"],
+    }
+    plan["plan_revision"] = _digest(plan)
+    return plan
+
+
+def build_goal_periodic_report_delivery_identity(
+    *,
+    goal_id: str,
+    period_start_at: str,
+    period_end_at: str,
+    route_id: str,
+) -> dict[str, Any]:
+    """Build the executor-independent identity for one Goal report delivery."""
+
+    normalized_goal_id = _text(goal_id, "goal_id")
+    normalized_route_id = _text(route_id, "route_id")
+    try:
+        start = datetime.fromisoformat(period_start_at.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(period_end_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("report period timestamps must be ISO-8601") from exc
+    if start.tzinfo is None or end.tzinfo is None:
+        raise ValueError("report period timestamps must include a timezone")
+    if end <= start:
+        raise ValueError("report period end must be after its start")
+    identity: dict[str, Any] = {
+        "schema_version": DELIVERY_IDENTITY_SCHEMA,
+        "goal_id": normalized_goal_id,
+        "period_start_at": start.astimezone(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "period_end_at": end.astimezone(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "route_id": normalized_route_id,
+    }
+    identity["idempotency_key"] = "periodic-report-goal:" + _digest(
+        identity
+    ).removeprefix("sha256:")
+    return identity
+
+
+def select_goal_periodic_report_executor(
+    *, reporting_agent_id: str, eligible_agent_ids: list[str]
+) -> dict[str, Any]:
+    """Prefer the selected candidate's reporter while keeping Goal-owned failover."""
+
+    reporter = _text(reporting_agent_id, "reporting_agent_id")
+    eligible = sorted(
+        {
+            str(agent_id).strip()
+            for agent_id in eligible_agent_ids
+            if str(agent_id).strip()
+        }
+    )
+    if reporter in eligible:
+        selected = reporter
+        reason = "reporting_agent_preferred"
+    elif eligible:
+        selected = eligible[0]
+        reason = "reporting_agent_unavailable_failover"
+    else:
+        selected = None
+        reason = "no_eligible_executor"
+    return {
+        "reporting_agent_id": reporter,
+        "selected_agent_id": selected,
+        "selection_reason": reason,
+        "eligible_agent_ids": eligible,
+    }
+
+
+def build_goal_periodic_report_delivery_plan(
+    request: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Arbitrate one effect-free Goal delivery plan from a reporting Agent event."""
+
+    payload = _mapping(request, "request")
+    _reject_unknown(
+        payload,
+        allowed={
+            "schema_version",
+            "goal",
+            "machine_defaults",
+            "period_window",
+            "reporting_agent_id",
+            "eligible_agent_ids",
+        },
+        label="request",
+    )
+    if payload.get("schema_version") != DELIVERY_PLAN_REQUEST_SCHEMA:
+        raise ValueError(f"request must use {DELIVERY_PLAN_REQUEST_SCHEMA}")
+    goal = _mapping(payload.get("goal"), "request.goal")
+    machine_defaults = _mapping(
+        payload.get("machine_defaults"), "request.machine_defaults"
+    )
+    period = _mapping(payload.get("period_window"), "request.period_window")
+    eligible_raw = payload.get("eligible_agent_ids")
+    if not isinstance(eligible_raw, list):
+        raise TypeError("request.eligible_agent_ids must be a list")
+    subscription = resolve_goal_periodic_report_subscription(goal, machine_defaults)
+    if subscription["enabled"] is not True:
+        return {
+            "ok": True,
+            "schema_version": DELIVERY_PLAN_SCHEMA,
+            "status": "not_subscribed",
+            "subscription": subscription,
+            "delivery_identity": None,
+            "executor": None,
+        }
+    route_ref = _text(subscription.get("route_ref"), "subscription.route_ref")
+    identity = build_goal_periodic_report_delivery_identity(
+        goal_id=str(subscription["goal_id"]),
+        period_start_at=_text(period.get("start_at"), "period_window.start_at"),
+        period_end_at=_text(period.get("end_at"), "period_window.end_at"),
+        route_id=route_ref,
+    )
+    executor = select_goal_periodic_report_executor(
+        reporting_agent_id=_text(
+            payload.get("reporting_agent_id"), "request.reporting_agent_id"
+        ),
+        eligible_agent_ids=[str(agent_id) for agent_id in eligible_raw],
+    )
+    return {
+        "ok": True,
+        "schema_version": DELIVERY_PLAN_SCHEMA,
+        "status": "ready" if executor["selected_agent_id"] else "executor_unavailable",
+        "subscription": subscription,
+        "delivery_identity": identity,
+        "executor": executor,
+    }
+
+
+__all__ = [
+    "BACKFILL_PLAN_SCHEMA",
+    "DELIVERY_IDENTITY_SCHEMA",
+    "DELIVERY_PLAN_REQUEST_SCHEMA",
+    "DELIVERY_PLAN_SCHEMA",
+    "GOAL_SUBSCRIPTION_SCHEMA",
+    "MACHINE_DEFAULTS_SCHEMA",
+    "PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA",
+    "build_goal_periodic_report_delivery_identity",
+    "build_goal_periodic_report_delivery_plan",
+    "normalize_loopx_machine_defaults",
+    "normalize_periodic_report_machine_defaults",
+    "periodic_report_machine_configuration_namespace",
+    "plan_periodic_report_machine_default_backfill",
+    "resolve_goal_periodic_report_subscription",
+    "select_goal_periodic_report_executor",
+]

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -158,6 +158,12 @@ def normalize_loopx_machine_defaults(raw: object) -> dict[str, Any]:
     )
 
 
+def loopx_machine_defaults_revision(raw: object) -> str:
+    """Compatibility revision for a validated machine configuration."""
+
+    return machine_configuration_revision(normalize_loopx_machine_defaults(raw))
+
+
 def _periodic_report_defaults(machine_defaults: Mapping[str, Any]) -> dict[str, Any]:
     normalized = normalize_loopx_machine_defaults(machine_defaults)
     return dict(normalized["namespaces"]["periodic_report"])
@@ -435,6 +441,7 @@ __all__ = [
     "PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA",
     "build_goal_periodic_report_delivery_identity",
     "build_goal_periodic_report_delivery_plan",
+    "loopx_machine_defaults_revision",
     "normalize_loopx_machine_defaults",
     "normalize_periodic_report_machine_defaults",
     "periodic_report_machine_configuration_namespace",

--- a/loopx/capabilities/periodic_report/machine_store.py
+++ b/loopx/capabilities/periodic_report/machine_store.py
@@ -1,0 +1,110 @@
+"""Compatibility aliases for the generic machine-configuration effect owner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ...registry import atomic_write_json
+from ..machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from ..machine_configuration.store import (
+    JsonWriter,
+    configure_machine_configuration,
+    inspect_machine_configuration,
+    machine_configuration_store_path,
+    plan_machine_configuration_rollback,
+    plan_machine_configuration_update,
+    read_machine_configuration,
+    rollback_machine_configuration,
+)
+
+
+def machine_defaults_store_path(runtime_root: Path) -> Path:
+    return machine_configuration_store_path(runtime_root)
+
+
+def read_periodic_report_machine_defaults(runtime_root: Path) -> dict[str, Any] | None:
+    return read_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+
+
+def inspect_periodic_report_machine_defaults(runtime_root: Path) -> dict[str, Any]:
+    return inspect_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+
+
+def plan_periodic_report_machine_defaults_update(
+    *, runtime_root: Path, machine_defaults: Mapping[str, Any]
+) -> dict[str, Any]:
+    return plan_machine_configuration_update(
+        runtime_root=runtime_root,
+        configuration=machine_defaults,
+        registry=build_builtin_machine_configuration_registry(),
+    )
+
+
+def configure_periodic_report_machine_defaults(
+    *,
+    runtime_root: Path,
+    machine_defaults: Mapping[str, Any],
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    return configure_machine_configuration(
+        runtime_root=runtime_root,
+        configuration=machine_defaults,
+        registry=build_builtin_machine_configuration_registry(),
+        execute=execute,
+        expected_plan_revision=expected_plan_revision,
+        now=now,
+        writer=writer,
+    )
+
+
+def plan_periodic_report_machine_defaults_rollback(
+    *, runtime_root: Path, transaction_id: str
+) -> dict[str, Any]:
+    return plan_machine_configuration_rollback(
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+        registry=build_builtin_machine_configuration_registry(),
+    )
+
+
+def rollback_periodic_report_machine_defaults(
+    *,
+    runtime_root: Path,
+    transaction_id: str,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    return rollback_machine_configuration(
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+        registry=build_builtin_machine_configuration_registry(),
+        execute=execute,
+        expected_plan_revision=expected_plan_revision,
+        now=now,
+        writer=writer,
+    )
+
+
+__all__ = [
+    "configure_periodic_report_machine_defaults",
+    "inspect_periodic_report_machine_defaults",
+    "machine_defaults_store_path",
+    "plan_periodic_report_machine_defaults_rollback",
+    "plan_periodic_report_machine_defaults_update",
+    "read_periodic_report_machine_defaults",
+    "rollback_periodic_report_machine_defaults",
+]

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -43,6 +43,10 @@ from .capabilities.periodic_report.cli import (
     handle_periodic_report_command,
     register_periodic_report_commands,
 )
+from .capabilities.machine_configuration.cli import (
+    handle_machine_configuration_command,
+    register_machine_configuration_commands,
+)
 from .capabilities.periodic_report.post_writeback_hook import (
     build_periodic_report_post_writeback_projection,
     periodic_report_post_writeback_hooks_for_goal,
@@ -270,6 +274,8 @@ def build_parser() -> LoopXArgumentParser:
         add_subcommand_format,
         provider_command_registrars=(register_lark_periodic_report_commands,),
     )
+
+    register_machine_configuration_commands(sub, add_subcommand_format)
 
     register_semantic_preference_commands(sub, add_subcommand_format)
 
@@ -606,6 +612,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if periodic_report_result is not None:
         return periodic_report_result
+
+    machine_configuration_result = handle_machine_configuration_command(
+        args,
+        runtime_root_arg=args.runtime_root,
+        registry_path=registry_path,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if machine_configuration_result is not None:
+        return machine_configuration_result
 
     semantic_preference_result = handle_semantic_preference_command(
         args,

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -1347,9 +1347,9 @@ def metadata_line_for_todo_block(
                 key
             ].normalize_for_write(value)
         elif key == "task_repository":
-            normalized = normalize_todo_task_repository(value)
-            if normalized:
-                metadata[key] = normalized
+            normalized_repository = normalize_todo_task_repository(value)
+            if normalized_repository:
+                metadata[key] = normalized_repository
             else:
                 metadata.pop(key, None)
         elif key == "required_capabilities":
@@ -1377,9 +1377,9 @@ def metadata_line_for_todo_block(
             else:
                 metadata.pop(key, None)
         elif key == "continuation_policy":
-            normalized = normalize_todo_continuation_policy(value)
-            if normalized:
-                metadata[key] = normalized
+            normalized_continuation_policy = normalize_todo_continuation_policy(value)
+            if normalized_continuation_policy:
+                metadata[key] = normalized_continuation_policy
             elif value:
                 raise ValueError(
                     "todo continuation_policy must be one of: "
@@ -1390,9 +1390,9 @@ def metadata_line_for_todo_block(
         elif key == "decision_scope":
             metadata[key] = require_todo_decision_scope(value)
         elif key == "required_decision_scopes":
-            normalized = require_todo_required_decision_scopes(value)
-            if normalized:
-                metadata[key] = normalized
+            normalized_decision_scopes = require_todo_required_decision_scopes(value)
+            if normalized_decision_scopes:
+                metadata[key] = normalized_decision_scopes
             else:
                 metadata.pop(key, None)
         elif key == "decision_outcome":
@@ -1404,9 +1404,9 @@ def metadata_line_for_todo_block(
             else:
                 metadata.pop(key, None)
         elif key == "no_followup":
-            normalized = normalize_todo_no_followup(value)
-            if normalized is not None:
-                metadata[key] = normalized
+            normalized_no_followup = normalize_todo_no_followup(value)
+            if normalized_no_followup is not None:
+                metadata[key] = normalized_no_followup
             else:
                 metadata.pop(key, None)
         elif key == "successor_todo_ids":
@@ -1416,15 +1416,15 @@ def metadata_line_for_todo_block(
             else:
                 metadata.pop(key, None)
         elif key in {"completion_continuation", "completion_recovery"}:
-            normalized = require_todo_completion_metadata(key, value)
-            if normalized:
-                metadata[key] = normalized
+            normalized_completion = require_todo_completion_metadata(key, value)
+            if normalized_completion:
+                metadata[key] = normalized_completion
             else:
                 metadata.pop(key, None)
         elif key in {"global_gate", "goal_bound"}:
-            normalized = normalize_todo_global_gate(value)
-            if normalized is not None:
-                metadata[key] = normalized
+            normalized_global_gate = normalize_todo_global_gate(value)
+            if normalized_global_gate is not None:
+                metadata[key] = normalized_global_gate
             else:
                 metadata.pop(key, None)
         elif str(value).strip():

--- a/tests/capabilities/test_machine_configuration_contract.py
+++ b/tests/capabilities/test_machine_configuration_contract.py
@@ -10,6 +10,7 @@ from loopx.capabilities.machine_configuration.contract import (
     MachineConfigurationRegistry,
     normalize_machine_configuration,
     project_machine_configuration,
+    remove_machine_configuration_namespace,
 )
 
 
@@ -78,3 +79,19 @@ def test_consumer_schema_version_and_fields_are_enforced() -> None:
     config["namespaces"]["example"]["surprise"] = True
     with pytest.raises(ValueError, match="example contains unsupported fields"):
         normalize_machine_configuration(config, registry=_registry())
+
+
+def test_removing_the_last_namespace_returns_document_absence() -> None:
+    assert (
+        remove_machine_configuration_namespace(
+            _config(), namespace="example", registry=_registry()
+        )
+        is None
+    )
+
+
+def test_removing_an_unknown_namespace_fails_closed() -> None:
+    with pytest.raises(ValueError, match="unsupported machine-configuration namespace"):
+        remove_machine_configuration_namespace(
+            _config(), namespace="unknown", registry=_registry()
+        )

--- a/tests/capabilities/test_machine_configuration_contract.py
+++ b/tests/capabilities/test_machine_configuration_contract.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from loopx.capabilities.machine_configuration.contract import (
+    MachineConfigurationNamespace,
+    MachineConfigurationRegistry,
+    normalize_machine_configuration,
+    project_machine_configuration,
+)
+
+
+def _normalize_example(value: Mapping[str, Any]) -> dict[str, Any]:
+    unknown = sorted(set(value) - {"schema_version", "enabled", "secret"})
+    if unknown:
+        raise ValueError("example contains unsupported fields: " + ", ".join(unknown))
+    if not isinstance(value.get("enabled"), bool):
+        raise TypeError("example.enabled must be a boolean")
+    return dict(value)
+
+
+def _registry() -> MachineConfigurationRegistry:
+    return MachineConfigurationRegistry().register(
+        MachineConfigurationNamespace(
+            namespace="example",
+            schema_versions=frozenset({"example_v0"}),
+            normalize=_normalize_example,
+            project_public=lambda value: {
+                key: item for key, item in value.items() if key != "secret"
+            },
+        )
+    )
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "example": {
+                "schema_version": "example_v0",
+                "enabled": True,
+                "secret": "redacted",
+            }
+        },
+    }
+
+
+def test_registered_namespace_is_normalized_and_publicly_projected() -> None:
+    assert normalize_machine_configuration(_config(), registry=_registry()) == _config()
+    assert project_machine_configuration(_config(), registry=_registry()) == {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {"example": {"schema_version": "example_v0", "enabled": True}},
+    }
+
+
+def test_unknown_namespace_and_unknown_envelope_field_fail_closed() -> None:
+    config = _config()
+    config["namespaces"] = {"unknown": {"schema_version": "unknown_v0"}}
+    with pytest.raises(ValueError, match="unsupported machine-configuration namespace"):
+        normalize_machine_configuration(config, registry=_registry())
+
+    config = _config()
+    config["arbitrary"] = True
+    with pytest.raises(ValueError, match="unsupported fields"):
+        normalize_machine_configuration(config, registry=_registry())
+
+
+def test_consumer_schema_version_and_fields_are_enforced() -> None:
+    config = _config()
+    config["namespaces"]["example"]["schema_version"] = "example_v1"
+    with pytest.raises(ValueError, match="unsupported schema_version"):
+        normalize_machine_configuration(config, registry=_registry())
+
+    config = _config()
+    config["namespaces"]["example"]["surprise"] = True
+    with pytest.raises(ValueError, match="example contains unsupported fields"):
+        normalize_machine_configuration(config, registry=_registry())

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -5,12 +5,21 @@ from pathlib import Path
 
 import pytest
 
+from loopx.capabilities.machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from loopx.capabilities.machine_configuration.store import (
+    configure_machine_configuration,
+)
 from loopx.capabilities.periodic_report.machine_defaults import (
     build_goal_periodic_report_delivery_identity,
     build_goal_periodic_report_delivery_plan,
     normalize_loopx_machine_defaults,
     resolve_goal_periodic_report_subscription,
     select_goal_periodic_report_executor,
+)
+from loopx.capabilities.periodic_report.machine_store import (
+    configure_periodic_report_machine_defaults,
 )
 from loopx.cli import main
 
@@ -46,6 +55,35 @@ def _goal(goal_id: str, *, status: str = "active") -> dict:
         "state_file": "GOAL.md",
         "status": status,
     }
+
+
+def _apply_defaults(runtime_root: Path, defaults: dict) -> None:
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+    )
+    configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+
+
+def _remove_defaults(runtime_root: Path) -> None:
+    registry = build_builtin_machine_configuration_registry()
+    preview = configure_machine_configuration(
+        runtime_root=runtime_root,
+        configuration=None,
+        registry=registry,
+    )
+    configure_machine_configuration(
+        runtime_root=runtime_root,
+        configuration=None,
+        registry=registry,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
 
 
 def test_machine_defaults_require_a_route_when_weekly_reports_are_enabled() -> None:
@@ -287,28 +325,19 @@ def test_delivery_identity_rejects_an_invalid_period() -> None:
         )
 
 
-def test_goal_delivery_plan_cli_prefers_the_reporting_agent(
+def test_goal_delivery_plan_cli_reads_live_default_for_the_same_goal(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     registry_path = tmp_path / "registry.json"
     registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    _apply_defaults(runtime_root, _defaults(route_ref="project-room-a"))
     request_path = tmp_path / "request.json"
     request_path.write_text(
         json.dumps(
             {
                 "schema_version": "periodic_report_goal_delivery_plan_request_v0",
-                "goal": {
-                    **_goal("research"),
-                    "control_plane": {
-                        "periodic_report": {
-                            "enabled": True,
-                            "profile_preset": "weekly-progress",
-                            "route_ref": "loopx-concierge",
-                            "timezone": "Asia/Shanghai",
-                            "source": "machine_default",
-                        }
-                    },
-                },
+                "goal": _goal("research"),
                 "period_window": {
                     "start_at": "2026-08-24T00:00:00+08:00",
                     "end_at": "2026-08-31T00:00:00+08:00",
@@ -319,12 +348,84 @@ def test_goal_delivery_plan_cli_prefers_the_reporting_agent(
         ),
         encoding="utf-8",
     )
+    request_before = request_path.read_bytes()
+    command = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "periodic-report",
+        "plan-goal-delivery",
+        "--request-json",
+        str(request_path),
+    ]
+
+    assert main(command) == 0
+    first = json.loads(capsys.readouterr().out)
+    _apply_defaults(runtime_root, _defaults(route_ref="project-room-b"))
+    assert main(command) == 0
+    second = json.loads(capsys.readouterr().out)
+    _remove_defaults(runtime_root)
+    assert main(command) == 0
+    removed = json.loads(capsys.readouterr().out)
+
+    assert first["status"] == second["status"] == "ready"
+    assert first["subscription"]["source"] == "machine_default"
+    assert first["subscription"]["route_ref"] == "project-room-a"
+    assert second["subscription"]["route_ref"] == "project-room-b"
+    assert first["subscription"]["source_revision"] != second["subscription"][
+        "source_revision"
+    ]
+    assert first["subscription"]["effective_revision"] != second["subscription"][
+        "effective_revision"
+    ]
+    assert second["executor"]["reporting_agent_id"] == "agent-b"
+    assert second["executor"]["selected_agent_id"] == "agent-b"
+    assert second["executor"]["selection_reason"] == "reporting_agent_preferred"
+    assert "agent_id" not in second["delivery_identity"]
+    assert removed["status"] == "not_subscribed"
+    assert removed["subscription"]["source"] == "not_configured"
+    assert removed["subscription"]["source_revision"] is None
+    assert request_path.read_bytes() == request_before
+
+
+def test_goal_delivery_plan_cli_fails_closed_on_invalid_machine_store(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    store_path = runtime_root / "machine" / "configuration.json"
+    store_path.parent.mkdir(parents=True)
+    invalid = _defaults()
+    invalid["namespaces"]["periodic_report"].pop("route_ref")
+    store_path.write_text(json.dumps(invalid), encoding="utf-8")
+    request_path = tmp_path / "request.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "periodic_report_goal_delivery_plan_request_v0",
+                "goal": _goal("research"),
+                "period_window": {
+                    "start_at": "2026-08-24T00:00:00+08:00",
+                    "end_at": "2026-08-31T00:00:00+08:00",
+                },
+                "reporting_agent_id": "agent-b",
+                "eligible_agent_ids": ["agent-b"],
+            }
+        ),
+        encoding="utf-8",
+    )
 
     assert (
         main(
             [
                 "--registry",
                 str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
                 "--format",
                 "json",
                 "periodic-report",
@@ -333,11 +434,9 @@ def test_goal_delivery_plan_cli_prefers_the_reporting_agent(
                 str(request_path),
             ]
         )
-        == 0
+        == 1
     )
     payload = json.loads(capsys.readouterr().out)
-    assert payload["status"] == "ready"
-    assert payload["executor"]["reporting_agent_id"] == "agent-b"
-    assert payload["executor"]["selected_agent_id"] == "agent-b"
-    assert payload["executor"]["selection_reason"] == "reporting_agent_preferred"
-    assert "agent_id" not in payload["delivery_identity"]
+    assert payload["ok"] is False
+    assert payload["command"] == "plan-goal-delivery"
+    assert "route_ref is required" in payload["error"]

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -68,39 +68,32 @@ def test_goal_override_beats_machine_default() -> None:
         }
     }
 
-    subscription = resolve_goal_periodic_report_subscription(goal, _defaults())
+    subscription = resolve_goal_periodic_report_subscription(goal)
 
     assert subscription["enabled"] is False
     assert subscription["route_ref"] == "project-room"
     assert subscription["source"] == "goal_override"
 
 
-def test_partial_goal_override_inherits_unspecified_machine_fields() -> None:
+def test_runtime_goal_subscription_does_not_fall_back_to_machine_defaults() -> None:
     goal = _goal("research")
     goal["control_plane"] = {"periodic_report": {"enabled": True}}
 
-    subscription = resolve_goal_periodic_report_subscription(goal, _defaults())
-
-    assert subscription["enabled"] is True
-    assert subscription["profile_preset"] == "weekly-progress"
-    assert subscription["route_ref"] == "loopx-concierge"
-    assert subscription["timezone"] == "Asia/Shanghai"
-    assert subscription["source"] == "goal_override"
+    with pytest.raises(ValueError, match="profile_preset"):
+        resolve_goal_periodic_report_subscription(goal)
 
 
-def test_unconfigured_goal_previews_machine_default_without_an_agent_identity() -> None:
-    subscription = resolve_goal_periodic_report_subscription(
-        _goal("research"), _defaults()
-    )
+def test_unconfigured_goal_is_not_subscribed_at_runtime() -> None:
+    subscription = resolve_goal_periodic_report_subscription(_goal("research"))
 
     assert subscription == {
         "schema_version": "periodic_report_goal_subscription_v0",
         "goal_id": "research",
-        "enabled": True,
-        "source": "machine_default_preview",
-        "profile_preset": "weekly-progress",
-        "route_ref": "loopx-concierge",
-        "timezone": "Asia/Shanghai",
+        "enabled": False,
+        "source": "not_configured",
+        "profile_preset": None,
+        "route_ref": None,
+        "timezone": "UTC",
         "effective_revision": subscription["effective_revision"],
     }
     assert "agent_id" not in subscription
@@ -193,11 +186,20 @@ def test_reporting_agent_is_preferred_but_failover_keeps_goal_identity() -> None
 
 
 def test_goal_delivery_plan_prefers_the_candidate_reporting_agent() -> None:
+    goal = _goal("research")
+    goal["control_plane"] = {
+        "periodic_report": {
+            "enabled": True,
+            "profile_preset": "weekly-progress",
+            "route_ref": "loopx-concierge",
+            "timezone": "Asia/Shanghai",
+            "source": "machine_default",
+        }
+    }
     result = build_goal_periodic_report_delivery_plan(
         {
             "schema_version": "periodic_report_goal_delivery_plan_request_v0",
-            "goal": _goal("research"),
-            "machine_defaults": _defaults(),
+            "goal": goal,
             "period_window": {
                 "start_at": "2026-08-24T00:00:00+08:00",
                 "end_at": "2026-08-31T00:00:00+08:00",
@@ -210,6 +212,50 @@ def test_goal_delivery_plan_prefers_the_candidate_reporting_agent() -> None:
     assert result["status"] == "ready"
     assert result["executor"]["selected_agent_id"] == "agent-b"
     assert "agent_id" not in result["delivery_identity"]
+
+
+def test_goal_delivery_plan_does_not_activate_an_unconfigured_goal() -> None:
+    result = build_goal_periodic_report_delivery_plan(
+        {
+            "schema_version": "periodic_report_goal_delivery_plan_request_v0",
+            "goal": _goal("research"),
+            "period_window": {
+                "start_at": "2026-08-24T00:00:00+08:00",
+                "end_at": "2026-08-31T00:00:00+08:00",
+            },
+            "reporting_agent_id": "agent-b",
+            "eligible_agent_ids": ["agent-a", "agent-b"],
+        }
+    )
+
+    assert result["status"] == "not_subscribed"
+    assert result["subscription"]["source"] == "not_configured"
+    assert result["delivery_identity"] is None
+    assert result["executor"] is None
+
+
+@pytest.mark.parametrize(
+    "invalid_agent_id",
+    [None, 1, True, {"id": "agent-a"}, ""],
+)
+def test_goal_delivery_executor_rejects_untyped_agent_ids(
+    invalid_agent_id: object,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=r"eligible_agent_ids\[0\]"):
+        select_goal_periodic_report_executor(
+            reporting_agent_id="agent-b",
+            eligible_agent_ids=[invalid_agent_id],
+        )
+
+
+def test_goal_delivery_executor_reports_an_empty_eligible_set() -> None:
+    result = select_goal_periodic_report_executor(
+        reporting_agent_id="agent-b",
+        eligible_agent_ids=[],
+    )
+
+    assert result["selected_agent_id"] is None
+    assert result["selection_reason"] == "no_eligible_executor"
 
 
 def test_delivery_identity_normalizes_equivalent_timestamp_offsets() -> None:
@@ -298,8 +344,18 @@ def test_goal_delivery_plan_cli_prefers_the_reporting_agent(
         json.dumps(
             {
                 "schema_version": "periodic_report_goal_delivery_plan_request_v0",
-                "goal": _goal("research"),
-                "machine_defaults": _defaults(),
+                "goal": {
+                    **_goal("research"),
+                    "control_plane": {
+                        "periodic_report": {
+                            "enabled": True,
+                            "profile_preset": "weekly-progress",
+                            "route_ref": "loopx-concierge",
+                            "timezone": "Asia/Shanghai",
+                            "source": "machine_default",
+                        }
+                    },
+                },
                 "period_window": {
                     "start_at": "2026-08-24T00:00:00+08:00",
                     "end_at": "2026-08-31T00:00:00+08:00",

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -9,7 +9,6 @@ from loopx.capabilities.periodic_report.machine_defaults import (
     build_goal_periodic_report_delivery_identity,
     build_goal_periodic_report_delivery_plan,
     normalize_loopx_machine_defaults,
-    plan_periodic_report_machine_default_backfill,
     resolve_goal_periodic_report_subscription,
     select_goal_periodic_report_executor,
 )
@@ -19,7 +18,7 @@ from loopx.cli import main
 def _defaults(*, enabled: bool = True, route_ref: str = "loopx-concierge") -> dict:
     periodic_report = {
         "enabled": enabled,
-        "inheritance": "materialize_on_goal_connect",
+        "inheritance": "live_machine_default",
         "timezone": "Asia/Shanghai",
     }
     if enabled:
@@ -68,7 +67,7 @@ def test_goal_override_beats_machine_default() -> None:
         }
     }
 
-    subscription = resolve_goal_periodic_report_subscription(goal)
+    subscription = resolve_goal_periodic_report_subscription(goal, _defaults())
 
     assert subscription["enabled"] is False
     assert subscription["route_ref"] == "project-room"
@@ -80,17 +79,18 @@ def test_runtime_goal_subscription_does_not_fall_back_to_machine_defaults() -> N
     goal["control_plane"] = {"periodic_report": {"enabled": True}}
 
     with pytest.raises(ValueError, match="profile_preset"):
-        resolve_goal_periodic_report_subscription(goal)
+        resolve_goal_periodic_report_subscription(goal, _defaults())
 
 
 def test_unconfigured_goal_is_not_subscribed_at_runtime() -> None:
-    subscription = resolve_goal_periodic_report_subscription(_goal("research"))
+    subscription = resolve_goal_periodic_report_subscription(_goal("research"), None)
 
     assert subscription == {
         "schema_version": "periodic_report_goal_subscription_v0",
         "goal_id": "research",
         "enabled": False,
         "source": "not_configured",
+        "source_revision": None,
         "profile_preset": None,
         "route_ref": None,
         "timezone": "UTC",
@@ -99,48 +99,26 @@ def test_unconfigured_goal_is_not_subscribed_at_runtime() -> None:
     assert "agent_id" not in subscription
 
 
-def test_backfill_preserves_overrides_and_excludes_unusable_goals() -> None:
-    inherited = _goal("inherited")
-    overridden = _goal("overridden")
-    overridden["control_plane"] = {
-        "periodic_report": {"enabled": False, "timezone": "UTC"}
-    }
-    missing = _goal("missing")
-    retired = _goal("retired", status="retired")
-    registry = {"goals": [inherited, overridden, missing, retired]}
+def test_existing_goal_follows_live_machine_default_without_mutation() -> None:
+    goal = _goal("research")
+    original = json.loads(json.dumps(goal))
 
-    plan = plan_periodic_report_machine_default_backfill(
-        registry,
-        _defaults(),
-        state_file_exists=lambda path: (
-            path == Path("/projects/inherited/GOAL.md")
-            or path == Path("/projects/overridden/GOAL.md")
-        ),
+    first = resolve_goal_periodic_report_subscription(
+        goal,
+        _defaults(route_ref="project-room-a"),
+    )
+    second = resolve_goal_periodic_report_subscription(
+        goal,
+        _defaults(route_ref="project-room-b"),
     )
 
-    assert plan["rows"] == [
-        {
-            "goal_id": "inherited",
-            "action": "materialize",
-            "reason": "machine_default_missing",
-        },
-        {
-            "goal_id": "overridden",
-            "action": "preserve",
-            "reason": "goal_override",
-        },
-        {
-            "goal_id": "missing",
-            "action": "excluded",
-            "reason": "authoritative_state_unavailable",
-        },
-        {
-            "goal_id": "retired",
-            "action": "excluded",
-            "reason": "goal_not_active",
-        },
-    ]
-    assert plan["writes_required"] == 1
+    assert first["source"] == "machine_default"
+    assert first["route_ref"] == "project-room-a"
+    assert second["source"] == "machine_default"
+    assert second["route_ref"] == "project-room-b"
+    assert first["source_revision"] != second["source_revision"]
+    assert first["effective_revision"] != second["effective_revision"]
+    assert goal == original
 
 
 def test_delivery_identity_is_goal_period_route_owned_not_agent_owned() -> None:
@@ -187,15 +165,6 @@ def test_reporting_agent_is_preferred_but_failover_keeps_goal_identity() -> None
 
 def test_goal_delivery_plan_prefers_the_candidate_reporting_agent() -> None:
     goal = _goal("research")
-    goal["control_plane"] = {
-        "periodic_report": {
-            "enabled": True,
-            "profile_preset": "weekly-progress",
-            "route_ref": "loopx-concierge",
-            "timezone": "Asia/Shanghai",
-            "source": "machine_default",
-        }
-    }
     result = build_goal_periodic_report_delivery_plan(
         {
             "schema_version": "periodic_report_goal_delivery_plan_request_v0",
@@ -206,7 +175,8 @@ def test_goal_delivery_plan_prefers_the_candidate_reporting_agent() -> None:
             },
             "reporting_agent_id": "agent-b",
             "eligible_agent_ids": ["agent-a", "agent-b"],
-        }
+        },
+        machine_defaults=_defaults(),
     )
 
     assert result["status"] == "ready"
@@ -283,55 +253,6 @@ def test_delivery_identity_rejects_an_invalid_period() -> None:
             period_end_at="2026-08-24T00:00:00Z",
             route_id="loopx-concierge",
         )
-
-
-def test_machine_default_preview_cli_is_an_effect_free_active_callsite(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    state_path = tmp_path / "GOAL.md"
-    state_path.write_text("# Goal\n", encoding="utf-8")
-    registry_path = tmp_path / "registry.json"
-    registry_path.write_text(
-        json.dumps(
-            {
-                "goals": [
-                    {
-                        "id": "research",
-                        "repo": str(tmp_path),
-                        "state_file": "GOAL.md",
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
-    defaults_path = tmp_path / "machine-defaults.json"
-    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
-
-    assert (
-        main(
-            [
-                "--registry",
-                str(registry_path),
-                "--format",
-                "json",
-                "periodic-report",
-                "plan-machine-defaults",
-                "--config-json",
-                str(defaults_path),
-            ]
-        )
-        == 0
-    )
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["writes_required"] == 1
-    assert payload["rows"] == [
-        {
-            "goal_id": "research",
-            "action": "materialize",
-            "reason": "machine_default_missing",
-        }
-    ]
 
 
 def test_goal_delivery_plan_cli_prefers_the_reporting_agent(

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.periodic_report.machine_defaults import (
+    build_goal_periodic_report_delivery_identity,
+    build_goal_periodic_report_delivery_plan,
+    normalize_loopx_machine_defaults,
+    plan_periodic_report_machine_default_backfill,
+    resolve_goal_periodic_report_subscription,
+    select_goal_periodic_report_executor,
+)
+from loopx.cli import main
+
+
+def _defaults(*, enabled: bool = True, route_ref: str = "loopx-concierge") -> dict:
+    periodic_report = {
+        "enabled": enabled,
+        "inheritance": "materialize_on_goal_connect",
+        "timezone": "Asia/Shanghai",
+    }
+    if enabled:
+        periodic_report.update(
+            {
+                "profile_preset": "weekly-progress",
+                "route_ref": route_ref,
+            }
+        )
+    return {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "periodic_report": {
+                "schema_version": "periodic_report_machine_defaults_v0",
+                **periodic_report,
+            }
+        },
+    }
+
+
+def _goal(goal_id: str, *, status: str = "active") -> dict:
+    return {
+        "id": goal_id,
+        "repo": f"/projects/{goal_id}",
+        "state_file": "GOAL.md",
+        "status": status,
+    }
+
+
+def test_machine_defaults_require_a_route_when_weekly_reports_are_enabled() -> None:
+    payload = _defaults()
+    payload["namespaces"]["periodic_report"].pop("route_ref")
+
+    with pytest.raises(ValueError, match="route_ref is required"):
+        normalize_loopx_machine_defaults(payload)
+
+
+def test_goal_override_beats_machine_default() -> None:
+    goal = _goal("research")
+    goal["control_plane"] = {
+        "periodic_report": {
+            "enabled": False,
+            "profile_preset": "weekly-progress",
+            "route_ref": "project-room",
+            "timezone": "UTC",
+        }
+    }
+
+    subscription = resolve_goal_periodic_report_subscription(goal, _defaults())
+
+    assert subscription["enabled"] is False
+    assert subscription["route_ref"] == "project-room"
+    assert subscription["source"] == "goal_override"
+
+
+def test_partial_goal_override_inherits_unspecified_machine_fields() -> None:
+    goal = _goal("research")
+    goal["control_plane"] = {"periodic_report": {"enabled": True}}
+
+    subscription = resolve_goal_periodic_report_subscription(goal, _defaults())
+
+    assert subscription["enabled"] is True
+    assert subscription["profile_preset"] == "weekly-progress"
+    assert subscription["route_ref"] == "loopx-concierge"
+    assert subscription["timezone"] == "Asia/Shanghai"
+    assert subscription["source"] == "goal_override"
+
+
+def test_unconfigured_goal_previews_machine_default_without_an_agent_identity() -> None:
+    subscription = resolve_goal_periodic_report_subscription(
+        _goal("research"), _defaults()
+    )
+
+    assert subscription == {
+        "schema_version": "periodic_report_goal_subscription_v0",
+        "goal_id": "research",
+        "enabled": True,
+        "source": "machine_default_preview",
+        "profile_preset": "weekly-progress",
+        "route_ref": "loopx-concierge",
+        "timezone": "Asia/Shanghai",
+        "effective_revision": subscription["effective_revision"],
+    }
+    assert "agent_id" not in subscription
+
+
+def test_backfill_preserves_overrides_and_excludes_unusable_goals() -> None:
+    inherited = _goal("inherited")
+    overridden = _goal("overridden")
+    overridden["control_plane"] = {
+        "periodic_report": {"enabled": False, "timezone": "UTC"}
+    }
+    missing = _goal("missing")
+    retired = _goal("retired", status="retired")
+    registry = {"goals": [inherited, overridden, missing, retired]}
+
+    plan = plan_periodic_report_machine_default_backfill(
+        registry,
+        _defaults(),
+        state_file_exists=lambda path: (
+            path == Path("/projects/inherited/GOAL.md")
+            or path == Path("/projects/overridden/GOAL.md")
+        ),
+    )
+
+    assert plan["rows"] == [
+        {
+            "goal_id": "inherited",
+            "action": "materialize",
+            "reason": "machine_default_missing",
+        },
+        {
+            "goal_id": "overridden",
+            "action": "preserve",
+            "reason": "goal_override",
+        },
+        {
+            "goal_id": "missing",
+            "action": "excluded",
+            "reason": "authoritative_state_unavailable",
+        },
+        {
+            "goal_id": "retired",
+            "action": "excluded",
+            "reason": "goal_not_active",
+        },
+    ]
+    assert plan["writes_required"] == 1
+
+
+def test_delivery_identity_is_goal_period_route_owned_not_agent_owned() -> None:
+    first = build_goal_periodic_report_delivery_identity(
+        goal_id="research",
+        period_start_at="2026-08-24T00:00:00+08:00",
+        period_end_at="2026-08-31T00:00:00+08:00",
+        route_id="loopx-concierge",
+    )
+    replay = build_goal_periodic_report_delivery_identity(
+        goal_id="research",
+        period_start_at="2026-08-24T00:00:00+08:00",
+        period_end_at="2026-08-31T00:00:00+08:00",
+        route_id="loopx-concierge",
+    )
+
+    assert first == replay
+    assert set(first) == {
+        "schema_version",
+        "goal_id",
+        "period_start_at",
+        "period_end_at",
+        "route_id",
+        "idempotency_key",
+    }
+    assert "agent_id" not in first
+
+
+def test_reporting_agent_is_preferred_but_failover_keeps_goal_identity() -> None:
+    preferred = select_goal_periodic_report_executor(
+        reporting_agent_id="agent-b",
+        eligible_agent_ids=["agent-c", "agent-b", "agent-a"],
+    )
+    failover = select_goal_periodic_report_executor(
+        reporting_agent_id="agent-b",
+        eligible_agent_ids=["agent-c", "agent-a"],
+    )
+
+    assert preferred["selected_agent_id"] == "agent-b"
+    assert preferred["selection_reason"] == "reporting_agent_preferred"
+    assert failover["selected_agent_id"] == "agent-a"
+    assert failover["selection_reason"] == "reporting_agent_unavailable_failover"
+
+
+def test_goal_delivery_plan_prefers_the_candidate_reporting_agent() -> None:
+    result = build_goal_periodic_report_delivery_plan(
+        {
+            "schema_version": "periodic_report_goal_delivery_plan_request_v0",
+            "goal": _goal("research"),
+            "machine_defaults": _defaults(),
+            "period_window": {
+                "start_at": "2026-08-24T00:00:00+08:00",
+                "end_at": "2026-08-31T00:00:00+08:00",
+            },
+            "reporting_agent_id": "agent-b",
+            "eligible_agent_ids": ["agent-a", "agent-b"],
+        }
+    )
+
+    assert result["status"] == "ready"
+    assert result["executor"]["selected_agent_id"] == "agent-b"
+    assert "agent_id" not in result["delivery_identity"]
+
+
+def test_delivery_identity_normalizes_equivalent_timestamp_offsets() -> None:
+    local = build_goal_periodic_report_delivery_identity(
+        goal_id="research",
+        period_start_at="2026-08-24T08:00:00+08:00",
+        period_end_at="2026-08-31T08:00:00+08:00",
+        route_id="loopx-concierge",
+    )
+    utc = build_goal_periodic_report_delivery_identity(
+        goal_id="research",
+        period_start_at="2026-08-24T00:00:00Z",
+        period_end_at="2026-08-31T00:00:00Z",
+        route_id="loopx-concierge",
+    )
+
+    assert local == utc
+
+
+def test_delivery_identity_rejects_an_invalid_period() -> None:
+    with pytest.raises(ValueError, match="end must be after"):
+        build_goal_periodic_report_delivery_identity(
+            goal_id="research",
+            period_start_at="2026-08-31T00:00:00Z",
+            period_end_at="2026-08-24T00:00:00Z",
+            route_id="loopx-concierge",
+        )
+
+
+def test_machine_default_preview_cli_is_an_effect_free_active_callsite(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    state_path = tmp_path / "GOAL.md"
+    state_path.write_text("# Goal\n", encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "research",
+                        "repo": str(tmp_path),
+                        "state_file": "GOAL.md",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    defaults_path = tmp_path / "machine-defaults.json"
+    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--format",
+                "json",
+                "periodic-report",
+                "plan-machine-defaults",
+                "--config-json",
+                str(defaults_path),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["writes_required"] == 1
+    assert payload["rows"] == [
+        {
+            "goal_id": "research",
+            "action": "materialize",
+            "reason": "machine_default_missing",
+        }
+    ]
+
+
+def test_goal_delivery_plan_cli_prefers_the_reporting_agent(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    request_path = tmp_path / "request.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "periodic_report_goal_delivery_plan_request_v0",
+                "goal": _goal("research"),
+                "machine_defaults": _defaults(),
+                "period_window": {
+                    "start_at": "2026-08-24T00:00:00+08:00",
+                    "end_at": "2026-08-31T00:00:00+08:00",
+                },
+                "reporting_agent_id": "agent-b",
+                "eligible_agent_ids": ["agent-a", "agent-b"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--format",
+                "json",
+                "periodic-report",
+                "plan-goal-delivery",
+                "--request-json",
+                str(request_path),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ready"
+    assert payload["executor"]["reporting_agent_id"] == "agent-b"
+    assert payload["executor"]["selected_agent_id"] == "agent-b"
+    assert payload["executor"]["selection_reason"] == "reporting_agent_preferred"
+    assert "agent_id" not in payload["delivery_identity"]

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -121,6 +121,38 @@ def test_existing_goal_follows_live_machine_default_without_mutation() -> None:
     assert goal == original
 
 
+def test_periodic_report_provenance_ignores_unowned_machine_namespaces() -> None:
+    goal = _goal("research")
+    periodic_only = _defaults()
+    with_sibling = json.loads(json.dumps(periodic_only))
+    with_sibling["namespaces"]["search_defaults"] = {
+        "schema_version": "search_defaults_v0",
+        "provider": "example",
+    }
+
+    first = resolve_goal_periodic_report_subscription(goal, periodic_only)
+    second = resolve_goal_periodic_report_subscription(goal, with_sibling)
+
+    assert first == second
+
+
+def test_machine_document_without_periodic_namespace_is_not_configured() -> None:
+    subscription = resolve_goal_periodic_report_subscription(
+        _goal("research"),
+        {
+            "schema_version": "loopx_machine_configuration_v0",
+            "namespaces": {
+                "search_defaults": {
+                    "schema_version": "search_defaults_v0",
+                }
+            },
+        },
+    )
+
+    assert subscription["source"] == "not_configured"
+    assert subscription["source_revision"] is None
+
+
 def test_delivery_identity_is_goal_period_route_owned_not_agent_owned() -> None:
     first = build_goal_periodic_report_delivery_identity(
         goal_id="research",

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -32,7 +32,7 @@ def _defaults(*, route_ref: str = "loopx-concierge") -> dict:
             "periodic_report": {
                 "schema_version": "periodic_report_machine_defaults_v0",
                 "enabled": True,
-                "inheritance": "materialize_on_goal_connect",
+        "inheritance": "live_machine_default",
                 "profile_preset": "weekly-progress",
                 "route_ref": route_ref,
                 "timezone": "Asia/Shanghai",

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from loopx.capabilities.machine_configuration.store import (
+    configure_machine_configuration,
+    inspect_machine_configuration,
+)
+from loopx.capabilities.periodic_report.machine_store import (
+    configure_periodic_report_machine_defaults,
+    inspect_periodic_report_machine_defaults,
+    machine_defaults_store_path,
+    plan_periodic_report_machine_defaults_rollback,
+    read_periodic_report_machine_defaults,
+    rollback_periodic_report_machine_defaults,
+)
+from loopx.cli import main
+from loopx.registry import atomic_write_json
+
+
+def _defaults(*, route_ref: str = "loopx-concierge") -> dict:
+    return {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "periodic_report": {
+                "schema_version": "periodic_report_machine_defaults_v0",
+                "enabled": True,
+                "inheritance": "materialize_on_goal_connect",
+                "profile_preset": "weekly-progress",
+                "route_ref": route_ref,
+                "timezone": "Asia/Shanghai",
+            },
+        },
+    }
+
+
+def _apply(runtime_root: Path, defaults: dict) -> dict:
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+    )
+    return configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+        now=datetime(2026, 9, 3, tzinfo=timezone.utc),
+    )
+
+
+def test_configure_machine_defaults_is_preview_only_without_execute(
+    tmp_path: Path,
+) -> None:
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        machine_defaults=_defaults(),
+    )
+
+    assert preview["status"] == "preview"
+    assert preview["action"] == "create"
+    assert preview["writes_required"] == 1
+    assert not machine_defaults_store_path(tmp_path).exists()
+
+
+def test_generic_store_reports_changed_typed_namespaces(tmp_path: Path) -> None:
+    registry = build_builtin_machine_configuration_registry()
+    preview = configure_machine_configuration(
+        runtime_root=tmp_path,
+        configuration=_defaults(),
+        registry=registry,
+    )
+
+    assert preview["changed_namespaces"] == ["periodic_report"]
+    assert preview["machine_configuration"] == _defaults()
+
+
+def test_apply_requires_the_exact_preview_revision(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="expected_plan_revision is required"):
+        configure_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            machine_defaults=_defaults(),
+            execute=True,
+        )
+
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        machine_defaults=_defaults(),
+    )
+    with pytest.raises(ValueError, match="plan revision changed"):
+        configure_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            machine_defaults=_defaults(route_ref="different-route"),
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+        )
+
+
+def test_apply_persists_readback_backup_and_transaction_receipt(
+    tmp_path: Path,
+) -> None:
+    result = _apply(tmp_path, _defaults())
+
+    assert result["status"] == "applied"
+    assert result["readback_verified"] is True
+    assert result["rollback_available"] is True
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults()
+    receipt_path = tmp_path / result["transaction_ref"]
+    backup_path = tmp_path / result["backup_ref"]
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == result
+    backup = json.loads(backup_path.read_text(encoding="utf-8"))
+    assert backup["prior_revision"] == "absent"
+    assert backup["prior_machine_configuration"] is None
+    assert machine_defaults_store_path(tmp_path).stat().st_mode & 0o777 == 0o600
+
+
+def test_reapplying_the_same_defaults_is_idempotent(tmp_path: Path) -> None:
+    first = _apply(tmp_path, _defaults())
+    transaction_dir = tmp_path / "machine" / "configuration" / "transactions"
+    before = sorted(transaction_dir.iterdir())
+
+    second = _apply(tmp_path, _defaults())
+
+    assert first["status"] == "applied"
+    assert second["status"] == "unchanged"
+    assert second["transaction_id"] is None
+    assert sorted(transaction_dir.iterdir()) == before
+
+
+def test_rollback_restores_the_exact_prior_policy_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    _apply(tmp_path, _defaults(route_ref="original"))
+    update = _apply(tmp_path, _defaults(route_ref="replacement"))
+
+    preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+    )
+    assert preview["action"] == "restore"
+    result = rollback_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+        now=datetime(2026, 9, 3, 1, tzinfo=timezone.utc),
+    )
+
+    assert result["status"] == "rolled_back"
+    assert result["readback_verified"] is True
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults(
+        route_ref="original"
+    )
+
+    repeated_preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+    )
+    repeated = rollback_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+        execute=True,
+        expected_plan_revision=repeated_preview["plan_revision"],
+    )
+    assert repeated["status"] == "unchanged"
+    assert repeated["readback_verified"] is True
+
+
+def test_rollback_refuses_to_overwrite_a_newer_revision(tmp_path: Path) -> None:
+    first = _apply(tmp_path, _defaults(route_ref="first"))
+    _apply(tmp_path, _defaults(route_ref="second"))
+
+    preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=first["transaction_id"],
+    )
+
+    assert preview["action"] == "blocked"
+    assert preview["reason"] == "current_revision_changed"
+    assert preview["rollback_allowed"] is False
+    with pytest.raises(ValueError, match="blocked by a newer revision"):
+        rollback_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            transaction_id=first["transaction_id"],
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+        )
+
+
+def test_rollback_fails_closed_when_the_transaction_receipt_was_tampered(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, _defaults())
+    receipt_path = tmp_path / applied["transaction_ref"]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["applied_revision"] = "sha256:" + "0" * 64
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="transaction receipt is invalid"):
+        plan_periodic_report_machine_defaults_rollback(
+            runtime_root=tmp_path,
+            transaction_id=applied["transaction_id"],
+        )
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults()
+
+
+def test_apply_failure_restores_the_prior_policy(tmp_path: Path) -> None:
+    _apply(tmp_path, _defaults(route_ref="original"))
+    writes = 0
+
+    def fail_receipt(path: Path, payload: dict) -> None:
+        nonlocal writes
+        writes += 1
+        if writes == 3:
+            raise OSError("receipt write failed")
+        atomic_write_json(path, payload)
+
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        machine_defaults=_defaults(route_ref="replacement"),
+    )
+    with pytest.raises(RuntimeError, match="prior state was restored"):
+        configure_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            machine_defaults=_defaults(route_ref="replacement"),
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+            writer=fail_receipt,
+        )
+
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults(
+        route_ref="original"
+    )
+
+
+def test_machine_defaults_cli_previews_applies_reads_and_rolls_back(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    defaults_path = tmp_path / "defaults.json"
+    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "periodic-report",
+    ]
+
+    assert (
+        main(
+            [*common, "configure-machine-defaults", "--config-json", str(defaults_path)]
+        )
+        == 0
+    )
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["status"] == "preview"
+    assert not machine_defaults_store_path(runtime_root).exists()
+
+    assert (
+        main(
+            [
+                *common,
+                "configure-machine-defaults",
+                "--config-json",
+                str(defaults_path),
+                "--execute",
+                "--expected-plan-revision",
+                preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["status"] == "applied"
+
+    assert main([*common, "inspect-machine-defaults"]) == 0
+    inspection = json.loads(capsys.readouterr().out)
+    assert inspection["status"] == "configured"
+    assert inspection["machine_configuration"] == _defaults()
+
+    assert (
+        main(
+            [
+                *common,
+                "rollback-machine-defaults",
+                "--transaction-id",
+                applied["transaction_id"],
+            ]
+        )
+        == 0
+    )
+    rollback_preview = json.loads(capsys.readouterr().out)
+    assert rollback_preview["action"] == "delete"
+
+    assert (
+        main(
+            [
+                *common,
+                "rollback-machine-defaults",
+                "--transaction-id",
+                applied["transaction_id"],
+                "--execute",
+                "--expected-plan-revision",
+                rollback_preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    rolled_back = json.loads(capsys.readouterr().out)
+    assert rolled_back["status"] == "rolled_back"
+    assert not machine_defaults_store_path(runtime_root).exists()
+
+
+def test_canonical_machine_config_cli_uses_the_same_store_and_projection(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    defaults_path = tmp_path / "defaults.json"
+    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "machine-config",
+    ]
+
+    assert main([*common, "preview", "--config-json", str(defaults_path)]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["changed_namespaces"] == ["periodic_report"]
+
+    assert (
+        main(
+            [
+                *common,
+                "apply",
+                "--config-json",
+                str(defaults_path),
+                "--expected-plan-revision",
+                preview["plan_revision"],
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert main([*common, "inspect"]) == 0
+    inspection = json.loads(capsys.readouterr().out)
+    assert inspection == inspect_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+
+
+def test_inspection_is_path_free_and_reports_absence(tmp_path: Path) -> None:
+    result = inspect_periodic_report_machine_defaults(tmp_path)
+
+    assert result == {
+        "ok": True,
+        "schema_version": "machine_configuration_inspection_v0",
+        "status": "absent",
+        "defaults_ref": "machine/configuration.json",
+        "revision": "absent",
+        "changed_namespaces": [],
+        "machine_configuration": None,
+    }

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -81,6 +81,46 @@ def test_generic_store_reports_changed_typed_namespaces(tmp_path: Path) -> None:
     assert preview["machine_configuration"] == _defaults()
 
 
+def test_generic_store_deletes_and_rolls_back_the_last_namespace(
+    tmp_path: Path,
+) -> None:
+    registry = build_builtin_machine_configuration_registry()
+    _apply(tmp_path, _defaults())
+
+    preview = configure_machine_configuration(
+        runtime_root=tmp_path,
+        configuration=None,
+        registry=registry,
+    )
+    assert preview["action"] == "delete"
+    assert preview["changed_namespaces"] == ["periodic_report"]
+    assert preview["machine_configuration"] is None
+
+    removed = configure_machine_configuration(
+        runtime_root=tmp_path,
+        configuration=None,
+        registry=registry,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+    assert removed["status"] == "applied"
+    assert removed["machine_configuration"] is None
+    assert not machine_defaults_store_path(tmp_path).exists()
+
+    rollback_preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=removed["transaction_id"],
+    )
+    restored = rollback_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        transaction_id=removed["transaction_id"],
+        execute=True,
+        expected_plan_revision=rollback_preview["plan_revision"],
+    )
+    assert restored["status"] == "rolled_back"
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults()
+
+
 def test_apply_requires_the_exact_preview_revision(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="expected_plan_revision is required"):
         configure_periodic_report_machine_defaults(
@@ -402,6 +442,46 @@ def test_periodic_report_compatibility_cli_renders_generic_machine_schemas(
     inspection = capsys.readouterr().out
     assert inspection.startswith("# Machine Configuration")
     assert "- status: `absent`" in inspection
+
+
+def test_machine_config_cli_removes_a_namespace_with_preview_fencing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    _apply(runtime_root, _defaults())
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "machine-config",
+        "remove",
+        "--namespace",
+        "periodic_report",
+    ]
+
+    assert main(common) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["action"] == "delete"
+
+    assert (
+        main(
+            [
+                *common,
+                "--execute",
+                "--expected-plan-revision",
+                preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result["status"] == "applied"
+    assert result["machine_configuration"] is None
 
 
 def test_inspection_is_path_free_and_reports_absence(tmp_path: Path) -> None:

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -366,6 +366,44 @@ def test_canonical_machine_config_cli_uses_the_same_store_and_projection(
     )
 
 
+def test_periodic_report_compatibility_cli_renders_generic_machine_schemas(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    defaults_path = tmp_path / "defaults.json"
+    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "periodic-report",
+    ]
+
+    assert (
+        main(
+            [
+                *common,
+                "configure-machine-defaults",
+                "--config-json",
+                str(defaults_path),
+            ]
+        )
+        == 0
+    )
+    preview = capsys.readouterr().out
+    assert preview.startswith("# Machine Configuration")
+    assert "- status: `preview`" in preview
+    assert "- action: `create`" in preview
+
+    assert main([*common, "inspect-machine-defaults"]) == 0
+    inspection = capsys.readouterr().out
+    assert inspection.startswith("# Machine Configuration")
+    assert "- status: `absent`" in inspection
+
+
 def test_inspection_is_path_free_and_reports_absence(tmp_path: Path) -> None:
     result = inspect_periodic_report_machine_defaults(tmp_path)
 

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -32,7 +32,7 @@ def _defaults(*, route_ref: str = "loopx-concierge") -> dict:
             "periodic_report": {
                 "schema_version": "periodic_report_machine_defaults_v0",
                 "enabled": True,
-        "inheritance": "live_machine_default",
+                "inheritance": "live_machine_default",
                 "profile_preset": "weekly-progress",
                 "route_ref": route_ref,
                 "timezone": "Asia/Shanghai",
@@ -324,6 +324,24 @@ def test_machine_defaults_cli_previews_applies_reads_and_rolls_back(
     applied = json.loads(capsys.readouterr().out)
     assert applied["status"] == "applied"
 
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "periodic-report",
+                "rollback-machine-defaults",
+                "--transaction-id",
+                applied["transaction_id"],
+            ]
+        )
+        == 0
+    )
+    rollback_markdown = capsys.readouterr().out
+    assert "- plan_revision: `sha256:" in rollback_markdown
+
     assert main([*common, "inspect-machine-defaults"]) == 0
     inspection = json.loads(capsys.readouterr().out)
     assert inspection["status"] == "configured"
@@ -379,6 +397,24 @@ def test_canonical_machine_config_cli_uses_the_same_store_and_projection(
         "json",
         "machine-config",
     ]
+
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "machine-config",
+                "preview",
+                "--config-json",
+                str(defaults_path),
+            ]
+        )
+        == 0
+    )
+    markdown_preview = capsys.readouterr().out
+    assert "- plan_revision: `sha256:" in markdown_preview
 
     assert main([*common, "preview", "--config-json", str(defaults_path)]) == 0
     preview = json.loads(capsys.readouterr().out)
@@ -437,6 +473,7 @@ def test_periodic_report_compatibility_cli_renders_generic_machine_schemas(
     assert preview.startswith("# Machine Configuration")
     assert "- status: `preview`" in preview
     assert "- action: `create`" in preview
+    assert "- plan_revision: `sha256:" in preview
 
     assert main([*common, "inspect-machine-defaults"]) == 0
     inspection = capsys.readouterr().out
@@ -463,6 +500,24 @@ def test_machine_config_cli_removes_a_namespace_with_preview_fencing(
         "--namespace",
         "periodic_report",
     ]
+
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "machine-config",
+                "remove",
+                "--namespace",
+                "periodic_report",
+            ]
+        )
+        == 0
+    )
+    markdown_preview = capsys.readouterr().out
+    assert "- plan_revision: `sha256:" in markdown_preview
 
     assert main(common) == 0
     preview = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Motivation

LoopX needs one durable, capability-neutral place for machine-level defaults. A capability should be able to register a typed namespace without inventing its own file format, revision model, transaction flow, or recovery path.

The effective policy is intentionally simple: a complete explicit Goal override wins; otherwise the Goal reads the current machine default; if neither exists, the capability is not configured. Existing Goals therefore follow later machine-default changes without rewriting Goal-owned state.

## What this PR owns

- A typed `MachineConfigurationRegistry` for namespace normalization and public projection.
- One durable machine document with read/create/update/remove operations.
- Preview-before-apply revision fencing, atomic write, readback, receipt, backup, failure recovery, and rollback.
- Reversible namespace removal. Removing the final namespace returns the machine document to `absent`.
- Periodic report as the first registered consumer, while keeping the platform contract capability-neutral.
- Live delivery composition: `periodic-report plan-goal-delivery` reads the durable machine store from the resolved runtime root.
- Explicit provenance: `source`, namespace-local `source_revision`, and `effective_revision`.
- Strict periodic-report executor identity validation: malformed or empty actor identities fail closed.
- Default Markdown previews expose `plan_revision`, so Preview → Apply/Remove/Rollback works without switching to JSON.
- A narrow strict-mypy cleanup for Todo metadata serialization using type-local normalizer variables.

## Authority model

```text
complete Goal override ----------------------+
                                             |
current machine namespace -- fallback -------+--> effective Goal configuration
                                             |
no override + no machine namespace ----------+--> not_configured
```

A Goal override is a complete pinned configuration; missing fields do not fall back to machine values. A Goal without an override resolves the current machine namespace on every delivery plan. Changing or removing machine policy therefore affects inherited behavior for existing Goals while the Goal request and registry records remain byte-for-byte unchanged.

Machine configuration is the policy owner, not the Goal-state writer. The CLI reads the typed store at the delivery composition boundary and fails closed when a configured document is invalid.

## Stacked program

- #3862 supplied the durable store and is incorporated into this branch.
- Runtime store wiring now lives in this PR, so #3863 is superseded by the live-default design and can close without a parallel migration path.
- #3865 consumes this contract for generic API and Dashboard operator surfaces, including provider-owned public-update semantics.

#3865 remains an operator-surface child of this PR.

## Validation

- 41 focused machine contract, store, authority, CLI, and periodic-report tests passed.
- Earlier broader qualification: 57 focused tests, scoped Ruff, configured strict-mypy kernel checks, and diff hygiene passed.
- CLI regression proves the same unmodified Goal follows route A → route B, then becomes `not_subscribed` after machine-default removal.
- Invalid durable machine state fails closed.
- Default Markdown preview/remove/rollback paths expose the exact `plan_revision` fence.
- Control-plane JavaScript suite reached 481 passes; its sole local failure was environment-only (`pg` package unavailable), outside this Python-only increment.

## Non-goals

- No partial field-by-field merge between Goal and machine configuration.
- No connect-time materialization or bulk migration of existing Goals.
- No generic operator UI or provider-private public-update contract; #3865 owns those surfaces.
- No Goal-level report aggregation, scheduling, or delivery effect.
