### PR TITLE
feat(benchmark): bind case insights to terminal runs

### DIFF
--- a/docs/architecture/rfcs/benchmark-study-upload-dashboard-v0.md
+++ b/docs/architecture/rfcs/benchmark-study-upload-dashboard-v0.md
@@ -108,6 +108,13 @@ The projection is not the analyst's raw evidence packet. It cannot contain raw
 task text, trajectory excerpts, hidden evaluator material, verifier tails, or
 host-local paths.
 
+An insight upload must attach to one already uploaded active exact-run board row.
+That row must be terminal with `insight.status=complete`, and its case, run, and
+outcome identities must match the projection. The board row remains the only arm,
+score, countability, integrity, and treatment-fidelity authority.
+This deliberately tightens the local simulation's prior permissive behavior:
+orphan, pre-terminal, and outcome-mismatched insight uploads are rejected.
+
 `benchmark_runtime_observation_v0` is reused unchanged for exact-job authority,
 runner liveness, terminal discovery, and runner-invalid classification.
 Occupancy and provider-pressure signals come from the existing concurrency
@@ -316,6 +323,13 @@ receipt，但不持有 provider 凭证，也不会在未单独激活 provider �
 
 该 projection 不是分析者的原始证据包，不得包含原始题目文本、轨迹片段、隐藏
 evaluator 材料、verifier 尾部输出或宿主机本地路径。
+
+insight 上传必须绑定到已上传且处于 active 状态的同一个 exact-run 实验板记录。
+该 run 必须已经终态，且 `insight.status=complete`；projection 的 case、run 和
+outcome 身份必须与其一致。arm、score、countability、integrity 与
+treatment-fidelity 的唯一权威仍是实验板记录。
+这是对本地模拟既有宽松行为的有意收紧：孤立、未终态或 outcome 不匹配的
+insight 上传会被拒绝。
 
 `benchmark_runtime_observation_v0` 原样复用于 exact-job authority、runner
 liveness、终态发现和 runner-invalid 分类。occupancy 与 provider-pressure 信号

--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -1223,6 +1223,48 @@ also obey existing legal run-state transitions. A study manifest is immutable
 comparison intent: change its design under a new `study_id` instead of superseding it.
 Supersession also stays within the producer that authored the prior record.
 
+### Upload a terminal case insight
+
+`benchmark_case_insight_projection_v0` is the public-safe child record for one
+exact run. Upload the run's terminal `benchmark_experiment_board_row_v0` first;
+its `insight.status` must be `complete`, and the projection's `case_id`, `run_id`,
+and `outcome_status` must match that active terminal row. The run identity already
+resolves its arm, so the insight cannot invent a second arm binding. Because the
+projection has no metric, countability, integrity, or treatment-fidelity fields,
+accepting it cannot change the run's score authority.
+
+This is an intentionally strict upload-ordering rule: orphan, pre-terminal, and
+outcome-mismatched insight records that older local simulations accepted are now
+rejected. Re-upload the terminal run row before uploading its insight; no existing
+score or experiment-board authority is rewritten.
+
+```json
+{
+  "schema_version": "benchmark_case_insight_projection_v0",
+  "benchmark_id": "example-benchmark@1",
+  "study_id": "example-study-v1",
+  "case_id": "case-1",
+  "run_id": "treatment-case-1-r1",
+  "outcome_status": "completed",
+  "failure_class": "none",
+  "causal_summary": "The implementation satisfied the declared contract after an independent boundary check.",
+  "expectedness": "expected",
+  "implication": "Retain the independent boundary check in this arm.",
+  "next_probe": "Repeat on a different public case family.",
+  "confidence": "high",
+  "evidence_refs": ["public-receipt:abc123"],
+  "privacy_classification": "public_safe",
+  "producer_redaction_attested": true
+}
+```
+
+Wrap it with the same `benchmark upload-envelope` command above using
+`--record-kind case_insight_projection`, then preview, execute, and read it back
+through the same local provider flow. The private analyst may use task text,
+trajectory, final workspace, hidden evaluation, and verifier details only after
+the run is terminal; those sources are reduced into the bounded fields and
+public-safe evidence handles above and are never uploaded themselves.
+
 Finally, derive a read-only `benchmark_study_dashboard_v0` packet. It exposes
 campaign, arm, case, and run projections with explicit denominators and provisional
 coverage, while delegating scores and matched comparisons to the experiment board.

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -468,11 +468,27 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
             "sequence": [
                 "validate_provider_neutral_study_manifest",
                 "wrap_one_allowlisted_public_safe_record_per_envelope",
+                "upload_exact_terminal_run_before_its_redacted_case_insight",
                 "preview_local_upload_without_writing",
                 "execute_local_simulation_when_explicitly_requested",
                 "verify_record_id_digest_and_provider_revision_by_readback",
                 "derive_read_only_dashboard_packet",
             ],
+            "case_insight_upload": {
+                "schema_version": "benchmark_case_insight_projection_v0",
+                "precondition": (
+                    "one active exact-run board record is terminal, has complete "
+                    "post-run analysis status, and matches case/run/outcome identity"
+                ),
+                "authority_boundary": (
+                    "the projection contains no score, countability, integrity, or "
+                    "treatment-fidelity fields and cannot mutate run authority"
+                ),
+                "evidence_boundary": (
+                    "only bounded redacted analysis and public-safe evidence handles "
+                    "or digests; raw trajectory and evaluator material stay private"
+                ),
+            },
             "external_provider_boundary": (
                 "The local simulation proves contract and readback behavior only. "
                 "Authentication, remote transport, retention, and publication need "

--- a/loopx/capabilities/benchmark_toolkit/experiment_board.py
+++ b/loopx/capabilities/benchmark_toolkit/experiment_board.py
@@ -61,6 +61,12 @@ _ROW_FIELDS = {
 }
 
 
+def benchmark_run_status_is_terminal(value: object) -> bool:
+    """Return whether a normalized run status closes its lifecycle."""
+
+    return isinstance(value, str) and value in _TERMINAL_RUN_STATUSES
+
+
 def _reject_unknown_fields(
     value: Mapping[str, Any],
     *,

--- a/loopx/capabilities/benchmark_toolkit/study_projection.py
+++ b/loopx/capabilities/benchmark_toolkit/study_projection.py
@@ -18,6 +18,7 @@ from ...file_lock import exclusive_file_lock
 from .experiment_board import (
     BENCHMARK_EXPERIMENT_BOARD_ROW_SCHEMA_VERSION,
     benchmark_experiment_board_row_key,
+    benchmark_run_status_is_terminal,
     build_benchmark_experiment_board,
     normalize_benchmark_experiment_board_row,
     preview_benchmark_experiment_board_upsert,
@@ -413,6 +414,9 @@ def normalize_benchmark_case_insight_projection(
     confidence = _token(payload.get("confidence"), field="confidence")
     if expectedness not in _EXPECTEDNESS or confidence not in _CONFIDENCE_LEVELS:
         raise ValueError("case insight expectedness or confidence is unsupported")
+    outcome_status = _token(payload.get("outcome_status"), field="outcome_status")
+    if not benchmark_run_status_is_terminal(outcome_status):
+        raise ValueError("case insight outcome_status must be terminal")
     raw_refs = payload.get("evidence_refs", [])
     if not isinstance(raw_refs, list) or len(raw_refs) > 16:
         raise ValueError("evidence_refs must contain at most 16 handles")
@@ -423,7 +427,7 @@ def normalize_benchmark_case_insight_projection(
         "study_id": _token(payload.get("study_id"), field="study_id"),
         "case_id": _token(payload.get("case_id"), field="case_id"),
         "run_id": _token(payload.get("run_id"), field="run_id"),
-        "outcome_status": _token(payload.get("outcome_status"), field="outcome_status"),
+        "outcome_status": outcome_status,
         "failure_class": _token(payload.get("failure_class"), field="failure_class"),
         "causal_summary": _bounded_text(
             payload.get("causal_summary"), field="causal_summary"
@@ -627,6 +631,45 @@ def _same_board_row(left: Mapping[str, Any], right: Mapping[str, Any]) -> bool:
     ) == benchmark_experiment_board_row_key(right)
 
 
+def _validate_case_insight_attachment(
+    envelope: Mapping[str, Any], active_envelopes: Iterable[Mapping[str, Any]]
+) -> None:
+    if envelope["record_kind"] != "case_insight_projection":
+        return
+    insight = envelope["payload"]
+    board_rows = [
+        candidate["payload"]
+        for candidate in active_envelopes
+        if candidate["record_kind"] == "experiment_board_row"
+        and candidate["benchmark_id"] == envelope["benchmark_id"]
+        and candidate["study_id"] == envelope["study_id"]
+        and candidate["payload"]["run_id"] == insight["run_id"]
+    ]
+    if len(board_rows) != 1:
+        raise ValueError(
+            "case-insight upload requires one active exact-run board record"
+        )
+    run = board_rows[0]
+    if run["case_id"] != insight["case_id"]:
+        raise ValueError("case insight identity does not match its board row")
+    if not benchmark_run_status_is_terminal(run["status"]):
+        raise ValueError("case-insight upload requires a terminal run")
+    if run["status"] != insight["outcome_status"]:
+        raise ValueError("case insight outcome does not match its terminal run")
+    if run["insight"]["status"] != "complete":
+        raise ValueError(
+            "case-insight upload requires complete post-run analysis status"
+        )
+
+
+def _validate_case_insight_attachments(
+    records: Iterable[Mapping[str, Any]],
+) -> None:
+    active_envelopes = _active_envelopes(records)
+    for envelope in active_envelopes:
+        _validate_case_insight_attachment(envelope, active_envelopes)
+
+
 def _validate_supersession(
     envelope: Mapping[str, Any], records: list[dict[str, Any]]
 ) -> None:
@@ -684,6 +727,7 @@ def _validate_supersession(
             raise ValueError("changed board-row upload requires explicit supersession")
         if related and supersedes not in {item["record_id"] for item in related}:
             raise ValueError("board-row upload must supersede its current run record")
+    _validate_case_insight_attachments([*records, {"envelope": envelope}])
 
 
 def _receipt(
@@ -999,25 +1043,23 @@ def build_benchmark_study_dashboard(
         if row["comparison_protocol_id"] != study["comparison_protocol_id"]:
             raise ValueError("board row comparison protocol does not match manifest")
 
-    insights = {
-        envelope["payload"]["run_id"]: envelope["payload"]
-        for envelope in envelopes
-        if envelope["record_kind"] == "case_insight_projection"
-    }
-    insight_records = [
-        envelope["payload"]
+    insight_envelopes = [
+        envelope
         for envelope in envelopes
         if envelope["record_kind"] == "case_insight_projection"
     ]
+    insights = {
+        envelope["payload"]["run_id"]: envelope["payload"]
+        for envelope in insight_envelopes
+    }
+    insight_records = [envelope["payload"] for envelope in insight_envelopes]
     if len(insights) != len(insight_records):
         raise ValueError("study upload store has multiple active insights for one run")
-    board_rows_by_run = {row["run_id"]: row for row in board_rows}
-    for insight in insight_records:
+    for insight_envelope in insight_envelopes:
+        insight = insight_envelope["payload"]
         if insight["case_id"] not in declared_cases:
             raise ValueError("case insight is outside manifest coverage")
-        run = board_rows_by_run.get(insight["run_id"])
-        if run is not None and run["case_id"] != insight["case_id"]:
-            raise ValueError("case insight identity does not match its board row")
+        _validate_case_insight_attachment(insight_envelope, envelopes)
     runtime_observations = [
         envelope["payload"]
         for envelope in envelopes

--- a/skills/loopx-benchmark/SKILL.md
+++ b/skills/loopx-benchmark/SKILL.md
@@ -36,6 +36,12 @@ typed study flow rather than sharing a runner-specific ledger or raw evidence:
 5. Derive the campaign/arm/case/run packet with `benchmark study-dashboard`; pass a
    compact four-arm contract only when the study preregistered that design.
 
+For `case_insight_projection`, first upload the same run's active terminal
+experiment-board row with `insight.status=complete`. The case, run, and outcome
+must match; the run row remains the only arm, score, countability, integrity, and
+treatment-fidelity authority. Reduce private post-run evidence to bounded prose
+and public-safe handles or digests before building the envelope.
+
 The local provider is a no-network simulation. It does not grant remote upload,
 publication, credentials, retention, or benchmark submission authority. Adapters
 keep their native metric names and reduce private post-run evidence before envelope

--- a/tests/capabilities/test_benchmark_study_projection.py
+++ b/tests/capabilities/test_benchmark_study_projection.py
@@ -26,6 +26,17 @@ from loopx.capabilities.benchmark_toolkit import (
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _loopx_json(*args: str) -> dict[str, object]:
+    result = subprocess.run(
+        [str(REPO_ROOT / "scripts/loopx"), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
 def _manifest(*, four_arm: bool = False) -> dict[str, object]:
     factors = [{"factor_id": "orchestrator", "levels": ["goal", "loopx"]}]
     arms: list[dict[str, object]] = [
@@ -121,6 +132,30 @@ def _manifest(*, four_arm: bool = False) -> dict[str, object]:
     }
 
 
+def _five_mode_manifest() -> dict[str, object]:
+    manifest = _manifest()
+    manifest["study_id"] = "five-mode-v1"
+    levels = ["plain", "goal", "managed_a", "managed_b", "scheduled"]
+    manifest["factors"] = [{"factor_id": "execution_mode", "levels": levels}]
+    manifest["arms"] = [
+        {
+            "arm_id": level,
+            "arm_role": (
+                "baseline"
+                if level == "plain"
+                else "control"
+                if level == "goal"
+                else "treatment"
+            ),
+            "factor_assignments": {"execution_mode": level},
+        }
+        for level in levels
+    ]
+    manifest["baseline_arm_id"] = "plain"
+    manifest["labels"] = {"title": "Fictional five-mode software benchmark"}
+    return manifest
+
+
 def _row(
     *,
     arm_id: str,
@@ -192,14 +227,19 @@ def _row(
     return row
 
 
-def _insight(*, study_id: str = "paired-v1") -> dict[str, object]:
+def _insight(
+    *,
+    study_id: str = "paired-v1",
+    run_id: str = "loopx_plain-case-1",
+    outcome_status: str = "completed",
+) -> dict[str, object]:
     return {
         "schema_version": BENCHMARK_CASE_INSIGHT_PROJECTION_SCHEMA_VERSION,
         "benchmark_id": "fixture-swe@1",
         "study_id": study_id,
         "case_id": "case-1",
-        "run_id": "loopx_plain-case-1",
-        "outcome_status": "completed",
+        "run_id": run_id,
+        "outcome_status": outcome_status,
         "failure_class": "none",
         "causal_summary": "The implementation preserved the declared API contract.",
         "expectedness": "expected",
@@ -235,6 +275,22 @@ def _envelope(
     )
 
 
+def _upload_default_insight_run(store: Path) -> dict[str, object]:
+    run = _envelope(
+        _row(
+            arm_id="loopx_plain",
+            arm_role="treatment",
+            feature=9,
+            reward=1,
+            anchor="goal_plain-case-1",
+        ),
+        record_kind="experiment_board_row",
+        key="insight-run",
+    )
+    simulate_benchmark_upload(store, run, execute=True)
+    return run
+
+
 def _four_arm_contract() -> dict[str, object]:
     return compact_benchmark_four_arm_contract(
         build_benchmark_four_arm_contract(
@@ -251,6 +307,7 @@ def test_two_arm_and_factorized_four_arm_manifests_validate() -> None:
     assert (
         len(normalize_benchmark_study_manifest(_manifest(four_arm=True))["arms"]) == 4
     )
+    assert len(normalize_benchmark_study_manifest(_five_mode_manifest())["arms"]) == 5
 
 
 @pytest.mark.parametrize("mutation", ["assignment", "baseline", "metrics"])
@@ -382,6 +439,7 @@ def test_changed_board_row_requires_legal_explicit_supersession(tmp_path: Path) 
 
 def test_case_insight_supersession_preserves_run_identity(tmp_path: Path) -> None:
     store = tmp_path / "simulated-upload.jsonl"
+    _upload_default_insight_run(store)
     first = _envelope(
         _insight(), record_kind="case_insight_projection", key="insight-1"
     )
@@ -425,6 +483,7 @@ def test_supersession_preserves_producer_and_immutable_study_identity(
     insight = _envelope(
         _insight(), record_kind="case_insight_projection", key="insight-v1"
     )
+    _upload_default_insight_run(store)
     simulate_benchmark_upload(store, insight, execute=True)
     other_producer = build_benchmark_upload_envelope(
         _insight(),
@@ -451,6 +510,114 @@ def test_redacted_insight_rejects_raw_fields_and_path_references() -> None:
     insight["evidence_refs"] = ["/tmp/private/trajectory.json"]
     with pytest.raises(ValueError, match="public-safe token"):
         normalize_benchmark_case_insight_projection(insight)
+    insight = _insight(outcome_status="running")
+    with pytest.raises(ValueError, match="must be terminal"):
+        normalize_benchmark_case_insight_projection(insight)
+
+
+def test_case_insight_upload_requires_exact_terminal_run(tmp_path: Path) -> None:
+    store = tmp_path / "simulated-upload.jsonl"
+    insight = _envelope(
+        _insight(), record_kind="case_insight_projection", key="insight-v1"
+    )
+    with pytest.raises(ValueError, match="exact-run board record"):
+        simulate_benchmark_upload(store, insight)
+
+    running = _row(
+        arm_id="loopx_plain",
+        arm_role="treatment",
+        feature=0,
+        reward=0,
+        anchor="goal_plain-case-1",
+    )
+    running.update(
+        {
+            "status": "running",
+            "metrics": {},
+            "countability": {
+                "integrity_qualified": False,
+                "official_result_present": False,
+                "score_countable": False,
+            },
+            "treatment_fidelity": "pending",
+            "effort": {},
+            "insight": {"status": "pending"},
+        }
+    )
+    running_envelope = _envelope(
+        running, record_kind="experiment_board_row", key="run-start"
+    )
+    simulate_benchmark_upload(store, running_envelope, execute=True)
+    with pytest.raises(ValueError, match="requires a terminal run"):
+        simulate_benchmark_upload(store, insight)
+
+    terminal_envelope = _envelope(
+        _row(
+            arm_id="loopx_plain",
+            arm_role="treatment",
+            feature=9,
+            reward=1,
+            anchor="goal_plain-case-1",
+        ),
+        record_kind="experiment_board_row",
+        key="run-terminal",
+        supersedes=running_envelope["record_id"],
+    )
+    simulate_benchmark_upload(store, terminal_envelope, execute=True)
+    accepted = simulate_benchmark_upload(store, insight, execute=True)
+    assert accepted["disposition"] == "accepted"
+
+    invalidated_run = copy.deepcopy(terminal_envelope["payload"])
+    invalidated_run["insight"] = {"status": "not_required"}
+    invalidation = _envelope(
+        invalidated_run,
+        record_kind="experiment_board_row",
+        key="run-without-insight",
+        supersedes=terminal_envelope["record_id"],
+    )
+    with pytest.raises(ValueError, match="complete post-run analysis"):
+        simulate_benchmark_upload(store, invalidation)
+
+    mismatch = _envelope(
+        _insight(outcome_status="cancelled"),
+        record_kind="case_insight_projection",
+        key="insight-mismatch",
+    )
+    with pytest.raises(ValueError, match="outcome does not match"):
+        simulate_benchmark_upload(store, mismatch)
+
+
+@pytest.mark.parametrize("status", ["runner_invalid", "cancelled"])
+def test_case_insight_upload_accepts_non_score_terminal_outcomes(
+    tmp_path: Path, status: str
+) -> None:
+    store = tmp_path / f"{status}.jsonl"
+    run = _row(
+        arm_id="goal_plain", arm_role="baseline", feature=0, reward=0
+    )
+    run.update(
+        {
+            "status": status,
+            "metrics": {},
+            "countability": {
+                "integrity_qualified": False,
+                "official_result_present": False,
+                "score_countable": False,
+            },
+        }
+    )
+    run_envelope = _envelope(
+        run, record_kind="experiment_board_row", key=f"{status}-run"
+    )
+    insight_envelope = _envelope(
+        _insight(run_id="goal_plain-case-1", outcome_status=status),
+        record_kind="case_insight_projection",
+        key=f"{status}-insight",
+    )
+    simulate_benchmark_upload(store, run_envelope, execute=True)
+    assert simulate_benchmark_upload(store, insight_envelope, execute=True)[
+        "disposition"
+    ] == "accepted"
 
 
 def test_dashboard_exposes_denominators_native_metrics_and_existing_comparisons() -> (
@@ -541,6 +708,14 @@ def test_four_arm_dashboard_reuses_factorial_authority() -> None:
         )
         for index, row in enumerate(rows)
     ]
+    records.append(
+        _envelope(
+            _insight(study_id="factorial-v1"),
+            record_kind="case_insight_projection",
+            key="factorial-insight",
+            study_id="factorial-v1",
+        )
+    )
     dashboard = build_benchmark_study_dashboard(
         _manifest(four_arm=True),
         records,
@@ -554,6 +729,11 @@ def test_four_arm_dashboard_reuses_factorial_authority() -> None:
         ]["difference_in_differences"]
         == 2
     )
+    assert next(
+        run
+        for run in dashboard["runs"]
+        if run["run_id"] == "loopx_plain-case-1"
+    )["redacted_insight"]["confidence"] == "high"
 
 
 def test_cli_local_simulation_flow(tmp_path: Path) -> None:
@@ -561,64 +741,51 @@ def test_cli_local_simulation_flow(tmp_path: Path) -> None:
     payload_path = tmp_path / "payload.json"
     envelope_path = tmp_path / "envelope.json"
     store = tmp_path / "store.jsonl"
-    manifest_path.write_text(json.dumps(_manifest()), encoding="utf-8")
-    baseline = _row(arm_id="goal_plain", arm_role="baseline", feature=6, reward=0)
+    manifest_path.write_text(json.dumps(_five_mode_manifest()), encoding="utf-8")
+    baseline = _row(
+        arm_id="plain",
+        arm_role="baseline",
+        feature=6,
+        reward=0,
+        study_id="five-mode-v1",
+    )
     payload_path.write_text(json.dumps(baseline), encoding="utf-8")
 
-    validate = subprocess.run(
-        [
-            str(REPO_ROOT / "scripts/loopx"),
-            "benchmark",
-            "study-validate",
-            "--manifest-json",
-            str(manifest_path),
-            "--format",
-            "json",
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=True,
+    validate = _loopx_json(
+        "benchmark",
+        "study-validate",
+        "--manifest-json",
+        str(manifest_path),
+        "--format",
+        "json",
     )
-    assert (
-        json.loads(validate.stdout)["schema_version"]
-        == BENCHMARK_STUDY_MANIFEST_SCHEMA_VERSION
+    assert validate["schema_version"] == BENCHMARK_STUDY_MANIFEST_SCHEMA_VERSION
+    envelope = _loopx_json(
+        "benchmark",
+        "upload-envelope",
+        "--payload-json",
+        str(payload_path),
+        "--record-kind",
+        "experiment_board_row",
+        "--producer-id",
+        "fixture-adapter",
+        "--producer-version",
+        "1.0.0",
+        "--benchmark-id",
+        "fixture-swe@1",
+        "--study-id",
+        "five-mode-v1",
+        "--idempotency-key",
+        "baseline-case-1",
+        "--observed-at",
+        "2026-09-02T12:00:00+00:00",
+        "--source-revision",
+        "0123456789abcdef",
+        "--format",
+        "json",
     )
-    built = subprocess.run(
-        [
-            str(REPO_ROOT / "scripts/loopx"),
-            "benchmark",
-            "upload-envelope",
-            "--payload-json",
-            str(payload_path),
-            "--record-kind",
-            "experiment_board_row",
-            "--producer-id",
-            "fixture-adapter",
-            "--producer-version",
-            "1.0.0",
-            "--benchmark-id",
-            "fixture-swe@1",
-            "--study-id",
-            "paired-v1",
-            "--idempotency-key",
-            "baseline-case-1",
-            "--observed-at",
-            "2026-09-02T12:00:00+00:00",
-            "--source-revision",
-            "0123456789abcdef",
-            "--format",
-            "json",
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    envelope = json.loads(built.stdout)
     envelope_path.write_text(json.dumps(envelope), encoding="utf-8")
-    base = [
-        str(REPO_ROOT / "scripts/loopx"),
+    upload_args = [
         "benchmark",
         "upload-local",
         "--envelope-json",
@@ -628,48 +795,73 @@ def test_cli_local_simulation_flow(tmp_path: Path) -> None:
         "--format",
         "json",
     ]
-    preview = subprocess.run(
-        base, cwd=REPO_ROOT, text=True, capture_output=True, check=True
+    assert _loopx_json(*upload_args)["write_performed"] is False
+    _loopx_json(*upload_args, "--execute")
+    readback = _loopx_json(
+        "benchmark",
+        "upload-readback",
+        "--store",
+        str(store),
+        "--record-id",
+        str(envelope["record_id"]),
+        "--format",
+        "json",
     )
-    assert json.loads(preview.stdout)["write_performed"] is False
-    subprocess.run(
-        [*base, "--execute"], cwd=REPO_ROOT, text=True, capture_output=True, check=True
+    assert readback["disposition"] == "readback_verified"
+
+    payload_path.write_text(
+        json.dumps(_insight(study_id="five-mode-v1", run_id="plain-case-1")),
+        encoding="utf-8",
     )
-    readback = subprocess.run(
-        [
-            str(REPO_ROOT / "scripts/loopx"),
-            "benchmark",
-            "upload-readback",
-            "--store",
-            str(store),
-            "--record-id",
-            envelope["record_id"],
-            "--format",
-            "json",
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=True,
+    insight_envelope = _loopx_json(
+        "benchmark",
+        "upload-envelope",
+        "--payload-json",
+        str(payload_path),
+        "--record-kind",
+        "case_insight_projection",
+        "--producer-id",
+        "fixture-adapter",
+        "--producer-version",
+        "1.0.0",
+        "--benchmark-id",
+        "fixture-swe@1",
+        "--study-id",
+        "five-mode-v1",
+        "--idempotency-key",
+        "insight-case-1",
+        "--observed-at",
+        "2026-09-02T12:01:00+00:00",
+        "--source-revision",
+        "0123456789abcdef",
+        "--format",
+        "json",
     )
-    assert json.loads(readback.stdout)["disposition"] == "readback_verified"
-    dashboard = subprocess.run(
-        [
-            str(REPO_ROOT / "scripts/loopx"),
-            "benchmark",
-            "study-dashboard",
-            "--manifest-json",
-            str(manifest_path),
-            "--store",
-            str(store),
-            "--format",
-            "json",
-        ],
-        cwd=REPO_ROOT,
-        text=True,
-        capture_output=True,
-        check=True,
+    envelope_path.write_text(json.dumps(insight_envelope), encoding="utf-8")
+    assert _loopx_json(*upload_args)["disposition"] == "preview_accepted"
+    _loopx_json(*upload_args, "--execute")
+    insight_readback = _loopx_json(
+        "benchmark",
+        "upload-readback",
+        "--store",
+        str(store),
+        "--record-id",
+        str(insight_envelope["record_id"]),
+        "--format",
+        "json",
     )
-    packet = json.loads(dashboard.stdout)
+    assert insight_readback["payload_digest"] == insight_envelope["payload_digest"]
+    packet = _loopx_json(
+        "benchmark",
+        "study-dashboard",
+        "--manifest-json",
+        str(manifest_path),
+        "--store",
+        str(store),
+        "--format",
+        "json",
+    )
+    assert packet["campaign"]["intended_arm_count"] == 5
     assert packet["campaign"]["selected_score_countable_cell_count"] == 1
+    assert packet["runs"][0]["redacted_insight"]["confidence"] == "high"
     assert packet["network_access_performed"] is False


### PR DESCRIPTION
## Summary

- make `case_insight_projection` an explicit child of one active exact terminal experiment-board run
- preserve the run row as sole authority for arm, score, countability, integrity, and treatment fidelity
- reject orphan, pre-terminal, outcome-mismatched, or later-invalidated insight attachments
- document the bounded redaction/evidence contract in benchmark-toolkit, its skill, and RFC #3812
- validate two-arm, factorized four-arm, and five-mode study shapes, including local CLI preview/execute/readback/dashboard flow

This extends the provider-neutral study upload contract implemented after RFC #3812 and checks compatibility with the public five-mode study shape contributed in #3838. It does not add a remote provider, publish benchmark data, launch jobs, or change scoring.

## Validation

- `python -m ruff check loopx/capabilities/benchmark_toolkit/experiment_board.py loopx/capabilities/benchmark_toolkit/study_projection.py loopx/capabilities/benchmark_toolkit/catalog_entry.py tests/capabilities/test_benchmark_study_projection.py`
- `pytest -q tests/capabilities/test_benchmark_*.py` — 231 passed
- `python -m compileall -q loopx/capabilities/benchmark_toolkit loopx/cli_commands/benchmark_study.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --goal-id loopx-deepswe-bench --tier standard` — 18/18 checks passed; public-boundary scan clean

## Review / merge hold

The generic canary classifies all benchmark-sensitive paths as requiring manual maintainer review. The owner has separately authorized self-merge for bounded benchmark helper changes. This PR changes no runner, scoring, leaderboard, submission, permission, or job-launch behavior, so I will perform exact-head review and use that authorization only if checks remain green.
