### PR TITLE
docs(extension): bound OpenAI-compatible rate-limit waits

### DIFF
--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -22,6 +22,8 @@ ports, accounts or private receipts.
 | Provider history and SSE normalizer prototypes | Upstreamed, not duplicated | CLIProxyAPI PR #5410 supersedes closed PR #5220 as the implementation owner |
 | uTLS connection experiments | Upstreamed, not duplicated | CLIProxyAPI PR #5261 is the implementation owner |
 | Route-specific fallback ring | Upstreamed, not duplicated | CLIProxyAPI PR #5336 is the implementation owner |
+| OpenAI-compatible bounded rate-limit waits | Upstreamed, not duplicated | CLIProxyAPI PR #5435 propagates `Retry-After`, uses a one-minute fallback only for explicit TPM limits, and leaves generic 429 behavior unchanged |
+| Delimiterless compatible SSE and recoverable orphan host outputs | Integrated public-safe patch, not duplicated | The CPA integration candidate carries the protocol repair until its upstream dependency chain is ready for an independent PR |
 
 ## Configuration References
 
@@ -43,7 +45,9 @@ The package keeps six credential-free examples:
 
 [`templates/codex-app-config.toml`](templates/codex-app-config.toml) and
 [`templates/cpa-config.public.yaml`](templates/cpa-config.public.yaml) preserve
-the working field shape and retry/Fast defaults. They contain placeholders and
+the working field shape and retry/Fast defaults. The App keeps its 30/30 outer
+recovery budget, while the OpenAI-compatible text fallback gets one additional
+provider round and a 65-second cooldown ceiling. They contain placeholders and
 omit all credential-bearing CPA sections. The extension never fills those
 placeholders or writes the templates into a Codex home.
 

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -94,7 +94,7 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 [`codex/integrated-dev`](https://github.com/huangruiteng/CLIProxyAPI/tree/codex/integrated-dev)
 按依赖顺序组合：history/SSE → uTLS transport → modality admission/normalizer → route fallback
 → delimiterless SSE / orphan host-output repair → bounded rate-limit waits。当前锁定 base 为
-`origin/dev@18e01a7`，候选 head 为 `a50250d`。这只是可回滚的 self-use candidate，不是
+`origin/dev@18e01a7`，候选 head 为 `5fec841`。这只是可回滚的 self-use candidate，不是
 upstream release。
 
 `reconcile_integration_candidate` 保存 source order、exact heads、required seams、current
@@ -108,9 +108,9 @@ base/source/head 漂移都只产生 `sync_required`；monitor 不自动合并或
 
 | 项目 | 锁定版本 | 本 runbook 使用的边界 |
 | --- | --- | --- |
-| CPA self-use build | operator-owned private receipt；当前公共整合候选为 `codex/integrated-dev@a50250d` | 多 Codex OAuth、provider-bound history、`additional_tools`、commit-before-failover、Ark Responses/SSE normalizer 与有界 rate-limit wait；二进制 digest 与安装位置不进入公共仓库 |
+| CPA self-use build | operator-owned private receipt；当前公共整合候选为 `codex/integrated-dev@5fec841` | 多 Codex OAuth、provider-bound history、`additional_tools`、已确认宿主控制输出的孤儿恢复、commit-before-failover、Ark Responses/SSE normalizer 与有界 rate-limit wait；二进制 digest 与安装位置不进入公共仓库 |
 | CPA upstream release baseline | [`a7e3596b7e351d800e58ed29529fbca3d1c18737`](https://github.com/router-for-me/CLIProxyAPI/commit/a7e3596b7e351d800e58ed29529fbca3d1c18737) | `fill-first`、priority、prefix、session affinity、stream bootstrap buffering、OpenAI-compatible provider 的原始基线 |
-| CPA public history candidate | [PR #5410 head `6f1c08c3603fe318d3cdde1db4f3cf8b030f6742`](https://github.com/router-for-me/CLIProxyAPI/pull/5410) | 当前 `dev` 上的 provider-history / SSE candidate；CI 通过，等待 review，不等于 upstream release |
+| CPA public history candidate | [PR #5410 head `952e2f587fa26934c32f8be80d7042e46a492b33`](https://github.com/router-for-me/CLIProxyAPI/pull/5410) | 当前 `dev` 上的 provider-history / SSE candidate；只恢复已确认且无 matching call 的宿主控制输出，未知或损坏的 tool history 仍 fail closed；等待 CI 与 review，不等于 upstream release |
 | ChatGPT uTLS transport candidate | [PR #5261 head `c8e76e1e76aba4cc2206cec9d2a6444c9f527998`](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | 复用 HTTP/2 transport、TLS session resumption、draining/异常连接重建；CI 已通过且 mergeable，仍在等待 review |
 | OpenAI-compatible rate-limit candidate | [PR #5435 head `6f16121554df25c9f9ab8de41e7b8157ef2d3c35`](https://github.com/router-for-me/CLIProxyAPI/pull/5435) | 透传 delta-seconds / HTTP-date `Retry-After`；只有明确 TPM 429 且 header 缺失时才使用一分钟 fallback；CI 与自动 review 通过，等待 maintainer review |
 | Passive quota observation | [PR #5211 merge `ca601db05d858472b25e7c56580555ab62b90e68`](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | management API 暴露 bounded quota signal 与 200 分钟 recent-request buckets；原始 auth identity 只在 operator adapter 内使用 |
@@ -131,7 +131,7 @@ base/source/head 漂移都只产生 `sync_required`；monitor 不自动合并或
 锁定 CPA baseline 上形成的 candidate 已 forward-port 到当前 `dev`，原 PR #5220 被 stale-base
 guard 自动关闭后由 [CLIProxyAPI PR #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410)
 替代。当前 self-use 二进制由 operator-owned private receipt 锁定，公共 history candidate head
-为 `6f1c08c`；它覆盖 provider-neutral `additional_tools` 与当前 review fixes。
+为 `952e2f5`；它覆盖 provider-neutral `additional_tools`、已确认孤儿宿主控制输出与当前 review fixes。
 上游 merge 仍是升级与公共分发渠道，不再是本机自用的前置条件。上游合并后仍须锁定
 merge commit，并重新运行本文矩阵。
 当前证据边界如下：
@@ -139,7 +139,7 @@ merge commit，并重新运行本文矩阵。
 | Surface | 当前进展 | 证据边界 |
 | --- | --- | --- |
 | A → B credential failover | loopback 与 live 均通过 | `fill-first`、priority、session affinity 与 commit 前 stream failover 已验证；live auto 请求在 A 建连失败后由 B 完成 |
-| Provider-bound history normalization | candidate、stale-task 与 `additional_tools` 回归通过 | 同 provider 的 A → B 也视为 scope 变化；跨 scope 时移除异源 identity / opaque state，保留可移植 summary、namespace/tool schema 与 tool call/result 因果链；unsupported item 仍返回 typed `409` |
+| Provider-bound history normalization | candidate、stale-task 与 `additional_tools` 回归通过 | 同 provider 的 A → B 也视为 scope 变化；跨 scope 时移除异源 identity / opaque state，保留可移植 summary、namespace/tool schema 与 tool call/result 因果链；仅丢弃已确认、无 `call_id` 且无 matching call 的宿主控制输出，unknown / paired missing-`call_id` 与 unsupported item 仍返回 typed `409` |
 | Ark Responses SSE lifecycle normalizer | candidate 与真实 endpoint 通过 | 只对显式 `is-compat: true` 的模型启用；原生 Codex stream 保持原字节路径；真实 Ark HTTP/SSE 返回完整 lifecycle |
 | A/B 环 → Ark 组合路径 | loopback 与分层 live 证据通过 | A → B、Prefer B → A 与隔离 A/B 后的 Ark tail 均已在 integrated self-use candidate 通过；公共分发仍依赖 CPA PR #5336 |
 | Route traversal readback | public contract 与 self-use live 均通过 | qualification 同时读回 entrypoint、ordered candidates、terminal tail 与 `max_cycles = 1`；只看到正确 selector 标签不能通过 |
@@ -148,7 +148,7 @@ merge commit，并重新运行本文矩阵。
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
 | Fast tier 投影 | 本机与 SSH App Server readback 通过 | Auto、Prefer A、Prefer B 各有显式 `fast/` sibling 行，默认 tier 为 `fast` 并在请求规整时强制 `priority`；普通行与 Luna 保持 `default`，Fast 行不进入 Ark |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | quota PR 已合并；四个分发 PR CI 通过 | #5211 merge `ca601db0`；#5410 head `6f1c08c`、#5261 head `c8e76e1`、#5336 head `cc16e38`、#5435 head `6f16121` 均等待 maintainer review |
+| CPA upstream review | quota PR 已合并；四个分发 PR 等待 maintainer review | #5211 merge `ca601db0`；#5410 head `952e2f5` 正在重跑 CI，#5261 head `c8e76e1`、#5336 head `cc16e38`、#5435 head `6f16121` 的既有 CI 已通过 |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
 | Ark 限流等待与大上下文重放 | candidate 与真实 endpoint 回归通过 | Codex App 保留 30/30 外层恢复预算；Ark provider 只允许一个附加 round，`Retry-After` 受 65 秒 ceiling 约束；明确 TPM 且无 header 时只补一个 60 秒窗口，普通 429 不臆造窗口 |
@@ -287,7 +287,7 @@ git clone https://github.com/router-for-me/CLIProxyAPI.git
 cd CLIProxyAPI
 git remote add self-use https://github.com/huangruiteng/CLIProxyAPI.git
 git fetch self-use codex/integrated-dev
-git checkout --detach a50250d9dfc5bd6c53c799d22cc470dd09b5278c
+git checkout --detach 5fec8415f647f5e2911426103a2671fa22cd301c
 go build -o ./bin/cliproxyapi ./cmd/server
 ```
 
@@ -787,7 +787,7 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 | Upstream | 计划 | 合并门槛 |
 | --- | --- | --- |
-| CPA | **公共分发 PR**：[history / SSE normalization #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) head `6f1c08c`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `cc16e38`；[OpenAI-compatible bounded rate-limit waits #5435](https://github.com/router-for-me/CLIProxyAPI/pull/5435) head `6f16121` | 截至 2026-09-03，四者 CI 通过并等待 review；self-use 锁定 integrated fork SHA，但不得把它表述为 upstream release |
+| CPA | **公共分发 PR**：[history / SSE normalization #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) head `952e2f5`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `cc16e38`；[OpenAI-compatible bounded rate-limit waits #5435](https://github.com/router-for-me/CLIProxyAPI/pull/5435) head `6f16121` | 截至 2026-09-03，#5410 更新后正在重跑 CI，其余三者既有 CI 通过；四者均等待 review；self-use 锁定 integrated fork SHA，但不得把它表述为 upstream release |
 | CPA modality-aware Auto | **待提交公共 PR**：required-modality admission、affinity invalidation、无 eligible provider 的 typed error | 先用 text-only fallback + image history 复现；验证 A/B 正常、B 网络失败、A/B 全不可用与旧 Ark affinity 四类路径；不得把图片剥离后继续文本请求 |
 | AgentSwap | **条件 PR**：只有 locked commit 的 Codex writer 不能保持 multipart tool-result 1:1，或需要 provider-neutral checkpoint export 时才提交 | round-trip test 先复现真实缺口；不增加在线 retry、模型选择或第二 data plane |
 | Codex App / App Server | **待验证上游 seam**：settings revision 持久化/readback 与 turn-start 原子顺序；compaction barrier 仍只需要 fork + navigate host hook | 新 turn 必须证明采用新 revision；旧 turn 的 retry 不得被 UI 显示伪装为新模型；hook 不获得 provider 路由、凭据或 LoopX authority |
@@ -796,7 +796,7 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 所以近期技术选型不是 CPA 或 AgentSwap 二选一，而是 **CPA online + AgentSwap offline**，
 同时保持单一在线 authority。当前自用运行锁定 operator-owned private receipt，公共 history
-候选跟踪 #5410 head `6f1c08c`，都不等待 upstream review 才能做本机资格验证；上游合并后再把 merge
+候选跟踪 #5410 head `952e2f5`，都不等待 upstream review 才能做本机资格验证；上游合并后再把 merge
 commit 作为升级候选并重跑 qualification。#5261 已进入 integrated self-use candidate 并完成连接
 复用、异常重建、session resumption 与安全重放矩阵；上游合并版本仍需重新资格化。AgentSwap 只有在独立、可复现的迁移
 缺口出现时才改。Codex App PR 不阻塞日常切换，只决定 barrier case 能否“一键 fork

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -65,10 +65,12 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 | LoopX | [#3737](https://github.com/huangruiteng/loopx/pull/3737) | merged | 增加 Luna，并把 A/B 选择收敛为同一账号环的首选入口 |
 | LoopX | [#3804](https://github.com/huangruiteng/loopx/pull/3804) | merged | 将宿主身份、路由选择、额度与真实 attempt chain 投影为无密运行状态 |
 | LoopX | [#3805](https://github.com/huangruiteng/loopx/pull/3805) | merged | 生成显式 Fast sibling rows，固化 `fast/` request normalization、默认 tier 与 A/B-only fallback |
+| LoopX | [#3828](https://github.com/huangruiteng/loopx/pull/3828) | merged | 把多 PR 整合候选、exact-head 漂移检测与可回滚部署顺序纳入 extension |
 | CLIProxyAPI | [#5211](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | merged | 被动观测 per-auth quota header 与最近请求计数；management 原始身份字段仍须由 operator adapter 脱敏 |
 | CLIProxyAPI | [#5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) | open / review required | provider-bound Responses history、`additional_tools` 与 Ark SSE normalizer；替代被自动关闭且无法 reopen 的 #5220 |
 | CLIProxyAPI | [#5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | open / review required | ChatGPT uTLS HTTP/2 连接池、TLS session resumption 与异常重建 |
 | CLIProxyAPI | [#5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) | open / review required | per-route credential priority；同一 A/B 账号环支持 Prefer A 与 Prefer B 两个入口 |
+| CLIProxyAPI | [#5435](https://github.com/router-for-me/CLIProxyAPI/pull/5435) | open / review required | 透传 OpenAI-compatible `Retry-After`；仅对明确 TPM 限流补一分钟有界等待，普通 429 不猜窗口 |
 
 这个索引只收录直接改变本能力契约、运行面或上游实现的 PR，不扩张成作者的全部 PR 列表。
 新 PR 创建后要在同一 PR 内登记；merge 后把状态和锁定 head/merge commit 一起刷新。
@@ -88,11 +90,12 @@ SSH 运行面的演进；CPA PR 承载进入在线 data plane 的通用修复。
 
 ### 持久整合候选
 
-三个公开 PR 与一个 operator-owned public-safe modality patch 通过
+四个公开 PR 与两个 operator-owned public-safe compatibility patches 通过
 [`codex/integrated-dev`](https://github.com/huangruiteng/CLIProxyAPI/tree/codex/integrated-dev)
-按依赖顺序组合：history/SSE → uTLS transport → modality admission/normalizer → route fallback。
-当前锁定 base 为 `origin/dev@8deeb4a`，候选 head 为 `4df2bf1`。这只是可回滚的 self-use
-candidate，不是 upstream release。
+按依赖顺序组合：history/SSE → uTLS transport → modality admission/normalizer → route fallback
+→ delimiterless SSE / orphan host-output repair → bounded rate-limit waits。当前锁定 base 为
+`origin/dev@18e01a7`，候选 head 为 `a50250d`。这只是可回滚的 self-use candidate，不是
+upstream release。
 
 `reconcile_integration_candidate` 保存 source order、exact heads、required seams、current
 observation 与 last-sync receipt，并把 Git 合并输入交给 LoopX core `integration-branch`。任何
@@ -105,10 +108,11 @@ base/source/head 漂移都只产生 `sync_required`；monitor 不自动合并或
 
 | 项目 | 锁定版本 | 本 runbook 使用的边界 |
 | --- | --- | --- |
-| CPA self-use build | operator-owned private receipt；当前公共整合候选为 `codex/integrated-dev@4df2bf1` | 多 Codex OAuth、provider-bound history、`additional_tools`、commit-before-failover、Ark Responses/SSE normalizer；二进制 digest 与安装位置不进入公共仓库 |
+| CPA self-use build | operator-owned private receipt；当前公共整合候选为 `codex/integrated-dev@a50250d` | 多 Codex OAuth、provider-bound history、`additional_tools`、commit-before-failover、Ark Responses/SSE normalizer 与有界 rate-limit wait；二进制 digest 与安装位置不进入公共仓库 |
 | CPA upstream release baseline | [`a7e3596b7e351d800e58ed29529fbca3d1c18737`](https://github.com/router-for-me/CLIProxyAPI/commit/a7e3596b7e351d800e58ed29529fbca3d1c18737) | `fill-first`、priority、prefix、session affinity、stream bootstrap buffering、OpenAI-compatible provider 的原始基线 |
 | CPA public history candidate | [PR #5410 head `6f1c08c3603fe318d3cdde1db4f3cf8b030f6742`](https://github.com/router-for-me/CLIProxyAPI/pull/5410) | 当前 `dev` 上的 provider-history / SSE candidate；CI 通过，等待 review，不等于 upstream release |
 | ChatGPT uTLS transport candidate | [PR #5261 head `c8e76e1e76aba4cc2206cec9d2a6444c9f527998`](https://github.com/router-for-me/CLIProxyAPI/pull/5261) | 复用 HTTP/2 transport、TLS session resumption、draining/异常连接重建；CI 已通过且 mergeable，仍在等待 review |
+| OpenAI-compatible rate-limit candidate | [PR #5435 head `6f16121554df25c9f9ab8de41e7b8157ef2d3c35`](https://github.com/router-for-me/CLIProxyAPI/pull/5435) | 透传 delta-seconds / HTTP-date `Retry-After`；只有明确 TPM 429 且 header 缺失时才使用一分钟 fallback；CI 与自动 review 通过，等待 maintainer review |
 | Passive quota observation | [PR #5211 merge `ca601db05d858472b25e7c56580555ab62b90e68`](https://github.com/router-for-me/CLIProxyAPI/pull/5211) | management API 暴露 bounded quota signal 与 200 分钟 recent-request buckets；原始 auth identity 只在 operator adapter 内使用 |
 | AgentSwap | [`c9b76f4a4adae81274eb8f52d428bba925a1a7ef`](https://github.com/bojieli/agentswap/commit/c9b76f4a4adae81274eb8f52d428bba925a1a7ef) | `teleport` / `handoff`、`--dry-run`、`--compact`、`--budget` |
 | Codex protocol reference | [`40b7560169c7274147a47f9b0c75db89fe016d34`](https://github.com/openai/codex/commit/40b7560169c7274147a47f9b0c75db89fe016d34) | `ResponseItem::Reasoning`、history normalization 和 remote compaction 行为的源码参照 |
@@ -144,9 +148,10 @@ merge commit，并重新运行本文矩阵。
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
 | Fast tier 投影 | 本机与 SSH App Server readback 通过 | Auto、Prefer A、Prefer B 各有显式 `fast/` sibling 行，默认 tier 为 `fast` 并在请求规整时强制 `priority`；普通行与 Luna 保持 `default`，Fast 行不进入 Ark |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
-| CPA upstream review | quota PR 已合并；三个分发 PR CI 通过 | #5211 merge `ca601db0`；#5410 head `6f1c08c`、#5261 head `c8e76e1`、#5336 head `cc16e38` 均等待 maintainer review |
+| CPA upstream review | quota PR 已合并；四个分发 PR CI 通过 | #5211 merge `ca601db0`；#5410 head `6f1c08c`、#5261 head `c8e76e1`、#5336 head `cc16e38`、#5435 head `6f16121` 均等待 maintainer review |
 | 上游回归 | 候选与当前 `dev` 已集成验证 | changed packages、race 与 server build 通过；全仓仅命中既有 `internal/home` 一秒同步 flake，同一失败在干净 `origin/dev` 上 50 次复现 2 次，PR 未改该目录，也不声称该测试通过 |
 | 真实 Ark endpoint qualification | 基础 Responses 与 auto fallback 已通过 | source-built candidate 经隔离 CPA 调用真实 OpenAI-compatible endpoint：HTTP 200、唯一 terminal，output item 严格 `added/done` 配对；额度分类由公开安全的黑盒 fixture 覆盖 |
+| Ark 限流等待与大上下文重放 | candidate 与真实 endpoint 回归通过 | Codex App 保留 30/30 外层恢复预算；Ark provider 只允许一个附加 round，`Retry-After` 受 65 秒 ceiling 约束；明确 TPM 且无 header 时只补一个 60 秒窗口，普通 429 不臆造窗口 |
 | 当前 Codex App | self-use 配置已安装并完成 CLI / App Server readback | 主 App 与 SSH host 都指向 loopback CPA；模型目录变化需要重启或重连对应 App Server 才能刷新 UI cache，旧 task store 不复制、不删除 |
 
 这张表刻意区分“adapter 证据”“provider 基础连通证据”和“live 路由证据”。真实 A → B
@@ -282,7 +287,7 @@ git clone https://github.com/router-for-me/CLIProxyAPI.git
 cd CLIProxyAPI
 git remote add self-use https://github.com/huangruiteng/CLIProxyAPI.git
 git fetch self-use codex/integrated-dev
-git checkout --detach 4df2bf1991ce1c9ebde7a2637d1158ddba3cdb14
+git checkout --detach a50250d9dfc5bd6c53c799d22cc470dd09b5278c
 go build -o ./bin/cliproxyapi ./cmd/server
 ```
 
@@ -340,7 +345,13 @@ compatibility matrix 通过后使用下面的高韧性 profile：
 # CPA：上游 credential / provider 重试层
 request-retry: 10
 max-retry-credentials: 0
-max-retry-interval: 0
+max-retry-interval: 65
+
+openai-compatibility:
+  - name: "<OPENAI_COMPATIBILITY_TEXT_FALLBACK>"
+    request-retry: 1
+    # base-url、models 与 api-key-entries 由 operator-owned secret/bootstrap
+    # 流程注入，不进入公共模板。
 ```
 
 ```toml
@@ -353,11 +364,14 @@ stream_max_retries = 30
 通过后的显式选择，不应回填成 CPA 通用默认值；升级 Codex、CPA 或 tool schema 后，仍要
 重新验证 spawn、wait、tool result、`additional_tools` 和 provider 切换。
 
-这些数字是当前故障分布下的**上限**，不是所有部署都应照抄的通用默认值。`10` 表示首轮
-credential 遍历之后最多允许十个附加 round；`max-retry-credentials: 0` 表示每轮不再
-人为截断 eligible credential；`max-retry-interval: 0` 表示 CPA 不等待 cooldown 后再开
-下一轮。App 的 `30 / 30` 是 CPA 之外的最后恢复余量，不代表每个 provider 都固定调用
-三十次。任何一层都必须服从请求取消、提交边界和端到端 wall-clock budget。
+这些数字是当前故障分布下的**上限**，不是所有部署都应照抄的通用默认值。全局 `10`
+保留 Codex credential 环的快速恢复余量；`max-retry-credentials: 0` 表示每轮不再人为截断
+eligible credential。OpenAI-compatible text fallback 用 provider override 收紧为 `1`：首轮
+失败后最多再尝试一次，避免同一大上下文在分钟限流窗口内被快速重放。`65` 只允许 CPA
+等待一个 provider 声明的分钟窗口及少量调度抖动，不是固定 sleep；没有 `Retry-After`
+且错误未明确声明 TPM 限流时，不臆造一分钟 cooldown。App 的 `30 / 30` 是 CPA 之外的
+最后恢复余量，不代表每个 provider 都固定调用三十次。任何一层都必须服从请求取消、
+提交边界和端到端 wall-clock budget。
 
 把重试分层，不能只把三个数字相乘：
 
@@ -373,7 +387,7 @@ credential 遍历之后最多允许十个附加 round；`max-retry-credentials: 
 1. DNS、TCP、TLS 或空闲 HTTP/2 连接失效：优先重用连接池；确需重拨时使用已有 TLS
    session。连接级第一次安全重拨立即执行，不先 sleep。
 2. 401：只刷新一次对应 credential；仍失败则标记该 credential 不健康并进入下一项。
-3. quota、overload、429 或可恢复 5xx：只在首个可见生成事件前遍历一次 A/B 环，再按 route 决定是否进入 Ark tail。
+3. quota、overload、429 或可恢复 5xx：只在首个可见生成事件前遍历一次 A/B 环，再按 route 决定是否进入 Ark tail。OpenAI-compatible 响应带 `Retry-After` 时保留其 delta-seconds 或 HTTP-date；header 缺失时只有明确 TPM 限流才补一分钟窗口，普通 429 继续走通用 bounded backoff。
 4. schema / lifecycle 破坏、foreign compaction barrier、不可恢复 4xx：fail closed，不用高
    retry 上限掩盖协议错误。
 5. 已发送文本 delta、tool call 或 tool result：返回明确错误和恢复入口，禁止透明重放。
@@ -387,8 +401,9 @@ credential 遍历之后最多允许十个附加 round；`max-retry-credentials: 
   和 TLS session cache；缓存淘汰时关闭 idle connection。对应公共实现见
   [CLIProxyAPI PR #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261)。
 - 第一条连接级安全重拨立即执行；后续外层重试使用 bounded exponential backoff + jitter。
-  CPA 当前 `max-retry-interval: 0` 用于快速轮转已知 eligible 项，不能取消 health / cooldown
-  分类后反复敲击同一个已失败 provider。
+  CPA 的 `max-retry-interval: 65` 只给已分类的 cooldown 一个上限；无等待的 eligible
+  credential 仍可快速轮转，但不能取消 health / cooldown 分类后反复敲击同一个已失败
+  provider。
 - 给整次 turn 设置 wall-clock budget，而不是在 CPA 已建立上游连接后增加固定响应 timeout。
   budget 耗尽就返回可恢复错误；不要因为 `10` 和 `30 / 30` 都未用完而继续等待。
 - 至少观测 DNS、TCP connect、TLS handshake、TLS resumed、HTTP/2 reused、TTFB、首个可见
@@ -758,6 +773,7 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 | Fast request normalization | 在 alias mapping 前捕获原始 `fast/` selector；剥离前缀后保持同一底层 route；普通 selector 的 model/tier 不被误改 |
 | SSH host 重连 | 同 alias、同远端 `CODEX_HOME` 下旧 task 可继续；catalog/CLI 刷新不删除或复制 session store |
 | 首字节前 quota / overload | CPA 可重试下一 eligible auth；客户端只看到一条回答 |
+| OpenAI-compatible 429 | delta-seconds / HTTP-date `Retry-After` 原样进入 cooldown；明确 TPM 且无 header 时最多等待一个 60 秒窗口；普通 429 不臆造窗口；Ark lane 最多一个附加 round |
 | 空闲 HTTP/2 连接断开 | 下一条安全请求自动重建连接；TLS session 恢复；不重复已提交输出 |
 | 高 retry profile | 故障注入下成功率不低于 qualification baseline；attempt 有界；p50/p95 TTFB、总 wall-clock 和分层错误可解释 |
 | 文本或 tool call 后失败 | 不透明重试；返回可恢复错误 |
@@ -771,7 +787,7 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 | Upstream | 计划 | 合并门槛 |
 | --- | --- | --- |
-| CPA | **公共分发 PR**：[history / SSE normalization #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) head `6f1c08c`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `cc16e38` | 截至 2026-09-02，三者 CI 通过并等待 review；self-use 锁定 integrated fork SHA，但不得把它表述为 upstream release |
+| CPA | **公共分发 PR**：[history / SSE normalization #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) head `6f1c08c`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `cc16e38`；[OpenAI-compatible bounded rate-limit waits #5435](https://github.com/router-for-me/CLIProxyAPI/pull/5435) head `6f16121` | 截至 2026-09-03，四者 CI 通过并等待 review；self-use 锁定 integrated fork SHA，但不得把它表述为 upstream release |
 | CPA modality-aware Auto | **待提交公共 PR**：required-modality admission、affinity invalidation、无 eligible provider 的 typed error | 先用 text-only fallback + image history 复现；验证 A/B 正常、B 网络失败、A/B 全不可用与旧 Ark affinity 四类路径；不得把图片剥离后继续文本请求 |
 | AgentSwap | **条件 PR**：只有 locked commit 的 Codex writer 不能保持 multipart tool-result 1:1，或需要 provider-neutral checkpoint export 时才提交 | round-trip test 先复现真实缺口；不增加在线 retry、模型选择或第二 data plane |
 | Codex App / App Server | **待验证上游 seam**：settings revision 持久化/readback 与 turn-start 原子顺序；compaction barrier 仍只需要 fork + navigate host hook | 新 turn 必须证明采用新 revision；旧 turn 的 retry 不得被 UI 显示伪装为新模型；hook 不获得 provider 路由、凭据或 LoopX authority |
@@ -806,6 +822,9 @@ commit 作为升级候选并重跑 qualification。#5261 已进入 integrated se
 7. **连接复用升级（self-use 已完成，上游待 review）**：#5261 已通过公共 CI 与 integrated
    self-use matrix，覆盖 HTTP/2 reuse、TLS resumed、draining transport close、异常重建和
    已提交输出不重放；上游合并后仍要以 merge commit 重新验证。
+8. **Ark 限流等待（self-use 已完成，上游待 review）**：#5435 已通过公共 CI、自动 review
+   与 integrated self-use 回归。App 仍保留 30/30；CPA 只为 Ark provider 代等一个明确窗口，
+   避免快速重放大上下文。上游合并后仍要以 merge commit 重新验证。
 
 回滚时停止新 CPA，恢复升级前的 Codex provider 配置和旧二进制 symlink。不要回滚 session
 数据库，不删除新 task，也不要把新旧 `CODEX_HOME` 合并。CC Switch 在这里提供 profile

--- a/packages/loopx-codex-provider-routing/examples/integration-candidate.json
+++ b/packages/loopx-codex-provider-routing/examples/integration-candidate.json
@@ -6,8 +6,10 @@
       "base_sha": "1111111111111111111111111111111111111111",
       "integration_sha": "6666666666666666666666666666666666666666",
       "source_heads": {
+        "compat-stream-repair": "7777777777777777777777777777777777777777",
         "history-normalization": "2222222222222222222222222222222222222222",
         "modality-routing": "4444444444444444444444444444444444444444",
+        "rate-limit-wait": "8888888888888888888888888888888888888888",
         "route-fallback": "5555555555555555555555555555555555555555",
         "transport-pool": "3333333333333333333333333333333333333333"
       }
@@ -16,8 +18,10 @@
       "base_sha": "1111111111111111111111111111111111111111",
       "integration_sha": "6666666666666666666666666666666666666666",
       "source_heads": {
+        "compat-stream-repair": "7777777777777777777777777777777777777777",
         "history-normalization": "2222222222222222222222222222222222222222",
         "modality-routing": "4444444444444444444444444444444444444444",
+        "rate-limit-wait": "8888888888888888888888888888888888888888",
         "route-fallback": "5555555555555555555555555555555555555555",
         "transport-pool": "3333333333333333333333333333333333333333"
       }
@@ -28,7 +32,8 @@
       "transport_pool",
       "modality_routing",
       "request_normalizer",
-      "route_fallback"
+      "route_fallback",
+      "retry_policy"
     ],
     "sources": [
       {
@@ -68,6 +73,25 @@
         "id": "route-fallback",
         "kind": "pull_request",
         "ref": "fork/route-specific-fallback"
+      },
+      {
+        "changed_seams": [
+          "history_projection",
+          "sse_lifecycle"
+        ],
+        "head_sha": "7777777777777777777777777777777777777777",
+        "id": "compat-stream-repair",
+        "kind": "public_safe_patch",
+        "ref": "operator/compat-stream-repair"
+      },
+      {
+        "changed_seams": [
+          "retry_policy"
+        ],
+        "head_sha": "8888888888888888888888888888888888888888",
+        "id": "rate-limit-wait",
+        "kind": "pull_request",
+        "ref": "fork/openai-compat-bounded-rate-limit-waits"
       }
     ]
   },

--- a/packages/loopx-codex-provider-routing/examples/upgrade-request.json
+++ b/packages/loopx-codex-provider-routing/examples/upgrade-request.json
@@ -9,6 +9,7 @@
       "model_catalog",
       "modality_routing",
       "request_normalizer",
+      "retry_policy",
       "route_fallback",
       "settings_revision"
     ],

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import importlib
 import json
+import re
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -24,6 +25,32 @@ project_runtime_status = contract.project_runtime_status
 qualify_heartbeat_transport = contract.qualify_heartbeat_transport
 qualify_snapshot = contract.qualify_snapshot
 reconcile_integration_candidate = contract.reconcile_integration_candidate
+
+
+def _assert_layered_retry_templates() -> None:
+    app = (PACKAGE_ROOT / "templates" / "codex-app-config.toml").read_text()
+    local_cpa = app.split("[model_providers.local-cpa]", maxsplit=1)[1]
+    request_retries = re.search(
+        r"(?m)^request_max_retries\s*=\s*(\d+)\s*$", local_cpa
+    )
+    stream_retries = re.search(
+        r"(?m)^stream_max_retries\s*=\s*(\d+)\s*$", local_cpa
+    )
+    assert request_retries is not None and int(request_retries.group(1)) == 30
+    assert stream_retries is not None and int(stream_retries.group(1)) == 30
+
+    cpa = (PACKAGE_ROOT / "templates" / "cpa-config.public.yaml").read_text()
+    interval = re.search(r"(?m)^max-retry-interval:\s*(\d+)\s*$", cpa)
+    assert interval is not None and int(interval.group(1)) >= 60
+    compat = re.search(
+        r"(?ms)^openai-compatibility:\s*\n(?P<body>(?:^[ \t].*(?:\n|$))*)",
+        cpa,
+    )
+    assert compat is not None
+    provider_retry = re.search(
+        r"(?m)^\s{4}request-retry:\s*(\d+)\s*$", compat.group("body")
+    )
+    assert provider_retry is not None and int(provider_retry.group(1)) == 1
 
 
 def _source() -> dict[str, Any]:
@@ -192,6 +219,7 @@ def expect_error(action: Callable[[], Any], message: str) -> None:
 
 
 def main() -> int:
+    _assert_layered_retry_templates()
     heartbeat = qualify_heartbeat_transport(
         {
             "turn_trigger": "automation_heartbeat",
@@ -605,6 +633,8 @@ def main() -> int:
         "fork/reusable-http2-transport",
         "operator/modality-routing",
         "fork/route-specific-fallback",
+        "operator/compat-stream-repair",
+        "fork/openai-compat-bounded-rate-limit-waits",
     ]
     assert integration["deployment_contract"]["session_store_policy"] == (
         "preserve_in_place_never_copy_or_delete"
@@ -612,9 +642,9 @@ def main() -> int:
 
     moved_source = copy.deepcopy(integration_request["integration"])
     moved_source["observed"]["source_heads"]["transport-pool"] = (
-        "7777777777777777777777777777777777777777"
+        "9999999999999999999999999999999999999999"
     )
-    moved_source["sources"][1]["head_sha"] = "7777777777777777777777777777777777777777"
+    moved_source["sources"][1]["head_sha"] = "9999999999999999999999999999999999999999"
     integration = reconcile_integration_candidate(moved_source)
     assert integration["sync_required"] is True
     assert integration["drift_reasons"] == [
@@ -622,7 +652,7 @@ def main() -> int:
             "kind": "source_moved",
             "source_id": "transport-pool",
             "last_sync_sha": "3333333333333333333333333333333333333333",
-            "observed_sha": "7777777777777777777777777777777777777777",
+            "observed_sha": "9999999999999999999999999999999999999999",
         }
     ]
 

--- a/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
+++ b/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
@@ -10,7 +10,18 @@ remote-management:
 
 request-retry: 10
 max-retry-credentials: 0
-max-retry-interval: 0
+# Permit one provider-declared minute window plus small scheduling jitter. This
+# is a ceiling, not a fixed sleep and not permission to invent a cooldown for a
+# generic 429 that has no Retry-After signal.
+max-retry-interval: 65
+
+# Credential-bearing fields are intentionally omitted. The OpenAI-compatible
+# text fallback uses one additional provider round so an explicit Retry-After,
+# or a provider error that explicitly identifies a TPM window, can be honored
+# once without multiplying a large request across the global retry budget.
+openai-compatibility:
+  - name: "<OPENAI_COMPATIBILITY_TEXT_FALLBACK>"
+    request-retry: 1
 
 routing:
   strategy: "fill-first"


### PR DESCRIPTION
## Summary

- keep the Codex App request/stream recovery budget at 30 while constraining the OpenAI-compatible fallback to one additional provider round
- allow a 65-second cooldown ceiling so provider-supplied `Retry-After` or an explicit TPM fallback can cover one minute window without multiplying large-context replays
- add CLIProxyAPI #5435 and the current integration seams to the public PR lineage and integration-candidate contract
- add a zero-dependency smoke that reads back the App and CPA retry template invariants

## Validation

- `python3 packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py` (Python 3.11 runtime)
- `python -m pytest -q tests/extensions/test_colocated_extension_layout.py` (2 passed)
- `loopx check --scan-path packages/loopx-codex-provider-routing` (public boundary clean; unrelated registry warnings only)
- `loopx canary premerge --from-git-diff` (passed; 8 selected checks, 0 failures, no manual holds)
- `git diff --check`

## Boundary

The change contains only public-safe configuration shape, symbolic integration receipts, documentation, and focused validation. It excludes credentials, account identity, local paths, task/session data, raw provider payloads, and runtime logs. Live installation and secret lifecycle remain operator-owned.

## Future-facing pass

The retry invariant is kept in the existing provider-routing extension and its durable smoke; no new capability or second routing authority is introduced.
