### PR TITLE
feat(machine-config): persist typed machine settings safely

### DIFF
--- a/loopx/capabilities/machine_configuration/cli.py
+++ b/loopx/capabilities/machine_configuration/cli.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ...paths import resolve_runtime_root
+from ...registry import read_json
+from .builtins import build_builtin_machine_configuration_registry
+from .store import (
+    configure_machine_configuration,
+    inspect_machine_configuration,
+    rollback_machine_configuration,
+)
+
+
+def _load_json_object(path_text: str) -> dict[str, Any]:
+    if path_text == "-":
+        payload = json.loads(sys.stdin.read())
+    else:
+        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path_text} must contain a JSON object")
+    return payload
+
+
+def _render(payload: dict[str, object]) -> str:
+    lines = ["# Machine Configuration", ""]
+    for key in (
+        "status",
+        "action",
+        "revision",
+        "current_revision",
+        "desired_revision",
+        "transaction_id",
+        "rollback_id",
+        "error",
+    ):
+        if key in payload:
+            lines.append(f"- {key}: `{payload.get(key)}`")
+    namespaces = payload.get("changed_namespaces")
+    if isinstance(namespaces, list):
+        lines.append(
+            f"- changed_namespaces: `{', '.join(map(str, namespaces)) or 'none'}`"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def register_machine_configuration_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "machine-config",
+        help="Inspect, preview, apply, or roll back typed machine configuration.",
+    )
+    commands = parser.add_subparsers(dest="machine_config_command", required=True)
+    preview = commands.add_parser("preview")
+    add_subcommand_format(preview)
+    preview.add_argument("--config-json", required=True)
+    apply = commands.add_parser("apply")
+    add_subcommand_format(apply)
+    apply.add_argument("--config-json", required=True)
+    apply.add_argument("--expected-plan-revision", required=True)
+    apply.add_argument("--execute", action="store_true", required=True)
+    inspect = commands.add_parser("inspect")
+    add_subcommand_format(inspect)
+    rollback = commands.add_parser("rollback")
+    add_subcommand_format(rollback)
+    rollback.add_argument("--transaction-id", required=True)
+    rollback.add_argument("--expected-plan-revision")
+    rollback.add_argument("--execute", action="store_true")
+
+
+def handle_machine_configuration_command(
+    args: argparse.Namespace,
+    *,
+    runtime_root_arg: str | None,
+    registry_path: Path,
+    output_format: Callable[..., str],
+    print_payload: Callable[
+        [dict[str, object], str, Callable[[dict[str, object]], str]], None
+    ],
+) -> int | None:
+    if args.command != "machine-config":
+        return None
+    registry = build_builtin_machine_configuration_registry()
+    runtime_root = resolve_runtime_root(
+        read_json(registry_path),
+        runtime_root_arg,
+        registry_path=registry_path,
+    )
+    try:
+        if args.machine_config_command == "preview":
+            payload = configure_machine_configuration(
+                runtime_root=runtime_root,
+                configuration=_load_json_object(args.config_json),
+                registry=registry,
+            )
+        elif args.machine_config_command == "apply":
+            payload = configure_machine_configuration(
+                runtime_root=runtime_root,
+                configuration=_load_json_object(args.config_json),
+                registry=registry,
+                execute=args.execute,
+                expected_plan_revision=args.expected_plan_revision,
+            )
+        elif args.machine_config_command == "inspect":
+            payload = inspect_machine_configuration(runtime_root, registry=registry)
+        else:
+            payload = rollback_machine_configuration(
+                runtime_root=runtime_root,
+                transaction_id=args.transaction_id,
+                registry=registry,
+                execute=args.execute,
+                expected_plan_revision=args.expected_plan_revision,
+            )
+    except (OSError, TypeError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "machine_configuration_error_v0",
+            "status": "invalid_request",
+            "error": str(exc),
+        }
+        print_payload(payload, output_format(args), _render)
+        return 2
+    print_payload(payload, output_format(args), _render)
+    return 0
+
+
+__all__ = [
+    "handle_machine_configuration_command",
+    "register_machine_configuration_commands",
+]

--- a/loopx/capabilities/machine_configuration/store.py
+++ b/loopx/capabilities/machine_configuration/store.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ...file_lock import exclusive_file_lock
+from ...registry import atomic_write_json, read_json
+from .contract import (
+    MachineConfigurationRegistry,
+    machine_configuration_revision,
+    normalize_machine_configuration,
+    project_machine_configuration,
+)
+
+
+MACHINE_CONFIGURATION_UPDATE_PLAN_SCHEMA = "machine_configuration_update_plan_v0"
+MACHINE_CONFIGURATION_TRANSACTION_SCHEMA = "machine_configuration_transaction_v0"
+MACHINE_CONFIGURATION_BACKUP_SCHEMA = "machine_configuration_backup_v0"
+MACHINE_CONFIGURATION_INSPECTION_SCHEMA = "machine_configuration_inspection_v0"
+MACHINE_CONFIGURATION_ROLLBACK_PLAN_SCHEMA = "machine_configuration_rollback_plan_v0"
+MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA = (
+    "machine_configuration_rollback_receipt_v0"
+)
+
+_MISSING_REVISION = "absent"
+_TRANSACTION_ID_RE = re.compile(r"^machine_configuration_[0-9a-f]{24}$")
+JsonWriter = Callable[[Path, dict[str, Any]], None]
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _now_iso(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    return current.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _runtime_root(runtime_root: Path) -> Path:
+    return runtime_root.expanduser().resolve()
+
+
+def machine_configuration_store_path(runtime_root: Path) -> Path:
+    return _runtime_root(runtime_root) / "machine" / "configuration.json"
+
+
+def _store_ref() -> str:
+    return "machine/configuration.json"
+
+
+def _transaction_ref(transaction_id: str) -> str:
+    return f"machine/configuration/transactions/{transaction_id}.json"
+
+
+def _backup_ref(transaction_id: str) -> str:
+    return f"machine/configuration/backups/{transaction_id}.json"
+
+
+def _transaction_path(runtime_root: Path, transaction_id: str) -> Path:
+    return _runtime_root(runtime_root) / _transaction_ref(transaction_id)
+
+
+def _backup_path(runtime_root: Path, transaction_id: str) -> Path:
+    return _runtime_root(runtime_root) / _backup_ref(transaction_id)
+
+
+def _safe_transaction_id(value: str) -> str:
+    transaction_id = str(value or "").strip()
+    if not _TRANSACTION_ID_RE.fullmatch(transaction_id):
+        raise ValueError("transaction_id is invalid")
+    return transaction_id
+
+
+def _new_transaction_id() -> str:
+    return f"machine_configuration_{uuid4().hex[:24]}"
+
+
+def _new_rollback_id() -> str:
+    return f"machine_configuration_rollback_{uuid4().hex[:24]}"
+
+
+def _secure_write(
+    path: Path, payload: dict[str, Any], *, writer: JsonWriter = atomic_write_json
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    writer(path, payload)
+    path.chmod(0o600)
+
+
+def read_machine_configuration(
+    runtime_root: Path, *, registry: MachineConfigurationRegistry
+) -> dict[str, Any] | None:
+    path = machine_configuration_store_path(runtime_root)
+    if not path.is_file():
+        return None
+    normalized: dict[str, Any] = normalize_machine_configuration(
+        read_json(path), registry=registry
+    )
+    return normalized
+
+
+def inspect_machine_configuration(
+    runtime_root: Path, *, registry: MachineConfigurationRegistry
+) -> dict[str, Any]:
+    current = read_machine_configuration(runtime_root, registry=registry)
+    return {
+        "ok": True,
+        "schema_version": MACHINE_CONFIGURATION_INSPECTION_SCHEMA,
+        "status": "configured" if current is not None else "absent",
+        "defaults_ref": _store_ref(),
+        "revision": (
+            machine_configuration_revision(current)
+            if current is not None
+            else _MISSING_REVISION
+        ),
+        "changed_namespaces": [],
+        "machine_configuration": (
+            project_machine_configuration(current, registry=registry)
+            if current is not None
+            else None
+        ),
+    }
+
+
+def _update_plan(
+    *,
+    current: Mapping[str, Any] | None,
+    desired: Mapping[str, Any],
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    normalized_desired = normalize_machine_configuration(desired, registry=registry)
+    normalized_current = (
+        normalize_machine_configuration(current, registry=registry)
+        if current is not None
+        else None
+    )
+    current_revision = (
+        machine_configuration_revision(normalized_current)
+        if normalized_current is not None
+        else _MISSING_REVISION
+    )
+    desired_revision = machine_configuration_revision(normalized_desired)
+    action = (
+        "create"
+        if normalized_current is None
+        else "unchanged"
+        if current_revision == desired_revision
+        else "update"
+    )
+    identity = {
+        "current_revision": current_revision,
+        "desired_revision": desired_revision,
+        "defaults_ref": _store_ref(),
+        "action": action,
+        "changed_namespaces": sorted(
+            namespace
+            for namespace in set(normalized_desired["namespaces"])
+            | set((normalized_current or {}).get("namespaces", {}))
+            if (normalized_current or {}).get("namespaces", {}).get(namespace)
+            != normalized_desired["namespaces"].get(namespace)
+        ),
+    }
+    return {
+        "ok": True,
+        "schema_version": MACHINE_CONFIGURATION_UPDATE_PLAN_SCHEMA,
+        "status": "preview",
+        **identity,
+        "plan_revision": _digest(identity),
+        "writes_required": int(action != "unchanged"),
+        "machine_configuration": project_machine_configuration(
+            normalized_desired, registry=registry
+        ),
+    }
+
+
+def plan_machine_configuration_update(
+    *,
+    runtime_root: Path,
+    configuration: Mapping[str, Any],
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    return _update_plan(
+        current=read_machine_configuration(runtime_root, registry=registry),
+        desired=configuration,
+        registry=registry,
+    )
+
+
+def _restore_prior_state(
+    *,
+    store_path: Path,
+    prior: Mapping[str, Any] | None,
+    writer: JsonWriter,
+) -> None:
+    if prior is None:
+        store_path.unlink(missing_ok=True)
+        return
+    _secure_write(store_path, dict(prior), writer=writer)
+
+
+def configure_machine_configuration(
+    *,
+    runtime_root: Path,
+    configuration: Mapping[str, Any],
+    registry: MachineConfigurationRegistry,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    """Preview or atomically apply one machine policy with a rollback receipt."""
+
+    preview = plan_machine_configuration_update(
+        runtime_root=runtime_root,
+        configuration=configuration,
+        registry=registry,
+    )
+    if not execute:
+        return preview
+    expected = str(expected_plan_revision or "").strip()
+    if not expected:
+        raise ValueError("expected_plan_revision is required when execute is true")
+
+    store_path = machine_configuration_store_path(runtime_root)
+    with exclusive_file_lock(store_path, operation="configure_machine_configuration"):
+        current = read_machine_configuration(runtime_root, registry=registry)
+        plan = _update_plan(current=current, desired=configuration, registry=registry)
+        if plan["plan_revision"] != expected:
+            raise ValueError(
+                "machine-configuration plan revision changed; preview again"
+            )
+        if plan["action"] == "unchanged":
+            return {
+                **plan,
+                "schema_version": MACHINE_CONFIGURATION_TRANSACTION_SCHEMA,
+                "status": "unchanged",
+                "transaction_id": None,
+                "transaction_ref": None,
+                "backup_ref": None,
+                "readback_verified": True,
+                "rollback_available": False,
+            }
+
+        transaction_id = _new_transaction_id()
+        backup_path = _backup_path(runtime_root, transaction_id)
+        receipt_path = _transaction_path(runtime_root, transaction_id)
+        prior_revision = str(plan["current_revision"])
+        backup = {
+            "schema_version": MACHINE_CONFIGURATION_BACKUP_SCHEMA,
+            "transaction_id": transaction_id,
+            "prior_revision": prior_revision,
+            "prior_machine_configuration": current,
+        }
+        desired = normalize_machine_configuration(configuration, registry=registry)
+        try:
+            _secure_write(backup_path, backup, writer=writer)
+            _secure_write(store_path, desired, writer=writer)
+            readback = read_machine_configuration(runtime_root, registry=registry)
+            if readback != desired:
+                raise RuntimeError(
+                    "machine-configuration readback did not match the requested policy"
+                )
+            receipt = {
+                "ok": True,
+                "schema_version": MACHINE_CONFIGURATION_TRANSACTION_SCHEMA,
+                "status": "applied",
+                "transaction_id": transaction_id,
+                "transaction_ref": _transaction_ref(transaction_id),
+                "backup_ref": _backup_ref(transaction_id),
+                "defaults_ref": _store_ref(),
+                "plan_revision": plan["plan_revision"],
+                "prior_revision": prior_revision,
+                "applied_revision": plan["desired_revision"],
+                "applied_at": _now_iso(now),
+                "readback_verified": True,
+                "rollback_available": True,
+                "changed_namespaces": plan["changed_namespaces"],
+                "machine_configuration": project_machine_configuration(
+                    readback, registry=registry
+                ),
+            }
+            receipt["receipt_revision"] = _digest(receipt)
+            _secure_write(receipt_path, receipt, writer=writer)
+            return receipt
+        except Exception as exc:
+            try:
+                _restore_prior_state(
+                    store_path=store_path, prior=current, writer=writer
+                )
+            except Exception as rollback_exc:
+                raise RuntimeError(
+                    "machine-configuration apply failed and automatic rollback also failed"
+                ) from rollback_exc
+            raise RuntimeError(
+                "machine-configuration apply failed; prior state was restored"
+            ) from exc
+
+
+def _read_transaction(runtime_root: Path, transaction_id: str) -> dict[str, Any]:
+    safe_id = _safe_transaction_id(transaction_id)
+    path = _transaction_path(runtime_root, safe_id)
+    if not path.is_file():
+        raise ValueError(f"machine-configuration transaction not found: {safe_id}")
+    receipt: dict[str, Any] = read_json(path)
+    if (
+        receipt.get("schema_version") != MACHINE_CONFIGURATION_TRANSACTION_SCHEMA
+        or receipt.get("transaction_id") != safe_id
+        or receipt.get("status") != "applied"
+        or receipt.get("transaction_ref") != _transaction_ref(safe_id)
+        or receipt.get("defaults_ref") != _store_ref()
+    ):
+        raise ValueError("machine-configuration transaction receipt is invalid")
+    receipt_revision = str(receipt.pop("receipt_revision", ""))
+    if receipt_revision != _digest(receipt):
+        raise ValueError("machine-configuration transaction receipt is invalid")
+    receipt["receipt_revision"] = receipt_revision
+    applied_revision = str(receipt.get("applied_revision") or "")
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", applied_revision):
+        raise ValueError("machine-configuration transaction revision is invalid")
+    return receipt
+
+
+def _read_backup(
+    runtime_root: Path,
+    transaction_id: str,
+    receipt: Mapping[str, Any],
+    *,
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    path = _backup_path(runtime_root, transaction_id)
+    if receipt.get("backup_ref") != _backup_ref(transaction_id) or not path.is_file():
+        raise ValueError("machine-configuration transaction backup is unavailable")
+    backup = read_json(path)
+    if (
+        backup.get("schema_version") != MACHINE_CONFIGURATION_BACKUP_SCHEMA
+        or backup.get("transaction_id") != transaction_id
+    ):
+        raise ValueError("machine-configuration transaction backup is invalid")
+    prior = backup.get("prior_machine_configuration")
+    normalized_prior = (
+        normalize_machine_configuration(prior, registry=registry)
+        if prior is not None
+        else None
+    )
+    prior_revision = (
+        machine_configuration_revision(normalized_prior)
+        if normalized_prior is not None
+        else _MISSING_REVISION
+    )
+    if prior_revision != backup.get("prior_revision") or prior_revision != receipt.get(
+        "prior_revision"
+    ):
+        raise ValueError(
+            "machine-configuration backup revision does not match its receipt"
+        )
+    return {**backup, "prior_machine_configuration": normalized_prior}
+
+
+def _rollback_plan(
+    *,
+    transaction_id: str,
+    receipt: Mapping[str, Any],
+    backup: Mapping[str, Any],
+    current: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    current_revision = (
+        machine_configuration_revision(current)
+        if current is not None
+        else _MISSING_REVISION
+    )
+    applied_revision = str(receipt.get("applied_revision") or "")
+    target_revision = str(backup.get("prior_revision") or "")
+    if current_revision == target_revision:
+        action, allowed, reason = "unchanged", True, "already_rolled_back"
+    elif current_revision != applied_revision:
+        action, allowed, reason = "blocked", False, "current_revision_changed"
+    else:
+        action = "delete" if target_revision == _MISSING_REVISION else "restore"
+        allowed, reason = True, "exact_applied_revision_matches"
+    identity = {
+        "transaction_id": transaction_id,
+        "current_revision": current_revision,
+        "applied_revision": applied_revision,
+        "target_revision": target_revision,
+        "action": action,
+    }
+    return {
+        "ok": True,
+        "schema_version": MACHINE_CONFIGURATION_ROLLBACK_PLAN_SCHEMA,
+        "status": "preview",
+        **identity,
+        "reason": reason,
+        "rollback_allowed": allowed,
+        "writes_required": int(action in {"delete", "restore"}),
+        "plan_revision": _digest(identity),
+    }
+
+
+def plan_machine_configuration_rollback(
+    *,
+    runtime_root: Path,
+    transaction_id: str,
+    registry: MachineConfigurationRegistry,
+) -> dict[str, Any]:
+    safe_id = _safe_transaction_id(transaction_id)
+    receipt = _read_transaction(runtime_root, safe_id)
+    backup = _read_backup(runtime_root, safe_id, receipt, registry=registry)
+    current = read_machine_configuration(runtime_root, registry=registry)
+    return _rollback_plan(
+        transaction_id=safe_id,
+        receipt=receipt,
+        backup=backup,
+        current=current,
+    )
+
+
+def rollback_machine_configuration(
+    *,
+    runtime_root: Path,
+    transaction_id: str,
+    registry: MachineConfigurationRegistry,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    preview = plan_machine_configuration_rollback(
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+        registry=registry,
+    )
+    if not execute:
+        return preview
+    expected = str(expected_plan_revision or "").strip()
+    if not expected:
+        raise ValueError("expected_plan_revision is required when execute is true")
+
+    safe_id = _safe_transaction_id(transaction_id)
+    store_path = machine_configuration_store_path(runtime_root)
+    with exclusive_file_lock(store_path, operation="rollback_machine_configuration"):
+        receipt = _read_transaction(runtime_root, safe_id)
+        backup = _read_backup(runtime_root, safe_id, receipt, registry=registry)
+        current = read_machine_configuration(runtime_root, registry=registry)
+        plan = _rollback_plan(
+            transaction_id=safe_id,
+            receipt=receipt,
+            backup=backup,
+            current=current,
+        )
+        if plan["plan_revision"] != expected:
+            raise ValueError(
+                "machine-configuration rollback plan changed; preview again"
+            )
+        if not plan["rollback_allowed"]:
+            raise ValueError(
+                "machine-configuration rollback is blocked by a newer revision"
+            )
+        if plan["action"] == "unchanged":
+            return {
+                **plan,
+                "schema_version": MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA,
+                "status": "unchanged",
+                "rollback_id": None,
+                "readback_verified": True,
+            }
+
+        prior = backup.get("prior_machine_configuration")
+        rollback_id = _new_rollback_id()
+        rollback_path = _runtime_root(runtime_root) / _transaction_ref(rollback_id)
+        try:
+            _restore_prior_state(store_path=store_path, prior=prior, writer=writer)
+            readback = read_machine_configuration(runtime_root, registry=registry)
+            if readback != prior:
+                raise RuntimeError(
+                    "machine-configuration rollback readback did not match backup"
+                )
+            result = {
+                "ok": True,
+                "schema_version": MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA,
+                "status": "rolled_back",
+                "rollback_id": rollback_id,
+                "rollback_ref": _transaction_ref(rollback_id),
+                "transaction_id": safe_id,
+                "plan_revision": plan["plan_revision"],
+                "restored_revision": plan["target_revision"],
+                "rolled_back_at": _now_iso(now),
+                "readback_verified": True,
+            }
+            _secure_write(rollback_path, result, writer=writer)
+            return result
+        except Exception as exc:
+            try:
+                _restore_prior_state(
+                    store_path=store_path, prior=current, writer=writer
+                )
+            except Exception as restore_exc:
+                raise RuntimeError(
+                    "machine-configuration rollback failed and applied state could not be restored"
+                ) from restore_exc
+            raise RuntimeError(
+                "machine-configuration rollback failed; applied state was restored"
+            ) from exc
+
+
+__all__ = [
+    "MACHINE_CONFIGURATION_BACKUP_SCHEMA",
+    "MACHINE_CONFIGURATION_INSPECTION_SCHEMA",
+    "MACHINE_CONFIGURATION_ROLLBACK_PLAN_SCHEMA",
+    "MACHINE_CONFIGURATION_ROLLBACK_RECEIPT_SCHEMA",
+    "MACHINE_CONFIGURATION_TRANSACTION_SCHEMA",
+    "MACHINE_CONFIGURATION_UPDATE_PLAN_SCHEMA",
+    "configure_machine_configuration",
+    "inspect_machine_configuration",
+    "machine_configuration_store_path",
+    "plan_machine_configuration_rollback",
+    "plan_machine_configuration_update",
+    "read_machine_configuration",
+    "rollback_machine_configuration",
+]

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -17,6 +17,11 @@ from .machine_defaults import (
     build_goal_periodic_report_delivery_plan,
     plan_periodic_report_machine_default_backfill,
 )
+from .machine_store import (
+    configure_periodic_report_machine_defaults,
+    inspect_periodic_report_machine_defaults,
+    rollback_periodic_report_machine_defaults,
+)
 from .extension_envelope import build_openviking_archive_execution_envelope
 from .presets import (
     PERIODIC_REPORT_PROFILE_PRESET_ALIASES,
@@ -114,6 +119,31 @@ def register_periodic_report_commands(
         required=True,
         help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
     )
+    configure_machine_defaults = commands.add_parser(
+        "configure-machine-defaults",
+        help="Preview or apply the runtime-root machine periodic-report policy.",
+    )
+    add_subcommand_format(configure_machine_defaults)
+    configure_machine_defaults.add_argument(
+        "--config-json",
+        required=True,
+        help="Path to loopx_machine_configuration_v0 JSON; use '-' for stdin.",
+    )
+    configure_machine_defaults.add_argument("--execute", action="store_true")
+    configure_machine_defaults.add_argument("--expected-plan-revision")
+    inspect_machine_defaults = commands.add_parser(
+        "inspect-machine-defaults",
+        help="Read back the runtime-root machine periodic-report policy.",
+    )
+    add_subcommand_format(inspect_machine_defaults)
+    rollback_machine_defaults = commands.add_parser(
+        "rollback-machine-defaults",
+        help="Preview or execute rollback of one exact machine-policy transaction.",
+    )
+    add_subcommand_format(rollback_machine_defaults)
+    rollback_machine_defaults.add_argument("--transaction-id", required=True)
+    rollback_machine_defaults.add_argument("--execute", action="store_true")
+    rollback_machine_defaults.add_argument("--expected-plan-revision")
     plan_goal_delivery = commands.add_parser(
         "plan-goal-delivery",
         help="Preview Goal-owned delivery identity and preferred Agent execution.",
@@ -302,6 +332,11 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
         )
     if payload.get("schema_version") in {
         "periodic_report_machine_default_backfill_plan_v0",
+        "periodic_report_machine_default_update_plan_v0",
+        "periodic_report_machine_default_transaction_v0",
+        "periodic_report_machine_default_inspection_v0",
+        "periodic_report_machine_default_rollback_plan_v0",
+        "periodic_report_machine_default_rollback_receipt_v0",
         "periodic_report_goal_delivery_plan_v0",
     }:
         return "\n".join(
@@ -395,6 +430,31 @@ def handle_periodic_report_command(
                 _load_json_object(args.config_json),
             )
             payload["ok"] = True
+        elif args.periodic_report_command in {
+            "configure-machine-defaults",
+            "inspect-machine-defaults",
+            "rollback-machine-defaults",
+        }:
+            registry = read_json(registry_path)
+            runtime_root = resolve_runtime_root(
+                registry, runtime_root_arg, registry_path=registry_path
+            )
+            if args.periodic_report_command == "configure-machine-defaults":
+                payload = configure_periodic_report_machine_defaults(
+                    runtime_root=runtime_root,
+                    machine_defaults=_load_json_object(args.config_json),
+                    execute=bool(args.execute),
+                    expected_plan_revision=args.expected_plan_revision,
+                )
+            elif args.periodic_report_command == "inspect-machine-defaults":
+                payload = inspect_periodic_report_machine_defaults(runtime_root)
+            else:
+                payload = rollback_periodic_report_machine_defaults(
+                    runtime_root=runtime_root,
+                    transaction_id=args.transaction_id,
+                    execute=bool(args.execute),
+                    expected_plan_revision=args.expected_plan_revision,
+                )
         elif args.periodic_report_command == "plan-goal-delivery":
             payload = build_goal_periodic_report_delivery_plan(
                 _load_json_object(args.request_json)

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -158,6 +158,12 @@ def normalize_loopx_machine_defaults(raw: object) -> dict[str, Any]:
     )
 
 
+def loopx_machine_defaults_revision(raw: object) -> str:
+    """Compatibility revision for a validated machine configuration."""
+
+    return machine_configuration_revision(normalize_loopx_machine_defaults(raw))
+
+
 def _periodic_report_defaults(machine_defaults: Mapping[str, Any]) -> dict[str, Any]:
     normalized = normalize_loopx_machine_defaults(machine_defaults)
     return dict(normalized["namespaces"]["periodic_report"])
@@ -435,6 +441,7 @@ __all__ = [
     "PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA",
     "build_goal_periodic_report_delivery_identity",
     "build_goal_periodic_report_delivery_plan",
+    "loopx_machine_defaults_revision",
     "normalize_loopx_machine_defaults",
     "normalize_periodic_report_machine_defaults",
     "periodic_report_machine_configuration_namespace",

--- a/loopx/capabilities/periodic_report/machine_store.py
+++ b/loopx/capabilities/periodic_report/machine_store.py
@@ -1,0 +1,110 @@
+"""Compatibility aliases for the generic machine-configuration effect owner."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ...registry import atomic_write_json
+from ..machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from ..machine_configuration.store import (
+    JsonWriter,
+    configure_machine_configuration,
+    inspect_machine_configuration,
+    machine_configuration_store_path,
+    plan_machine_configuration_rollback,
+    plan_machine_configuration_update,
+    read_machine_configuration,
+    rollback_machine_configuration,
+)
+
+
+def machine_defaults_store_path(runtime_root: Path) -> Path:
+    return machine_configuration_store_path(runtime_root)
+
+
+def read_periodic_report_machine_defaults(runtime_root: Path) -> dict[str, Any] | None:
+    return read_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+
+
+def inspect_periodic_report_machine_defaults(runtime_root: Path) -> dict[str, Any]:
+    return inspect_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+
+
+def plan_periodic_report_machine_defaults_update(
+    *, runtime_root: Path, machine_defaults: Mapping[str, Any]
+) -> dict[str, Any]:
+    return plan_machine_configuration_update(
+        runtime_root=runtime_root,
+        configuration=machine_defaults,
+        registry=build_builtin_machine_configuration_registry(),
+    )
+
+
+def configure_periodic_report_machine_defaults(
+    *,
+    runtime_root: Path,
+    machine_defaults: Mapping[str, Any],
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    return configure_machine_configuration(
+        runtime_root=runtime_root,
+        configuration=machine_defaults,
+        registry=build_builtin_machine_configuration_registry(),
+        execute=execute,
+        expected_plan_revision=expected_plan_revision,
+        now=now,
+        writer=writer,
+    )
+
+
+def plan_periodic_report_machine_defaults_rollback(
+    *, runtime_root: Path, transaction_id: str
+) -> dict[str, Any]:
+    return plan_machine_configuration_rollback(
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+        registry=build_builtin_machine_configuration_registry(),
+    )
+
+
+def rollback_periodic_report_machine_defaults(
+    *,
+    runtime_root: Path,
+    transaction_id: str,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    return rollback_machine_configuration(
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+        registry=build_builtin_machine_configuration_registry(),
+        execute=execute,
+        expected_plan_revision=expected_plan_revision,
+        now=now,
+        writer=writer,
+    )
+
+
+__all__ = [
+    "configure_periodic_report_machine_defaults",
+    "inspect_periodic_report_machine_defaults",
+    "machine_defaults_store_path",
+    "plan_periodic_report_machine_defaults_rollback",
+    "plan_periodic_report_machine_defaults_update",
+    "read_periodic_report_machine_defaults",
+    "rollback_periodic_report_machine_defaults",
+]

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -43,6 +43,10 @@ from .capabilities.periodic_report.cli import (
     handle_periodic_report_command,
     register_periodic_report_commands,
 )
+from .capabilities.machine_configuration.cli import (
+    handle_machine_configuration_command,
+    register_machine_configuration_commands,
+)
 from .capabilities.periodic_report.post_writeback_hook import (
     build_periodic_report_post_writeback_projection,
     periodic_report_post_writeback_hooks_for_goal,
@@ -268,6 +272,8 @@ def build_parser() -> LoopXArgumentParser:
         add_subcommand_format,
         provider_command_registrars=(register_lark_periodic_report_commands,),
     )
+
+    register_machine_configuration_commands(sub, add_subcommand_format)
 
     register_semantic_preference_commands(sub, add_subcommand_format)
 
@@ -603,6 +609,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if periodic_report_result is not None:
         return periodic_report_result
+
+    machine_configuration_result = handle_machine_configuration_command(
+        args,
+        runtime_root_arg=args.runtime_root,
+        registry_path=registry_path,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if machine_configuration_result is not None:
+        return machine_configuration_result
 
     semantic_preference_result = handle_semantic_preference_command(
         args,

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from loopx.capabilities.machine_configuration.store import (
+    configure_machine_configuration,
+    inspect_machine_configuration,
+)
+from loopx.capabilities.periodic_report.machine_store import (
+    configure_periodic_report_machine_defaults,
+    inspect_periodic_report_machine_defaults,
+    machine_defaults_store_path,
+    plan_periodic_report_machine_defaults_rollback,
+    read_periodic_report_machine_defaults,
+    rollback_periodic_report_machine_defaults,
+)
+from loopx.cli import main
+from loopx.registry import atomic_write_json
+
+
+def _defaults(*, route_ref: str = "loopx-concierge") -> dict:
+    return {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "periodic_report": {
+                "schema_version": "periodic_report_machine_defaults_v0",
+                "enabled": True,
+                "inheritance": "materialize_on_goal_connect",
+                "profile_preset": "weekly-progress",
+                "route_ref": route_ref,
+                "timezone": "Asia/Shanghai",
+            },
+        },
+    }
+
+
+def _apply(runtime_root: Path, defaults: dict) -> dict:
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+    )
+    return configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+        now=datetime(2026, 9, 3, tzinfo=timezone.utc),
+    )
+
+
+def test_configure_machine_defaults_is_preview_only_without_execute(
+    tmp_path: Path,
+) -> None:
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        machine_defaults=_defaults(),
+    )
+
+    assert preview["status"] == "preview"
+    assert preview["action"] == "create"
+    assert preview["writes_required"] == 1
+    assert not machine_defaults_store_path(tmp_path).exists()
+
+
+def test_generic_store_reports_changed_typed_namespaces(tmp_path: Path) -> None:
+    registry = build_builtin_machine_configuration_registry()
+    preview = configure_machine_configuration(
+        runtime_root=tmp_path,
+        configuration=_defaults(),
+        registry=registry,
+    )
+
+    assert preview["changed_namespaces"] == ["periodic_report"]
+    assert preview["machine_configuration"] == _defaults()
+
+
+def test_apply_requires_the_exact_preview_revision(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="expected_plan_revision is required"):
+        configure_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            machine_defaults=_defaults(),
+            execute=True,
+        )
+
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        machine_defaults=_defaults(),
+    )
+    with pytest.raises(ValueError, match="plan revision changed"):
+        configure_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            machine_defaults=_defaults(route_ref="different-route"),
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+        )
+
+
+def test_apply_persists_readback_backup_and_transaction_receipt(
+    tmp_path: Path,
+) -> None:
+    result = _apply(tmp_path, _defaults())
+
+    assert result["status"] == "applied"
+    assert result["readback_verified"] is True
+    assert result["rollback_available"] is True
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults()
+    receipt_path = tmp_path / result["transaction_ref"]
+    backup_path = tmp_path / result["backup_ref"]
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == result
+    backup = json.loads(backup_path.read_text(encoding="utf-8"))
+    assert backup["prior_revision"] == "absent"
+    assert backup["prior_machine_configuration"] is None
+    assert machine_defaults_store_path(tmp_path).stat().st_mode & 0o777 == 0o600
+
+
+def test_reapplying_the_same_defaults_is_idempotent(tmp_path: Path) -> None:
+    first = _apply(tmp_path, _defaults())
+    transaction_dir = tmp_path / "machine" / "configuration" / "transactions"
+    before = sorted(transaction_dir.iterdir())
+
+    second = _apply(tmp_path, _defaults())
+
+    assert first["status"] == "applied"
+    assert second["status"] == "unchanged"
+    assert second["transaction_id"] is None
+    assert sorted(transaction_dir.iterdir()) == before
+
+
+def test_rollback_restores_the_exact_prior_policy_and_is_idempotent(
+    tmp_path: Path,
+) -> None:
+    _apply(tmp_path, _defaults(route_ref="original"))
+    update = _apply(tmp_path, _defaults(route_ref="replacement"))
+
+    preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+    )
+    assert preview["action"] == "restore"
+    result = rollback_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+        now=datetime(2026, 9, 3, 1, tzinfo=timezone.utc),
+    )
+
+    assert result["status"] == "rolled_back"
+    assert result["readback_verified"] is True
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults(
+        route_ref="original"
+    )
+
+    repeated_preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+    )
+    repeated = rollback_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        transaction_id=update["transaction_id"],
+        execute=True,
+        expected_plan_revision=repeated_preview["plan_revision"],
+    )
+    assert repeated["status"] == "unchanged"
+    assert repeated["readback_verified"] is True
+
+
+def test_rollback_refuses_to_overwrite_a_newer_revision(tmp_path: Path) -> None:
+    first = _apply(tmp_path, _defaults(route_ref="first"))
+    _apply(tmp_path, _defaults(route_ref="second"))
+
+    preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=tmp_path,
+        transaction_id=first["transaction_id"],
+    )
+
+    assert preview["action"] == "blocked"
+    assert preview["reason"] == "current_revision_changed"
+    assert preview["rollback_allowed"] is False
+    with pytest.raises(ValueError, match="blocked by a newer revision"):
+        rollback_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            transaction_id=first["transaction_id"],
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+        )
+
+
+def test_rollback_fails_closed_when_the_transaction_receipt_was_tampered(
+    tmp_path: Path,
+) -> None:
+    applied = _apply(tmp_path, _defaults())
+    receipt_path = tmp_path / applied["transaction_ref"]
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    receipt["applied_revision"] = "sha256:" + "0" * 64
+    receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="transaction receipt is invalid"):
+        plan_periodic_report_machine_defaults_rollback(
+            runtime_root=tmp_path,
+            transaction_id=applied["transaction_id"],
+        )
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults()
+
+
+def test_apply_failure_restores_the_prior_policy(tmp_path: Path) -> None:
+    _apply(tmp_path, _defaults(route_ref="original"))
+    writes = 0
+
+    def fail_receipt(path: Path, payload: dict) -> None:
+        nonlocal writes
+        writes += 1
+        if writes == 3:
+            raise OSError("receipt write failed")
+        atomic_write_json(path, payload)
+
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=tmp_path,
+        machine_defaults=_defaults(route_ref="replacement"),
+    )
+    with pytest.raises(RuntimeError, match="prior state was restored"):
+        configure_periodic_report_machine_defaults(
+            runtime_root=tmp_path,
+            machine_defaults=_defaults(route_ref="replacement"),
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+            writer=fail_receipt,
+        )
+
+    assert read_periodic_report_machine_defaults(tmp_path) == _defaults(
+        route_ref="original"
+    )
+
+
+def test_machine_defaults_cli_previews_applies_reads_and_rolls_back(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    defaults_path = tmp_path / "defaults.json"
+    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "periodic-report",
+    ]
+
+    assert (
+        main(
+            [*common, "configure-machine-defaults", "--config-json", str(defaults_path)]
+        )
+        == 0
+    )
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["status"] == "preview"
+    assert not machine_defaults_store_path(runtime_root).exists()
+
+    assert (
+        main(
+            [
+                *common,
+                "configure-machine-defaults",
+                "--config-json",
+                str(defaults_path),
+                "--execute",
+                "--expected-plan-revision",
+                preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["status"] == "applied"
+
+    assert main([*common, "inspect-machine-defaults"]) == 0
+    inspection = json.loads(capsys.readouterr().out)
+    assert inspection["status"] == "configured"
+    assert inspection["machine_configuration"] == _defaults()
+
+    assert (
+        main(
+            [
+                *common,
+                "rollback-machine-defaults",
+                "--transaction-id",
+                applied["transaction_id"],
+            ]
+        )
+        == 0
+    )
+    rollback_preview = json.loads(capsys.readouterr().out)
+    assert rollback_preview["action"] == "delete"
+
+    assert (
+        main(
+            [
+                *common,
+                "rollback-machine-defaults",
+                "--transaction-id",
+                applied["transaction_id"],
+                "--execute",
+                "--expected-plan-revision",
+                rollback_preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    rolled_back = json.loads(capsys.readouterr().out)
+    assert rolled_back["status"] == "rolled_back"
+    assert not machine_defaults_store_path(runtime_root).exists()
+
+
+def test_canonical_machine_config_cli_uses_the_same_store_and_projection(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    defaults_path = tmp_path / "defaults.json"
+    defaults_path.write_text(json.dumps(_defaults()), encoding="utf-8")
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "machine-config",
+    ]
+
+    assert main([*common, "preview", "--config-json", str(defaults_path)]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["changed_namespaces"] == ["periodic_report"]
+
+    assert (
+        main(
+            [
+                *common,
+                "apply",
+                "--config-json",
+                str(defaults_path),
+                "--expected-plan-revision",
+                preview["plan_revision"],
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert main([*common, "inspect"]) == 0
+    inspection = json.loads(capsys.readouterr().out)
+    assert inspection == inspect_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+
+
+def test_inspection_is_path_free_and_reports_absence(tmp_path: Path) -> None:
+    result = inspect_periodic_report_machine_defaults(tmp_path)
+
+    assert result == {
+        "ok": True,
+        "schema_version": "machine_configuration_inspection_v0",
+        "status": "absent",
+        "defaults_ref": "machine/configuration.json",
+        "revision": "absent",
+        "changed_namespaces": [],
+        "machine_configuration": None,
+    }


### PR DESCRIPTION
Part of #3859. Stacked on #3861.

## Summary

- add one generic machine-configuration effect owner at `machine/configuration.json`
- provide whole-document preview/apply/inspect/rollback with file locking, atomic writes, backups, revision fences, transaction receipts, readback verification, and automatic recovery
- expose canonical `loopx machine-config preview|apply|inspect|rollback` commands for typed machine settings
- return namespace change sets and public-safe projections suitable for the Dashboard contract
- retain the previous periodic-report machine-default commands only as compatibility aliases to the same store and registry

Periodic reporting is the first registered consumer, not the owner of the store. Goal subscription/backfill/routing logic stays in periodic-report and no second configuration source is introduced.

## Validation

- 27 focused contract/store/CLI tests passed
- scoped Ruff passed
- scoped strict mypy passed; repository-wide mypy still has unrelated existing failures
- Python compile and `git diff --check` passed
- refreshed CI is in progress
- refreshed change-quality receipt and premerge canary are required before merge

## Boundary

No `.local`, runtime state, credentials, local paths, raw provider identifiers, or trajectories are included.