### PR TITLE
Add SWE-Marathon case-insight projections

### DIFF
--- a/benchmark/swe-marathon/case_insights.json
+++ b/benchmark/swe-marathon/case_insights.json
@@ -1,0 +1,102 @@
+{
+  "note": "public-safe case-insight projections for the codex×LoopX SWE-Marathon study; conforms to benchmark_case_insight_projection_v0 (upstream #3878 / RFC #3812). Attaching to an experiment-board run is a follow-up.",
+  "schema_version": "benchmark_case_insight_projection_v0",
+  "count": 5,
+  "records": [
+    {
+      "schema_version": "benchmark_case_insight_projection_v0",
+      "benchmark_id": "swe-marathon",
+      "study_id": "codex-loopx-access-modes",
+      "case_id": "kubernetes-rust-rewrite",
+      "run_id": "kubernetes-rust-rewrite__codex-cli",
+      "outcome_status": "runner_invalid",
+      "failure_class": "build_failed_gate_zeroed",
+      "causal_summary": "codex-cli 在 kubernetes-rust-rewrite 构建阶段失败，partial_score 被门禁归零；属运行/环境侧失败，非模型能力定论。",
+      "expectedness": "unexpected",
+      "implication": "该格作为观测计入 matched 分母并单列标注，不单臂剔除。",
+      "next_probe": "重复运行以区分偶发构建失败与稳定失配；必要时对齐镜像/依赖。",
+      "confidence": "medium",
+      "evidence_refs": [
+        "run:kubernetes-rust-rewrite__codex-cli"
+      ],
+      "privacy_classification": "public_safe",
+      "producer_redaction_attested": true
+    },
+    {
+      "schema_version": "benchmark_case_insight_projection_v0",
+      "benchmark_id": "swe-marathon",
+      "study_id": "codex-loopx-access-modes",
+      "case_id": "kubernetes-rust-rewrite",
+      "run_id": "kubernetes-rust-rewrite__heartbeat",
+      "outcome_status": "completed",
+      "failure_class": "none_observed",
+      "causal_summary": "heartbeat 在 kubernetes-rust-rewrite 由外部 driver 持有 Turn 边界、每轮重读 worktree，经 9 轮续跑稳定收敛（reward=1.0, partial=1.0）。",
+      "expectedness": "expected",
+      "implication": "external automation 驱动的续跑在无人长程下更稳（本轮观测，非因果定论）。",
+      "next_probe": "在更多任务与重复运行上验证该趋势是否持续。",
+      "confidence": "low",
+      "evidence_refs": [
+        "run:kubernetes-rust-rewrite__heartbeat"
+      ],
+      "privacy_classification": "public_safe",
+      "producer_redaction_attested": true
+    },
+    {
+      "schema_version": "benchmark_case_insight_projection_v0",
+      "benchmark_id": "swe-marathon",
+      "study_id": "codex-loopx-access-modes",
+      "case_id": "vliw-kernel-optimization",
+      "run_id": "vliw-kernel-optimization__heartbeat",
+      "outcome_status": "completed",
+      "failure_class": "none_observed",
+      "causal_summary": "heartbeat 在 vliw-kernel-optimization 由外部 driver 持有 Turn 边界、每轮重读 worktree，经 1 轮续跑稳定收敛（reward=1.0, partial=1.0）。",
+      "expectedness": "expected",
+      "implication": "external automation 驱动的续跑在无人长程下更稳（本轮观测，非因果定论）。",
+      "next_probe": "在更多任务与重复运行上验证该趋势是否持续。",
+      "confidence": "low",
+      "evidence_refs": [
+        "run:vliw-kernel-optimization__heartbeat"
+      ],
+      "privacy_classification": "public_safe",
+      "producer_redaction_attested": true
+    },
+    {
+      "schema_version": "benchmark_case_insight_projection_v0",
+      "benchmark_id": "swe-marathon",
+      "study_id": "codex-loopx-access-modes",
+      "case_id": "zstd-decoder",
+      "run_id": "zstd-decoder__codex-cli",
+      "outcome_status": "runner_invalid",
+      "failure_class": "unattended_continuation_idle_churn",
+      "causal_summary": "codex-cli 在 zstd-decoder 多轮续跑退化为空转：unblock=8、cont=10、终态未 complete；与其 guard 缺 --begin-turn、按人值守 TUI 设计而被适配到无人运行有关（假设）。",
+      "expectedness": "unexpected",
+      "implication": "codex-cli 的表现更可能受 harness 与无人运行方式匹配度影响，而非模型能力弱。",
+      "next_probe": "补 --begin-turn / 对齐回合边界后重跑；比较有效工作 Turn 与重复 blocked。",
+      "confidence": "medium",
+      "evidence_refs": [
+        "run:zstd-decoder__codex-cli"
+      ],
+      "privacy_classification": "public_safe",
+      "producer_redaction_attested": true
+    },
+    {
+      "schema_version": "benchmark_case_insight_projection_v0",
+      "benchmark_id": "swe-marathon",
+      "study_id": "codex-loopx-access-modes",
+      "case_id": "zstd-decoder",
+      "run_id": "zstd-decoder__heartbeat",
+      "outcome_status": "completed",
+      "failure_class": "none_observed",
+      "causal_summary": "heartbeat 在 zstd-decoder 由外部 driver 持有 Turn 边界、每轮重读 worktree，经 4 轮续跑稳定收敛（reward=1.0, partial=1.0）。",
+      "expectedness": "expected",
+      "implication": "external automation 驱动的续跑在无人长程下更稳（本轮观测，非因果定论）。",
+      "next_probe": "在更多任务与重复运行上验证该趋势是否持续。",
+      "confidence": "low",
+      "evidence_refs": [
+        "run:zstd-decoder__heartbeat"
+      ],
+      "privacy_classification": "public_safe",
+      "producer_redaction_attested": true
+    }
+  ]
+}

--- a/benchmark/swe-marathon/scoring/case_insights.py
+++ b/benchmark/swe-marathon/scoring/case_insights.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""把五模式聚合（viz/data.json）里的观察，投影成 LoopX 官方的
+`benchmark_case_insight_projection_v0` 记录（见 upstream #3878 / RFC #3812）。
+
+契约要点（对齐 loopx/capabilities/benchmark_toolkit/study_projection.py）：
+  · 每条 insight 是某次 terminal run 的 child：带 case_id + run_id + terminal outcome_status
+  · privacy_classification = public_safe；producer_redaction_attested = True
+  · 只放**精简/脱敏**结论：causal_summary / implication / next_probe 各 ≤600 字符
+  · evidence_refs 只放句柄（run_dir 之类），**不含** raw 轨迹/工具输出
+  · outcome_status ∈ {completed, runner_invalid, cancelled}（终态）
+  · expectedness ∈ {expected, unexpected, mixed, unknown}；confidence ∈ {low, medium, high}
+
+本脚本只**产出**记录，不上传；真正 attach 需要 experiment-board 上对应的 run row
+（见 README 血缘：board run 属后续 follow-up）。用法：
+    case_insights.py viz/data.json case_insights.json
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+from _common import safe_path
+
+SCHEMA = "benchmark_case_insight_projection_v0"
+BENCHMARK_ID = "swe-marathon"
+STUDY_ID = "codex-loopx-access-modes"
+TERMINAL = {"completed", "runner_invalid", "cancelled"}
+_COMPLETE = "complete"
+
+
+def _clip(s: str, limit: int = 600) -> str:
+    s = " ".join((s or "").split())
+    return s if len(s) <= limit else s[:limit - 1] + "…"
+
+
+def _run_id(run_dir: str, task: str, arm: str) -> str:
+    """从 run_dir 派生稳定、public-safe 的 run 句柄。
+
+    刻意**不含** stamp：run_dir 里带的是具体运行时间戳（过细的私有细节），
+    evidence 句柄只保留 case+arm 这一层，避免把运行时刻也列入公开产物。
+    """
+    raw = f"{task}__{arm}"
+    return re.sub(r"[^A-Za-z0-9._-]", "-", raw).strip("-._")
+
+
+def _outcome_status(cell: dict) -> str:
+    """把我们的 goal-receipt 状态映射到契约的终态。
+
+    complete → completed；构建失败/blocked/其它 → runner_invalid（该次运行未产出
+    可countable的能力结果，属运行侧失败，不是模型能力定论）。
+    """
+    if cell.get("status") == "complete" and not cell.get("build_failed"):
+        return "completed"
+    return "runner_invalid"
+
+
+def _build_failed_insight(task: str, arm: str) -> tuple:
+    return ("build_failed_gate_zeroed",
+            (f"{arm} 在 {task} 构建阶段失败，partial_score 被门禁归零；"
+             f"属运行/环境侧失败，非模型能力定论。"),
+            "该格作为观测计入 matched 分母并单列标注，不单臂剔除。",
+            "重复运行以区分偶发构建失败与稳定失配；必要时对齐镜像/依赖。",
+            "unexpected", "medium")
+
+
+def _idle_churn_insight(task: str, arm: str, unblock: int, cont: int) -> tuple:
+    return ("unattended_continuation_idle_churn",
+            (f"{arm} 在 {task} 多轮续跑退化为空转：unblock={unblock}、cont={cont}、"
+             f"终态未 {_COMPLETE}；与其 guard 缺 --begin-turn、按人值守 TUI 设计而被"
+             f"适配到无人运行有关（假设）。"),
+            "codex-cli 的表现更可能受 harness 与无人运行方式匹配度影响，而非模型能力弱。",
+            "补 --begin-turn / 对齐回合边界后重跑；比较有效工作 Turn 与重复 blocked。",
+            "unexpected", "medium")
+
+
+def _stable_continuation_insight(task: str, arm: str, cont: int,
+                                 reward, partial) -> tuple:
+    return ("none_observed",
+            (f"{arm} 在 {task} 由外部 driver 持有 Turn 边界、每轮重读 worktree，"
+             f"经 {cont} 轮续跑稳定收敛（reward={reward}, partial={partial}）。"),
+            "external automation 驱动的续跑在无人长程下更稳（本轮观测，非因果定论）。",
+            "在更多任务与重复运行上验证该趋势是否持续。",
+            "expected", "low")
+
+
+def _insight_for(task: str, arm: str, cell: dict) -> dict | None:
+    """只为**有明确洞见**的 case 生成记录（否则返回 None）。"""
+    partial = cell.get("partial")
+    reward = cell.get("reward")
+    build_failed = bool(cell.get("build_failed"))
+    unblock = cell.get("unblock") or 0
+    cont = cell.get("cont") or 0
+    status = cell.get("status")
+
+    if build_failed:
+        (fc, causal, impl, probe, exp, conf) = _build_failed_insight(task, arm)
+    elif arm == "codex-cli" and status != _COMPLETE and unblock >= 5:
+        (fc, causal, impl, probe, exp, conf) = _idle_churn_insight(task, arm, unblock, cont)
+    elif (arm == "heartbeat" and status == _COMPLETE and cont > 0
+          and (reward == 1 or (partial or 0) >= 0.99)):
+        (fc, causal, impl, probe, exp, conf) = _stable_continuation_insight(
+            task, arm, cont, reward, partial)
+    else:
+        return None
+
+    rid = _run_id(cell.get("run_dir", ""), task, arm)
+    return {
+        "schema_version": SCHEMA,
+        "benchmark_id": BENCHMARK_ID,
+        "study_id": STUDY_ID,
+        "case_id": task,
+        "run_id": rid,
+        "outcome_status": _outcome_status(cell),
+        "failure_class": fc,
+        "causal_summary": _clip(causal),
+        "expectedness": exp,
+        "implication": _clip(impl),
+        "next_probe": _clip(probe),
+        "confidence": conf,
+        # 只放 case+arm 句柄（无 stamp / 无 raw）；具体 run 目录属私有证据。
+        "evidence_refs": [f"run:{rid}"],
+        "privacy_classification": "public_safe",
+        "producer_redaction_attested": True,
+    }
+
+
+def build(data: dict) -> list[dict]:
+    out = []
+    for task, cols in data.get("cells", {}).items():
+        for arm, cell in cols.items():
+            if not isinstance(cell, dict):
+                continue
+            rec = _insight_for(task, arm, cell)
+            if rec:
+                out.append(rec)
+    out.sort(key=lambda r: (r["case_id"], r["run_id"]))
+    return out
+
+
+def main() -> int:
+    src = safe_path(sys.argv[1] if len(sys.argv) > 1 else "viz/data.json")
+    outp = safe_path(sys.argv[2] if len(sys.argv) > 2 else "case_insights.json")
+    data = json.loads(src.read_text())
+    records = build(data)
+    payload = {
+        "note": ("public-safe case-insight projections for the codex×LoopX SWE-Marathon "
+                 "study; conforms to benchmark_case_insight_projection_v0 (upstream #3878 / "
+                 "RFC #3812). Attaching to an experiment-board run is a follow-up."),
+        "schema_version": SCHEMA,
+        "count": len(records),
+        "records": records,
+    }
+    outp.write_text(json.dumps(payload, ensure_ascii=False, indent=2))
+    print(f"写出 {outp}：{len(records)} 条 case-insight")
+    for r in records:
+        print(f"  {r['case_id']:26} {r['failure_class']:34} "
+              f"exp={r['expectedness']:10} conf={r['confidence']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmark/swe-marathon/scoring/test_case_insights.py
+++ b/benchmark/swe-marathon/scoring/test_case_insights.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""case_insights.py 的回归测试：产出的记录必须满足 LoopX 官方
+`benchmark_case_insight_projection_v0` 契约（upstream #3878 / RFC #3812）。
+
+契约规则内联自 loopx/capabilities/benchmark_toolkit/study_projection.py 的
+normalize_benchmark_case_insight_projection（该模块依赖 loopx 深层包，无法单文件加载，
+故在此按同一规则断言；字段/取值集合与上游一致）。可直接 `python3 test_case_insights.py`。
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import case_insights
+
+_SCHEMA = "benchmark_case_insight_projection_v0"
+_TERMINAL = {"completed", "runner_invalid", "cancelled"}
+_EXPECT = {"expected", "unexpected", "mixed", "unknown"}
+_CONF = {"low", "medium", "high"}
+_ALLOWED = {
+    "schema_version", "benchmark_id", "study_id", "case_id", "run_id", "outcome_status",
+    "failure_class", "causal_summary", "expectedness", "implication", "next_probe",
+    "confidence", "evidence_refs", "privacy_classification", "producer_redaction_attested",
+}
+
+
+def _assert_contract(p: dict) -> None:
+    assert set(p) <= _ALLOWED, f"unknown fields: {set(p) - _ALLOWED}"
+    assert p["schema_version"] == _SCHEMA
+    assert p["privacy_classification"] == "public_safe"
+    assert p["producer_redaction_attested"] is True
+    assert p["expectedness"] in _EXPECT
+    assert p["confidence"] in _CONF
+    assert p["outcome_status"] in _TERMINAL
+    refs = p.get("evidence_refs", [])
+    assert isinstance(refs, list) and len(refs) <= 16
+    for x in refs:
+        assert isinstance(x, str) and x.strip()
+        # public-safe：句柄不得内联 raw 轨迹/工具输出
+        assert "\n" not in x
+    for f in ("benchmark_id", "study_id", "case_id", "run_id", "failure_class"):
+        assert isinstance(p[f], str) and p[f].strip(), f"empty token: {f}"
+    for f in ("causal_summary", "implication", "next_probe"):
+        assert isinstance(p[f], str) and len(p[f]) <= 600, f"bounded_text: {f}"
+
+
+def _sample_data() -> dict:
+    def cell(task, arm, **kw):
+        base = {"task": task, "arm": arm, "reward": 0.0, "partial": 0.0,
+                "build_failed": False, "status": None, "cont": 0, "unblock": 0,
+                "run_dir": f"{task}/{arm}/20260102-030405/{arm}"}
+        base.update(kw)
+        return base
+    cells = {
+        "kubernetes-rust-rewrite": {
+            "codex-cli": cell("kubernetes-rust-rewrite", "codex-cli",
+                              build_failed=True, status="blocked", unblock=8, cont=10),
+            "heartbeat": cell("kubernetes-rust-rewrite", "heartbeat",
+                              reward=1.0, partial=1.0, status="complete"),
+        },
+        "zstd-decoder": {
+            "codex-cli": cell("zstd-decoder", "codex-cli",
+                              partial=0.60, status="blocked", unblock=8, cont=10),
+        },
+        "excel-clone": {  # 无明确洞见 → 不应生成记录
+            "plain": cell("excel-clone", "plain", partial=0.49),
+        },
+    }
+    return {"cells": cells}
+
+
+def test_records_conform_to_contract():
+    recs = case_insights.build(_sample_data())
+    assert recs, "should produce at least one insight"
+    for r in recs:
+        _assert_contract(r)
+
+
+def test_build_failure_and_idle_churn_detected():
+    recs = case_insights.build(_sample_data())
+    fclasses = {(r["case_id"], r["failure_class"]) for r in recs}
+    assert ("kubernetes-rust-rewrite", "build_failed_gate_zeroed") in fclasses
+    assert ("zstd-decoder", "unattended_continuation_idle_churn") in fclasses
+    # 无洞见的普通格不产出
+    assert not any(r["case_id"] == "excel-clone" for r in recs)
+
+
+def test_build_failure_maps_to_runner_invalid():
+    recs = case_insights.build(_sample_data())
+    bf = next(r for r in recs if r["failure_class"] == "build_failed_gate_zeroed")
+    assert bf["outcome_status"] == "runner_invalid"
+
+
+def test_cli_writes_valid_file():
+    data = _sample_data()
+    with tempfile.TemporaryDirectory() as d:
+        src = Path(d) / "data.json"
+        out = Path(d) / "case_insights.json"
+        src.write_text(json.dumps(data))
+        import sys
+        argv = sys.argv
+        sys.argv = ["case_insights.py", str(src), str(out)]
+        try:
+            case_insights.main()
+        finally:
+            sys.argv = argv
+        payload = json.loads(out.read_text())
+        assert payload["schema_version"] == _SCHEMA
+        assert payload["count"] == len(payload["records"])
+        for r in payload["records"]:
+            _assert_contract(r)
+
+
+def _run() -> int:
+    fails = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"  PASS {name}")
+            except AssertionError as e:
+                fails += 1
+                print(f"  FAIL {name}: {e}")
+    print("OK" if not fails else f"{fails} failed")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run())


### PR DESCRIPTION
Project the five-mode SWE-Marathon study's per-case observations into LoopX's **public-safe** `benchmark_case_insight_projection_v0` records (follows #3878 / RFC #3812).

- `scoring/case_insights.py` — derive insight records from the pinned `data.json`.
- `scoring/test_case_insights.py` — assert every record satisfies the upstream contract (field set, terminal outcome_status, public_safe, redaction-attested, ≤600-char text, handle-only evidence_refs).
- `case_insights.json` — 5 pinned records: build-failure gate-zero, codex-cli unattended continuation idle-churn, heartbeat stable continuation.

All are `public_safe` with `producer_redaction_attested=true`; `evidence_refs` carry only `run:<case>__<arm>` handles (no raw trajectories, no timestamps). Attaching each record to an experiment-board terminal run row is left as a follow-up (board run rows are not yet uploaded).