### PR TITLE
fix(periodic-report): require valid completed timestamps in progress snapshot facts

### DIFF
--- a/loopx/capabilities/periodic_report/project_progress_snapshot.py
+++ b/loopx/capabilities/periodic_report/project_progress_snapshot.py
@@ -10,6 +10,41 @@ from ...registry import find_registry_goal, read_json, resolve_state_file
 from .incremental import select_incremental_project_progress
 
 
+def _stage_timestamp(value: str) -> datetime | None:
+    """Parse an offset-aware ISO-8601 timestamp or reject the value.
+
+    Sibling validations (``_validated_snapshot_timestamp``,
+    ``_actual_work_window``, ``incremental._timestamp``) all reject naive
+    timestamps, so stage filtering must not compare offset-naive and
+    offset-aware datetimes either.
+    """
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return parsed
+
+
+def _outcome_completed_at(
+    item: Mapping[str, Any], *, stage_time: datetime
+) -> str | None:
+    """Return the durable completion timestamp an outcome fact may carry.
+
+    A done todo without a trustworthy completion timestamp (handwritten
+    agent-lane entries may omit them) must not become an outcome fact: the
+    frozen fact would fail timestamp validation on every consumption retry.
+    """
+
+    raw = str(item.get("completed_at") or item.get("updated_at") or "").strip()
+    parsed = _stage_timestamp(raw)
+    if parsed is None or parsed > stage_time:
+        return None
+    return raw
+
+
 _META_ACTION_KINDS = frozenset(
     {
         "consume_periodic_report_intent",
@@ -68,16 +103,18 @@ def build_project_progress_snapshot_from_state(
     )
     agent_summary = parsed.get("agent_todos")
     items = agent_summary.get("items") if isinstance(agent_summary, Mapping) else []
-    stage_time = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+    stage_time = _stage_timestamp(completed_at)
+    if stage_time is None:
+        raise ValueError("periodic-report stage completion timestamp is invalid")
 
     def not_after_stage(item: Mapping[str, Any]) -> bool:
         raw = str(item.get("updated_at") or item.get("completed_at") or "").strip()
         if not raw:
             return True
-        try:
-            return datetime.fromisoformat(raw.replace("Z", "+00:00")) <= stage_time
-        except ValueError:
+        parsed = _stage_timestamp(raw)
+        if parsed is None:
             return False
+        return parsed <= stage_time
 
     done = [
         dict(item)
@@ -91,6 +128,9 @@ def build_project_progress_snapshot_from_state(
     done.sort(key=lambda item: str(item.get("updated_at") or ""), reverse=True)
     progress_items: list[dict[str, Any]] = []
     for index, item in enumerate(done):
+        outcome_completed_at = _outcome_completed_at(item, stage_time=stage_time)
+        if outcome_completed_at is None:
+            continue
         summary = " ".join(
             str(
                 item.get("evidence") or item.get("note") or item.get("text") or ""
@@ -105,9 +145,7 @@ def build_project_progress_snapshot_from_state(
                 "content_kind": "outcome",
                 "value_rank": 10 + index,
                 "source_ref": f"todo:{item.get('todo_id')}",
-                "completed_at": str(
-                    item.get("completed_at") or item.get("updated_at") or ""
-                ),
+                "completed_at": outcome_completed_at,
             }
         )
     open_items = [

--- a/tests/capabilities/test_periodic_report_incremental.py
+++ b/tests/capabilities/test_periodic_report_incremental.py
@@ -488,3 +488,188 @@ def test_snapshot_skips_done_items_without_valid_completion_timestamps(
         )
         is None
     )
+
+
+def test_snapshot_accepts_offset_and_z_suffix_timestamps_with_subsecond_precision(
+    tmp_path: Path,
+) -> None:
+    state = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Completed exactly at the stage boundary.\n"
+        "  <!-- loopx:todo todo_id=todo_boundary status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T08:00:00Z"
+        " completed_at=2026-08-01T08:00:00Z -->\n"
+        "- [x] Offset-suffix outcome with microseconds.\n"
+        "  <!-- loopx:todo todo_id=todo_offset status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:30:00.123456+00:00"
+        " completed_at=2026-08-01T07:30:00.123456+00:00 -->\n"
+        "- [x] Z-suffix outcome with milliseconds.\n"
+        "  <!-- loopx:todo todo_id=todo_zulu status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:00:00.500Z"
+        " completed_at=2026-08-01T07:00:00.500Z -->\n"
+    )
+    snapshot = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T08:00:00+00:00",
+    )
+
+    assert snapshot is not None
+    assert [item["source_ref"] for item in snapshot["items"]] == [
+        "todo:todo_boundary",
+        "todo:todo_offset",
+        "todo:todo_zulu",
+    ]
+    assert [item["completed_at"] for item in snapshot["items"]] == [
+        "2026-08-01T08:00:00Z",
+        "2026-08-01T07:30:00.123456+00:00",
+        "2026-08-01T07:00:00.500Z",
+    ]
+
+
+def test_snapshot_skips_done_items_completed_after_the_stage_boundary(
+    tmp_path: Path,
+) -> None:
+    state = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Completion stamped after the stage.\n"
+        "  <!-- loopx:todo todo_id=todo_future status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:00:00Z"
+        " completed_at=2026-08-01T09:30:00Z -->\n"
+        "- [x] Whole item updated after the stage.\n"
+        "  <!-- loopx:todo todo_id=todo_late status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T09:00:00Z"
+        " completed_at=2026-08-01T09:00:00Z -->\n"
+        "- [x] Completion stamped inside the stage.\n"
+        "  <!-- loopx:todo todo_id=todo_instage status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:10:00Z"
+        " completed_at=2026-08-01T07:10:00Z -->\n"
+    )
+    snapshot = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T08:00:00Z",
+    )
+
+    assert snapshot is not None
+    assert [item["source_ref"] for item in snapshot["items"]] == [
+        "todo:todo_instage"
+    ]
+    assert snapshot["items"][0]["completed_at"] == "2026-08-01T07:10:00Z"
+
+
+def test_snapshot_falls_back_to_updated_at_and_skips_unusable_timestamps(
+    tmp_path: Path,
+) -> None:
+    state = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Outcome relying on the updated_at fallback.\n"
+        "  <!-- loopx:todo todo_id=todo_fallback status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:00:00Z -->\n"
+        "- [x] Outcome with neither timestamp present.\n"
+        "  <!-- loopx:todo todo_id=todo_missing status=done"
+        f" task_class=advancement_task claimed_by={AGENT_ID} -->\n"
+        "- [x] Outcome with both timestamps unreadable.\n"
+        "  <!-- loopx:todo todo_id=todo_garbage status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=not-a-date"
+        " completed_at=garbage -->\n"
+        "- [x] Non-date updated_at with a readable completed_at.\n"
+        "  <!-- loopx:todo todo_id=todo_numeric status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=12345"
+        " completed_at=2026-08-01T07:20:00Z -->\n"
+    )
+    snapshot = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T08:00:00Z",
+    )
+
+    assert snapshot is not None
+    assert [item["source_ref"] for item in snapshot["items"]] == [
+        "todo:todo_fallback"
+    ]
+    assert snapshot["items"][0]["completed_at"] == "2026-08-01T07:00:00Z"
+
+
+def test_snapshot_rejects_invalid_stage_completion_timestamps(
+    tmp_path: Path,
+) -> None:
+    state = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Valid outcome that must not be reached.\n"
+        "  <!-- loopx:todo todo_id=todo_valid status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:00:00Z -->\n"
+    )
+    for invalid_stage in ("2026-08-01T08:00:00", "not-a-timestamp"):
+        with pytest.raises(ValueError, match="stage completion timestamp"):
+            build_project_progress_snapshot_from_state(
+                state_text=state,
+                goal={"id": GOAL_ID},
+                state_path=tmp_path / "goal.md",
+                goal_id=GOAL_ID,
+                agent_id=AGENT_ID,
+                completed_at=invalid_stage,
+            )
+
+
+def test_snapshot_keeps_valid_item_order_and_ids_when_invalid_items_are_skipped(
+    tmp_path: Path,
+) -> None:
+    state = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Valid outcome finished first.\n"
+        "  <!-- loopx:todo todo_id=todo_valid_late status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:30:00Z -->\n"
+        "- [x] Naive timestamp outcome sorted first.\n"
+        "  <!-- loopx:todo todo_id=todo_naive_first status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:50:00 -->\n"
+        "- [x] Valid completion stamped after the stage.\n"
+        "  <!-- loopx:todo todo_id=todo_future_mid status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:20:00Z"
+        " completed_at=2026-08-01T09:00:00Z -->\n"
+        "- [x] Valid outcome finished last.\n"
+        "  <!-- loopx:todo todo_id=todo_valid_early status=done"
+        " task_class=advancement_task"
+        f" claimed_by={AGENT_ID} updated_at=2026-08-01T07:10:00Z -->\n"
+    )
+    snapshot = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T08:00:00Z",
+    )
+
+    assert snapshot is not None
+    assert [item["source_ref"] for item in snapshot["items"]] == [
+        "todo:todo_valid_late",
+        "todo:todo_valid_early",
+    ]
+    assert [item["item_id"] for item in snapshot["items"]] == [
+        "completed_1",
+        "completed_3",
+    ]
+    assert [item["value_rank"] for item in snapshot["items"]] == [10, 12]

--- a/tests/capabilities/test_periodic_report_incremental.py
+++ b/tests/capabilities/test_periodic_report_incremental.py
@@ -441,3 +441,50 @@ def test_snapshot_applies_cursor_before_the_six_item_report_limit(
     assert second is not None
     assert len(second["items"]) == 1
     assert second["items"][0]["title"] == "Completed item 0."
+
+
+def test_snapshot_skips_done_items_without_valid_completion_timestamps(
+    tmp_path: Path,
+) -> None:
+    state = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Valid outcome with receipt.\n"
+        "  <!-- loopx:todo todo_id=todo_valid status=done task_class=advancement_task "
+        f"claimed_by={AGENT_ID} updated_at=2026-08-01T07:00:00Z -->\n"
+        "- [x] Handwritten outcome without a timestamp.\n"
+        "  <!-- loopx:todo todo_id=todo_handwritten status=done"
+        f" task_class=advancement_task claimed_by={AGENT_ID} -->\n"
+        "- [x] Naive timestamp outcome.\n"
+        "  <!-- loopx:todo todo_id=todo_naive status=done task_class=advancement_task "
+        f"claimed_by={AGENT_ID} updated_at=2026-08-01T07:30:00 -->\n"
+    )
+    snapshot = build_project_progress_snapshot_from_state(
+        state_text=state,
+        goal={"id": GOAL_ID},
+        state_path=tmp_path / "goal.md",
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        completed_at="2026-08-01T08:00:00Z",
+    )
+
+    assert snapshot is not None
+    assert [item["source_ref"] for item in snapshot["items"]] == ["todo:todo_valid"]
+    assert snapshot["items"][0]["completed_at"] == "2026-08-01T07:00:00Z"
+
+    handwritten_only = (
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [x] Handwritten outcome without a timestamp.\n"
+        "  <!-- loopx:todo todo_id=todo_handwritten status=done"
+        f" task_class=advancement_task claimed_by={AGENT_ID} -->\n"
+    )
+    assert (
+        build_project_progress_snapshot_from_state(
+            state_text=handwritten_only,
+            goal={"id": GOAL_ID},
+            state_path=tmp_path / "goal.md",
+            goal_id=GOAL_ID,
+            agent_id=AGENT_ID,
+            completed_at="2026-08-01T08:00:00Z",
+        )
+        is None
+    )

--- a/tests/capabilities/test_periodic_report_pending_intent.py
+++ b/tests/capabilities/test_periodic_report_pending_intent.py
@@ -513,6 +513,37 @@ def test_consumption_uses_the_stage_progress_snapshot(tmp_path: Path) -> None:
     )
 
 
+def test_consumption_skips_done_todos_without_valid_completion_timestamps(
+    tmp_path: Path,
+) -> None:
+    registry, runtime = _fixture(tmp_path)
+    state_path = registry.parent / "ACTIVE_GOAL_STATE.md"
+    state_path.write_text(
+        state_path.read_text(encoding="utf-8")
+        + "- [x] Handwritten outcome without a timestamp.\n"
+        "  <!-- loopx:todo todo_id=todo_handwritten status=done"
+        f" task_class=advancement_task claimed_by={AGENT_ID} -->\n",
+        encoding="utf-8",
+    )
+
+    result = consume_pending_periodic_report_intent(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+        execute=True,
+    )
+    assert result["status"] == "editorial_required"
+    request = json.loads(
+        Path(result["editorial_request_path"]).read_text(encoding="utf-8")
+    )
+    facts = request["facts"]
+
+    assert [fact["source_ref"] for fact in facts] == ["todo:todo_finished"]
+    assert facts[0]["completed_at"] == "2026-08-30T09:00:00Z"
+    assert not any("Handwritten outcome" in fact["title"] for fact in facts)
+
+
 def test_publication_candidate_keeps_the_trigger_snapshot_baseline(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Completed-todo facts in the periodic-report progress snapshot could carry a missing or naive `completed_at`, which wedged the downstream pending intent permanently or escaped the typed boundary with a `TypeError`.
- Facts with a missing/invalid `completed_at` timestamp are now skipped at snapshot construction (fail-closed to "do not publish malformed data"), and the stage-window comparison treats naive timestamps as invalid values instead of raising.
- Two regression tests cover both paths; neither path had any coverage before (existing fixtures always populate `updated_at`).

## Issue Or Task

- Closes #
- Contributor task ID:

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other: focused pytest subset (`tests/capabilities/test_periodic_report*.py`) green; red/green probe confirmed the new tests fail when the guard is removed; `ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation` clean.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [x] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: main
- Direction tracker or promotion unit:

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
