### PR TITLE
feat(periodic-report): materialize Goal defaults safely

### DIFF
--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -6,6 +6,13 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from .capabilities.periodic_report.machine_defaults import (
+    materialize_goal_periodic_report_subscription,
+)
+from .capabilities.machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from .capabilities.machine_configuration.store import read_machine_configuration
 from .control_plane.runtime.time import now_local_iso
 from .control_plane.runtime.public_safety import public_safe_compact_text
 from .control_plane.todos.active_state_editing import (
@@ -43,15 +50,9 @@ DEFAULT_DOMAIN = "project-goal-control-plane"
 GENERIC_ONBOARDING_ADAPTER_KINDS = frozenset(
     {"generic_project_goal_v0", "read_only_project_map_v0"}
 )
-HEARTBEAT_OPT_IN_STATUS_REQUIRED = (
-    "requires explicit heartbeat=yes/no before a recurring Codex App automation is installed"
-)
-HEARTBEAT_OPT_IN_STATUS_PREAUTHORIZED = (
-    "explicitly preauthorized; create or update the host loop before claiming recurring automation is active"
-)
-HEARTBEAT_OPT_IN_STATUS_DECLINED = (
-    "explicitly declined; keep the goal manual or on-demand unless the user later opts in"
-)
+HEARTBEAT_OPT_IN_STATUS_REQUIRED = "requires explicit heartbeat=yes/no before a recurring Codex App automation is installed"
+HEARTBEAT_OPT_IN_STATUS_PREAUTHORIZED = "explicitly preauthorized; create or update the host loop before claiming recurring automation is active"
+HEARTBEAT_OPT_IN_STATUS_DECLINED = "explicitly declined; keep the goal manual or on-demand unless the user later opts in"
 HEARTBEAT_OPT_IN_INSTRUCTION = (
     "Ask the user whether to enable the Codex App heartbeat. heartbeat=yes means create or update a recurring "
     "Codex App automation from an identity-scoped `loopx heartbeat-prompt --thin` task body; heartbeat=no means "
@@ -141,7 +142,9 @@ def repair_missing_todo_source_sections(state_text: str) -> tuple[str, list[str]
     return "\n".join(lines) + trailing_newline, added_roles
 
 
-def onboarding_candidates(onboarding_scan: dict[str, Any] | None) -> list[dict[str, Any]]:
+def onboarding_candidates(
+    onboarding_scan: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
     if not isinstance(onboarding_scan, dict):
         return []
     candidates = onboarding_scan.get("agent_todo_candidates")
@@ -292,7 +295,11 @@ def onboarding_agent_review_todo_text(
     autonomous_choice_required: bool,
     heartbeat_choice_required: bool,
 ) -> str | None:
-    if not acceptance_required and not autonomous_choice_required and not heartbeat_choice_required:
+    if (
+        not acceptance_required
+        and not autonomous_choice_required
+        and not heartbeat_choice_required
+    ):
         return None
     prompts: list[str] = []
     if acceptance_required:
@@ -343,7 +350,11 @@ def onboarding_next_action(
             return validation_action["text"]
         return "Initial routing is owned by the connected domain adapter."
     need_heartbeat_choice = codex_app_heartbeat == "ask"
-    if not accept_onboarding_agent_todos or not begin_autonomous_advance or need_heartbeat_choice:
+    if (
+        not accept_onboarding_agent_todos
+        or not begin_autonomous_advance
+        or need_heartbeat_choice
+    ):
         asks: list[str] = []
         if not accept_onboarding_agent_todos:
             asks.append("which proposed onboarding agent todos to accept")
@@ -351,7 +362,9 @@ def onboarding_next_action(
             asks.append("whether Codex may start autonomous advancement")
         if need_heartbeat_choice:
             asks.append("whether to enable the Codex App heartbeat")
-        follow_up = "then write accepted choices and refresh state before delivery work."
+        follow_up = (
+            "then write accepted choices and refresh state before delivery work."
+        )
         heartbeat_follow_up = ""
         if need_heartbeat_choice:
             heartbeat_follow_up = (
@@ -668,7 +681,9 @@ def build_goal_entry(
     }
 
 
-def merge_goal(registry: dict[str, Any], goal_entry: dict[str, Any], *, force: bool) -> tuple[dict[str, Any], str]:
+def merge_goal(
+    registry: dict[str, Any], goal_entry: dict[str, Any], *, force: bool
+) -> tuple[dict[str, Any], str]:
     goals = registry.get("goals")
     if not isinstance(goals, list):
         goals = []
@@ -746,7 +761,9 @@ def bootstrap_project(
     if not registry_path.is_absolute():
         registry_path = project / registry_path
     goal_id = goal_id or default_goal_id(project)
-    state_file = state_file or (project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md")
+    state_file = state_file or (
+        project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    )
     state_file = state_file.expanduser()
     if not state_file.is_absolute():
         state_file = project / state_file
@@ -800,6 +817,35 @@ def bootstrap_project(
         execution_profile=execution_profile,
         display_name=display_name,
     )
+    existing_goal = next(
+        (
+            item
+            for item in registry.get("goals", [])
+            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    periodic_report_default_materialized = False
+    if existing_goal is None:
+        machine_defaults = read_machine_configuration(
+            runtime_root, registry=build_builtin_machine_configuration_registry()
+        )
+        if machine_defaults is not None:
+            materialized_goal = materialize_goal_periodic_report_subscription(
+                goal_entry, machine_defaults
+            )
+            periodic_report_default_materialized = materialized_goal != goal_entry
+            goal_entry = materialized_goal
+    elif existing_goal is not None:
+        existing_control_plane = existing_goal.get("control_plane")
+        if isinstance(existing_control_plane, dict) and isinstance(
+            existing_control_plane.get("periodic_report"), dict
+        ):
+            candidate_control_plane = dict(goal_entry.get("control_plane") or {})
+            candidate_control_plane["periodic_report"] = dict(
+                existing_control_plane["periodic_report"]
+            )
+            goal_entry["control_plane"] = candidate_control_plane
     registry, registry_goal_action = merge_goal(registry, goal_entry, force=force)
 
     state_exists = state_file.exists()
@@ -817,8 +863,8 @@ def bootstrap_project(
         "kept-existing",
         "kept-existing-preserve-todos",
     }:
-        repaired_state_text, repaired_todo_source_roles = repair_missing_todo_source_sections(
-            state_file.read_text(encoding="utf-8")
+        repaired_state_text, repaired_todo_source_roles = (
+            repair_missing_todo_source_sections(state_file.read_text(encoding="utf-8"))
         )
     todo_source_migration = (
         {
@@ -842,7 +888,9 @@ def bootstrap_project(
         # A forced rebuild replaces todos, never the goal's handoff contract:
         # the declared mode is carried into the rewritten front matter, and an
         # invalid declaration fails closed before anything is rewritten.
-        declared_handoff_mode = goal_handoff_mode(state_file.read_text(encoding="utf-8"))
+        declared_handoff_mode = goal_handoff_mode(
+            state_file.read_text(encoding="utf-8")
+        )
         force_bootstrap_warning = {
             "kind": "force_reconnect_existing_active_state",
             "state_file": str(state_file),
@@ -857,11 +905,21 @@ def bootstrap_project(
             "preserve_todos_option": "--preserve-todos",
         }
     actions = [
-        {"path": str(registry_path), "action": "would-write" if dry_run else "wrote", "goal": registry_goal_action},
+        {
+            "path": str(registry_path),
+            "action": "would-write" if dry_run else "wrote",
+            "goal": registry_goal_action,
+        },
         {
             "path": str(state_file),
-            "action": dry_state_actions.get(state_action, "would-write") if dry_run else state_action,
-            **({"todo_source_migration": todo_source_migration} if todo_source_migration else {}),
+            "action": dry_state_actions.get(state_action, "would-write")
+            if dry_run
+            else state_action,
+            **(
+                {"todo_source_migration": todo_source_migration}
+                if todo_source_migration
+                else {}
+            ),
         },
     ]
     if sync_global:
@@ -895,7 +953,9 @@ def bootstrap_project(
     global_sync: dict[str, Any] | None = None
     global_writability: dict[str, Any] | None = None
     if sync_global and not dry_run:
-        global_writability = probe_registry_write_path(runtime_root / "registry.global.json", create_parent=True)
+        global_writability = probe_registry_write_path(
+            runtime_root / "registry.global.json", create_parent=True
+        )
         if not global_writability.get("ok"):
             for action in actions:
                 if action.get("path") == str(runtime_root / "registry.global.json"):
@@ -911,7 +971,9 @@ def bootstrap_project(
                 "error_kind": "global_registry_write_denied",
                 "global_registry_writability": global_writability,
                 "requires_global_registry_repair": True,
-                "requires_host_permission": bool(global_writability.get("requires_host_permission")),
+                "requires_host_permission": bool(
+                    global_writability.get("requires_host_permission")
+                ),
                 "recommended_action": global_writability.get("recommended_action"),
             }
             return {
@@ -935,12 +997,18 @@ def bootstrap_project(
                 "begin_autonomous_advance": begin_autonomous_advance,
                 "codex_app_heartbeat": codex_app_heartbeat,
                 "onboarding_connection_validation": onboarding_connection_validation,
-                "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
-                "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
+                "onboarding_acceptance_required": bool(
+                    onboarding_scan and not accept_onboarding_agent_todos
+                ),
+                "autonomous_advance_choice_required": bool(
+                    onboarding_scan and not begin_autonomous_advance
+                ),
                 "heartbeat_opt_in_required": heartbeat_required,
                 "host_loop_activation_required": host_loop_required,
                 "heartbeat_opt_in_instruction": (
-                    heartbeat_instruction(codex_app_heartbeat) if onboarding_scan else None
+                    heartbeat_instruction(codex_app_heartbeat)
+                    if onboarding_scan
+                    else None
                 ),
                 "onboarding_todos_written": False,
                 "accept_candidate_commands": accept_candidate_commands,
@@ -957,7 +1025,9 @@ def bootstrap_project(
                     "and packaged workflow skills, then confirm with loopx doctor before continuing."
                 ),
                 "private_boundary_note": "Add .loopx/ and .codex/goals/ to the project .gitignore if the goal state contains private evidence.",
-                "error": str(global_writability.get("error") or "global registry is not writable"),
+                "error": str(
+                    global_writability.get("error") or "global registry is not writable"
+                ),
             }
     if not dry_run:
         write_json(registry_path, registry)
@@ -1009,17 +1079,24 @@ def bootstrap_project(
         "todo_source_migration": todo_source_migration,
         "force_bootstrap_warning": force_bootstrap_warning,
         "execution_profile": execution_profile,
+        "periodic_report_default_materialized": periodic_report_default_materialized,
         "onboarding_scan": onboarding_scan,
         "onboarding_agent_todo_candidates": candidates,
         "accept_onboarding_agent_todos": accept_onboarding_agent_todos,
         "begin_autonomous_advance": begin_autonomous_advance,
         "codex_app_heartbeat": codex_app_heartbeat,
         "onboarding_connection_validation": onboarding_connection_validation,
-        "onboarding_acceptance_required": bool(onboarding_scan and not accept_onboarding_agent_todos),
-        "autonomous_advance_choice_required": bool(onboarding_scan and not begin_autonomous_advance),
+        "onboarding_acceptance_required": bool(
+            onboarding_scan and not accept_onboarding_agent_todos
+        ),
+        "autonomous_advance_choice_required": bool(
+            onboarding_scan and not begin_autonomous_advance
+        ),
         "heartbeat_opt_in_required": heartbeat_required,
         "host_loop_activation_required": host_loop_required,
-        "heartbeat_opt_in_instruction": heartbeat_instruction(codex_app_heartbeat) if onboarding_scan else None,
+        "heartbeat_opt_in_instruction": heartbeat_instruction(codex_app_heartbeat)
+        if onboarding_scan
+        else None,
         "onboarding_todos_written": bool(
             onboarding_scan and state_action in {"created", "replaced"} and not dry_run
         ),
@@ -1090,7 +1167,9 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
         "## Actions",
     ]
     for action in payload.get("actions") or []:
-        lines.append(f"- `{action.get('path')}`: {action.get('action')} ({action.get('goal', '')})")
+        lines.append(
+            f"- `{action.get('path')}`: {action.get('action')} ({action.get('goal', '')})"
+        )
 
     force_warning = payload.get("force_bootstrap_warning")
     if isinstance(force_warning, dict):
@@ -1209,5 +1288,7 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
         )
 
     if payload.get("private_boundary_note"):
-        lines.extend(["", "## Boundary Note", str(payload.get("private_boundary_note"))])
+        lines.extend(
+            ["", "## Boundary Note", str(payload.get("private_boundary_note"))]
+        )
     return "\n".join(lines)

--- a/loopx/capabilities/periodic_report/__init__.py
+++ b/loopx/capabilities/periodic_report/__init__.py
@@ -27,6 +27,7 @@ from .core import build_periodic_report_run
 from .machine_defaults import (
     build_goal_periodic_report_delivery_identity,
     build_goal_periodic_report_delivery_plan,
+    materialize_goal_periodic_report_subscription,
     normalize_loopx_machine_defaults,
     normalize_periodic_report_machine_defaults,
     periodic_report_machine_configuration_namespace,
@@ -83,6 +84,7 @@ __all__ = [
     "normalize_loopx_machine_defaults",
     "normalize_periodic_report_machine_defaults",
     "periodic_report_machine_configuration_namespace",
+    "materialize_goal_periodic_report_subscription",
     "plan_periodic_report_machine_default_backfill",
     "normalize_periodic_report_audience_policy",
     "normalize_periodic_report_sink_bindings",

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -13,6 +13,10 @@ from ...extensions.runtime import (
 )
 from ...rollout_event_log import iter_rollout_events
 from .core import build_periodic_report_run
+from .goal_materialization import (
+    migrate_periodic_report_goal_materializations,
+    rollback_periodic_report_goal_materializations,
+)
 from .machine_defaults import (
     build_goal_periodic_report_delivery_plan,
     plan_periodic_report_machine_default_backfill,
@@ -144,6 +148,21 @@ def register_periodic_report_commands(
     rollback_machine_defaults.add_argument("--transaction-id", required=True)
     rollback_machine_defaults.add_argument("--execute", action="store_true")
     rollback_machine_defaults.add_argument("--expected-plan-revision")
+    migrate_machine_defaults = commands.add_parser(
+        "migrate-machine-defaults",
+        help="Preview or apply machine periodic-report defaults to eligible Goals.",
+    )
+    add_subcommand_format(migrate_machine_defaults)
+    migrate_machine_defaults.add_argument("--execute", action="store_true")
+    migrate_machine_defaults.add_argument("--expected-plan-revision")
+    rollback_goal_materialization = commands.add_parser(
+        "rollback-goal-materialization",
+        help="Preview or rollback one exact Goal materialization transaction.",
+    )
+    add_subcommand_format(rollback_goal_materialization)
+    rollback_goal_materialization.add_argument("--transaction-id", required=True)
+    rollback_goal_materialization.add_argument("--execute", action="store_true")
+    rollback_goal_materialization.add_argument("--expected-plan-revision")
     plan_goal_delivery = commands.add_parser(
         "plan-goal-delivery",
         help="Preview Goal-owned delivery identity and preferred Agent execution.",
@@ -337,6 +356,10 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
         "machine_configuration_rollback_plan_v0",
         "machine_configuration_rollback_receipt_v0",
         "periodic_report_machine_default_backfill_plan_v0",
+        "periodic_report_goal_materialization_plan_v0",
+        "periodic_report_goal_materialization_transaction_v0",
+        "periodic_report_goal_materialization_rollback_plan_v0",
+        "periodic_report_goal_materialization_rollback_receipt_v0",
         "periodic_report_goal_delivery_plan_v0",
     }:
         machine_configuration = str(payload.get("schema_version") or "").startswith(
@@ -371,6 +394,58 @@ def render_periodic_report_markdown(payload: dict[str, object]) -> str:
             f"- retry_allowed: `{retry_info.get('allowed')}`",
             "",
         ]
+    )
+
+
+_MACHINE_DEFAULT_COMMANDS = {
+    "configure-machine-defaults",
+    "inspect-machine-defaults",
+    "rollback-machine-defaults",
+    "migrate-machine-defaults",
+    "rollback-goal-materialization",
+}
+
+
+def _handle_machine_default_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+) -> dict[str, Any]:
+    registry = read_json(registry_path)
+    runtime_root = resolve_runtime_root(
+        registry, runtime_root_arg, registry_path=registry_path
+    )
+    command = args.periodic_report_command
+    if command == "configure-machine-defaults":
+        return configure_periodic_report_machine_defaults(
+            runtime_root=runtime_root,
+            machine_defaults=_load_json_object(args.config_json),
+            execute=bool(args.execute),
+            expected_plan_revision=args.expected_plan_revision,
+        )
+    if command == "inspect-machine-defaults":
+        return inspect_periodic_report_machine_defaults(runtime_root)
+    if command == "migrate-machine-defaults":
+        return migrate_periodic_report_goal_materializations(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            execute=bool(args.execute),
+            expected_plan_revision=args.expected_plan_revision,
+        )
+    if command == "rollback-goal-materialization":
+        return rollback_periodic_report_goal_materializations(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            transaction_id=args.transaction_id,
+            execute=bool(args.execute),
+            expected_plan_revision=args.expected_plan_revision,
+        )
+    return rollback_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        transaction_id=args.transaction_id,
+        execute=bool(args.execute),
+        expected_plan_revision=args.expected_plan_revision,
     )
 
 
@@ -438,31 +513,12 @@ def handle_periodic_report_command(
                 _load_json_object(args.config_json),
             )
             payload["ok"] = True
-        elif args.periodic_report_command in {
-            "configure-machine-defaults",
-            "inspect-machine-defaults",
-            "rollback-machine-defaults",
-        }:
-            registry = read_json(registry_path)
-            runtime_root = resolve_runtime_root(
-                registry, runtime_root_arg, registry_path=registry_path
+        elif args.periodic_report_command in _MACHINE_DEFAULT_COMMANDS:
+            payload = _handle_machine_default_command(
+                args,
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
             )
-            if args.periodic_report_command == "configure-machine-defaults":
-                payload = configure_periodic_report_machine_defaults(
-                    runtime_root=runtime_root,
-                    machine_defaults=_load_json_object(args.config_json),
-                    execute=bool(args.execute),
-                    expected_plan_revision=args.expected_plan_revision,
-                )
-            elif args.periodic_report_command == "inspect-machine-defaults":
-                payload = inspect_periodic_report_machine_defaults(runtime_root)
-            else:
-                payload = rollback_periodic_report_machine_defaults(
-                    runtime_root=runtime_root,
-                    transaction_id=args.transaction_id,
-                    execute=bool(args.execute),
-                    expected_plan_revision=args.expected_plan_revision,
-                )
         elif args.periodic_report_command == "plan-goal-delivery":
             payload = build_goal_periodic_report_delivery_plan(
                 _load_json_object(args.request_json)

--- a/loopx/capabilities/periodic_report/goal_materialization.py
+++ b/loopx/capabilities/periodic_report/goal_materialization.py
@@ -1,0 +1,698 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import ExitStack
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ...file_lock import exclusive_file_lock
+from ...global_registry import preserve_attention_override, sanitize_goal_for_global
+from ...registry import atomic_write_json, read_json, registry_goals
+from ..machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from ..machine_configuration.store import read_machine_configuration
+from .machine_defaults import (
+    materialize_goal_periodic_report_subscription,
+    normalize_loopx_machine_defaults,
+)
+
+
+GOAL_MATERIALIZATION_PLAN_SCHEMA = "periodic_report_goal_materialization_plan_v0"
+GOAL_MATERIALIZATION_TRANSACTION_SCHEMA = (
+    "periodic_report_goal_materialization_transaction_v0"
+)
+GOAL_MATERIALIZATION_BACKUP_SCHEMA = "periodic_report_goal_materialization_backup_v0"
+GOAL_MATERIALIZATION_ROLLBACK_PLAN_SCHEMA = (
+    "periodic_report_goal_materialization_rollback_plan_v0"
+)
+GOAL_MATERIALIZATION_ROLLBACK_RECEIPT_SCHEMA = (
+    "periodic_report_goal_materialization_rollback_receipt_v0"
+)
+
+_TRANSACTION_ID_RE = re.compile(r"^goal_materialization_[0-9a-f]{24}$")
+_TERMINAL_GOAL_STATUSES = {
+    "archived",
+    "canceled",
+    "cancelled",
+    "completed",
+    "disconnected",
+    "retired",
+    "stopped",
+}
+JsonWriter = Callable[[Path, dict[str, Any]], None]
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _now_iso(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    return current.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    return left.expanduser().resolve() == right.expanduser().resolve()
+
+
+def _is_global_registry(path: Path, payload: Mapping[str, Any]) -> bool:
+    role = str(payload.get("registry_role") or payload.get("role") or "")
+    return role == "global-local" or path.name == "registry.global.json"
+
+
+def _state_path(goal: Mapping[str, Any]) -> Path | None:
+    repo = str(goal.get("repo") or "").strip()
+    state_file = str(goal.get("state_file") or "").strip()
+    if not repo or not state_file:
+        return None
+    path = Path(state_file).expanduser()
+    return path if path.is_absolute() else Path(repo).expanduser() / path
+
+
+def _goal(payload: Mapping[str, Any], goal_id: str) -> dict[str, Any] | None:
+    return next(
+        (
+            item
+            for item in registry_goals(dict(payload))
+            if str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+
+
+def _periodic(goal: Mapping[str, Any]) -> dict[str, Any] | None:
+    control_plane = goal.get("control_plane")
+    if not isinstance(control_plane, Mapping):
+        return None
+    periodic = control_plane.get("periodic_report")
+    return dict(periodic) if isinstance(periodic, Mapping) else None
+
+
+def _transaction_id(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not _TRANSACTION_ID_RE.fullmatch(normalized):
+        raise ValueError("transaction_id is invalid")
+    return normalized
+
+
+def _transaction_dir(runtime_root: Path, transaction_id: str) -> Path:
+    return (
+        runtime_root.expanduser().resolve()
+        / "machine"
+        / "periodic-report"
+        / "goal-materializations"
+        / transaction_id
+    )
+
+
+def _transaction_ref(transaction_id: str, name: str) -> str:
+    return f"machine/periodic-report/goal-materializations/{transaction_id}/{name}.json"
+
+
+def _registry_key(path: Path) -> str:
+    return "registry_" + hashlib.sha256(
+        str(path.expanduser().resolve()).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+def _known_registry_paths(registry_path: Path) -> dict[str, Path]:
+    root_path = registry_path.expanduser().resolve()
+    root_payload = read_json(root_path)
+    paths = {root_path}
+    if _is_global_registry(root_path, root_payload):
+        for goal in registry_goals(root_payload):
+            source_path = _source_path(
+                root_path=root_path,
+                root_is_global=True,
+                projected_goal=goal,
+            )
+            if source_path is not None:
+                paths.add(source_path)
+    return {_registry_key(path): path for path in paths}
+
+
+def _secure_write(path: Path, payload: dict[str, Any], *, writer: JsonWriter) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    writer(path, payload)
+    path.chmod(0o600)
+
+
+def _source_path(
+    *, root_path: Path, root_is_global: bool, projected_goal: Mapping[str, Any]
+) -> Path | None:
+    if not root_is_global:
+        return root_path
+    source = str(projected_goal.get("source_registry") or "").strip()
+    return Path(source).expanduser().resolve() if source else None
+
+
+def _load_source_goal(
+    *,
+    projected_goal: Mapping[str, Any],
+    root_path: Path,
+    root_is_global: bool,
+    payloads: dict[Path, dict[str, Any]],
+) -> tuple[Path | None, dict[str, Any] | None, str | None]:
+    status = str(projected_goal.get("status") or "active").strip().lower()
+    if status in _TERMINAL_GOAL_STATUSES:
+        return None, None, "goal_not_active"
+    source_path = _source_path(
+        root_path=root_path,
+        root_is_global=root_is_global,
+        projected_goal=projected_goal,
+    )
+    if source_path is None or not source_path.is_file():
+        return source_path, None, "authoritative_registry_unavailable"
+    try:
+        if source_path not in payloads:
+            payloads[source_path] = read_json(source_path)
+    except (OSError, ValueError):
+        return source_path, None, "authoritative_registry_unavailable"
+    goal_id = str(projected_goal.get("id") or "").strip()
+    source_goal = _goal(payloads[source_path], goal_id)
+    if source_goal is None:
+        return source_path, None, "authoritative_goal_unavailable"
+    return source_path, source_goal, None
+
+
+def _materialization_outcome(
+    source_goal: Mapping[str, Any],
+    machine_defaults: Mapping[str, Any],
+) -> tuple[str, str, dict[str, Any] | None]:
+    status = str(source_goal.get("status") or "active").strip().lower()
+    if status in _TERMINAL_GOAL_STATUSES:
+        return "excluded", "goal_not_active", None
+    state_path = _state_path(source_goal)
+    if state_path is None or not state_path.is_file():
+        return "excluded", "authoritative_state_unavailable", None
+    existing = _periodic(source_goal)
+    if existing is not None and existing.get("source") != "machine_default":
+        return "preserve", "goal_override", None
+    updated_goal = materialize_goal_periodic_report_subscription(
+        source_goal,
+        machine_defaults,
+        update_inherited=True,
+    )
+    if updated_goal == source_goal:
+        return "unchanged", "already_materialized", None
+    if existing is None:
+        return "materialize", "machine_default_missing", updated_goal
+    return "update", "inherited_default_revision_changed", updated_goal
+
+
+def _build_snapshot(
+    *, registry_path: Path, runtime_root: Path, synced_at: str | None = None
+) -> dict[str, Any]:
+    root_path = registry_path.expanduser().resolve()
+    root_payload = read_json(root_path)
+    machine_defaults = read_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+    if machine_defaults is None:
+        raise ValueError("periodic-report machine defaults are not configured")
+    normalized_defaults = normalize_loopx_machine_defaults(machine_defaults)
+    root_is_global = _is_global_registry(root_path, root_payload)
+    payloads: dict[Path, dict[str, Any]] = {root_path: root_payload}
+    rows: list[dict[str, Any]] = []
+    changes: list[tuple[str, Path, dict[str, Any]]] = []
+
+    for projected_goal in registry_goals(root_payload):
+        goal_id = str(projected_goal.get("id") or "").strip()
+        source_path, source_goal, exclusion = _load_source_goal(
+            projected_goal=projected_goal,
+            root_path=root_path,
+            root_is_global=root_is_global,
+            payloads=payloads,
+        )
+        if exclusion is not None:
+            action, reason = "excluded", exclusion
+        else:
+            assert source_goal is not None and source_path is not None
+            action, reason, updated_goal = _materialization_outcome(
+                source_goal, normalized_defaults
+            )
+            if updated_goal is not None:
+                changes.append((goal_id, source_path, updated_goal))
+        rows.append({"goal_id": goal_id, "action": action, "reason": reason})
+
+    updated_payloads = {
+        path: copy.deepcopy(payload) for path, payload in payloads.items()
+    }
+    sync_timestamp = synced_at or "<apply-time>"
+    for goal_id, source_path, updated_goal in changes:
+        source_payload = updated_payloads[source_path]
+        source_payload["goals"] = [
+            updated_goal if str(item.get("id") or "") == goal_id else item
+            for item in registry_goals(source_payload)
+        ]
+        if root_is_global and not _same_path(source_path, root_path):
+            incoming = sanitize_goal_for_global(
+                updated_goal,
+                source_registry=source_path,
+                synced_at=sync_timestamp,
+            )
+            updated_payloads[root_path]["goals"] = [
+                preserve_attention_override(item, incoming)
+                if str(item.get("id") or "") == goal_id
+                else item
+                for item in registry_goals(updated_payloads[root_path])
+            ]
+
+    counts = {
+        action: sum(row["action"] == action for row in rows)
+        for action in ("materialize", "update", "unchanged", "preserve", "excluded")
+    }
+    registry_revisions = [
+        {
+            "registry_key": _registry_key(path),
+            "before_revision": _digest(payloads[path]),
+        }
+        for path in sorted(payloads, key=str)
+    ]
+    identity = {
+        "machine_defaults_revision": _digest(normalized_defaults),
+        "root_registry_revision": _digest(root_payload),
+        "registry_revisions": registry_revisions,
+        "rows": rows,
+    }
+    plan = {
+        "ok": True,
+        "schema_version": GOAL_MATERIALIZATION_PLAN_SCHEMA,
+        "status": "preview",
+        **identity,
+        "counts": counts,
+        "writes_required": counts["materialize"] + counts["update"],
+        "registries_write_required": sum(
+            updated_payloads[path] != payloads[path] for path in payloads
+        ),
+        "plan_revision": _digest(identity),
+    }
+    return {
+        "plan": plan,
+        "paths": sorted(payloads, key=str),
+        "before": payloads,
+        "after": updated_payloads,
+        "machine_defaults": normalized_defaults,
+    }
+
+
+def plan_periodic_report_goal_materialization(
+    *, registry_path: Path, runtime_root: Path
+) -> dict[str, Any]:
+    return dict(
+        _build_snapshot(registry_path=registry_path, runtime_root=runtime_root)["plan"]
+    )
+
+
+def _restore(entries: Sequence[Mapping[str, Any]], *, writer: JsonWriter) -> None:
+    for entry in reversed(entries):
+        path = entry["path"]
+        if not isinstance(path, Path):
+            raise TypeError("validated registry path is required")
+        writer(path, dict(entry["payload"]))
+
+
+def _apply_transaction(
+    *,
+    snapshot: Mapping[str, Any],
+    entries: Sequence[Mapping[str, Any]],
+    backup_path: Path,
+    receipt_path: Path,
+    backup: dict[str, Any],
+    transaction_id: str,
+    applied_at: str,
+    writer: JsonWriter,
+) -> dict[str, Any]:
+    written: list[Mapping[str, Any]] = []
+    try:
+        _secure_write(backup_path, backup, writer=writer)
+        for entry, path in zip(entries, snapshot["paths"], strict=True):
+            if snapshot["after"][path] == snapshot["before"][path]:
+                continue
+            written.append({"path": path, "payload": entry["payload"]})
+            writer(path, snapshot["after"][path])
+        for path in snapshot["paths"]:
+            if read_json(path) != snapshot["after"][path]:
+                raise RuntimeError("goal-materialization registry readback mismatch")
+        plan = snapshot["plan"]
+        receipt = {
+            "ok": True,
+            "schema_version": GOAL_MATERIALIZATION_TRANSACTION_SCHEMA,
+            "status": "applied",
+            "transaction_id": transaction_id,
+            "transaction_ref": _transaction_ref(transaction_id, "transaction"),
+            "backup_ref": _transaction_ref(transaction_id, "backup"),
+            "backup_revision": _digest(backup),
+            "plan_revision": plan["plan_revision"],
+            "applied_at": applied_at,
+            "counts": plan["counts"],
+            "writes_required": plan["writes_required"],
+            "registries_written": len(written),
+            "readback_verified": True,
+            "rollback_available": True,
+        }
+        receipt["receipt_revision"] = _digest(receipt)
+        _secure_write(receipt_path, receipt, writer=writer)
+        return receipt
+    except Exception as exc:
+        try:
+            _restore(written, writer=writer)
+        except Exception as rollback_exc:
+            raise RuntimeError(
+                "goal materialization failed and automatic restoration also failed"
+            ) from rollback_exc
+        raise RuntimeError(
+            "goal materialization failed; prior registries were restored"
+        ) from exc
+
+
+def migrate_periodic_report_goal_materializations(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    preview = plan_periodic_report_goal_materialization(
+        registry_path=registry_path, runtime_root=runtime_root
+    )
+    if not execute:
+        return preview
+    expected = str(expected_plan_revision or "").strip()
+    if not expected:
+        raise ValueError("expected_plan_revision is required when execute is true")
+
+    initial = _build_snapshot(registry_path=registry_path, runtime_root=runtime_root)
+    lock_paths = list(initial["paths"])
+    with ExitStack() as locks:
+        for path in lock_paths:
+            locks.enter_context(
+                exclusive_file_lock(
+                    path, operation="periodic_report_goal_materialization"
+                )
+            )
+        applied_at = _now_iso(now)
+        snapshot = _build_snapshot(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            synced_at=applied_at,
+        )
+        plan = snapshot["plan"]
+        if plan["plan_revision"] != expected:
+            raise ValueError(
+                "goal-materialization plan revision changed; preview again"
+            )
+        if plan["writes_required"] == 0:
+            return {
+                **plan,
+                "schema_version": GOAL_MATERIALIZATION_TRANSACTION_SCHEMA,
+                "status": "unchanged",
+                "transaction_id": None,
+                "transaction_ref": None,
+                "backup_ref": None,
+                "readback_verified": True,
+                "rollback_available": False,
+            }
+
+        transaction_id = f"goal_materialization_{uuid4().hex[:24]}"
+        directory = _transaction_dir(runtime_root, transaction_id)
+        backup_path = directory / "backup.json"
+        receipt_path = directory / "transaction.json"
+        entries = [
+            {
+                "registry_key": _registry_key(path),
+                "path": str(path),
+                "before_revision": _digest(snapshot["before"][path]),
+                "after_revision": _digest(snapshot["after"][path]),
+                "payload": snapshot["before"][path],
+            }
+            for path in snapshot["paths"]
+        ]
+        backup = {
+            "schema_version": GOAL_MATERIALIZATION_BACKUP_SCHEMA,
+            "transaction_id": transaction_id,
+            "plan_revision": plan["plan_revision"],
+            "registries": entries,
+        }
+        return _apply_transaction(
+            snapshot=snapshot,
+            entries=entries,
+            backup_path=backup_path,
+            receipt_path=receipt_path,
+            backup=backup,
+            transaction_id=transaction_id,
+            applied_at=applied_at,
+            writer=writer,
+        )
+
+
+def _read_transaction(
+    *, registry_path: Path, runtime_root: Path, transaction_id: str
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    safe_id = _transaction_id(transaction_id)
+    directory = _transaction_dir(runtime_root, safe_id)
+    receipt = read_json(directory / "transaction.json")
+    backup = read_json(directory / "backup.json")
+    receipt_revision = receipt.get("receipt_revision")
+    unsigned_receipt = {
+        key: value for key, value in receipt.items() if key != "receipt_revision"
+    }
+    if (
+        receipt.get("schema_version") != GOAL_MATERIALIZATION_TRANSACTION_SCHEMA
+        or receipt.get("status") != "applied"
+        or receipt.get("transaction_id") != safe_id
+        or _digest(unsigned_receipt) != receipt_revision
+        or backup.get("schema_version") != GOAL_MATERIALIZATION_BACKUP_SCHEMA
+        or backup.get("transaction_id") != safe_id
+        or backup.get("plan_revision") != receipt.get("plan_revision")
+        or _digest(backup) != receipt.get("backup_revision")
+    ):
+        raise ValueError("goal-materialization transaction is invalid")
+    entries = backup.get("registries")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("goal-materialization backup is invalid")
+    known_paths = _known_registry_paths(registry_path)
+    seen_keys: set[str] = set()
+    validated_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            raise ValueError("goal-materialization backup registry entry is invalid")
+        registry_key = str(entry.get("registry_key") or "")
+        path = known_paths.get(registry_key)
+        payload = entry.get("payload")
+        if (
+            path is None
+            or registry_key in seen_keys
+            or str(path) != entry.get("path")
+            or not isinstance(payload, Mapping)
+            or _digest(payload) != entry.get("before_revision")
+            or not str(entry.get("after_revision") or "").startswith("sha256:")
+        ):
+            raise ValueError("goal-materialization backup registry entry is invalid")
+        seen_keys.add(registry_key)
+        validated_entries.append({**entry, "path": path, "payload": dict(payload)})
+    return receipt, validated_entries
+
+
+def _revision_state(
+    *, current_revision: str, before_revision: str, after_revision: str
+) -> str:
+    if current_revision == before_revision:
+        return "before"
+    if current_revision == after_revision:
+        return "after"
+    return "changed"
+
+
+def _rollback_plan(
+    *, transaction_id: str, entries: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    states: list[str] = []
+    revisions: list[dict[str, str]] = []
+    for entry in entries:
+        path = entry["path"]
+        if not isinstance(path, Path):
+            raise TypeError("validated registry path is required")
+        current_revision = _digest(read_json(path)) if path.is_file() else "absent"
+        before_revision = str(entry.get("before_revision") or "")
+        after_revision = str(entry.get("after_revision") or "")
+        state = _revision_state(
+            current_revision=current_revision,
+            before_revision=before_revision,
+            after_revision=after_revision,
+        )
+        states.append(state)
+        revisions.append(
+            {
+                "registry_key": str(entry.get("registry_key") or ""),
+                "current_revision": current_revision,
+                "before_revision": before_revision,
+                "after_revision": after_revision,
+            }
+        )
+    if all(state == "before" for state in states):
+        action, allowed, reason = "unchanged", True, "already_rolled_back"
+    elif all(state in {"before", "after"} for state in states) and any(
+        state == "after" for state in states
+    ):
+        action, allowed, reason = "restore", True, "exact_applied_revisions_match"
+    else:
+        action, allowed, reason = "blocked", False, "registry_revision_changed"
+    identity = {
+        "transaction_id": transaction_id,
+        "registry_revisions": revisions,
+        "action": action,
+    }
+    return {
+        "ok": True,
+        "schema_version": GOAL_MATERIALIZATION_ROLLBACK_PLAN_SCHEMA,
+        "status": "preview",
+        **identity,
+        "reason": reason,
+        "rollback_allowed": allowed,
+        "writes_required": sum(state == "after" for state in states),
+        "plan_revision": _digest(identity),
+    }
+
+
+def plan_periodic_report_goal_materialization_rollback(
+    *, registry_path: Path, runtime_root: Path, transaction_id: str
+) -> dict[str, Any]:
+    _, entries = _read_transaction(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+    )
+    return _rollback_plan(
+        transaction_id=_transaction_id(transaction_id),
+        entries=entries,
+    )
+
+
+def _execute_rollback(
+    entries: Sequence[Mapping[str, Any]], *, writer: JsonWriter
+) -> None:
+    applied_entries: list[dict[str, Any]] = []
+    for entry in entries:
+        path = entry["path"]
+        current_payload = read_json(path)
+        if _digest(current_payload) == str(entry["after_revision"]):
+            applied_entries.append({"path": path, "payload": current_payload})
+    try:
+        for entry in entries:
+            path = entry["path"]
+            if _digest(read_json(path)) == str(entry["after_revision"]):
+                writer(path, dict(entry["payload"]))
+        if any(
+            _digest(read_json(entry["path"])) != str(entry["before_revision"])
+            for entry in entries
+        ):
+            raise RuntimeError("goal-materialization rollback readback mismatch")
+    except Exception as exc:
+        try:
+            _restore(applied_entries, writer=writer)
+        except Exception as restore_exc:
+            raise RuntimeError(
+                "goal-materialization rollback failed and applied state could not be restored"
+            ) from restore_exc
+        raise RuntimeError(
+            "goal-materialization rollback failed; applied state was restored"
+        ) from exc
+
+
+def rollback_periodic_report_goal_materializations(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    transaction_id: str,
+    execute: bool = False,
+    expected_plan_revision: str | None = None,
+    now: datetime | None = None,
+    writer: JsonWriter = atomic_write_json,
+) -> dict[str, Any]:
+    preview = plan_periodic_report_goal_materialization_rollback(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        transaction_id=transaction_id,
+    )
+    if not execute:
+        return preview
+    expected = str(expected_plan_revision or "").strip()
+    if not expected:
+        raise ValueError("expected_plan_revision is required when execute is true")
+    safe_id = _transaction_id(transaction_id)
+    _, entries = _read_transaction(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        transaction_id=safe_id,
+    )
+    lock_paths = sorted((entry["path"] for entry in entries), key=str)
+    with ExitStack() as locks:
+        for path in lock_paths:
+            locks.enter_context(
+                exclusive_file_lock(path, operation="rollback_goal_materialization")
+            )
+        plan = _rollback_plan(transaction_id=safe_id, entries=entries)
+        if plan["plan_revision"] != expected:
+            raise ValueError(
+                "goal-materialization rollback plan changed; preview again"
+            )
+        if not plan["rollback_allowed"]:
+            raise ValueError(
+                "goal-materialization rollback is blocked by a newer revision"
+            )
+        if plan["action"] == "unchanged":
+            return {
+                **plan,
+                "schema_version": GOAL_MATERIALIZATION_ROLLBACK_RECEIPT_SCHEMA,
+                "status": "unchanged",
+                "rollback_id": None,
+                "readback_verified": True,
+            }
+        _execute_rollback(entries, writer=writer)
+        rollback_id = f"goal_materialization_rollback_{uuid4().hex[:24]}"
+        receipt = {
+            "ok": True,
+            "schema_version": GOAL_MATERIALIZATION_ROLLBACK_RECEIPT_SCHEMA,
+            "status": "rolled_back",
+            "rollback_id": rollback_id,
+            "transaction_id": safe_id,
+            "plan_revision": plan["plan_revision"],
+            "registries_restored": plan["writes_required"],
+            "rolled_back_at": _now_iso(now),
+            "readback_verified": True,
+        }
+        _secure_write(
+            _transaction_dir(runtime_root, safe_id) / f"{rollback_id}.json",
+            receipt,
+            writer=writer,
+        )
+        return receipt
+
+
+__all__ = [
+    "GOAL_MATERIALIZATION_BACKUP_SCHEMA",
+    "GOAL_MATERIALIZATION_PLAN_SCHEMA",
+    "GOAL_MATERIALIZATION_ROLLBACK_PLAN_SCHEMA",
+    "GOAL_MATERIALIZATION_ROLLBACK_RECEIPT_SCHEMA",
+    "GOAL_MATERIALIZATION_TRANSACTION_SCHEMA",
+    "migrate_periodic_report_goal_materializations",
+    "plan_periodic_report_goal_materialization",
+    "plan_periodic_report_goal_materialization_rollback",
+    "rollback_periodic_report_goal_materializations",
+]

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 from collections.abc import Callable, Mapping
@@ -261,6 +262,37 @@ def _materialized_periodic_config(
     return periodic
 
 
+def materialize_goal_periodic_report_subscription(
+    goal: Mapping[str, Any],
+    machine_defaults: Mapping[str, Any],
+    *,
+    update_inherited: bool = False,
+) -> dict[str, Any]:
+    """Copy a machine default into one Goal without replacing an override.
+
+    Goal connection uses the default ``update_inherited=False`` mode, so only a
+    newly unconfigured Goal is changed.  The explicit migration transaction
+    opts into ``update_inherited=True`` to advance an older inherited revision.
+    """
+
+    normalized_goal = copy.deepcopy(_mapping(goal, "goal"))
+    _text(normalized_goal.get("id"), "goal.id")
+    existing = _goal_periodic_report(normalized_goal)
+    if existing is not None and (
+        existing.get("source") != "machine_default" or not update_inherited
+    ):
+        return normalized_goal
+    control_plane_raw = normalized_goal.get("control_plane")
+    control_plane = (
+        copy.deepcopy(dict(control_plane_raw))
+        if isinstance(control_plane_raw, Mapping)
+        else {}
+    )
+    control_plane["periodic_report"] = _materialized_periodic_config(machine_defaults)
+    normalized_goal["control_plane"] = control_plane
+    return normalized_goal
+
+
 def _state_path(goal: Mapping[str, Any]) -> Path | None:
     state_file = str(goal.get("state_file") or "").strip()
     repo = str(goal.get("repo") or "").strip()
@@ -459,6 +491,7 @@ __all__ = [
     "build_goal_periodic_report_delivery_identity",
     "build_goal_periodic_report_delivery_plan",
     "loopx_machine_defaults_revision",
+    "materialize_goal_periodic_report_subscription",
     "normalize_loopx_machine_defaults",
     "normalize_periodic_report_machine_defaults",
     "periodic_report_machine_configuration_namespace",

--- a/loopx/cli_commands/project.py
+++ b/loopx/cli_commands/project.py
@@ -4,6 +4,13 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
+from ..capabilities.periodic_report.machine_defaults import (
+    materialize_goal_periodic_report_subscription,
+)
+from ..capabilities.machine_configuration.builtins import (
+    build_builtin_machine_configuration_registry,
+)
+from ..capabilities.machine_configuration.store import read_machine_configuration
 from ..control_plane.projects.registry import (
     PROJECT_KINDS,
     bind_session,
@@ -11,8 +18,36 @@ from ..control_plane.projects.registry import (
     resolve_project,
     unbind_session,
 )
+from ..history import load_registry
+from ..paths import DEFAULT_RUNTIME_ROOT
 
-PrintPayload = Callable[[dict[str, object], str, Callable[[dict[str, object]], str]], None]
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]], None
+]
+
+
+def _new_goal_control_plane(
+    *, registry_path: Path, runtime_root_arg: str | None, goal_id: str
+) -> dict[str, object] | None:
+    if runtime_root_arg:
+        runtime_root = Path(runtime_root_arg).expanduser()
+    elif registry_path.is_file():
+        registry = load_registry(registry_path)
+        runtime_root = Path(
+            str(registry.get("common_runtime_root") or DEFAULT_RUNTIME_ROOT)
+        ).expanduser()
+    else:
+        runtime_root = DEFAULT_RUNTIME_ROOT
+    defaults = read_machine_configuration(
+        runtime_root, registry=build_builtin_machine_configuration_registry()
+    )
+    if defaults is None:
+        return None
+    materialized = materialize_goal_periodic_report_subscription(
+        {"id": goal_id}, defaults
+    )
+    control_plane = materialized.get("control_plane")
+    return dict(control_plane) if isinstance(control_plane, dict) else None
 
 
 def register_project_commands(
@@ -35,7 +70,9 @@ def register_project_commands(
     register_parser.add_argument("--goal-id", required=True)
     register_parser.add_argument("--objective", required=True)
     register_parser.add_argument("--non-goal", action="append", default=[])
-    register_parser.add_argument("--acceptance", action="append", default=[], required=True)
+    register_parser.add_argument(
+        "--acceptance", action="append", default=[], required=True
+    )
     register_parser.add_argument("--unknown", action="append", default=[])
     register_parser.add_argument("--next-effect", required=True)
     register_parser.add_argument("--stop-condition", required=True)
@@ -102,9 +139,16 @@ def handle_project_command(
         return None
     try:
         if args.project_command == "register":
+            goal_control_plane = _new_goal_control_plane(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+            )
             payload = register_project_goal(
                 registry_path=registry_path,
-                runtime_root=Path(runtime_root_arg).expanduser() if runtime_root_arg else None,
+                runtime_root=Path(runtime_root_arg).expanduser()
+                if runtime_root_arg
+                else None,
                 project_id=args.project_id,
                 project_kind=args.project_kind,
                 knowledge_root=Path(args.knowledge_root),
@@ -117,6 +161,7 @@ def handle_project_command(
                 stop_condition=args.stop_condition,
                 repository_bindings=args.repository,
                 external_locator_bindings=args.external_locator,
+                goal_control_plane=goal_control_plane,
             )
         elif args.project_command == "bind-session":
             payload = bind_session(

--- a/loopx/control_plane/projects/registry.py
+++ b/loopx/control_plane/projects/registry.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import copy
 import json
 import os
 import re
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -201,6 +203,7 @@ def register_project_goal(
     stop_condition: str,
     repository_bindings: list[str],
     external_locator_bindings: list[str],
+    goal_control_plane: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     project_id = _identifier(project_id, field="project_id")
     goal_id = _identifier(goal_id, field="goal_id")
@@ -301,6 +304,13 @@ def register_project_goal(
             ),
             None,
         )
+        if existing_goal is None:
+            if goal_control_plane is not None:
+                goal_record["control_plane"] = copy.deepcopy(dict(goal_control_plane))
+        else:
+            existing_control_plane = existing_goal.get("control_plane")
+            if isinstance(existing_control_plane, dict):
+                goal_record["control_plane"] = copy.deepcopy(existing_control_plane)
         if existing_project is not None and existing_project != project_record:
             raise ValueError(f"project_id conflicts with existing registration: {project_id}")
         if existing_goal is not None and existing_goal != goal_record:

--- a/tests/capabilities/test_periodic_report_goal_materialization.py
+++ b/tests/capabilities/test_periodic_report_goal_materialization.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.bootstrap import bootstrap_project
+from loopx.capabilities.periodic_report.goal_materialization import (
+    migrate_periodic_report_goal_materializations,
+    plan_periodic_report_goal_materialization,
+    plan_periodic_report_goal_materialization_rollback,
+    rollback_periodic_report_goal_materializations,
+)
+from loopx.capabilities.periodic_report.machine_store import (
+    machine_defaults_store_path,
+)
+from loopx.cli import main
+from loopx.registry import atomic_write_json, read_json
+
+
+def _digest(value: object) -> str:
+    encoded = json.dumps(
+        value, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _defaults(*, route_ref: str = "loopx-concierge") -> dict:
+    return {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "periodic_report": {
+                "schema_version": "periodic_report_machine_defaults_v0",
+                "enabled": True,
+                "inheritance": "materialize_on_goal_connect",
+                "profile_preset": "weekly-progress",
+                "route_ref": route_ref,
+                "timezone": "Asia/Shanghai",
+            },
+        },
+    }
+
+
+def _write_defaults(runtime_root: Path, *, route_ref: str = "loopx-concierge") -> None:
+    path = machine_defaults_store_path(runtime_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(path, _defaults(route_ref=route_ref))
+
+
+def _write_source(
+    root: Path,
+    goal_id: str,
+    *,
+    periodic_report: dict | None = None,
+    status: str = "active",
+) -> Path:
+    state_path = root / goal_id / "ACTIVE_GOAL_STATE.md"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("# Goal\n", encoding="utf-8")
+    goal = {
+        "id": goal_id,
+        "status": status,
+        "repo": str(root),
+        "state_file": str(state_path.relative_to(root)),
+    }
+    if periodic_report is not None:
+        goal["control_plane"] = {"periodic_report": periodic_report}
+    registry_path = root / f"{goal_id}.registry.json"
+    atomic_write_json(
+        registry_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "project-local",
+            "goals": [goal],
+        },
+    )
+    return registry_path
+
+
+def _global_goal(source_registry: Path, goal_id: str) -> dict:
+    goal = read_json(source_registry)["goals"][0]
+    return {**goal, "source_registry": str(source_registry)}
+
+
+def test_new_goal_connect_materializes_machine_default(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    registry_path = project / ".loopx" / "registry.json"
+    _write_defaults(runtime_root)
+
+    result = bootstrap_project(
+        project=project,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="research",
+        objective="Produce a verified research result.",
+        domain="research",
+        role="primary",
+        parent_goal_id=None,
+        state_file=None,
+        goal_doc=None,
+        adapter_kind="read_only_project_map_v0",
+        adapter_status="connected",
+        next_probe=None,
+        spawn_allowed=False,
+        max_children=0,
+        allowed_domains=[],
+        write_scope=[],
+        onboarding_scan_enabled=False,
+        force=False,
+        dry_run=False,
+        sync_global=False,
+    )
+
+    goal = read_json(registry_path)["goals"][0]
+    assert result["periodic_report_default_materialized"] is True
+    assert goal["control_plane"]["periodic_report"] == {
+        "enabled": True,
+        "profile_preset": "weekly-progress",
+        "route_ref": "loopx-concierge",
+        "source": "machine_default",
+        "source_revision": goal["control_plane"]["periodic_report"]["source_revision"],
+        "timezone": "Asia/Shanghai",
+    }
+    assert "agent_id" not in goal["control_plane"]["periodic_report"]
+
+
+def test_forced_reconnect_preserves_existing_goal_override(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    project.mkdir()
+    registry_path = project / ".loopx" / "registry.json"
+    _write_defaults(runtime_root)
+    common = dict(
+        project=project,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="research",
+        objective="Produce a verified research result.",
+        domain="research",
+        role="primary",
+        parent_goal_id=None,
+        state_file=None,
+        goal_doc=None,
+        adapter_kind="read_only_project_map_v0",
+        adapter_status="connected",
+        next_probe=None,
+        spawn_allowed=False,
+        max_children=0,
+        allowed_domains=[],
+        write_scope=[],
+        onboarding_scan_enabled=False,
+        dry_run=False,
+        sync_global=False,
+    )
+    bootstrap_project(**common, force=False)
+    registry = read_json(registry_path)
+    registry["goals"][0]["control_plane"]["periodic_report"] = {
+        "enabled": False,
+        "route_ref": "research-room",
+        "source": "goal_override",
+    }
+    atomic_write_json(registry_path, registry)
+
+    bootstrap_project(**common, force=True)
+
+    periodic = read_json(registry_path)["goals"][0]["control_plane"]["periodic_report"]
+    assert periodic == {
+        "enabled": False,
+        "route_ref": "research-room",
+        "source": "goal_override",
+    }
+
+
+def test_project_register_cli_materializes_machine_default(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    knowledge_root = tmp_path / "project"
+    registry_path = tmp_path / "registry.json"
+    _write_defaults(runtime_root)
+
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "project",
+                "register",
+                "--project-id",
+                "research-project",
+                "--project-kind",
+                "work",
+                "--knowledge-root",
+                str(knowledge_root),
+                "--goal-id",
+                "research",
+                "--objective",
+                "Produce a verified research result.",
+                "--acceptance",
+                "A reviewed result exists.",
+                "--next-effect",
+                "Inspect the evidence.",
+                "--stop-condition",
+                "Stop when evidence is unavailable.",
+            ]
+        )
+        == 0
+    )
+
+    periodic = read_json(registry_path)["goals"][0]["control_plane"]["periodic_report"]
+    assert periodic["source"] == "machine_default"
+    assert periodic["route_ref"] == "loopx-concierge"
+
+
+def test_migration_preserves_override_and_excludes_unavailable_goals(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    inherited = _write_source(tmp_path / "inherited", "inherited")
+    overridden = _write_source(
+        tmp_path / "overridden",
+        "overridden",
+        periodic_report={"enabled": False, "source": "goal_override"},
+    )
+    retired = _write_source(tmp_path / "retired", "retired", status="retired")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [
+                _global_goal(inherited, "inherited"),
+                _global_goal(overridden, "overridden"),
+                _global_goal(retired, "retired"),
+                {
+                    "id": "missing",
+                    "status": "active",
+                    "repo": str(tmp_path / "missing"),
+                    "state_file": "ACTIVE_GOAL_STATE.md",
+                },
+            ],
+        },
+    )
+
+    plan = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+
+    assert plan["rows"] == [
+        {
+            "goal_id": "inherited",
+            "action": "materialize",
+            "reason": "machine_default_missing",
+        },
+        {
+            "goal_id": "overridden",
+            "action": "preserve",
+            "reason": "goal_override",
+        },
+        {"goal_id": "retired", "action": "excluded", "reason": "goal_not_active"},
+        {
+            "goal_id": "missing",
+            "action": "excluded",
+            "reason": "authoritative_registry_unavailable",
+        },
+    ]
+    assert plan["writes_required"] == 1
+
+
+def test_authoritative_terminal_state_beats_a_stale_global_projection(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research", status="retired")
+    projected = _global_goal(source_path, "research")
+    projected["status"] = "active"
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [projected],
+        },
+    )
+
+    plan = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+
+    assert plan["rows"] == [
+        {"goal_id": "research", "action": "excluded", "reason": "goal_not_active"}
+    ]
+    assert plan["writes_required"] == 0
+
+
+def test_apply_readback_and_rollback_cover_source_and_global_projection(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [_global_goal(source_path, "research")],
+        },
+    )
+    source_before = read_json(source_path)
+    global_before = read_json(global_path)
+    preview = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+
+    applied = migrate_periodic_report_goal_materializations(
+        registry_path=global_path,
+        runtime_root=runtime_root,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+
+    assert applied["status"] == "applied"
+    assert applied["readback_verified"] is True
+    assert applied["registries_written"] == 2
+    source_goal = read_json(source_path)["goals"][0]
+    global_goal = read_json(global_path)["goals"][0]
+    assert source_goal["control_plane"]["periodic_report"]["source"] == (
+        "machine_default"
+    )
+    assert (
+        global_goal["control_plane"]["periodic_report"]
+        == source_goal["control_plane"]["periodic_report"]
+    )
+
+    rollback_preview = plan_periodic_report_goal_materialization_rollback(
+        registry_path=global_path,
+        runtime_root=runtime_root,
+        transaction_id=applied["transaction_id"],
+    )
+    rolled_back = rollback_periodic_report_goal_materializations(
+        registry_path=global_path,
+        runtime_root=runtime_root,
+        transaction_id=applied["transaction_id"],
+        execute=True,
+        expected_plan_revision=rollback_preview["plan_revision"],
+    )
+
+    assert rolled_back["status"] == "rolled_back"
+    assert rolled_back["readback_verified"] is True
+    assert read_json(source_path) == source_before
+    assert read_json(global_path) == global_before
+
+
+def test_apply_refuses_a_concurrent_source_registry_revision(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [_global_goal(source_path, "research")],
+        },
+    )
+    preview = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+    concurrent = read_json(source_path)
+    concurrent["concurrent_revision"] = 1
+    atomic_write_json(source_path, concurrent)
+
+    with pytest.raises(ValueError, match="plan revision changed"):
+        migrate_periodic_report_goal_materializations(
+            registry_path=global_path,
+            runtime_root=runtime_root,
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+        )
+
+    assert "control_plane" not in read_json(source_path)["goals"][0]
+
+
+def test_rollback_rejects_a_tampered_local_backup(tmp_path: Path) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [_global_goal(source_path, "research")],
+        },
+    )
+    preview = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+    applied = migrate_periodic_report_goal_materializations(
+        registry_path=global_path,
+        runtime_root=runtime_root,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+    backup_path = (
+        runtime_root
+        / "machine"
+        / "periodic-report"
+        / "goal-materializations"
+        / applied["transaction_id"]
+        / "backup.json"
+    )
+    backup = read_json(backup_path)
+    backup["registries"][0]["payload"]["tampered"] = True
+    atomic_write_json(backup_path, backup)
+
+    with pytest.raises(ValueError, match="transaction is invalid"):
+        plan_periodic_report_goal_materialization_rollback(
+            registry_path=global_path,
+            runtime_root=runtime_root,
+            transaction_id=applied["transaction_id"],
+        )
+
+
+def test_rollback_rejects_a_backup_path_outside_the_registry_allowlist(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [_global_goal(source_path, "research")],
+        },
+    )
+    preview = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+    applied = migrate_periodic_report_goal_materializations(
+        registry_path=global_path,
+        runtime_root=runtime_root,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+    transaction_dir = (
+        runtime_root
+        / "machine"
+        / "periodic-report"
+        / "goal-materializations"
+        / applied["transaction_id"]
+    )
+    backup_path = transaction_dir / "backup.json"
+    receipt_path = transaction_dir / "transaction.json"
+    backup = read_json(backup_path)
+    backup["registries"][0]["path"] = str(tmp_path / "outside.json")
+    atomic_write_json(backup_path, backup)
+    receipt = read_json(receipt_path)
+    receipt["backup_revision"] = _digest(backup)
+    receipt.pop("receipt_revision")
+    receipt["receipt_revision"] = _digest(receipt)
+    atomic_write_json(receipt_path, receipt)
+
+    with pytest.raises(ValueError, match="backup registry entry is invalid"):
+        plan_periodic_report_goal_materialization_rollback(
+            registry_path=global_path,
+            runtime_root=runtime_root,
+            transaction_id=applied["transaction_id"],
+        )
+
+
+def test_failed_cross_registry_readback_restores_every_written_registry(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [_global_goal(source_path, "research")],
+        },
+    )
+    source_before = read_json(source_path)
+    global_before = read_json(global_path)
+    preview = plan_periodic_report_goal_materialization(
+        registry_path=global_path, runtime_root=runtime_root
+    )
+    corrupted_once = False
+
+    def corrupt_global_once(path: Path, payload: dict) -> None:
+        nonlocal corrupted_once
+        atomic_write_json(path, payload)
+        if path == global_path and not corrupted_once:
+            corrupted_once = True
+            changed = read_json(path)
+            changed["corrupted"] = True
+            atomic_write_json(path, changed)
+
+    with pytest.raises(RuntimeError, match="prior registries were restored"):
+        migrate_periodic_report_goal_materializations(
+            registry_path=global_path,
+            runtime_root=runtime_root,
+            execute=True,
+            expected_plan_revision=preview["plan_revision"],
+            writer=corrupt_global_once,
+        )
+
+    assert read_json(source_path) == source_before
+    assert read_json(global_path) == global_before
+
+
+def test_goal_materialization_cli_previews_applies_and_rolls_back(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    _write_defaults(runtime_root)
+    source_path = _write_source(tmp_path / "source", "research")
+    global_path = runtime_root / "registry.global.json"
+    atomic_write_json(
+        global_path,
+        {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "common_runtime_root": str(runtime_root),
+            "goals": [_global_goal(source_path, "research")],
+        },
+    )
+    base = [
+        "--registry",
+        str(global_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "periodic-report",
+    ]
+
+    assert main([*base, "migrate-machine-defaults"]) == 0
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["writes_required"] == 1
+
+    assert (
+        main(
+            [
+                *base,
+                "migrate-machine-defaults",
+                "--execute",
+                "--expected-plan-revision",
+                preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["status"] == "applied"
+
+    assert (
+        main(
+            [
+                *base,
+                "rollback-goal-materialization",
+                "--transaction-id",
+                applied["transaction_id"],
+            ]
+        )
+        == 0
+    )
+    rollback_preview = json.loads(capsys.readouterr().out)
+    assert rollback_preview["rollback_allowed"] is True
+
+    assert (
+        main(
+            [
+                *base,
+                "rollback-goal-materialization",
+                "--transaction-id",
+                applied["transaction_id"],
+                "--execute",
+                "--expected-plan-revision",
+                rollback_preview["plan_revision"],
+            ]
+        )
+        == 0
+    )
+    rolled_back = json.loads(capsys.readouterr().out)
+    assert rolled_back["status"] == "rolled_back"


### PR DESCRIPTION
## Motivation

The machine configuration platform becomes useful only when a newly connected Goal can receive a stable Goal-owned configuration. This PR closes that activation path for periodic reports while preserving the authority rule established by #3861: machine policy is read only at materialization time; Goal runtime reads only Goal-owned state.

## What this PR owns

- Materialize periodic-report defaults when a new Goal is connected.
- Keep explicit Goal overrides authoritative and never overwrite them with machine changes.
- Provide a separately reviewed existing-Goal migration with preview, revision fencing, lock, backup, readback, receipt, and rollback.
- Update Goal source registry and global projection together, with recovery if either authoritative write cannot be verified.
- Keep the periodic-report compatibility CLI on the same transaction path.

## Authority model

```text
new Goal connect
    + machine defaults
    + explicit Goal override (wins)
             |
             v
      Goal-owned configuration
             |
             v
         Goal runtime

existing Goal + changed machine defaults
             |
             +-- no effect by default
             +-- explicit preview/apply migration only
```

The migration transaction is intentionally separate from generic machine-document CRUD: it coordinates Goal-owned authoritative sources and therefore has different locks, receipts, rollback scope, and failure modes.

## Dependency

- Base: #3861
- Parallel operator surface: #3865

This PR does not depend on #3865.

## Validation

- 45 focused contract, store, and Goal-materialization tests
- Ruff
- Diff hygiene

Coverage includes new Goal inheritance, explicit override precedence, existing-Goal no-drift behavior, migration preview/apply, stale revisions, cross-source readback, and rollback.

## Non-goals

- No dynamic runtime merge with machine configuration.
- No automatic migration of existing Goals.
- No generic operator UI; that belongs to #3865.
- No Goal-level aggregation, arbitration, scheduling, or delivery implementation.
