### PR TITLE
fix(lark): compare group-history window bounds chronologically

### DIFF
--- a/loopx/extensions/lark/group_history_cursor.py
+++ b/loopx/extensions/lark/group_history_cursor.py
@@ -26,6 +26,12 @@ def normalize_group_history_timestamp(value: str, *, field: str) -> str:
     return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _timestamp_order_key(value: str) -> datetime:
+    """Compare normalized RFC3339 values by time, not variable-width text."""
+
+    return datetime.fromisoformat(value)
+
+
 def group_history_source_fingerprint(
     *,
     route_key: str,
@@ -98,10 +104,14 @@ def load_group_history_cursor(
     coverage_end = normalize_group_history_timestamp(
         str(raw_coverage_end or ""), field="coverage_end"
     )
+    window_start_time = _timestamp_order_key(window_start)
+    window_end_time = _timestamp_order_key(window_end)
+    coverage_start_time = _timestamp_order_key(coverage_start)
+    coverage_end_time = _timestamp_order_key(coverage_end)
     if (
-        not window_start < window_end
-        or not coverage_start <= coverage_end
-        or (coverage_end > window_end and window_kind != "earlier")
+        not window_start_time < window_end_time
+        or not coverage_start_time <= coverage_end_time
+        or (coverage_end_time > window_end_time and window_kind != "earlier")
     ):
         raise ValueError("Lark group-history cursor window is invalid")
     history_complete = payload.get("history_complete")
@@ -222,8 +232,10 @@ def resolve_group_history_window(
     requested_start: str,
     snapshot_end: str,
 ) -> tuple[dict[str, Any], str, bool]:
+    requested_start_time = _timestamp_order_key(requested_start)
+    snapshot_end_time = _timestamp_order_key(snapshot_end)
     if existing is None:
-        if requested_start >= snapshot_end:
+        if requested_start_time >= snapshot_end_time:
             raise ValueError("Lark group-history start must be earlier than now")
         return (
             _new_group_history_cursor(
@@ -240,10 +252,13 @@ def resolve_group_history_window(
             False,
         )
     state = dict(existing)
+    coverage_start_time = _timestamp_order_key(str(state["coverage_start"]))
+    coverage_end_time = _timestamp_order_key(str(state["coverage_end"]))
+    window_start_time = _timestamp_order_key(str(state["window_start"]))
     if state["history_complete"] is not True:
         forward_start_is_covered = (
             state["window_kind"] == "forward"
-            and state["coverage_start"] <= requested_start <= state["window_start"]
+            and coverage_start_time <= requested_start_time <= window_start_time
         )
         if requested_start != state["window_start"] and not forward_start_is_covered:
             raise ValueError(
@@ -251,11 +266,11 @@ def resolve_group_history_window(
             )
         return state, "resumed", False
     if (
-        requested_start >= state["coverage_start"]
-        and snapshot_end <= state["coverage_end"]
+        requested_start_time >= coverage_start_time
+        and snapshot_end_time <= coverage_end_time
     ):
         return state, "replayed", True
-    if requested_start < state["coverage_start"]:
+    if requested_start_time < coverage_start_time:
         if state["earlier_start_used"] is True:
             raise ValueError(
                 "Lark group-history earlier-start backfill is already used"

--- a/tests/extensions/test_lark_group_history.py
+++ b/tests/extensions/test_lark_group_history.py
@@ -453,6 +453,58 @@ def test_completed_cursor_fetches_new_messages_from_a_later_provider_window(
     assert replay_runner.calls == []
 
 
+def test_completed_cursor_compares_fractional_timestamp_bounds_chronologically(
+    tmp_path: Path,
+) -> None:
+    project, config = _project(tmp_path)
+    initial_now = datetime(2026, 8, 21, tzinfo=UTC)
+    catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=PageRunner(
+            [
+                {
+                    "messages": [_message("om_initial", "initial context")],
+                    "total": 1,
+                    "has_more": False,
+                    "page_token": "",
+                }
+            ]
+        ),
+        now=initial_now,
+    )
+    fractional_now = initial_now.replace(microsecond=500_000)
+    later = PageRunner(
+        [
+            {
+                "messages": [],
+                "total": 0,
+                "has_more": False,
+                "page_token": "",
+            }
+        ]
+    )
+
+    receipt = catch_up_lark_group_history(
+        project=project,
+        config_path=config,
+        route_key="requirements-a",
+        start=START,
+        execute=True,
+        runner=later,
+        now=fractional_now,
+    )
+
+    assert receipt["cursor_transition"] == "forward_window_initialized"
+    assert receipt["external_read_performed"] is True
+    argv = later.calls[0]
+    assert argv[argv.index("--start") + 1] == "2026-08-21T00:00:00Z"
+    assert argv[argv.index("--end") + 1] == "2026-08-21T00:00:00.500000Z"
+
+
 def test_forward_window_resumes_pagination_with_original_requested_start(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Fixes the group-history cursor window comparisons in `group_history_cursor.py` to compare time, not variable-width RFC3339 text.
- A fractional-second snapshot is no longer misclassified as already covered when it is chronologically later.
- Adds a regression test covering a `now` with `.500000` microsecond precision.

## Validation

- `pytest -q tests/extensions/test_lark_group_history.py` (21 passed)
- `ruff check loopx/extensions/lark/group_history_cursor.py tests/extensions/test_lark_group_history.py` (passed)
- `mypy loopx/extensions/lark/group_history_cursor.py` (passed)
- `git diff --check` (passed)
- `loopx change-quality record/verify` (pass, receipt `cqr_132150ac6bec2ff2c12b`)
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard` (gate passed, self_merge_allowed=true)

Follow-up to #3816: the original PR was merged before this fractional-boundary fix landed.
