### PR TITLE
perf(summary): reuse collected run history

### DIFF
--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -63,6 +63,7 @@ def build_run_history(
     compact_run: RunCompactor,
     quota_status: QuotaStatus,
     display_limit: int | None = None,
+    recent_run_limit: int | None = None,
 ) -> dict[str, Any]:
     display_limit = None if display_limit is None else max(0, display_limit)
     goals: list[dict[str, Any]] = []
@@ -123,8 +124,9 @@ def build_run_history(
         for run in history.get("runs") or []
         if isinstance(run, dict)
     ]
-    if display_limit is not None:
-        recent_runs = recent_runs[:display_limit]
+    recent_limit = recent_run_limit if recent_run_limit is not None else display_limit
+    if recent_limit is not None:
+        recent_runs = recent_runs[: max(0, recent_limit)]
     return {
         "available": True,
         "goal_count": history.get("goal_count"),

--- a/loopx/control_plane/status/collection.py
+++ b/loopx/control_plane/status/collection.py
@@ -44,9 +44,14 @@ def collect_status(
     goal_id: str | None = None,
     available_capabilities: Any = None,
     include_public_boundary_scan: bool = True,
+    recent_run_limit: int | None = None,
 ) -> dict[str, Any]:
     display_limit = max(0, limit)
-    control_plane_limit = max(display_limit, context.status_control_plane_context_limit)
+    control_plane_limit = max(
+        display_limit,
+        context.status_control_plane_context_limit,
+        max(0, recent_run_limit) if recent_run_limit is not None else 0,
+    )
     goal_filter = str(goal_id or "").strip() or None
     registry = context.load_registry(registry_path)
     runtime_root = context.resolve_runtime_root(
@@ -91,6 +96,7 @@ def collect_status(
         goal_id_filter=goal_filter,
         display_limit=display_limit,
         todo_index_limit=max(context.max_todo_index_items, display_limit),
+        recent_run_limit=recent_run_limit,
     )
     promotion_gate = context.build_promotion_gate(
         registry_path=registry_path,

--- a/loopx/control_plane/status/runtime_summaries.py
+++ b/loopx/control_plane/status/runtime_summaries.py
@@ -89,6 +89,7 @@ def build_status_runtime_summaries(
     display_limit: int,
     todo_index_limit: int,
     context: StatusRuntimeSummaryContext,
+    recent_run_limit: int | None = None,
 ) -> dict[str, Any]:
     def event_class_for_run(run: dict[str, Any]) -> str:
         return event_ledger_event_class(run, context=context)
@@ -105,6 +106,7 @@ def build_status_runtime_summaries(
             compact_run=context.compact_run,
             quota_status=context.quota_status,
             display_limit=display_limit,
+            recent_run_limit=recent_run_limit,
         ),
         "event_ledger_summary": build_event_ledger_summary(
             history,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1257,6 +1257,7 @@ def build_status_runtime_summaries(
     goal_id_filter: str | None,
     display_limit: int,
     todo_index_limit: int,
+    recent_run_limit: int | None = None,
 ) -> dict[str, Any]:
     return _build_status_runtime_summaries_read_model(
         history=history,
@@ -1265,6 +1266,7 @@ def build_status_runtime_summaries(
         goal_id_filter=goal_id_filter,
         display_limit=display_limit,
         todo_index_limit=todo_index_limit,
+        recent_run_limit=recent_run_limit,
         context=build_status_runtime_summary_context(),
     )
 
@@ -1298,6 +1300,7 @@ def collect_status(
     goal_id: str | None = None,
     available_capabilities: Any = None,
     include_public_boundary_scan: bool = True,
+    recent_run_limit: int | None = None,
 ) -> dict[str, Any]:
     return _collect_status_read_model(
         registry_path=registry_path,
@@ -1308,5 +1311,6 @@ def collect_status(
         goal_id=goal_id,
         available_capabilities=available_capabilities,
         include_public_boundary_scan=include_public_boundary_scan,
+        recent_run_limit=recent_run_limit,
         context=build_status_collection_context(),
     )

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -7,8 +7,6 @@ from typing import Any
 from .control_plane.runtime.time import now_utc, now_utc_iso
 from .control_plane.todos.decision_scope import todo_gate_relation
 from .control_plane.todos.user_gate import open_user_gate_todo_items
-from .history import collect_history, load_registry
-from .paths import resolve_runtime_root
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
 from .presentation.public_safety import public_safe_boundary, redact_public_text
@@ -562,19 +560,13 @@ def build_summary_all(
     limit: int,
 ) -> dict[str, Any]:
     normalized_range, since = _parse_time_range(time_range)
+    recent_progress_limit = max(limit * 2, 5)
     status_payload = collect_status(
         registry_path=registry_path,
         runtime_root_override=runtime_root_override,
         scan_roots=scan_roots,
         limit=max(limit, 1),
-    )
-    registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
-    history_payload = collect_history(
-        registry_path=registry_path,
-        runtime_root=runtime_root,
-        goal_id=None,
-        limit=max(limit * 2, 5),
+        recent_run_limit=recent_progress_limit,
     )
 
     queue = _as_dict(status_payload.get("attention_queue"))
@@ -605,7 +597,12 @@ def build_summary_all(
 
     global_registry = _as_dict(status_payload.get("global_registry"))
     risks = [_risk_from_finding(item) for item in _as_list(global_registry.get("findings")) if isinstance(item, dict)]
-    recent_progress = _recent_progress(history_payload, since=since, limit=limit)
+    run_history = _as_dict(status_payload.get("run_history"))
+    recent_progress = _recent_progress(
+        {"runs": _as_list(run_history.get("recent_runs"))},
+        since=since,
+        limit=limit,
+    )
 
     runnable_count = sum(1 for lane in lanes if lane.get("status") in {"eligible", "run", "normal_run"})
     waiting_count = sum(1 for lane in lanes if str(lane.get("waiting_on") or "") in {"controller", "user", "external"})

--- a/tests/control_plane/test_status_runtime_summaries.py
+++ b/tests/control_plane/test_status_runtime_summaries.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from loopx.control_plane.runtime.run_history import build_run_history
+
+
+def _history() -> dict[str, Any]:
+    return {
+        "goals": [],
+        "runs": [
+            {
+                "goal_id": "goal-one",
+                "generated_at": f"2026-01-01T00:00:0{index}Z",
+                "classification": "state_refreshed",
+            }
+            for index in range(3)
+        ],
+    }
+
+
+def _build(*, display_limit: int, recent_run_limit: int | None = None) -> dict[str, Any]:
+    return build_run_history(
+        _history(),
+        latest_run=lambda _goal: None,
+        goal_lifecycle_fields=lambda _goal, _run: {
+            "lifecycle_phase": "registered",
+            "lifecycle_flags": [],
+        },
+        subagent_activity_for_goal=lambda _goal: None,
+        compact_run=lambda run: dict(run),
+        quota_status=lambda _goal: {},
+        display_limit=display_limit,
+        recent_run_limit=recent_run_limit,
+    )
+
+
+def test_recent_run_limit_is_separate_from_display_limit() -> None:
+    default = _build(display_limit=1)
+    extended = _build(display_limit=1, recent_run_limit=3)
+
+    assert len(default["recent_runs"]) == 1
+    assert len(extended["recent_runs"]) == 3

--- a/tests/test_summary_all.py
+++ b/tests/test_summary_all.py
@@ -70,9 +70,6 @@ def test_blocked_visible_todo_is_not_counted_as_runnable(monkeypatch, tmp_path) 
     }
 
     monkeypatch.setattr(summary_all, "collect_status", lambda **_: status_payload)
-    monkeypatch.setattr(summary_all, "load_registry", lambda _: {})
-    monkeypatch.setattr(summary_all, "resolve_runtime_root", lambda *_: tmp_path)
-    monkeypatch.setattr(summary_all, "collect_history", lambda **_: {"runs": []})
     monkeypatch.setattr(
         summary_all,
         "build_quota_should_run",
@@ -102,6 +99,50 @@ def test_blocked_visible_todo_is_not_counted_as_runnable(monkeypatch, tmp_path) 
                 "Wait for the projected user/controller decision before "
                 "running the blocked path."
             ),
+        }
+    ]
+
+
+def test_summary_all_reuses_status_recent_run_projection(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    recent_run = {
+        "goal_id": "progress-goal",
+        "generated_at": "2099-01-01T00:00:00Z",
+        "classification": "state_refreshed",
+        "recommended_action": "Continue the bounded work.",
+    }
+    status_payload = {
+        "ok": True,
+        "attention_queue": {"items": []},
+        "global_registry": {"findings": []},
+        "run_history": {"recent_runs": [recent_run]},
+    }
+    calls: list[dict[str, object]] = []
+
+    def collect_status(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return status_payload
+
+    monkeypatch.setattr(summary_all, "collect_status", collect_status)
+
+    payload = summary_all.build_summary_all(
+        registry_path=tmp_path / "registry.json",
+        runtime_root_override=None,
+        scan_roots=[],
+        agent_id=None,
+        time_range="99999d",
+        limit=3,
+    )
+
+    assert calls[0]["recent_run_limit"] == 6
+    assert payload["recent_progress"] == [
+        {
+            "goal_id": "progress-goal",
+            "generated_at": "2099-01-01T00:00:00Z",
+            "classification": "state_refreshed",
+            "recommended_action": "Continue the bounded work.",
         }
     ]
 


### PR DESCRIPTION
## Summary

`global-summary` 目前先调用完整的 `collect_status()`，其中已经收集并生成了 compact run-history projection；随后又重新加载 registry、解析 runtime root，并再次完整扫描 history，只为了构造 `recent_progress`。历史 index 较大时，这会让一次全局摘要重复读取相同的 run history。

本 PR 让 status read-model 支持一个可选的 `recent_run_limit`：

- `global-summary` 请求足够的 recent run 窗口，并直接复用 `status_payload.run_history.recent_runs`；
- 普通 `status` 未传该参数时保持原有 display limit 和输出行为；
- 没有跨请求缓存，不改变 history 的新鲜度或权限边界；
- `recent_progress` 仍使用原有的时间过滤和 public-safe 文本压缩。

## Measurement

同一份包含 10,000 条 history index 记录的 synthetic public-safe fixture：

- 优化前：`load_index()` 调用 3 次，约 `1.19s`；
- 优化后：调用 2 次，约 `0.51s`；
- `recent_progress` 数量保持一致。

## Validation

- Focused summary/status/history tests: `25 passed`
- `status-collection-readmodel-smoke.py`: passed
- `global-manager-command-cli-smoke.py`: passed
- `status-projection-cache-smoke.py`: passed
- `status-quota-perf-budget-smoke.py`: passed
- `loopx canary premerge --from-git-diff`: passed, 17 checks
- Ruff, py_compile, diff-check: passed
- Full pytest: `5065 passed, 12 skipped, 1 unrelated environment-sensitive failure`; failing test passes in isolation

No dependency was added.