### PR TITLE
fix(lark): use kernel file lock for collector route reconcile

### DIFF
--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -62,6 +62,7 @@ from ..extensions.runtime import (
     default_extension_state_file,
     resolve_extension_activation,
 )
+from ..file_lock import lock_timeout_error_fields
 
 
 def _goal_inbox_config(
@@ -708,6 +709,7 @@ def handle_lark_inbox_command(
             "ok": False,
             "schema_version": "lark_event_inbox_error_v0",
             "error": str(exc),
+            **lock_timeout_error_fields(exc),
         }
     if activation is not None and payload.get("ok"):
         payload["extension_activation"] = activation

--- a/loopx/extensions/lark/event_collector_routes.py
+++ b/loopx/extensions/lark/event_collector_routes.py
@@ -6,11 +6,11 @@ import hashlib
 import json
 import os
 import tempfile
-from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from ...file_lock import exclusive_file_lock
 from .event_collector import (
     CHAT_RE,
     CONFIG_SCHEMA_VERSION,
@@ -116,21 +116,6 @@ def _atomic_write_collector_config(path: Path, payload: Mapping[str, Any]) -> No
         if descriptor >= 0:
             os.close(descriptor)
         temporary.unlink(missing_ok=True)
-
-
-@contextmanager
-def _collector_route_reconcile_lock(path: Path) -> Iterator[None]:
-    lock_path = path.with_suffix(path.suffix + ".route-reconcile.lock")
-    try:
-        descriptor = os.open(lock_path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-    except FileExistsError as exc:
-        raise ValueError("collector route reconcile is already in progress") from exc
-    try:
-        os.write(descriptor, b"locked\n")
-        yield
-    finally:
-        os.close(descriptor)
-        lock_path.unlink(missing_ok=True)
 
 
 def _prepare_route_reconcile(
@@ -332,7 +317,7 @@ def reconcile_lark_event_collector_route(
             execute=False,
         )
     path = _project_config_path(project, config_path)
-    with _collector_route_reconcile_lock(path):
+    with exclusive_file_lock(path, operation="lark_collector_route_reconcile"):
         return _reconcile_lark_event_collector_route_once(
             project=project,
             config_path=path,

--- a/tests/extensions/test_lark_event_collector_routing.py
+++ b/tests/extensions/test_lark_event_collector_routing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,7 @@ from loopx.extensions.lark.routed_inbox import (
     resolve_routed_lark_inbox_config,
     resolve_routed_lark_inbox_route,
 )
+from loopx.file_lock import LockAcquireTimeoutError, exclusive_file_lock
 
 
 def _project(tmp_path: Path) -> Path:
@@ -301,15 +303,29 @@ def test_collector_route_reconcile_rejects_binding_conflicts_without_writing(
 
 def test_collector_route_reconcile_rejects_concurrent_writer_without_writing(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     project, collector, _, _ = _two_route_config(tmp_path)
     before = collector.read_bytes()
     chat_id = "oc_public_fixture_locked"
     inbox = _write_inbox(project, name="requirements-locked", chat_id=chat_id)
-    lock = collector.with_suffix(collector.suffix + ".route-reconcile.lock")
-    lock.write_text("locked\n", encoding="utf-8")
+    original_lock = exclusive_file_lock
 
-    with pytest.raises(ValueError, match="already in progress"):
+    def fail_fast_lock(
+        path: Path, *, operation: str | None = None
+    ) -> AbstractContextManager[Path]:
+        return original_lock(path, timeout_seconds=0, operation=operation)
+
+    monkeypatch.setattr(
+        event_collector_routes,
+        "exclusive_file_lock",
+        fail_fast_lock,
+    )
+
+    with (
+        exclusive_file_lock(collector, operation="test_lark_route_holder"),
+        pytest.raises(LockAcquireTimeoutError),
+    ):
         reconcile_lark_event_collector_route(
             project=project,
             config_path=collector,
@@ -320,6 +336,81 @@ def test_collector_route_reconcile_rejects_concurrent_writer_without_writing(
         )
 
     assert collector.read_bytes() == before
+
+
+def test_collector_route_reconcile_ignores_released_lock_file(
+    tmp_path: Path,
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+    chat_id = "oc_public_fixture_released_lock"
+    inbox = _write_inbox(project, name="requirements-released-lock", chat_id=chat_id)
+    with exclusive_file_lock(collector, operation="test_released_lark_route_lock"):
+        pass
+
+    receipt = reconcile_lark_event_collector_route(
+        project=project,
+        config_path=collector,
+        route_key="requirements-released-lock",
+        chat_id=chat_id,
+        event_inbox_config=inbox,
+        execute=True,
+    )
+
+    assert receipt["status"] == "applied"
+    assert receipt["write_performed"] is True
+
+
+def test_cli_collector_route_reconcile_preserves_typed_lock_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project, collector, _, _ = _two_route_config(tmp_path)
+    chat_id = "oc_public_fixture_cli_locked"
+    inbox = _write_inbox(project, name="requirements-cli-locked", chat_id=chat_id)
+    monkeypatch.setattr(
+        lark_inbox,
+        "_resolve_lark_activation",
+        lambda *_args, **_kwargs: {"enabled": True},
+    )
+    original_lock = exclusive_file_lock
+
+    def fail_fast_lock(
+        path: Path, *, operation: str | None = None
+    ) -> AbstractContextManager[Path]:
+        return original_lock(path, timeout_seconds=0, operation=operation)
+
+    monkeypatch.setattr(
+        event_collector_routes,
+        "exclusive_file_lock",
+        fail_fast_lock,
+    )
+    rendered: list[dict[str, object]] = []
+    args = argparse.Namespace(
+        command="lark-inbox",
+        lark_inbox_command="collector-route-reconcile",
+        project=str(project),
+        config=str(collector),
+        route_key="requirements-cli-locked",
+        chat_id=chat_id,
+        event_inbox_config=inbox,
+        execute=True,
+    )
+
+    with exclusive_file_lock(collector, operation="test_lark_route_cli_holder"):
+        code = lark_inbox.handle_lark_inbox_command(
+            args,
+            registry_path=tmp_path / "registry.json",
+            runtime_root_arg=None,
+            output_format=lambda _args: "json",
+            print_payload=lambda payload, *_args: rendered.append(payload),
+        )
+
+    assert code == 1
+    assert rendered[0]["error_code"] == "lock_acquire_timeout"
+    assert rendered[0]["incident_recorded"] is True
+    serialized = json.dumps(rendered[0])
+    assert chat_id not in serialized
+    assert inbox not in serialized
+    assert str(project) not in serialized
 
 
 def test_collector_route_reconcile_rolls_back_unverified_write(


### PR DESCRIPTION
## Summary

- Removes `_collector_route_reconcile_lock`, the O_EXCL file-existence lock that could leave a permanent stale sidecar after a hard kill.
- Uses `exclusive_file_lock(path, operation="lark_collector_route_reconcile")`, matching the repository file-lock protocol where kernel ownership, not file existence, determines the lock.
- Preserves a typed `lock_acquire_timeout` envelope from the CLI without leaking the target config path or chat id.
- Adds regression tests for a true concurrent writer, a released lock file, and CLI typed timeout behavior.

## Validation

- `pytest -q tests/extensions/test_lark_event_collector_routing.py` (28 passed)
- `ruff check loopx/cli_commands/lark_inbox.py loopx/extensions/lark/event_collector_routes.py tests/extensions/test_lark_event_collector_routing.py` (passed)
- `mypy loopx/cli_commands/lark_inbox.py loopx/extensions/lark/event_collector_routes.py` (no new errors from this diff; repo-wide unrelated mypy errors remain)
- `git diff --check` (passed)
- `loopx change-quality record/verify` (pass, receipt `cqr_178d08e1e04bf32e1987`)
- `loopx canary premerge --from-git-diff --goal-id loopx-meta --tier standard` (gate passed, self_merge_allowed=true)

Follow-up to #3817: the original PR merged with the P2 stale-lock caveat; this PR lands the kernel-lock fix.
