### PR TITLE
fix(benchmark): exclude terminal-only control from persistence

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -1148,15 +1148,23 @@ loopx benchmark treatment-continuation-receipt \
 
 The observation names startup state, whether the review is complete, counts of
 post-start Todo transitions, technical replans, and control closeouts, terminal
-control settlement, and whether pre-commit validation was observed. It contains no
-task text, trajectory content, paths, run identity, verifier output, or score.
+control settlement, and whether pre-commit validation was observed. Count a Todo
+transition only when it advances or revises task-facing technical work before the
+result is fixed. Count a technical replan only when it changes that technical
+course. Record terminal-only Todo settlement, replan bookkeeping, and final
+closeout under `control_closeout_count`; those events are visible but do not prove
+continued technical control. The observation contains no task text, trajectory
+content, paths, run identity, verifier output, or score.
 
 The receipt classifies the mechanism as `sustained`, `startup_only`, `unknown`, or
-`not_applicable`. Here, `sustained` means at least one semantic control transition
-was observed after qualified startup; terminal settlement remains a separate field.
-Absence becomes `startup_only` only when the authorized post-run observation is
-complete. This receipt is analysis-only: it never changes score countability,
-integrity qualification, treatment fidelity, or matched-pair eligibility.
+`not_applicable`. Here, `sustained` means at least one qualifying task-facing Todo
+transition or technical replan was observed after qualified startup and before the
+result was fixed. Terminal-only control never establishes `sustained`, even when
+terminal settlement succeeds; the existing total and per-kind event counts still
+record that closeout activity. Absence becomes `startup_only` only when the
+authorized post-run observation is complete. This receipt is analysis-only: it
+never changes score countability, integrity qualification, treatment fidelity, or
+matched-pair eligibility.
 
 ## Study manifest, local upload simulation, and dashboard packet
 

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -677,6 +677,13 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "review observes qualified startup and zero post-start semantic "
                 "control transitions; otherwise absence remains unknown."
             ),
+            "persistence_rule": (
+                "Only task-facing Todo transitions and technical replans that "
+                "change the solving course before the result is fixed establish "
+                "sustained control. Terminal-only Todo settlement, replan "
+                "bookkeeping, and closeout remain recorded as closeout events but "
+                "do not establish persistence."
+            ),
             "observation_template": {
                 "schema_version": (
                     "benchmark_treatment_continuation_observation_v0"

--- a/loopx/capabilities/benchmark_toolkit/treatment_continuation.py
+++ b/loopx/capabilities/benchmark_toolkit/treatment_continuation.py
@@ -26,6 +26,10 @@ _CONTROL_EVENT_FIELDS = {
     "technical_replan_count",
     "control_closeout_count",
 }
+_SUSTAINING_CONTROL_EVENT_FIELDS = {
+    "todo_transition_count",
+    "technical_replan_count",
+}
 _STARTUP_STATES = {"qualified", "not_qualified", "unknown", "not_applicable"}
 _TERMINAL_CONTROL_STATES = {
     "settled",
@@ -63,12 +67,15 @@ def _reason_codes(
     observation_complete: bool,
     terminal_control_state: str,
     precommit_validation_state: str,
+    terminal_only_control_observed: bool,
 ) -> list[str]:
     reasons = [f"control_persistence_{classification}"]
     if startup_state != "qualified" and classification != "not_applicable":
         reasons.append(f"startup_{startup_state}")
     if not observation_complete and classification == "unknown":
         reasons.append("post_run_observation_incomplete")
+    if terminal_only_control_observed:
+        reasons.append("terminal_only_control_does_not_establish_persistence")
     reasons.append(f"terminal_control_{terminal_control_state}")
     reasons.append(f"precommit_validation_{precommit_validation_state}")
     return reasons
@@ -79,9 +86,10 @@ def build_benchmark_treatment_continuation_receipt(
 ) -> dict[str, object]:
     """Build a score-neutral receipt from compact post-run mechanism facts.
 
-    ``sustained`` means at least one semantic control transition was observed
-    after qualified startup. It does not imply that terminal control state was
-    settled; that fact is projected independently.
+    ``sustained`` means at least one task-facing Todo transition or technical
+    replan changed the solving course after qualified startup and before the
+    result was fixed. Terminal-only settlement and closeout remain visible but
+    cannot establish persistence by themselves.
     """
 
     if not isinstance(observation, Mapping):
@@ -128,6 +136,10 @@ def build_benchmark_treatment_continuation_receipt(
         for field in sorted(_CONTROL_EVENT_FIELDS)
     }
     event_count = sum(event_counts.values())
+    sustaining_event_count = sum(
+        event_counts[field] for field in _SUSTAINING_CONTROL_EVENT_FIELDS
+    )
+    terminal_only_event_count = event_counts["control_closeout_count"]
 
     if not treatment_applicable:
         if startup_state != "not_applicable":
@@ -143,7 +155,7 @@ def build_benchmark_treatment_continuation_receipt(
         if startup_state == "not_applicable":
             raise ValueError("applicable treatment cannot use not_applicable startup")
         classification = "unknown"
-    elif event_count:
+    elif sustaining_event_count:
         classification = "sustained"
     elif observation_complete:
         classification = "startup_only"
@@ -167,6 +179,7 @@ def build_benchmark_treatment_continuation_receipt(
             observation_complete=observation_complete,
             terminal_control_state=terminal_control_state,
             precommit_validation_state=precommit_validation_state,
+            terminal_only_control_observed=terminal_only_event_count > 0,
         ),
         "score_semantics": {
             "score_countability_unchanged": True,

--- a/tests/capabilities/test_benchmark_treatment_continuation.py
+++ b/tests/capabilities/test_benchmark_treatment_continuation.py
@@ -69,6 +69,47 @@ def test_receipt_reports_post_start_semantic_control_without_claiming_closeout()
     assert "terminal_control_unsettled" in receipt["reason_codes"]
 
 
+def test_terminal_only_closeout_does_not_establish_sustained_control() -> None:
+    observation = _observation()
+    observation["post_start_control_events"] = {
+        "todo_transition_count": 0,
+        "technical_replan_count": 0,
+        "control_closeout_count": 3,
+    }
+    observation["terminal_control_state"] = "settled"
+
+    receipt = build_benchmark_treatment_continuation_receipt(observation)
+
+    assert receipt["classification"] == "startup_only"
+    assert receipt["post_start_control_observed"] is True
+    assert receipt["post_start_control_event_count"] == 3
+    assert receipt["post_start_control_event_counts"] == {
+        "control_closeout_count": 3,
+        "technical_replan_count": 0,
+        "todo_transition_count": 0,
+    }
+    assert (
+        "terminal_only_control_does_not_establish_persistence"
+        in receipt["reason_codes"]
+    )
+
+
+def test_incomplete_terminal_only_observation_remains_unknown() -> None:
+    observation = _observation()
+    observation["observation_complete"] = False
+    observation["post_start_control_events"] = {
+        "todo_transition_count": 0,
+        "technical_replan_count": 0,
+        "control_closeout_count": 1,
+    }
+
+    receipt = build_benchmark_treatment_continuation_receipt(observation)
+
+    assert receipt["classification"] == "unknown"
+    assert receipt["post_start_control_event_count"] == 1
+    assert "post_run_observation_incomplete" in receipt["reason_codes"]
+
+
 def test_absence_requires_complete_post_run_observation() -> None:
     observation = _observation()
     observation["observation_complete"] = False
@@ -195,6 +236,7 @@ def test_catalog_teaches_score_neutral_treatment_continuation_readback() -> None
     ]
     assert continuation["score_semantics"] == "unchanged"
     assert "does not change" in continuation["analysis_boundary"]
+    assert "terminal-only" in continuation["persistence_rule"].lower()
     assert continuation["observation_template"]["schema_version"] == (
         "benchmark_treatment_continuation_observation_v0"
     )


### PR DESCRIPTION
## Summary

- keep the public v0 treatment-continuation receipt and existing event totals
- classify sustained control only from task-facing Todo transitions or technical replans before the result is fixed
- report terminal-only closeout separately without changing score, integrity, fidelity, or matched-pair semantics
- document the analyst counting boundary and add complete/incomplete terminal-only regressions

## Validation

- `pytest -q tests/capabilities/test_benchmark_treatment_continuation.py` — 13 passed
- benchmark capability suite — 233 passed
- `python -m ruff check ...` — passed
- `loopx canary premerge --from-git-diff` — 18/18 checks passed; benchmark-sensitive manual review hold retained
- `loopx check` — public boundary clean (3040 files; unrelated existing state-projection warnings only)

## Review boundary

This changes post-run mechanism-analysis classification only. It does not launch jobs or change benchmark scoring, countability, integrity qualification, treatment fidelity, or matched-pair eligibility.