### PR TITLE
fix(todos): preserve repository-bound PR resume evidence

### DIFF
--- a/loopx/control_plane/todos/resume_condition.py
+++ b/loopx/control_plane/todos/resume_condition.py
@@ -37,6 +37,14 @@ _PR_REF_NUMBER_PATTERN = re.compile(
     r"(?:/pull/|#|pr[-_\s]*)([1-9]\d{0,8})(?:\b|/|#|\?|$)",
     re.IGNORECASE,
 )
+_GITHUB_PULL_URL_PATTERN = re.compile(
+    r"^https://github\.com/([^/]+/[^/]+)/pull/([1-9]\d{0,8})(?:\b|/|#|\?)",
+    re.IGNORECASE,
+)
+_QUALIFIED_PR_REF_PATTERN = re.compile(
+    r"^([a-z\d_.-]+/[a-z\d_.-]+)#([1-9]\d{0,8})$",
+    re.IGNORECASE,
+)
 _PR_MERGED_EVENT_KINDS = {
     "pr_merge",
     "pr_merged",
@@ -128,24 +136,72 @@ def _pr_ref_number(value: Any) -> int | None:
     return int(match.group(1)) if match else None
 
 
-def _resume_pr_numbers(items: list[dict[str, Any]]) -> set[int]:
-    numbers: set[int] = set()
+def _normalized_pr_ref(value: Any) -> tuple[str | None, int] | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    pull_url = _GITHUB_PULL_URL_PATTERN.match(candidate)
+    if pull_url:
+        return pull_url.group(1), int(pull_url.group(2))
+    qualified = _QUALIFIED_PR_REF_PATTERN.match(candidate)
+    if qualified:
+        return qualified.group(1), int(qualified.group(2))
+    number = _pr_ref_number(candidate)
+    return (None, number) if number is not None else None
+
+
+def _github_repository(value: Any) -> str | None:
+    candidate = str(value or "").strip().lower()
+    prefix = "git:github.com/"
+    if not candidate.startswith(prefix):
+        return None
+    repository = candidate[len(prefix) :].rstrip("/")
+    return repository if len(repository.split("/")) == 2 else None
+
+
+def _resume_pr_targets(
+    items: list[dict[str, Any]],
+) -> set[tuple[str | None, int]]:
+    targets: set[tuple[str | None, int]] = set()
     for item in items:
         resume_when = normalize_supported_todo_resume_when(item.get("resume_when"))
         if not resume_when or not resume_when.startswith(
             f"{TODO_RESUME_KIND_PR_MERGED}:"
         ):
             continue
-        number = _pr_ref_number(resume_when)
-        if number is not None:
-            numbers.add(number)
-    return numbers
+        target = _normalized_pr_ref(resume_when.partition(":")[2])
+        if target is None:
+            continue
+        repository, number = target
+        targets.add(
+            (
+                repository or _github_repository(item.get("task_repository")),
+                number,
+            )
+        )
+    return targets
+
+
+def _pr_ref_matches_targets(
+    value: Any,
+    *,
+    targets: set[tuple[str | None, int]],
+) -> bool:
+    ref = _normalized_pr_ref(value)
+    if ref is None:
+        return False
+    repository, number = ref
+    return any(
+        target_number == number
+        and (target_repository is None or target_repository == repository)
+        for target_repository, target_number in targets
+    )
 
 
 def _compact_merge_event(
     event: Mapping[str, Any],
     *,
-    target_numbers: set[int],
+    targets: set[tuple[str | None, int]],
 ) -> dict[str, Any] | None:
     event_kind = str(event.get("event_kind") or "").strip().lower()
     if event_kind not in _PR_MERGED_EVENT_KINDS:
@@ -157,11 +213,17 @@ def _compact_merge_event(
             compact[field] = value.strip()
     refs: list[str] = []
     direct_ref = event.get("pr_ref")
-    if isinstance(direct_ref, str):
+    if isinstance(direct_ref, str) and _pr_ref_matches_targets(
+        direct_ref, targets=targets
+    ):
         refs.append(direct_ref)
         compact["pr_ref"] = direct_ref
     code_refs = event.get("code_refs")
-    if isinstance(code_refs, Mapping) and isinstance(code_refs.get("pr_ref"), str):
+    if (
+        isinstance(code_refs, Mapping)
+        and isinstance(code_refs.get("pr_ref"), str)
+        and _pr_ref_matches_targets(code_refs["pr_ref"], targets=targets)
+    ):
         refs.append(code_refs["pr_ref"])
         compact["code_refs"] = {"pr_ref": code_refs["pr_ref"]}
     source_refs: list[dict[str, str]] = []
@@ -172,11 +234,12 @@ def _compact_merge_event(
         ref = source_ref.get("ref")
         if kind not in {"pull_request", "pr"} or not isinstance(ref, str):
             continue
-        refs.append(ref)
-        source_refs.append({"kind": kind, "ref": ref})
+        if _pr_ref_matches_targets(ref, targets=targets):
+            refs.append(ref)
+            source_refs.append({"kind": kind, "ref": ref})
     if source_refs:
         compact["source_refs"] = source_refs
-    if not any(_pr_ref_number(ref) in target_numbers for ref in refs):
+    if not refs:
         return None
     return compact
 
@@ -185,14 +248,14 @@ def _compact_resume_rollout_events(
     items: list[dict[str, Any]],
     rollout_events: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]]:
-    target_numbers = _resume_pr_numbers(items)
-    if not target_numbers:
+    targets = _resume_pr_targets(items)
+    if not targets:
         return []
     compacted: list[dict[str, Any]] = []
     for event in reversed(rollout_events or []):
         if not isinstance(event, Mapping):
             continue
-        compact = _compact_merge_event(event, target_numbers=target_numbers)
+        compact = _compact_merge_event(event, targets=targets)
         if compact is None:
             continue
         compacted.append(compact)

--- a/tests/control_plane/test_todo_resume_condition_adapter.py
+++ b/tests/control_plane/test_todo_resume_condition_adapter.py
@@ -132,3 +132,101 @@ def test_resume_evaluator_retains_the_latest_bounded_matching_events(
     assert len(compacted) == 256
     assert compacted[0]["event_id"] == "merge-44"
     assert compacted[-1]["event_id"] == "merge-299"
+
+
+def test_resume_evaluator_filters_exact_repository_before_bounding_events(
+    monkeypatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_runtime(method: str, request: dict[str, Any]) -> dict[str, Any]:
+        captured.update(request)
+        assert method == "todo.resume_condition.evaluate"
+        return {
+            "schema_version": "todo_resume_evaluation_v0",
+            "conditions": [],
+        }
+
+    monkeypatch.setattr(resume_condition, "effect_runtime_result", fake_runtime)
+    events = [
+        {
+            "event_id": "exact-repository-merge",
+            "event_kind": "pr_merge",
+            "pr_ref": "owner/repo#42",
+        },
+        *[
+            {
+                "event_id": f"other-repository-merge-{index}",
+                "event_kind": "pr_merge",
+                "pr_ref": "other/repo#42",
+            }
+            for index in range(300)
+        ],
+    ]
+
+    resume_condition.evaluate_todo_resume_conditions(
+        [
+            {
+                "todo_id": "todo_waiting",
+                "status": "deferred",
+                "resume_when": "pr_merged:owner/repo#42",
+            }
+        ],
+        source_items=[],
+        rollout_events=events,
+    )
+
+    assert captured["rollout_events"] == [
+        {
+            "event_kind": "pr_merge",
+            "event_id": "exact-repository-merge",
+            "pr_ref": "owner/repo#42",
+        }
+    ]
+
+
+def test_resume_evaluator_uses_task_repository_to_bound_unqualified_pr_wait(
+    monkeypatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_runtime(method: str, request: dict[str, Any]) -> dict[str, Any]:
+        captured.update(request)
+        assert method == "todo.resume_condition.evaluate"
+        return {
+            "schema_version": "todo_resume_evaluation_v0",
+            "conditions": [],
+        }
+
+    monkeypatch.setattr(resume_condition, "effect_runtime_result", fake_runtime)
+    resume_condition.evaluate_todo_resume_conditions(
+        [
+            {
+                "todo_id": "todo_waiting",
+                "status": "deferred",
+                "resume_when": "pr_merged:#42",
+                "task_repository": "git:github.com/owner/repo",
+            }
+        ],
+        source_items=[],
+        rollout_events=[
+            {
+                "event_id": "wrong-repository",
+                "event_kind": "pr_merge",
+                "pr_ref": "other/repo#42",
+            },
+            {
+                "event_id": "matching-repository",
+                "event_kind": "pr_merge",
+                "pr_ref": "https://github.com/owner/repo/pull/42",
+            },
+        ],
+    )
+
+    assert captured["rollout_events"] == [
+        {
+            "event_kind": "pr_merge",
+            "event_id": "matching-repository",
+            "pr_ref": "https://github.com/owner/repo/pull/42",
+        }
+    ]


### PR DESCRIPTION
## Summary

- bind PR-merge rollout compaction to the exact `(repository, PR number)` identity before applying the 256-event cap
- resolve legacy `pr_merged:#N` waits through the Todo's GitHub `task_repository` when available
- retain number-only matching only for genuinely repository-unbound compatibility data

## Motivation

Follow-up to #3882. The first bounded rollout projection filtered merge events by PR number alone. Newer same-number events from unrelated repositories could therefore consume the cap and evict the exact repository event, leaving a satisfied Todo deferred indefinitely.

This keeps the 2 MiB Effect-runtime request guard intact. The durable fix is a bounded, domain-relevant projection; raising the transport ceiling would only postpone failure as Goal history continues to grow.

## Validation

- `npm run test:control-plane`: 483 passed, 1 explicitly gated PostgreSQL live integration skipped
- `npm run typecheck:control-plane`: passed
- focused Python Todo resume/external-wait tests: 13 passed
- focused Ruff and mypy: passed
- `loopx canary premerge --from-git-diff`: 15/15 selected checks plus 4 direct checks passed; no failures or warnings
- `git diff --check`: passed

## Boundary

Only public control-plane code and focused regression tests are included. No local state, credentials, raw logs, or private material are part of this change.
