### PR TITLE
fix(periodic-report): honor live machine defaults

### DIFF
--- a/loopx/capabilities/machine_configuration/cli.py
+++ b/loopx/capabilities/machine_configuration/cli.py
@@ -18,6 +18,7 @@ from .store import (
     configure_machine_configuration,
     inspect_machine_configuration,
     read_machine_configuration,
+    read_stored_machine_configuration,
     rollback_machine_configuration,
 )
 
@@ -62,7 +63,9 @@ def _render(payload: dict[str, object]) -> str:
             title = str(item.get("title") or namespace)
             versions = item.get("schema_versions")
             version_text = (
-                ", ".join(map(str, versions)) if isinstance(versions, list) else "unknown"
+                ", ".join(map(str, versions))
+                if isinstance(versions, list)
+                else "unknown"
             )
             lines.append(f"- `{namespace}` — {title} (`{version_text}`)")
     return "\n".join(lines) + "\n"
@@ -169,7 +172,7 @@ def handle_machine_configuration_command(
             configuration = _load_json_object(args.config_json)
             if args.namespace:
                 configuration = merge_machine_configuration_namespace(
-                    read_machine_configuration(runtime_root, registry=registry),
+                    read_stored_machine_configuration(runtime_root),
                     namespace=args.namespace,
                     namespace_configuration=configuration,
                     registry=registry,
@@ -183,7 +186,7 @@ def handle_machine_configuration_command(
             configuration = _load_json_object(args.config_json)
             if args.namespace:
                 configuration = merge_machine_configuration_namespace(
-                    read_machine_configuration(runtime_root, registry=registry),
+                    read_stored_machine_configuration(runtime_root),
                     namespace=args.namespace,
                     namespace_configuration=configuration,
                     registry=registry,

--- a/loopx/capabilities/machine_configuration/contract.py
+++ b/loopx/capabilities/machine_configuration/contract.py
@@ -123,11 +123,25 @@ def merge_machine_configuration_namespace(
     """Build one whole-document update while preserving sibling namespaces."""
 
     contract = registry.resolve(namespace)
+    # Namespace updates are also the recovery path for an installed namespace
+    # whose previously valid value no longer satisfies the current contract.
+    # Keep the stored value opaque until the owning namespace has replaced it;
+    # the final whole-document normalization below still validates every
+    # sibling and the new value before a plan can be produced.
     normalized_current = (
-        normalize_machine_configuration(current, registry=registry)
+        _mapping(current, "machine_configuration")
         if current is not None
         else {"schema_version": MACHINE_CONFIGURATION_SCHEMA, "namespaces": {}}
     )
+    if normalized_current.get("schema_version") != MACHINE_CONFIGURATION_SCHEMA:
+        raise ValueError(
+            f"machine_configuration must use {MACHINE_CONFIGURATION_SCHEMA}"
+        )
+    unknown = sorted(set(normalized_current) - {"schema_version", "namespaces"})
+    if unknown:
+        raise ValueError(
+            "machine_configuration contains unsupported fields: " + ", ".join(unknown)
+        )
     current_namespaces = _mapping(
         normalized_current.get("namespaces"), "machine_configuration.namespaces"
     )

--- a/loopx/capabilities/machine_configuration/store.py
+++ b/loopx/capabilities/machine_configuration/store.py
@@ -111,6 +111,23 @@ def read_machine_configuration(
     return normalized
 
 
+def read_stored_machine_configuration(runtime_root: Path) -> dict[str, Any] | None:
+    """Read the exact stored envelope for fenced repair and rollback.
+
+    Normal reads remain fail-closed through ``read_machine_configuration``.
+    Mutation planning needs the prior bytes even when one namespace became
+    legacy, otherwise the transactional API cannot replace or restore it.
+    """
+
+    path = machine_configuration_store_path(runtime_root)
+    if not path.is_file():
+        return None
+    payload = read_json(path)
+    if not isinstance(payload, dict):
+        raise ValueError("machine_configuration must be an object")
+    return payload
+
+
 def inspect_machine_configuration(
     runtime_root: Path, *, registry: MachineConfigurationRegistry
 ) -> dict[str, Any]:
@@ -145,14 +162,10 @@ def _update_plan(
         if desired is not None
         else None
     )
-    normalized_current = (
-        normalize_machine_configuration(current, registry=registry)
-        if current is not None
-        else None
-    )
+    stored_current = dict(current) if current is not None else None
     current_revision = (
-        machine_configuration_revision(normalized_current)
-        if normalized_current is not None
+        machine_configuration_revision(stored_current)
+        if stored_current is not None
         else _MISSING_REVISION
     )
     desired_revision = (
@@ -162,7 +175,7 @@ def _update_plan(
     )
     action = (
         "create"
-        if normalized_current is None and normalized_desired is not None
+        if stored_current is None and normalized_desired is not None
         else "unchanged"
         if current_revision == desired_revision
         else "delete"
@@ -177,8 +190,8 @@ def _update_plan(
         "changed_namespaces": sorted(
             namespace
             for namespace in set((normalized_desired or {}).get("namespaces", {}))
-            | set((normalized_current or {}).get("namespaces", {}))
-            if (normalized_current or {}).get("namespaces", {}).get(namespace)
+            | set((stored_current or {}).get("namespaces", {}))
+            if (stored_current or {}).get("namespaces", {}).get(namespace)
             != (normalized_desired or {}).get("namespaces", {}).get(namespace)
         ),
     }
@@ -204,7 +217,7 @@ def plan_machine_configuration_update(
     registry: MachineConfigurationRegistry,
 ) -> dict[str, Any]:
     return _update_plan(
-        current=read_machine_configuration(runtime_root, registry=registry),
+        current=read_stored_machine_configuration(runtime_root),
         desired=configuration,
         registry=registry,
     )
@@ -247,7 +260,7 @@ def configure_machine_configuration(
 
     store_path = machine_configuration_store_path(runtime_root)
     with exclusive_file_lock(store_path, operation="configure_machine_configuration"):
-        current = read_machine_configuration(runtime_root, registry=registry)
+        current = read_stored_machine_configuration(runtime_root)
         plan = _update_plan(current=current, desired=configuration, registry=registry)
         if plan["plan_revision"] != expected:
             raise ValueError(
@@ -372,11 +385,9 @@ def _read_backup(
     ):
         raise ValueError("machine-configuration transaction backup is invalid")
     prior = backup.get("prior_machine_configuration")
-    normalized_prior = (
-        normalize_machine_configuration(prior, registry=registry)
-        if prior is not None
-        else None
-    )
+    if prior is not None and not isinstance(prior, Mapping):
+        raise ValueError("machine-configuration transaction backup is invalid")
+    normalized_prior = dict(prior) if prior is not None else None
     prior_revision = (
         machine_configuration_revision(normalized_prior)
         if normalized_prior is not None
@@ -440,7 +451,7 @@ def plan_machine_configuration_rollback(
     safe_id = _safe_transaction_id(transaction_id)
     receipt = _read_transaction(runtime_root, safe_id)
     backup = _read_backup(runtime_root, safe_id, receipt, registry=registry)
-    current = read_machine_configuration(runtime_root, registry=registry)
+    current = read_stored_machine_configuration(runtime_root)
     return _rollback_plan(
         transaction_id=safe_id,
         receipt=receipt,
@@ -475,7 +486,7 @@ def rollback_machine_configuration(
     with exclusive_file_lock(store_path, operation="rollback_machine_configuration"):
         receipt = _read_transaction(runtime_root, safe_id)
         backup = _read_backup(runtime_root, safe_id, receipt, registry=registry)
-        current = read_machine_configuration(runtime_root, registry=registry)
+        current = read_stored_machine_configuration(runtime_root)
         plan = _rollback_plan(
             transaction_id=safe_id,
             receipt=receipt,
@@ -504,7 +515,7 @@ def rollback_machine_configuration(
         rollback_path = _runtime_root(runtime_root) / _transaction_ref(rollback_id)
         try:
             _restore_prior_state(store_path=store_path, prior=prior, writer=writer)
-            readback = read_machine_configuration(runtime_root, registry=registry)
+            readback = read_stored_machine_configuration(runtime_root)
             if readback != prior:
                 raise RuntimeError(
                     "machine-configuration rollback readback did not match backup"
@@ -550,5 +561,6 @@ __all__ = [
     "plan_machine_configuration_rollback",
     "plan_machine_configuration_update",
     "read_machine_configuration",
+    "read_stored_machine_configuration",
     "rollback_machine_configuration",
 ]

--- a/loopx/capabilities/periodic_report/post_writeback_hook.py
+++ b/loopx/capabilities/periodic_report/post_writeback_hook.py
@@ -16,12 +16,15 @@ from ...control_plane.goals.goal_frontier import (
 from ...control_plane.todos.active_state_todo_parser import parse_active_state_todos
 from ...control_plane.todos.quota_summary import summarize_user_todos_for_quota
 from ...history import collect_history, load_registry
+from ...paths import resolve_runtime_root
 from ...registry import registry_goals
 from .stage_completion import STAGE_COMPLETION_RECEIPT_SCHEMA
 from .stage_completion import derive_periodic_report_stage_completion_from_runs
 from .presets import build_periodic_report_preset_activation
 from .project_progress_snapshot import build_project_progress_snapshot_from_state
 from .incremental import read_periodic_report_publication_cursor
+from .machine_defaults import resolve_goal_periodic_report_subscription
+from .machine_store import read_periodic_report_machine_defaults
 from .triggers import build_periodic_report_trigger_decision
 
 
@@ -60,14 +63,38 @@ def _goal_config(registry_path: Path, goal_id: str) -> Mapping[str, Any]:
 
 
 def periodic_report_post_writeback_hooks_for_goal(
-    *, registry_path: Path, goal_id: str
+    *, registry_path: Path, goal_id: str, runtime_root: Path | None = None
 ) -> tuple[PostWritebackHookRegistration, ...]:
-    """Resolve the explicit project profile opt-in at the composition root."""
+    """Resolve a Goal override or live machine-default profile at composition."""
 
-    config = _goal_config(registry_path, goal_id)
-    if config.get("enabled") is not True:
+    registry = load_registry(registry_path)
+    effective_runtime_root = runtime_root or resolve_runtime_root(
+        registry,
+        registry_path=registry_path,
+    )
+    goal = next(
+        (
+            item
+            for item in registry_goals(registry)
+            if str(item.get("id") or "").strip() == str(goal_id or "").strip()
+        ),
+        None,
+    )
+    if not isinstance(goal, Mapping):
         return ()
-    preset = str(config.get("profile_preset") or "").strip()
+    goal_override = _goal_config(registry_path, goal_id)
+    if goal_override:
+        if goal_override.get("enabled") is not True:
+            return ()
+        preset = str(goal_override.get("profile_preset") or "").strip()
+    else:
+        subscription = resolve_goal_periodic_report_subscription(
+            goal,
+            read_periodic_report_machine_defaults(effective_runtime_root),
+        )
+        if subscription.get("enabled") is not True:
+            return ()
+        preset = str(subscription.get("profile_preset") or "").strip()
     if not preset:
         return ()
     activation = build_periodic_report_preset_activation(preset)

--- a/loopx/extensions/lark/periodic_report_delivery.py
+++ b/loopx/extensions/lark/periodic_report_delivery.py
@@ -18,10 +18,17 @@ from ...capabilities.periodic_report.incremental import (
     commit_periodic_report_publication_cursor,
     find_periodic_report_publication_candidate,
 )
+from ...capabilities.periodic_report.machine_defaults import (
+    resolve_goal_periodic_report_subscription,
+)
+from ...capabilities.periodic_report.machine_store import (
+    read_periodic_report_machine_defaults,
+)
 from . import LARK_EXTENSION_ID, LARK_GOAL_CHANNEL_PERMISSION
 from .goal_channel_contracts import (
     binding_for_goal,
     default_goal_channel_binding_path,
+    goal_from_registry,
     read_goal_channel_binding,
 )
 from .goal_channel_targets import (
@@ -43,6 +50,7 @@ from .goal_channel_transport import (
 )
 from .presentation.kanban import CommandRunner, default_subprocess_runner
 from .presentation.periodic_report import periodic_report_lark_sink_adapter
+from ...registry import read_json
 
 
 GOAL_CHANNEL_DELIVERY_REQUEST_SCHEMA = (
@@ -144,9 +152,28 @@ def _resolved_goal_channel_binding(
         default_goal_channel_binding_path(registry_path)
     )
     raw = binding_for_goal(payload, goal_id)
+    target_ref = str((raw or {}).get("target_ref") or "").strip()
     if raw is None:
-        raise ValueError("periodic report delivery requires a Goal Channel binding")
-    target_ref = str(raw.get("target_ref") or "").strip()
+        goal = goal_from_registry(read_json(registry_path), goal_id)
+        subscription = resolve_goal_periodic_report_subscription(
+            goal,
+            read_periodic_report_machine_defaults(runtime_root),
+        )
+        if subscription.get("enabled") is not True:
+            raise ValueError(
+                "periodic report delivery requires an enabled subscription"
+            )
+        target_ref = str(subscription.get("route_ref") or "").strip()
+        if not target_ref:
+            raise ValueError("periodic report subscription route is missing")
+        raw = {
+            "goal_id": goal_id,
+            "provider": "lark",
+            "enabled": True,
+            "target_ref": target_ref,
+            "channel": {},
+            "identity": {},
+        }
     target = None
     if target_ref:
         target = goal_channel_target_for_name(
@@ -155,8 +182,17 @@ def _resolved_goal_channel_binding(
         )
         if target is None:
             raise ValueError("periodic report Goal Channel target is missing")
+    resolution_payload = payload
+    if binding_for_goal(payload, goal_id) is None:
+        resolution_payload = {
+            **payload,
+            "bindings": {
+                **dict(payload.get("bindings") or {}),
+                goal_id: raw,
+            },
+        }
     resolved = binding_for_goal(
-        payload,
+        resolution_payload,
         goal_id,
         provider_target=target,
     )
@@ -611,7 +647,9 @@ def deliver_periodic_report_to_goal_channel(
             else None
         ),
         "boundary": {
-            "goal_channel_binding_required": True,
+            "goal_channel_binding_required": False,
+            "goal_channel_binding_preferred": True,
+            "machine_default_route_allowed_when_unbound": True,
             "project_bot_identity_required": True,
             "caller_identity_override_allowed": False,
             "exact_sender_and_chat_readback_required": True,

--- a/tests/capabilities/test_periodic_report_machine_store.py
+++ b/tests/capabilities/test_periodic_report_machine_store.py
@@ -401,9 +401,7 @@ def test_canonical_machine_config_cli_uses_the_same_store_and_projection(
     assert main([*common, "describe"]) == 0
     catalog = json.loads(capsys.readouterr().out)
     assert catalog["schema_version"] == "machine_configuration_catalog_v0"
-    assert [item["namespace"] for item in catalog["namespaces"]] == [
-        "periodic_report"
-    ]
+    assert [item["namespace"] for item in catalog["namespaces"]] == ["periodic_report"]
 
     assert (
         main(
@@ -600,6 +598,90 @@ def test_canonical_machine_config_cli_accepts_one_namespace_patch(
     )
     applied = json.loads(capsys.readouterr().out)
     assert applied["status"] == "applied"
+
+
+def test_namespace_patch_transactionally_replaces_legacy_installed_value(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    store_path = machine_defaults_store_path(runtime_root)
+    store_path.parent.mkdir(parents=True)
+    legacy = _defaults()
+    legacy["namespaces"]["periodic_report"]["inheritance"] = (
+        "materialize_on_goal_connect"
+    )
+    store_path.write_text(json.dumps(legacy), encoding="utf-8")
+    namespace_path = tmp_path / "periodic-report.json"
+    namespace_path.write_text(
+        json.dumps(_defaults()["namespaces"]["periodic_report"]), encoding="utf-8"
+    )
+    common = [
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "machine-config",
+    ]
+
+    assert main([*common, "inspect"]) == 2
+    assert (
+        "must be live_machine_default" in json.loads(capsys.readouterr().out)["error"]
+    )
+
+    assert (
+        main(
+            [
+                *common,
+                "preview",
+                "--namespace",
+                "periodic_report",
+                "--config-json",
+                str(namespace_path),
+            ]
+        )
+        == 0
+    )
+    preview = json.loads(capsys.readouterr().out)
+    assert preview["action"] == "update"
+    assert preview["changed_namespaces"] == ["periodic_report"]
+
+    assert (
+        main(
+            [
+                *common,
+                "apply",
+                "--namespace",
+                "periodic_report",
+                "--config-json",
+                str(namespace_path),
+                "--expected-plan-revision",
+                preview["plan_revision"],
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["status"] == "applied"
+    assert applied["rollback_available"] is True
+    assert json.loads(store_path.read_text(encoding="utf-8")) == _defaults()
+
+    rollback_preview = plan_periodic_report_machine_defaults_rollback(
+        runtime_root=runtime_root,
+        transaction_id=applied["transaction_id"],
+    )
+    restored = rollback_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        transaction_id=applied["transaction_id"],
+        execute=True,
+        expected_plan_revision=rollback_preview["plan_revision"],
+    )
+    assert restored["status"] == "rolled_back"
+    assert json.loads(store_path.read_text(encoding="utf-8")) == legacy
 
 
 def test_inspection_is_path_free_and_reports_absence(tmp_path: Path) -> None:

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -333,7 +333,9 @@ def test_periodic_report_hook_requires_explicit_goal_profile_opt_in(tmp_path) ->
 
     assert (
         periodic_report_post_writeback_hooks_for_goal(
-            registry_path=registry_path, goal_id="goal-1"
+            registry_path=registry_path,
+            runtime_root=tmp_path / "runtime",
+            goal_id="goal-1",
         )
         == ()
     )
@@ -343,7 +345,7 @@ def test_periodic_report_hook_requires_explicit_goal_profile_opt_in(tmp_path) ->
     registry_path.write_text(json.dumps(registry), encoding="utf-8")
 
     hooks = periodic_report_post_writeback_hooks_for_goal(
-        registry_path=registry_path, goal_id="goal-1"
+        registry_path=registry_path, runtime_root=tmp_path / "runtime", goal_id="goal-1"
     )
     assert len(hooks) == 1
     assert hooks[0].hook_id == "periodic_report.runtime_trigger"
@@ -372,6 +374,51 @@ def test_periodic_report_hook_requires_explicit_goal_profile_opt_in(tmp_path) ->
     assert decision["eligible"] is True
     assert decision["selected_trigger_kind"] == "bounded_segment_milestone"
     assert decision["boundary"]["external_writes_performed"] is False
+
+
+def test_periodic_report_hook_uses_live_machine_default_without_goal_mutation(
+    tmp_path,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_payload = {"goals": [{"id": "goal-1"}]}
+    registry_path.write_text(json.dumps(registry_payload), encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    defaults = {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "periodic_report": {
+                "schema_version": "periodic_report_machine_defaults_v0",
+                "enabled": True,
+                "inheritance": "live_machine_default",
+                "profile_preset": "weekly-progress",
+                "route_ref": "loopx-concierge",
+                "timezone": "Asia/Shanghai",
+            }
+        },
+    }
+    from loopx.capabilities.periodic_report.machine_store import (
+        configure_periodic_report_machine_defaults,
+    )
+
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+    )
+    configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+
+    hooks = periodic_report_post_writeback_hooks_for_goal(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="goal-1",
+    )
+
+    assert len(hooks) == 1
+    assert json.loads(registry_path.read_text(encoding="utf-8")) == registry_payload
 
 
 def test_periodic_report_projection_reduces_durable_successor_transition(
@@ -572,7 +619,9 @@ def test_post_writeback_concurrent_exact_dispatch_single_flight(tmp_path) -> Non
 
     def worker() -> None:
         barrier.wait()
-        res = dispatch_post_writeback_hooks([hook], hook_input=_input(), journal=journal)
+        res = dispatch_post_writeback_hooks(
+            [hook], hook_input=_input(), journal=journal
+        )
         results.append(res)
 
     t1 = threading.Thread(target=worker)
@@ -793,7 +842,9 @@ def test_post_writeback_concurrent_exact_dispatch_lease_timeout_isolated(
     assert result_timeout["invoked_count"] == 0
     assert len(result_timeout["failures"]) == 1
     assert result_timeout["failures"][0]["error_code"] == "lock_acquire_timeout"
-    assert result_timeout["failures"][0]["hook_id"] == "periodic_report.stage_completion"
+    assert (
+        result_timeout["failures"][0]["hook_id"] == "periodic_report.stage_completion"
+    )
 
     # Slow worker completes successfully and records intent
     assert result_slow["primary_writeback_preserved"] is True
@@ -805,9 +856,7 @@ def test_post_writeback_concurrent_exact_dispatch_lease_timeout_isolated(
     assert calls == 1
 
     # Subsequent dispatch replays cleanly from terminal receipt without invoking producer
-    replay = dispatch_post_writeback_hooks(
-        [hook], hook_input=_input(), journal=journal
-    )
+    replay = dispatch_post_writeback_hooks([hook], hook_input=_input(), journal=journal)
     assert replay["intent_count"] == 1
     assert replay["invoked_count"] == 0
     assert replay["replayed_hooks"] == ["periodic_report.stage_completion"]

--- a/tests/extensions/test_periodic_report_goal_channel_delivery.py
+++ b/tests/extensions/test_periodic_report_goal_channel_delivery.py
@@ -15,6 +15,10 @@ from loopx.extensions.lark.goal_channel_contracts import (
     GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
     write_goal_channel_binding,
 )
+from loopx.extensions.lark.goal_channel_targets import add_lark_goal_channel_target
+from loopx.capabilities.periodic_report.machine_store import (
+    configure_periodic_report_machine_defaults,
+)
 from loopx.extensions.lark.periodic_report_delivery import (
     DELIVERY_INTENT_SCHEMA,
     GOAL_CHANNEL_DELIVERY_REQUEST_SCHEMA,
@@ -202,6 +206,100 @@ def _write_binding(
             },
         },
     )
+
+
+def _write_machine_default_route(runtime_root: Path) -> None:
+    target_path = runtime_root / "goal-channel-targets.json"
+    add_lark_goal_channel_target(
+        target_path=target_path,
+        target_name="loopx-concierge",
+        chat_id=CHAT_ID,
+        chat_name="LoopX Concierge",
+        identity_mode="project_bot",
+        sender_profile="project-reporter",
+        sender_identity="bot",
+        bot_app_id=APP_ID,
+        bot_display_name="Project Reporter",
+        cli_bin="lark-cli",
+        execute=True,
+    )
+    defaults = {
+        "schema_version": "loopx_machine_configuration_v0",
+        "namespaces": {
+            "periodic_report": {
+                "schema_version": "periodic_report_machine_defaults_v0",
+                "enabled": True,
+                "inheritance": "live_machine_default",
+                "profile_preset": "weekly-progress",
+                "route_ref": "loopx-concierge",
+                "timezone": "Asia/Shanghai",
+            }
+        },
+    }
+    preview = configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+    )
+    configure_periodic_report_machine_defaults(
+        runtime_root=runtime_root,
+        machine_defaults=defaults,
+        execute=True,
+        expected_plan_revision=preview["plan_revision"],
+    )
+
+
+def test_unbound_goal_uses_live_machine_default_shared_target(tmp_path: Path) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    runtime_root = tmp_path / "runtime"
+    registry_path.parent.mkdir()
+    registry_path.write_text(json.dumps({"goals": [{"id": GOAL_ID}]}), encoding="utf-8")
+    _write_machine_default_route(runtime_root)
+    calls: list[list[str]] = []
+
+    result = deliver_periodic_report_to_goal_channel(
+        _request(),
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        extension_activation=_extension_activation(),
+        execute=True,
+        runner=_runner(calls),
+    )
+
+    assert result["status"] == "satisfied"
+    assert result["boundary"]["machine_default_route_allowed_when_unbound"] is True
+    assert not (registry_path.parent / "goal-channel.json").exists()
+
+
+def test_explicit_goal_channel_binding_wins_over_machine_default_route(
+    tmp_path: Path,
+) -> None:
+    registry_path = tmp_path / ".loopx" / "registry.json"
+    runtime_root = tmp_path / "runtime"
+    registry_path.parent.mkdir()
+    registry_path.write_text(json.dumps({"goals": [{"id": GOAL_ID}]}), encoding="utf-8")
+    _write_binding(registry_path)
+    _write_machine_default_route(runtime_root)
+    targets_path = runtime_root / "goal-channel-targets.json"
+    targets = json.loads(targets_path.read_text(encoding="utf-8"))
+    targets["targets"]["loopx-concierge"]["identity"]["sender_profile"] = (
+        "must-not-be-used"
+    )
+    targets_path.write_text(json.dumps(targets), encoding="utf-8")
+    calls: list[list[str]] = []
+
+    result = deliver_periodic_report_to_goal_channel(
+        _request(),
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+        extension_activation=_extension_activation(),
+        execute=True,
+        runner=_runner(calls),
+    )
+
+    assert result["status"] == "satisfied"
+    assert all("must-not-be-used" not in args for args in calls)
 
 
 def _runner(calls: list[list[str]], *, normalized_readback: bool = False):


### PR DESCRIPTION
## Summary

- make namespace-scoped machine-configuration updates capable of transactionally replacing an installed legacy namespace while normal reads remain fail-closed
- activate periodic-report post-writeback hooks from the live machine default when a Goal has no explicit override
- allow unbound Goals to resolve the machine-default shared route directly, while preserving explicit Goal Channel bindings as the stronger authority
- add migration, rollback, inheritance, and explicit-binding precedence regressions

## Product and architecture judgment

Machine-default weekly reports previously had two disconnected pieces: configuration could be stored, but existing Goals did not consume the live default end to end, and a newly invalid legacy namespace could not be upgraded through the same transactional API because planning tried to validate the old value first. The implementation repairs that lifecycle without mutating every Goal or creating per-Goal delivery artifacts.

The authority order is explicit: Goal override and Goal Channel binding win; only an unconfigured Goal inherits the machine default. The bounded future-facing pass reuses the generic machine-configuration transaction and the existing periodic-report/Lark provider seams rather than adding a second configuration store.

## Validation

- focused pytest: 44 passed
- changed Python files compile
- TypeScript control-plane typecheck
- TypeScript control-plane tests: 483 passed, 1 PostgreSQL live test skipped by its declared environment gate
- `loopx canary premerge --from-git-diff`: 12/12 selected checks passed; merge gate passed
- `git diff --check`

Full-repository mypy is not a clean project gate on current main; it reports existing errors across unrelated modules. No credential, provider identifier, local state, or private delivery value is included in this PR.

## Remaining risk

This changes runtime periodic-report activation for machines that explicitly enable a live default. It does not enable a default by itself, does not overwrite existing Goal bindings, and keeps delivery fail-closed if the referenced shared target is unavailable.
