### PR TITLE
fix(benchmark): ignore patch payload URLs in integrity scan

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -12,7 +12,7 @@ from enum import Enum
 from typing import Any
 from urllib.parse import urlsplit
 
-from .environment_access import credential_probe_present
+from .environment_access import _heredoc_delimiters, credential_probe_present
 
 BENCHMARK_INTEGRITY_POLICY_SCHEMA_VERSION = "benchmark_integrity_policy_v0"
 BENCHMARK_RUNTIME_INTEGRITY_ATTESTATION_SCHEMA_VERSION = (
@@ -124,6 +124,9 @@ _HTTP_URL_PATTERN = re.compile(r"(?is)https?://[^\s\"'<>]+")
 _GIT_CLONE_COMMAND_PATTERN = re.compile(r"(?is)\bgit\s+clone\b")
 _GIT_REMOTE_PATTERN = re.compile(
     r"(?is)(?:\b(?:git|ssh)://[^\s\"'<>]+|(?<![A-Za-z0-9_.@/-])[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+:[^\s\"'<>]+)"
+)
+_PATCH_STDIN_COMMAND_PATTERN = re.compile(
+    r"(?:^|[\s/])apply_patch(?:\s|$)|(?:^|\s)--apply-patch(?:\s|$)"
 )
 _COMMAND_TEXT_FIELDS = ("cmd", "command")
 _COMMAND_ARGUMENT_FIELDS = ("args", "argv")
@@ -484,6 +487,33 @@ def _command_text_values(value: object) -> Iterable[str]:
             yield from _command_text_values(item)
 
 
+def _without_patch_stdin_bodies(command: str) -> str:
+    """Exclude heredoc source payloads consumed by patch commands.
+
+    The shell executes the declaration line, while ``apply_patch`` and the
+    benchmark bridge's ``--apply-patch`` mode consume the heredoc body as
+    source data.  URLs or command-looking text inside that patch are not
+    network requests.  Keep bodies for every other heredoc fail-closed because
+    they may be executable input to a shell or interpreter.
+    """
+
+    visible_lines: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for raw_line in command.splitlines(keepends=True):
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = raw_line.rstrip("\r\n")
+            if strip_tabs:
+                candidate = candidate.lstrip("\t")
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        visible_lines.append(raw_line)
+        if _PATCH_STDIN_COMMAND_PATTERN.search(raw_line):
+            pending.extend(_heredoc_delimiters(raw_line))
+    return "".join(visible_lines)
+
+
 def _scope_for_url(url: str) -> NetworkRequestScope:
     if _loopback_http_url(url):
         return NetworkRequestScope.LOOPBACK
@@ -494,7 +524,12 @@ def _network_request_scope(arguments: object) -> NetworkRequestScope:
     """Classify common shell HTTP requests while preserving argv association."""
 
     scope = NetworkRequestScope.NONE
-    command_texts = tuple(dict.fromkeys(_command_text_values(arguments)))
+    command_texts = tuple(
+        dict.fromkeys(
+            _without_patch_stdin_bodies(text)
+            for text in _command_text_values(arguments)
+        )
+    )
     for text in command_texts:
         if not _NETWORK_COMMAND_PATTERN.search(text):
             continue
@@ -509,7 +544,10 @@ def _network_request_scope(arguments: object) -> NetworkRequestScope:
     # Unknown command/target field names cannot prove safe association. If the
     # same argument object contains a supported network client and literal URLs,
     # classify those URLs fail-closed instead of silently losing split argv.
-    leaves = tuple(_argument_text_values(arguments))
+    leaves = tuple(
+        _without_patch_stdin_bodies(text)
+        for text in _argument_text_values(arguments)
+    )
     if not any(_NETWORK_COMMAND_PATTERN.search(text) for text in leaves):
         return scope
     for text in leaves:

--- a/loopx/capabilities/benchmark_toolkit/integrity.py
+++ b/loopx/capabilities/benchmark_toolkit/integrity.py
@@ -6,6 +6,7 @@ import hashlib
 import ipaddress
 import json
 import re
+import shlex
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from enum import Enum
@@ -125,9 +126,7 @@ _GIT_CLONE_COMMAND_PATTERN = re.compile(r"(?is)\bgit\s+clone\b")
 _GIT_REMOTE_PATTERN = re.compile(
     r"(?is)(?:\b(?:git|ssh)://[^\s\"'<>]+|(?<![A-Za-z0-9_.@/-])[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+:[^\s\"'<>]+)"
 )
-_PATCH_STDIN_COMMAND_PATTERN = re.compile(
-    r"(?:^|[\s/])apply_patch(?:\s|$)|(?:^|\s)--apply-patch(?:\s|$)"
-)
+_PATCH_BRIDGE_EXECUTABLES = frozenset({"pier-env-exec"})
 _COMMAND_TEXT_FIELDS = ("cmd", "command")
 _COMMAND_ARGUMENT_FIELDS = ("args", "argv")
 # ATIF currently carries a function name rather than a typed side-effect class.
@@ -487,6 +486,64 @@ def _command_text_values(value: object) -> Iterable[str]:
             yield from _command_text_values(item)
 
 
+def _patch_heredoc_declarations(
+    command_line: str,
+) -> tuple[tuple[str, bool, bool], ...]:
+    """Bind each heredoc to its own shell segment and patch consumer.
+
+    The boolean in each result says whether that one body is proven to be
+    patch data.  Unknown syntax and unknown ``--apply-patch`` consumers stay
+    visible so the integrity scan fails closed.
+    """
+
+    try:
+        lexer = shlex.shlex(
+            command_line,
+            posix=True,
+            punctuation_chars=";&|\n<>",
+        )
+        lexer.whitespace = " \t\r"
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return tuple((*declaration, False) for declaration in _heredoc_delimiters(command_line))
+
+    declarations: list[tuple[str, bool, bool]] = []
+    segment: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token and all(character in ";&|\n" for character in token):
+            segment = []
+            index += 1
+            continue
+        if token != "<<":
+            segment.append(token)
+            index += 1
+            continue
+
+        index += 1
+        strip_tabs = index < len(tokens) and tokens[index] == "-"
+        if strip_tabs:
+            index += 1
+        if index >= len(tokens):
+            break
+        delimiter = tokens[index]
+        if not strip_tabs and delimiter.startswith("-") and len(delimiter) > 1:
+            strip_tabs = True
+            delimiter = delimiter[1:]
+
+        executable = segment[0].rsplit("/", 1)[-1] if segment else ""
+        proven_patch_consumer = executable == "apply_patch" or (
+            executable in _PATCH_BRIDGE_EXECUTABLES and "--apply-patch" in segment
+        )
+        if delimiter and all(character not in ";&|\n<>" for character in delimiter):
+            declarations.append((delimiter, strip_tabs, proven_patch_consumer))
+        index += 1
+    return tuple(declarations)
+
+
 def _without_patch_stdin_bodies(command: str) -> str:
     """Exclude heredoc source payloads consumed by patch commands.
 
@@ -498,19 +555,20 @@ def _without_patch_stdin_bodies(command: str) -> str:
     """
 
     visible_lines: list[str] = []
-    pending: list[tuple[str, bool]] = []
+    pending: list[tuple[str, bool, bool]] = []
     for raw_line in command.splitlines(keepends=True):
         if pending:
-            delimiter, strip_tabs = pending[0]
+            delimiter, strip_tabs, hide_body = pending[0]
             candidate = raw_line.rstrip("\r\n")
             if strip_tabs:
                 candidate = candidate.lstrip("\t")
             if candidate == delimiter:
                 pending.pop(0)
+            elif not hide_body:
+                visible_lines.append(raw_line)
             continue
         visible_lines.append(raw_line)
-        if _PATCH_STDIN_COMMAND_PATTERN.search(raw_line):
-            pending.extend(_heredoc_delimiters(raw_line))
+        pending.extend(_patch_heredoc_declarations(raw_line))
     return "".join(visible_lines)
 
 

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -654,6 +654,79 @@ SCRIPT
     assert receipt["evidence_counts"]["external_network_request"] == 1
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        """printf '%s\\n' --apply-patch && sh <<'SCRIPT'
+curl https://example.invalid/probe
+SCRIPT
+""",
+        """echo apply_patch && sh <<'SCRIPT'
+curl https://example.invalid/probe
+SCRIPT
+""",
+        """tool --apply-patch <<'PATCH'
+curl https://example.invalid/probe
+PATCH
+""",
+        """pier-env-exec --apply-patch <<'PATCH'; sh <<'SCRIPT'
+curl https://inside-patch.invalid/example
+PATCH
+curl https://example.invalid/probe
+SCRIPT
+""",
+    ],
+)
+def test_non_patch_heredoc_cannot_borrow_patch_marker(command: str) -> None:
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+def test_patch_and_shell_heredocs_on_one_line_keep_only_shell_body() -> None:
+    command = """/opt/bin/apply_patch <<'PATCH' && sh <<'SCRIPT'
+*** Begin Patch
+*** Update File: docs/api.md
+@@
++curl https://inside-patch.invalid/example
+*** End Patch
+PATCH
+curl https://example.invalid/probe
+SCRIPT
+"""
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+def test_network_commands_around_patch_heredoc_remain_visible() -> None:
+    command = """curl https://before.invalid/probe
+'./apply_patch' <<'PATCH'
+*** Begin Patch
+*** Update File: docs/api.md
+@@
++curl https://inside-patch.invalid/example
+*** End Patch
+PATCH
+curl https://after.invalid/probe
+"""
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
 def test_loopback_scope_requires_external_network_denial_attestation() -> None:
     receipt = build_benchmark_integrity_qualification(
         trajectory=_trajectory(command="curl http://127.0.0.1:9090/health"),

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -601,6 +601,59 @@ def test_loopback_http_requires_explicit_network_scope() -> None:
     assert "loopback_network_request" in receipt["blockers"]
 
 
+def test_patch_heredoc_url_is_not_classified_as_network_access() -> None:
+    command = """pier-env-exec --cwd /app --apply-patch <<'PATCH'
+*** Begin Patch
+*** Update File: docs/api.md
+@@
++curl http://localhost:9090/api/v1/status
+*** End Patch
+PATCH
+"""
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is True
+    assert receipt["evidence_counts"]["loopback_network_request"] == 0
+    assert receipt["evidence_counts"]["external_network_request"] == 0
+
+
+def test_network_command_after_patch_heredoc_remains_visible() -> None:
+    command = """pier-env-exec --cwd /app --apply-patch <<'PATCH'
+*** Begin Patch
+*** Update File: docs/api.md
+@@
++curl http://localhost:9090/api/v1/status
+*** End Patch
+PATCH
+curl https://example.invalid/probe
+"""
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["loopback_network_request"] == 0
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
+def test_shell_heredoc_network_command_remains_fail_closed() -> None:
+    command = """sh <<'SCRIPT'
+curl https://example.invalid/probe
+SCRIPT
+"""
+    receipt = build_benchmark_integrity_qualification(
+        trajectory=_trajectory(command=command),
+        runtime_attestation=_attestation(),
+    )
+
+    assert receipt["integrity_qualified"] is False
+    assert receipt["evidence_counts"]["external_network_request"] == 1
+
+
 def test_loopback_scope_requires_external_network_denial_attestation() -> None:
     receipt = build_benchmark_integrity_qualification(
         trajectory=_trajectory(command="curl http://127.0.0.1:9090/health"),


### PR DESCRIPTION
## Summary

- distinguish patch heredoc source data from executed shell network commands
- keep real commands after a patch payload and executable shell heredocs fail-closed
- add focused regression coverage for loopback and external URL examples in patches

## Validation

- `python -m pytest tests/capabilities/test_benchmark_toolkit.py -q` (98 passed)
- real terminal-trajectory replay: false network evidence removed, integrity qualification succeeds
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard` (all 9 executed checks passed; benchmark-sensitive manual review hold remains)
- public/private scan clean; no raw benchmark artifacts or local paths included

## Review hold

This changes integrity classification behavior. Please review the boundary: only heredoc bodies consumed by `apply_patch` or bridge `--apply-patch` are excluded; ordinary shell heredocs remain visible to network classification.