### PR TITLE
feat(provider): qualify runtime recovery boundaries

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -14,6 +14,12 @@ Integration candidate: `codex_provider_integration_candidate_v0`
 
 Heartbeat transport qualification: `codex_app_heartbeat_transport_qualification_v0`
 
+Desktop patch qualification: `codex_desktop_patch_qualification_v0`
+
+Quota recovery qualification: `codex_quota_recovery_qualification_v0`
+
+Tool transport qualification: `codex_tool_transport_qualification_v0`
+
 The provider accepts exactly one public-safe operation per invocation and
 returns a deterministic JSON result. An input containing credential-shaped
 keys fails before any operation runs.
@@ -67,13 +73,21 @@ traversed at most once. A route may then append a terminal fallback tail, but
 the tail is not a ring member and is never revisited. Explicit Ark remains a
 manual hard pin.
 
-Resilient routes apply two admission filters before ring traversal and
+Resilient routes apply baseline admission filters before ring traversal and
 affinity:
 
 1. every candidate must support all modalities required by the complete
    request history;
 2. when Fast is selected, every candidate must support the requested service
    tier.
+
+A third filter applies when the host requires a specific tool item transport.
+Native Codex profiles default to both `function_call` and `custom_tool_call`;
+generic OpenAI-compatible profiles default to `function_call` only, while an
+adapter that truly preserves custom items may declare that capability. A Code
+Mode request requiring `custom_tool_call` therefore cannot silently fall
+through to a function-only fallback. The separate qualification operation
+compares requested and observed item types and requires completed dispatch.
 
 Affinity can reorder only the remaining eligible ring members. If none remain,
 the route fails closed before the first visible output or tool call. A
@@ -90,6 +104,21 @@ to `priority`, while ordinary rows preserve the request. A preserved
 admission, so both the explicit sibling row and the native Fast entry are
 limited to Fast-capable providers. It never accepts a prompt or request body.
 A Fast request cannot fall through to a provider that does not support Fast.
+
+An applied quota reset is ordered against the observation that created a
+provider cooldown. When the reset is newer, the old cooldown is stale: CPA must
+invalidate it and probe that account before selecting a fallback. A fresh probe
+may either succeed or return a new quota limit; only the latter permits a new
+cooldown and fallback. This contract prevents a reset account from remaining
+unreachable until an obsolete expiry.
+
+Patched desktop builds have a separate post-build gate. The patch anchor must
+be unique for the current build, every changed ASAR member must have matching
+per-file integrity, the resulting ASAR header digest must match bundle
+metadata, the runtime must be signed and launch, and the patched heartbeat path
+must pass readback. Whole-archive hashing is not a substitute for Electron's
+header and per-file checks. The provider consumes only booleans and counts;
+bundle mutation and signing remain operator effects.
 
 Codex App settings use the same evidence rule. A selector label is not proof
 that a running turn adopted the new model. Qualification requires a durable

--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -82,12 +82,13 @@ affinity:
    tier.
 
 A third filter applies when the host requires a specific tool item transport.
-Native Codex profiles default to both `function_call` and `custom_tool_call`;
-generic OpenAI-compatible profiles default to `function_call` only, while an
-adapter that truly preserves custom items may declare that capability. A Code
-Mode request requiring `custom_tool_call` therefore cannot silently fall
-through to a function-only fallback. The separate qualification operation
-compares requested and observed item types and requires completed dispatch.
+Every profile that omits `tool_transports`, including a legacy native Codex
+profile, defaults conservatively to `function_call` only. An adapter may declare
+`custom_tool_call` only after it has proved that it preserves the raw payload
+and item type. A Code Mode request requiring `custom_tool_call` therefore cannot
+silently fall through to an unqualified or function-only provider. The separate
+qualification operation compares requested and observed item types and requires
+completed dispatch.
 
 Affinity can reorder only the remaining eligible ring members. If none remain,
 the route fails closed before the first visible output or tool call. A

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -44,7 +44,9 @@ qualification.
   The operation accepts no prompt, auth or request body. A caller may require
   `custom_tool_call`; providers that only preserve ordinary `function_call`
   items are then removed before traversal, so Code Mode fails closed instead
-  of reaching an incompatible fallback.
+  of reaching an incompatible fallback. Missing capability metadata is treated
+  as function-only, including for catalogs generated before version 0.7.0;
+  custom transport support must be declared explicitly after qualification.
 
 `qualify_desktop_patch`
 : Checks the public-safe post-build evidence for a patched desktop runtime:

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -41,7 +41,16 @@ qualification.
   request tier to `priority`; an ordinary selector preserves the caller's
   service tier. If that preserved tier is `priority`, candidate admission still
   switches to Fast-capable-only, so the native Fast entry cannot reach Ark.
-  The operation accepts no prompt, auth or request body.
+  The operation accepts no prompt, auth or request body. A caller may require
+  `custom_tool_call`; providers that only preserve ordinary `function_call`
+  items are then removed before traversal, so Code Mode fails closed instead
+  of reaching an incompatible fallback.
+
+`qualify_desktop_patch`
+: Checks the public-safe post-build evidence for a patched desktop runtime:
+  one versioned patch anchor, every changed file's ASAR integrity, the ASAR
+  header digest stored in bundle metadata, code signature, launch and heartbeat
+  readback. It diagnoses upgrade drift but never edits or signs an App bundle.
 
 `qualify_snapshot`
 : Checks the content-free App/CPA readback: visible and hidden routes, input
@@ -65,6 +74,17 @@ qualification.
   qualification also requires proof that the next observed action followed the
   preserved instruction; HTTP success alone cannot pass. Unknown, paired or
   empty outputs must remain a typed `409` failure.
+
+`qualify_quota_recovery`
+: Orders a successful account quota reset against the cooldown observation that
+  preceded it. A newer reset must invalidate the old cooldown and trigger a
+  bounded account probe before fallback is admitted; only a fresh quota-limited
+  probe may create a replacement cooldown.
+
+`qualify_tool_transport`
+: Checks that a requested tool item type survives provider adaptation and that
+  host dispatch completes. In particular, Code Mode `custom_tool_call` must not
+  be downgraded to `function_call {"input": ...}`.
 
 `project_runtime_status`
 : Joins a stable, route-independent host ChatGPT identity state with a
@@ -112,6 +132,18 @@ loopx extension run loopx-codex-provider-routing \
   --execute \
   --format json
 loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/desktop-patch.json \
+  --execute \
+  --format json
+loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/quota-recovery.json \
+  --execute \
+  --format json
+loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/tool-transport.json \
+  --execute \
+  --format json
+loopx extension run loopx-codex-provider-routing \
   --input-json packages/loopx-codex-provider-routing/examples/integration-candidate.json \
   --execute \
   --format json
@@ -129,7 +161,10 @@ The earlier operator scripts split into three classes:
 | --- | --- |
 | Secret-free profile/catalog compiler | Migrated into `compile_catalog` and strengthened with modality/service-tier eligibility |
 | Fast selector catalog generation and request-tier normalization | Migrated into `compile_catalog` plus `normalize_selector_request`; the CPA adapter remains the online enforcement point |
+| Code Mode tool-shape admission and readback | Migrated into profile `tool_transports`, `normalize_selector_request` and `qualify_tool_transport`; an incompatible fallback fails before first output |
 | App/CPA model readback assertions | Migrated as the content-free `qualify_snapshot` contract |
+| Patched desktop ASAR/signature/launch checks | Migrated as `qualify_desktop_patch`; the effectful bundle patcher stays operator-owned |
+| Quota reset versus cached cooldown reconciliation | Migrated as `qualify_quota_recovery`; live cooldown invalidation and probing stay CPA-owned |
 | Ordered PR/patch candidate inventory and drift detection | Migrated as `reconcile_integration_candidate`; Git composition remains owned by LoopX core `integration-branch` |
 | Upgrade matrix, snapshot order and rollback triggers | Migrated as `upgrade_plan`; effect execution remains operator-owned |
 | CPA process launcher, OAuth login/reconcile, Ark key loading | Excluded; these are provider runtime and credential lifecycle, not LoopX state |
@@ -147,6 +182,7 @@ integration because it is useful beyond CPA.
 
 ```bash
 python3 packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+python3 packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
 python3 -m pytest -q tests/extensions/test_colocated_extension_layout.py
 loopx check --scan-path packages/loopx-codex-provider-routing
 ```

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -12,6 +12,9 @@ ports, accounts or private receipts.
 | Generate explicit Fast sibling rows and inject the Fast request tier | Migrated as a public-safe compiler/normalizer contract | `contract.py::compile_catalog` plus `normalize_selector_request`; the live CPA adapter/plugin enforces the same decision before alias mapping |
 | Project host identity separately from actual A/B routing and quota | Migrated as a public-safe adapter boundary | `contract.py::project_runtime_status`; raw CPA management responses and logs remain operator-local |
 | Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
+| Verify a patched desktop runtime across versioned anchors, ASAR member/header integrity, signature, launch and heartbeat readback | Migrated as a read-only qualification | `qualify_desktop_patch`; patching, signing and process lifecycle remain operator-owned effects |
+| Invalidate a provider cooldown after a newer successful quota reset | Migrated as a recovery ordering contract | `qualify_quota_recovery`; CPA owns the live invalidation and bounded reprobe |
+| Preserve Code Mode tool item shape across heterogeneous fallback | Migrated as admission plus qualification | profile `tool_transports`, `normalize_selector_request` and `qualify_tool_transport`; adapters must prove custom-item preservation before declaring support |
 | Reconcile an ordered multi-PR candidate against exact heads and required seams | Migrated as a public-safe planning contract | `reconcile_integration_candidate` returns core `integration-branch` inputs; Git effects remain outside the extension |
 | Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
 | Snapshot App/selector configuration, validate hashes and roll back selected files | Planning contract migrated | `upgrade_plan` owns order, matrix and rollback trigger; filesystem effects need a future request-bound execution envelope |
@@ -27,7 +30,7 @@ ports, accounts or private receipts.
 
 ## Configuration References
 
-The package keeps six credential-free examples:
+The package keeps credential-free examples for every operation, including:
 
 - [`examples/request.json`](examples/request.json): logical profiles and model
   routes backed by one bounded account ring for `compile_catalog`;
@@ -42,6 +45,12 @@ The package keeps six credential-free examples:
 - [`examples/integration-candidate.json`](examples/integration-candidate.json):
   ordered source refs, exact heads, required seams and last-sync observations
   for `reconcile_integration_candidate`.
+- [`examples/desktop-patch.json`](examples/desktop-patch.json): post-build ASAR,
+  signature, launch and heartbeat qualification;
+- [`examples/quota-recovery.json`](examples/quota-recovery.json): reset/cooldown
+  ordering with bounded reprobe;
+- [`examples/tool-transport.json`](examples/tool-transport.json): requested and
+  observed tool item transport plus dispatch outcome.
 
 [`templates/codex-app-config.toml`](templates/codex-app-config.toml) and
 [`templates/cpa-config.public.yaml`](templates/cpa-config.public.yaml) preserve

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -791,11 +791,11 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 本机 bundle 路径、账号身份、task ID、原始日志、OAuth 和 reset token 都不得进入
 LoopX state 或公开 PR。
 
-`tool_transports` 是 profile capability，不是根据模型名字猜测的路由规则。默认情况下，
-原生 Codex profile 声明 `function_call` 与 `custom_tool_call`；普通
-OpenAI-compatible profile 只声明 `function_call`。只有适配器已经实现并验证 custom item
-保真时，才可显式追加 `custom_tool_call`。这样 text-only Ark 可以继续作为普通文本回答的
-terminal tail，却不会接住会触发 Code Mode `exec` 的 turn。
+`tool_transports` 是 profile capability，不是根据模型名字猜测的路由规则。字段缺失时，
+包括 0.6.x 生成的原生 Codex profile 在内，一律保守视为只支持 `function_call`。只有适配器
+已经实现并验证 custom item 保真时，才可显式声明 `custom_tool_call`。这样升级旧 catalog
+不会扩大隐式 authority；text-only Ark 可以继续作为普通文本回答的 terminal tail，却不会
+接住会触发 Code Mode `exec` 的 turn。
 
 ## Compatibility matrix
 

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -274,6 +274,13 @@ provider 下 `requiresOpenaiAuth = false`，因此不能根据模型 route 同�
 才记为 fallback。原始 management 响应、auth filename、email、请求内容和 task/session ID
 不得进入 LoopX 仓库或 extension 输入。
 
+额度采集由 operator adapter 通过宿主支持的 account/rate-limit 只读接口完成，再把窗口映射为
+symbolic profile observation。不要为了查询额度抢占正在运行的 App IPC 单客户端连接，也不要把
+宿主 auth token 交给 LoopX extension。若必须启动隔离的 App Server probe，probe 应使用独立
+socket、只读方法和有界生命周期；extension 最终只接收 `used_percent`、窗口长度、reset 时间与
+recent activity。reset 本身仍是 operator-owned effect，成功后交给 `qualify_quota_recovery`
+验证 cooldown 失效与 reprobe 顺序。
+
 这里的“开启自动切换开关”不是修改 CPA 的一个全局布尔值，而是让 App selector 暴露并
 允许选择 `auto/...` 虚拟模型。A/B 也不再表示 hard pin，而是同一账号环的两个首选入口；
 只有显式 Ark 仍固定单一 provider。CPA 只按已验收的 provider pool 执行自动路由。
@@ -767,6 +774,28 @@ result 在目标 Codex rollout 中只能写成一个逻辑 `function_call_output
 状态机里。pre-commit attempt 可以换目标并重新生成 derived projection；post-commit
 attempt 只能向当前 task 报错，不能继续沿 failover 队列。这个原则同时约束 HTTP error、
 in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event。
+
+## 运行时恢复与兼容门
+
+在把异构 provider 纳入自动 fallback 前，还要过三类独立恢复门。它们不能被“HTTP 200”
+或“进程已经启动”替代：
+
+| 故障面 | 必须观察 | fail-closed 行为 |
+| --- | --- | --- |
+| 桌面补丁升级 | 当前构建只有一个已应用锚点；所有改动文件的 ASAR integrity 匹配；header digest 与 bundle metadata 匹配；签名、启动、heartbeat readback 均成功 | 停留在旧 runtime 或回滚，不把未知构建投入使用 |
+| quota reset | reset receipt 晚于 cooldown 来源；旧 cooldown 已失效；目标账号先完成一次 bounded probe | probe 前不得因旧 cooldown 直接选择 fallback；新 probe 明确 quota-limited 后才允许新 cooldown |
+| Code Mode 工具 | selector normalization 声明 `required_tool_transport=custom_tool_call`；实际响应仍为 `custom_tool_call`；host dispatch 完成 | function-only provider 在遍历前被过滤；适配层若降级 item type，qualification 失败 |
+
+这三类证据分别由 `qualify_desktop_patch`、`qualify_quota_recovery`、
+`qualify_tool_transport` 接收。它们只处理 symbolic、content-free observation。
+本机 bundle 路径、账号身份、task ID、原始日志、OAuth 和 reset token 都不得进入
+LoopX state 或公开 PR。
+
+`tool_transports` 是 profile capability，不是根据模型名字猜测的路由规则。默认情况下，
+原生 Codex profile 声明 `function_call` 与 `custom_tool_call`；普通
+OpenAI-compatible profile 只声明 `function_call`。只有适配器已经实现并验证 custom item
+保真时，才可显式追加 `custom_tool_call`。这样 text-only Ark 可以继续作为普通文本回答的
+terminal tail，却不会接住会触发 Code Mode `exec` 的 turn。
 
 ## Compatibility matrix
 

--- a/packages/loopx-codex-provider-routing/examples/desktop-patch.json
+++ b/packages/loopx-codex-provider-routing/examples/desktop-patch.json
@@ -1,0 +1,13 @@
+{
+  "desktop_patch": {
+    "anchor_state": "patched_unique",
+    "changed_file_count": 2,
+    "header_integrity_matches_bundle_metadata": true,
+    "heartbeat_readback_succeeded": true,
+    "launch_succeeded": true,
+    "per_file_integrity_match_count": 2,
+    "signature_valid": true
+  },
+  "operation": "qualify_desktop_patch",
+  "schema_version": "loopx_codex_provider_routing_request_v0"
+}

--- a/packages/loopx-codex-provider-routing/examples/normalize-request.json
+++ b/packages/loopx-codex-provider-routing/examples/normalize-request.json
@@ -7,21 +7,24 @@
           "input_modalities": ["text", "image"],
           "priority": 300,
           "provider": "codex",
-          "supports_fast": true
+          "supports_fast": true,
+          "tool_transports": ["function_call", "custom_tool_call"]
         },
         {
           "id": "codex-b",
           "input_modalities": ["text", "image"],
           "priority": 200,
           "provider": "codex",
-          "supports_fast": true
+          "supports_fast": true,
+          "tool_transports": ["function_call", "custom_tool_call"]
         },
         {
           "id": "ark-text",
           "input_modalities": ["text"],
           "priority": 100,
           "provider": "openai_compatibility",
-          "supports_fast": false
+          "supports_fast": false,
+          "tool_transports": ["function_call"]
         }
       ],
       "rings": [
@@ -51,6 +54,7 @@
       ]
     },
     "model_selector": "fast/auto/gpt-5.6-sol",
+    "required_tool_transport": "custom_tool_call",
     "service_tier": "default"
   },
   "operation": "normalize_selector_request",

--- a/packages/loopx-codex-provider-routing/examples/quota-recovery.json
+++ b/packages/loopx-codex-provider-routing/examples/quota-recovery.json
@@ -1,0 +1,13 @@
+{
+  "operation": "qualify_quota_recovery",
+  "quota_recovery": {
+    "cooldown_expires_at": "2026-09-05T10:00:00Z",
+    "cooldown_invalidated": true,
+    "cooldown_source_observed_at": "2026-09-01T10:00:00Z",
+    "fallback_attempted": false,
+    "post_reset_probe": "success",
+    "reset_observed_at": "2026-09-01T11:00:00Z",
+    "reset_outcome": "applied"
+  },
+  "schema_version": "loopx_codex_provider_routing_request_v0"
+}

--- a/packages/loopx-codex-provider-routing/examples/request.json
+++ b/packages/loopx-codex-provider-routing/examples/request.json
@@ -11,7 +11,11 @@
         ],
         "priority": 300,
         "provider": "codex",
-        "supports_fast": true
+        "supports_fast": true,
+        "tool_transports": [
+          "function_call",
+          "custom_tool_call"
+        ]
       },
       {
         "id": "codex-b",
@@ -21,7 +25,11 @@
         ],
         "priority": 200,
         "provider": "codex",
-        "supports_fast": true
+        "supports_fast": true,
+        "tool_transports": [
+          "function_call",
+          "custom_tool_call"
+        ]
       },
       {
         "id": "ark-text",
@@ -30,7 +38,10 @@
         ],
         "priority": 100,
         "provider": "openai_compatibility",
-        "supports_fast": false
+        "supports_fast": false,
+        "tool_transports": [
+          "function_call"
+        ]
       }
     ],
     "rings": [

--- a/packages/loopx-codex-provider-routing/examples/runtime-status.json
+++ b/packages/loopx-codex-provider-routing/examples/runtime-status.json
@@ -44,7 +44,8 @@
           ],
           "priority": 300,
           "provider": "codex",
-          "supports_fast": true
+          "supports_fast": true,
+          "tool_transports": ["function_call", "custom_tool_call"]
         },
         {
           "id": "codex-b",
@@ -54,7 +55,8 @@
           ],
           "priority": 200,
           "provider": "codex",
-          "supports_fast": true
+          "supports_fast": true,
+          "tool_transports": ["function_call", "custom_tool_call"]
         },
         {
           "id": "ark-text",
@@ -63,7 +65,8 @@
           ],
           "priority": 100,
           "provider": "openai_compatibility",
-          "supports_fast": false
+          "supports_fast": false,
+          "tool_transports": ["function_call"]
         }
       ],
       "rings": [
@@ -110,6 +113,7 @@
       "modality": "text",
       "observed_at": "2026-09-01T08:00:00Z",
       "outcome": "success",
+      "required_tool_transport": "custom_tool_call",
       "route_slug": "codex-b/gpt-5.6-sol",
       "selected_profile": "codex-a"
     },

--- a/packages/loopx-codex-provider-routing/examples/tool-transport.json
+++ b/packages/loopx-codex-provider-routing/examples/tool-transport.json
@@ -1,0 +1,9 @@
+{
+  "operation": "qualify_tool_transport",
+  "schema_version": "loopx_codex_provider_routing_request_v0",
+  "tool_transport": {
+    "dispatch_outcome": "completed",
+    "observed_transport": "custom_tool_call",
+    "requested_transport": "custom_tool_call"
+  }
+}

--- a/packages/loopx-codex-provider-routing/examples/upgrade-request.json
+++ b/packages/loopx-codex-provider-routing/examples/upgrade-request.json
@@ -4,14 +4,17 @@
   "upgrade": {
     "changed_seams": [
       "history_projection",
+      "desktop_runtime_patch",
       "integration_candidate",
       "transport_pool",
       "model_catalog",
       "modality_routing",
       "request_normalizer",
+      "quota_recovery",
       "retry_policy",
       "route_fallback",
-      "settings_revision"
+      "settings_revision",
+      "tool_transport"
     ],
     "current_ref": "public-current-ref",
     "target_ref": "public-target-ref"

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.6.0"
+version = "0.7.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.6.0"
+version = "0.7.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/schemas/request.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/request.schema.json
@@ -7,12 +7,15 @@
         "operation": {
           "const": "qualify_heartbeat_transport"
         },
+        "desktop_patch": false,
         "host_control_recovery": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
         "status": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -24,12 +27,15 @@
         "operation": {
           "const": "qualify_host_control_recovery"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
         "status": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -41,12 +47,15 @@
         "operation": {
           "const": "reconcile_integration_candidate"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
         "status": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -58,12 +67,15 @@
         "operation": {
           "const": "project_runtime_status"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -75,12 +87,15 @@
         "operation": {
           "const": "compile_catalog"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
         "status": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -92,12 +107,15 @@
         "operation": {
           "const": "normalize_selector_request"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "integration": false,
         "snapshot": false,
         "source": false,
         "status": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -109,12 +127,15 @@
         "operation": {
           "const": "qualify_snapshot"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "integration": false,
         "normalization": false,
         "source": false,
         "status": false,
+        "quota_recovery": false,
+        "tool_transport": false,
         "upgrade": false
       },
       "required": [
@@ -126,24 +147,96 @@
         "operation": {
           "const": "upgrade_plan"
         },
+        "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "integration": false,
         "normalization": false,
         "snapshot": false,
         "source": false,
-        "status": false
+        "status": false,
+        "quota_recovery": false,
+        "tool_transport": false
       },
       "required": [
         "upgrade"
       ]
+    },
+    {
+      "properties": {
+        "operation": {
+          "const": "qualify_desktop_patch"
+        },
+        "heartbeat_transport": false,
+        "host_control_recovery": false,
+        "integration": false,
+        "normalization": false,
+        "quota_recovery": false,
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "tool_transport": false,
+        "upgrade": false
+      },
+      "required": [
+        "desktop_patch"
+      ]
+    },
+    {
+      "properties": {
+        "operation": {
+          "const": "qualify_quota_recovery"
+        },
+        "desktop_patch": false,
+        "heartbeat_transport": false,
+        "host_control_recovery": false,
+        "integration": false,
+        "normalization": false,
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "tool_transport": false,
+        "upgrade": false
+      },
+      "required": [
+        "quota_recovery"
+      ]
+    },
+    {
+      "properties": {
+        "operation": {
+          "const": "qualify_tool_transport"
+        },
+        "desktop_patch": false,
+        "heartbeat_transport": false,
+        "host_control_recovery": false,
+        "integration": false,
+        "normalization": false,
+        "quota_recovery": false,
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "upgrade": false
+      },
+      "required": [
+        "tool_transport"
+      ]
     }
   ],
   "properties": {
+    "desktop_patch": {
+      "type": "object"
+    },
     "heartbeat_transport": {
       "type": "object"
     },
     "host_control_recovery": {
+      "type": "object"
+    },
+    "quota_recovery": {
+      "type": "object"
+    },
+    "tool_transport": {
       "type": "object"
     },
     "operation": {
@@ -151,9 +244,12 @@
         "compile_catalog",
         "normalize_selector_request",
         "project_runtime_status",
+        "qualify_desktop_patch",
         "qualify_heartbeat_transport",
         "qualify_host_control_recovery",
+        "qualify_quota_recovery",
         "qualify_snapshot",
+        "qualify_tool_transport",
         "reconcile_integration_candidate",
         "upgrade_plan"
       ]

--- a/packages/loopx-codex-provider-routing/schemas/response.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/response.schema.json
@@ -45,9 +45,12 @@
         "compile_catalog",
         "normalize_selector_request",
         "project_runtime_status",
+        "qualify_desktop_patch",
         "qualify_heartbeat_transport",
         "qualify_host_control_recovery",
+        "qualify_quota_recovery",
         "qualify_snapshot",
+        "qualify_tool_transport",
         "reconcile_integration_candidate",
         "upgrade_plan"
       ]

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -359,7 +359,29 @@ def main() -> int:
     legacy_catalog = compile_catalog(legacy_source)
     assert next(
         profile for profile in legacy_catalog["profiles"] if profile["id"] == "codex-a"
-    )["tool_transports"] == ["function_call", "custom_tool_call"]
+    )["tool_transports"] == ["function_call"]
+    legacy_standard = normalize_selector_request(
+        {
+            "catalog_source": legacy_source,
+            "model_selector": "codex-a/gpt-5.6-sol",
+            "required_tool_transport": "function_call",
+        }
+    )
+    assert legacy_standard["eligible_candidates"] == [
+        "codex-a",
+        "codex-b",
+        "ark-text",
+    ]
+    expect_error(
+        lambda: normalize_selector_request(
+            {
+                "catalog_source": legacy_source,
+                "model_selector": "codex-a/gpt-5.6-sol",
+                "required_tool_transport": "custom_tool_call",
+            }
+        ),
+        "legacy catalog inferred unproven custom_tool_call support",
+    )
     assert auto["fast_candidates"] == ["codex-a", "codex-b"]
     assert auto["routing_policy"]["session_affinity"] == "hint_revalidated_per_attempt"
     assert auto["ring_id"] == "codex-accounts"

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -350,6 +350,16 @@ def main() -> int:
     )
     assert auto["eligible_candidates"]["image"] == ["codex-a", "codex-b"]
     assert auto["eligible_candidates"]["text"] == ["codex-a", "codex-b", "ark-text"]
+    assert next(
+        profile for profile in catalog["profiles"] if profile["id"] == "ark-text"
+    )["tool_transports"] == ["function_call"]
+    legacy_source = copy.deepcopy(_source())
+    for profile in legacy_source["profiles"]:
+        profile.pop("tool_transports")
+    legacy_catalog = compile_catalog(legacy_source)
+    assert next(
+        profile for profile in legacy_catalog["profiles"] if profile["id"] == "codex-a"
+    )["tool_transports"] == ["function_call", "custom_tool_call"]
     assert auto["fast_candidates"] == ["codex-a", "codex-b"]
     assert auto["routing_policy"]["session_affinity"] == "hint_revalidated_per_attempt"
     assert auto["ring_id"] == "codex-accounts"
@@ -403,6 +413,31 @@ def main() -> int:
     )
     assert normalized_standard["normalized_model_selector"] == ("codex-b/gpt-5.6-sol")
     assert normalized_standard["service_tier"] == {"action": "preserve"}
+    normalized_code_mode = normalize_selector_request(
+        {
+            "catalog_source": _source(),
+            "model_selector": "codex-b/gpt-5.6-sol",
+            "required_tool_transport": "custom_tool_call",
+        }
+    )
+    assert normalized_code_mode["eligible_candidates"] == ["codex-b", "codex-a"]
+    assert normalized_code_mode["fallback_policy"] == "required_tool_transport_only"
+    custom_preserving_source = copy.deepcopy(_source())
+    custom_preserving_source["profiles"][2]["tool_transports"].append(
+        "custom_tool_call"
+    )
+    normalized_custom_adapter = normalize_selector_request(
+        {
+            "catalog_source": custom_preserving_source,
+            "model_selector": "auto/gpt-5.6-sol",
+            "required_tool_transport": "custom_tool_call",
+        }
+    )
+    assert normalized_custom_adapter["eligible_candidates"] == [
+        "codex-a",
+        "codex-b",
+        "ark-text",
+    ]
     normalized_standard_priority = normalize_selector_request(
         {
             "catalog_source": _source(),
@@ -437,6 +472,19 @@ def main() -> int:
     )
     runtime = project_runtime_status(preferred_fallback)
     assert runtime["execution"]["fallback_used"] is True
+
+    code_mode_to_ark = _runtime_status()
+    code_mode_to_ark["execution_observation"].update(
+        {
+            "required_tool_transport": "custom_tool_call",
+            "attempted_profiles": ["codex-a", "codex-b", "ark-text"],
+            "selected_profile": "ark-text",
+        }
+    )
+    expect_error(
+        lambda: project_runtime_status(code_mode_to_ark),
+        "custom_tool_call request was allowed to fall back to function-only provider",
+    )
 
     fast_fallback = _runtime_status()
     fast_fallback["execution_observation"].update(
@@ -695,17 +743,23 @@ def main() -> int:
             "target_ref": "public-target-ref",
             "changed_seams": [
                 "transport_pool",
+                "desktop_runtime_patch",
                 "modality_routing",
                 "request_normalizer",
+                "quota_recovery",
                 "settings_revision",
+                "tool_transport",
             ],
         }
     )
     assert "h2_reuse" in plan["required_checks"]
+    assert "asar_member_integrity" in plan["required_checks"]
     assert "no_eligible_fail_closed" in plan["required_checks"]
     assert "ordinary_selector_preserved" in plan["required_checks"]
     assert "effective_priority_admission" in plan["required_checks"]
     assert "turn_revision_match" in plan["required_checks"]
+    assert "stale_cooldown_invalidation" in plan["required_checks"]
+    assert "custom_tool_item_preserved" in plan["required_checks"]
 
     integration_request = json.loads(
         (PACKAGE_ROOT / "examples" / "integration-candidate.json").read_text()
@@ -761,8 +815,11 @@ def main() -> int:
         "normalize-request.json",
         "runtime-status.json",
         "qualification-snapshot.json",
+        "desktop-patch.json",
         "heartbeat-transport.json",
         "host-control-recovery.json",
+        "quota-recovery.json",
+        "tool-transport.json",
         "integration-candidate.json",
         "upgrade-request.json",
     ):

--- a/packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
@@ -1,0 +1,112 @@
+"""Focused negative-path smoke for provider runtime recovery contracts."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT / "src"))
+
+contract = importlib.import_module("loopx_codex_provider_routing.contract")
+qualify_desktop_patch = contract.qualify_desktop_patch
+qualify_quota_recovery = contract.qualify_quota_recovery
+qualify_tool_transport = contract.qualify_tool_transport
+
+
+def main() -> int:
+    desktop_patch = qualify_desktop_patch(
+        {
+            "anchor_state": "patched_unique",
+            "changed_file_count": 2,
+            "per_file_integrity_match_count": 2,
+            "header_integrity_matches_bundle_metadata": True,
+            "signature_valid": True,
+            "launch_succeeded": True,
+            "heartbeat_readback_succeeded": True,
+        }
+    )
+    assert desktop_patch["qualified"] is True
+
+    stale_asar = qualify_desktop_patch(
+        {
+            "anchor_state": "unsupported",
+            "changed_file_count": 2,
+            "per_file_integrity_match_count": 0,
+            "header_integrity_matches_bundle_metadata": False,
+            "signature_valid": True,
+            "launch_succeeded": False,
+            "heartbeat_readback_succeeded": False,
+        }
+    )
+    assert stale_asar["qualified"] is False
+    assert {
+        "desktop_patch_anchor_unsupported",
+        "asar_file_integrity_stale",
+        "asar_header_integrity_stale",
+        "desktop_launch_failed",
+        "heartbeat_transport_readback_failed",
+    } <= set(stale_asar["failure_codes"])
+
+    quota_recovery = qualify_quota_recovery(
+        {
+            "reset_outcome": "applied",
+            "reset_observed_at": "2026-09-01T11:00:00Z",
+            "cooldown_source_observed_at": "2026-09-01T10:00:00Z",
+            "cooldown_expires_at": "2026-09-05T10:00:00Z",
+            "cooldown_invalidated": True,
+            "post_reset_probe": "success",
+            "fallback_attempted": False,
+        }
+    )
+    assert quota_recovery["qualified"] is True
+    assert quota_recovery["expected_action"] == "invalidate_and_probe"
+
+    stale_cooldown = qualify_quota_recovery(
+        {
+            "reset_outcome": "applied",
+            "reset_observed_at": "2026-09-01T11:00:00Z",
+            "cooldown_source_observed_at": "2026-09-01T10:00:00Z",
+            "cooldown_expires_at": "2026-09-05T10:00:00Z",
+            "cooldown_invalidated": False,
+            "post_reset_probe": "not_attempted",
+            "fallback_attempted": True,
+        }
+    )
+    assert stale_cooldown["qualified"] is False
+    assert set(stale_cooldown["failure_codes"]) == {
+        "stale_quota_cooldown_retained",
+        "post_reset_probe_missing",
+        "fallback_selected_before_recovered_account_probe",
+    }
+
+    tool_transport = qualify_tool_transport(
+        {
+            "requested_transport": "custom_tool_call",
+            "observed_transport": "custom_tool_call",
+            "dispatch_outcome": "completed",
+        }
+    )
+    assert tool_transport["qualified"] is True
+
+    downgraded_tool = qualify_tool_transport(
+        {
+            "requested_transport": "custom_tool_call",
+            "observed_transport": "function_call",
+            "dispatch_outcome": "rejected_incompatible_payload",
+        }
+    )
+    assert downgraded_tool["qualified"] is False
+    assert downgraded_tool["responsible_layer"] == "provider_response_adapter"
+    assert set(downgraded_tool["failure_codes"]) == {
+        "tool_transport_downgraded",
+        "tool_dispatch_incomplete",
+    }
+
+    print("ok: provider recovery contracts smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.7.0"

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -13,9 +13,12 @@ from .contract import (
     compile_catalog,
     normalize_selector_request,
     project_runtime_status,
+    qualify_desktop_patch,
     qualify_heartbeat_transport,
     qualify_host_control_recovery,
+    qualify_quota_recovery,
     qualify_snapshot,
+    qualify_tool_transport,
     reconcile_integration_candidate,
     reject_private_material,
 )
@@ -47,9 +50,12 @@ def _doctor() -> int:
                 "compile_catalog",
                 "normalize_selector_request",
                 "project_runtime_status",
+                "qualify_desktop_patch",
                 "qualify_heartbeat_transport",
                 "qualify_host_control_recovery",
+                "qualify_quota_recovery",
                 "qualify_snapshot",
+                "qualify_tool_transport",
                 "reconcile_integration_candidate",
                 "upgrade_plan",
             ],
@@ -70,9 +76,12 @@ def _run_request(request: Any) -> dict[str, Any]:
         "compile_catalog": "source",
         "normalize_selector_request": "normalization",
         "project_runtime_status": "status",
+        "qualify_desktop_patch": "desktop_patch",
         "qualify_heartbeat_transport": "heartbeat_transport",
         "qualify_host_control_recovery": "host_control_recovery",
+        "qualify_quota_recovery": "quota_recovery",
         "qualify_snapshot": "snapshot",
+        "qualify_tool_transport": "tool_transport",
         "reconcile_integration_candidate": "integration",
         "upgrade_plan": "upgrade",
     }
@@ -101,6 +110,11 @@ def _run_request(request: Any) -> dict[str, Any]:
         if not isinstance(status, Mapping):
             raise ValueError("project_runtime_status requires object `status`")
         result = project_runtime_status(status)
+    elif operation == "qualify_desktop_patch":
+        desktop_patch = request.get("desktop_patch")
+        if not isinstance(desktop_patch, Mapping):
+            raise ValueError("qualify_desktop_patch requires object `desktop_patch`")
+        result = qualify_desktop_patch(desktop_patch)
     elif operation == "qualify_heartbeat_transport":
         heartbeat_transport = request.get("heartbeat_transport")
         if not isinstance(heartbeat_transport, Mapping):
@@ -115,11 +129,21 @@ def _run_request(request: Any) -> dict[str, Any]:
                 "qualify_host_control_recovery requires object `host_control_recovery`"
             )
         result = qualify_host_control_recovery(host_control_recovery)
+    elif operation == "qualify_quota_recovery":
+        quota_recovery = request.get("quota_recovery")
+        if not isinstance(quota_recovery, Mapping):
+            raise ValueError("qualify_quota_recovery requires object `quota_recovery`")
+        result = qualify_quota_recovery(quota_recovery)
     elif operation == "qualify_snapshot":
         snapshot = request.get("snapshot")
         if not isinstance(snapshot, Mapping):
             raise ValueError("qualify_snapshot requires object `snapshot`")
         result = qualify_snapshot(snapshot)
+    elif operation == "qualify_tool_transport":
+        tool_transport = request.get("tool_transport")
+        if not isinstance(tool_transport, Mapping):
+            raise ValueError("qualify_tool_transport requires object `tool_transport`")
+        result = qualify_tool_transport(tool_transport)
     elif operation == "reconcile_integration_candidate":
         integration = request.get("integration")
         if not isinstance(integration, Mapping):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
+from datetime import datetime
 from itertools import pairwise
 from typing import Any
 
@@ -12,6 +13,9 @@ RESPONSE_SCHEMA_VERSION = "loopx_codex_provider_routing_response_v0"
 INTEGRATION_CANDIDATE_SCHEMA_VERSION = "codex_provider_integration_candidate_v0"
 HEARTBEAT_TRANSPORT_SCHEMA_VERSION = "codex_app_heartbeat_transport_qualification_v0"
 HOST_CONTROL_RECOVERY_SCHEMA_VERSION = "codex_host_control_recovery_qualification_v0"
+DESKTOP_PATCH_SCHEMA_VERSION = "codex_desktop_patch_qualification_v0"
+QUOTA_RECOVERY_SCHEMA_VERSION = "codex_quota_recovery_qualification_v0"
+TOOL_TRANSPORT_SCHEMA_VERSION = "codex_tool_transport_qualification_v0"
 
 RECOVERABLE_HOST_CONTROL_NAMES = {
     "automation_update",
@@ -38,12 +42,15 @@ FORBIDDEN_KEYS = {
 }
 ALLOWED_MODALITIES = {"text", "image"}
 ALLOWED_PROVIDERS = {"codex", "openai_compatibility"}
+ALLOWED_TOOL_TRANSPORTS = {"function_call", "custom_tool_call"}
 ALLOWED_REASONING_LEVELS = {"low", "medium", "high", "xhigh", "max", "ultra"}
 ALLOWED_CHANGE_SEAMS = {
+    "desktop_runtime_patch",
     "history_projection",
     "integration_candidate",
     "modality_routing",
     "model_catalog",
+    "quota_recovery",
     "request_normalizer",
     "retry_policy",
     "route_fallback",
@@ -51,6 +58,7 @@ ALLOWED_CHANGE_SEAMS = {
     "sse_lifecycle",
     "ssh_bridge",
     "transport_pool",
+    "tool_transport",
 }
 SYMBOLIC_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 MODEL_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9./-]{0,127}$")
@@ -101,6 +109,291 @@ def _boolean(value: Any, field: str, *, default: bool | None = None) -> bool:
     if not isinstance(value, bool):
         raise TypeError(f"{field} must be a boolean")
     return value
+
+
+def _utc_datetime(value: Any, field: str) -> datetime:
+    timestamp = _timestamp(value, field)
+    return datetime.fromisoformat(timestamp)
+
+
+def qualify_desktop_patch(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Qualify an already-built, patched Codex desktop runtime."""
+
+    reject_private_material(observation)
+    _reject_unexpected_keys(
+        observation,
+        {
+            "anchor_state",
+            "changed_file_count",
+            "per_file_integrity_match_count",
+            "header_integrity_matches_bundle_metadata",
+            "signature_valid",
+            "launch_succeeded",
+            "heartbeat_readback_succeeded",
+        },
+        "desktop_patch",
+    )
+    anchor_state = _non_empty_string(
+        observation.get("anchor_state"), "desktop_patch.anchor_state"
+    )
+    if anchor_state not in {
+        "unpatched_unique",
+        "patched_unique",
+        "unsupported",
+        "ambiguous",
+    }:
+        raise ValueError("desktop_patch.anchor_state is unsupported")
+    changed_file_count = observation.get("changed_file_count")
+    match_count = observation.get("per_file_integrity_match_count")
+    if (
+        not isinstance(changed_file_count, int)
+        or isinstance(changed_file_count, bool)
+        or changed_file_count < 0
+    ):
+        raise TypeError(
+            "desktop_patch.changed_file_count must be a non-negative integer"
+        )
+    if (
+        not isinstance(match_count, int)
+        or isinstance(match_count, bool)
+        or match_count < 0
+    ):
+        raise TypeError(
+            "desktop_patch.per_file_integrity_match_count must be a non-negative "
+            "integer"
+        )
+    if changed_file_count == 0:
+        raise ValueError("desktop_patch.changed_file_count must be positive")
+    if match_count > changed_file_count:
+        raise ValueError(
+            "desktop_patch.per_file_integrity_match_count exceeds changed files"
+        )
+
+    anchor_failure_codes = {
+        "unpatched_unique": "desktop_patch_not_applied",
+        "unsupported": "desktop_patch_anchor_unsupported",
+        "ambiguous": "desktop_patch_anchor_ambiguous",
+    }
+    checks = [
+        {
+            "id": "patched_anchor_unique",
+            "passed": anchor_state == "patched_unique",
+            "failure_code": anchor_failure_codes.get(
+                anchor_state, "desktop_patch_anchor_not_unique"
+            ),
+        },
+        {
+            "id": "per_file_integrity",
+            "passed": match_count == changed_file_count,
+            "failure_code": "asar_file_integrity_stale",
+        },
+        {
+            "id": "header_integrity",
+            "passed": _boolean(
+                observation.get("header_integrity_matches_bundle_metadata"),
+                "desktop_patch.header_integrity_matches_bundle_metadata",
+            ),
+            "failure_code": "asar_header_integrity_stale",
+        },
+        {
+            "id": "signature",
+            "passed": _boolean(
+                observation.get("signature_valid"),
+                "desktop_patch.signature_valid",
+            ),
+            "failure_code": "desktop_signature_invalid",
+        },
+        {
+            "id": "launch",
+            "passed": _boolean(
+                observation.get("launch_succeeded"),
+                "desktop_patch.launch_succeeded",
+            ),
+            "failure_code": "desktop_launch_failed",
+        },
+        {
+            "id": "heartbeat_readback",
+            "passed": _boolean(
+                observation.get("heartbeat_readback_succeeded"),
+                "desktop_patch.heartbeat_readback_succeeded",
+            ),
+            "failure_code": "heartbeat_transport_readback_failed",
+        },
+    ]
+    failure_codes = [check["failure_code"] for check in checks if not check["passed"]]
+    return {
+        "schema_version": DESKTOP_PATCH_SCHEMA_VERSION,
+        "qualified": not failure_codes,
+        "failure_codes": failure_codes,
+        "checks": checks,
+        "required_order": [
+            "match_exactly_one_versioned_anchor",
+            "apply_length_preserving_patch",
+            "refresh_changed_file_integrity",
+            "refresh_asar_header_integrity_in_bundle_metadata",
+            "sign_runtime",
+            "launch_runtime",
+            "read_back_heartbeat_transport",
+        ],
+        "responsible_layer": "codex_desktop_runtime_builder",
+        "effect_boundary": "content_free_observation_only",
+    }
+
+
+def qualify_quota_recovery(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Ensure an applied account reset invalidates older provider cooldown state."""
+
+    reject_private_material(observation)
+    _reject_unexpected_keys(
+        observation,
+        {
+            "reset_outcome",
+            "reset_observed_at",
+            "cooldown_source_observed_at",
+            "cooldown_expires_at",
+            "cooldown_invalidated",
+            "post_reset_probe",
+            "fallback_attempted",
+        },
+        "quota_recovery",
+    )
+    reset_outcome = _non_empty_string(
+        observation.get("reset_outcome"), "quota_recovery.reset_outcome"
+    )
+    if reset_outcome not in {"applied", "not_applied"}:
+        raise ValueError("quota_recovery.reset_outcome is unsupported")
+    reset_at = _utc_datetime(
+        observation.get("reset_observed_at"), "quota_recovery.reset_observed_at"
+    )
+    cooldown_source_at = _utc_datetime(
+        observation.get("cooldown_source_observed_at"),
+        "quota_recovery.cooldown_source_observed_at",
+    )
+    cooldown_expires_at = _utc_datetime(
+        observation.get("cooldown_expires_at"),
+        "quota_recovery.cooldown_expires_at",
+    )
+    if cooldown_expires_at <= cooldown_source_at:
+        raise ValueError("quota_recovery cooldown expiry must follow its source")
+    invalidated = _boolean(
+        observation.get("cooldown_invalidated"),
+        "quota_recovery.cooldown_invalidated",
+    )
+    probe = _non_empty_string(
+        observation.get("post_reset_probe"), "quota_recovery.post_reset_probe"
+    )
+    if probe not in {"not_attempted", "success", "quota_limited", "transport_failed"}:
+        raise ValueError("quota_recovery.post_reset_probe is unsupported")
+    fallback_attempted = _boolean(
+        observation.get("fallback_attempted"),
+        "quota_recovery.fallback_attempted",
+    )
+
+    reset_supersedes_cooldown = (
+        reset_outcome == "applied" and reset_at > cooldown_source_at
+    )
+    if reset_supersedes_cooldown:
+        checks = [
+            {
+                "id": "cooldown_invalidated",
+                "passed": invalidated,
+                "failure_code": "stale_quota_cooldown_retained",
+            },
+            {
+                "id": "account_reprobed",
+                "passed": probe in {"success", "quota_limited"},
+                "failure_code": "post_reset_probe_missing",
+            },
+            {
+                "id": "fallback_gated_by_probe",
+                "passed": not fallback_attempted or probe == "quota_limited",
+                "failure_code": "fallback_selected_before_recovered_account_probe",
+            },
+        ]
+        expected_action = "invalidate_and_probe"
+    else:
+        checks = [
+            {
+                "id": "cooldown_retained_without_newer_reset",
+                "passed": not invalidated,
+                "failure_code": "cooldown_invalidated_without_newer_reset",
+            }
+        ]
+        expected_action = "retain_cooldown"
+    failure_codes = [check["failure_code"] for check in checks if not check["passed"]]
+    return {
+        "schema_version": QUOTA_RECOVERY_SCHEMA_VERSION,
+        "qualified": not failure_codes,
+        "failure_codes": failure_codes,
+        "reset_supersedes_cooldown": reset_supersedes_cooldown,
+        "expected_action": expected_action,
+        "checks": checks,
+        "required_contract": {
+            "reset_receipt_ordering": "newer_reset_invalidates_older_cooldown",
+            "fallback_gate": "probe_recovered_account_before_fallback",
+            "new_quota_limit": "a_new_probe_may_create_a_new_cooldown",
+        },
+        "responsible_layer": "cpa_provider_health_state",
+        "effect_boundary": "content_free_observation_only",
+    }
+
+
+def qualify_tool_transport(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Qualify the response item shape used to dispatch one tool call."""
+
+    reject_private_material(observation)
+    _reject_unexpected_keys(
+        observation,
+        {"requested_transport", "observed_transport", "dispatch_outcome"},
+        "tool_transport",
+    )
+    requested = _non_empty_string(
+        observation.get("requested_transport"),
+        "tool_transport.requested_transport",
+    )
+    observed = _non_empty_string(
+        observation.get("observed_transport"),
+        "tool_transport.observed_transport",
+    )
+    if requested not in ALLOWED_TOOL_TRANSPORTS:
+        raise ValueError("tool_transport.requested_transport is unsupported")
+    if observed not in ALLOWED_TOOL_TRANSPORTS:
+        raise ValueError("tool_transport.observed_transport is unsupported")
+    outcome = _non_empty_string(
+        observation.get("dispatch_outcome"), "tool_transport.dispatch_outcome"
+    )
+    if outcome not in {"completed", "not_dispatched", "rejected_incompatible_payload"}:
+        raise ValueError("tool_transport.dispatch_outcome is unsupported")
+    checks = [
+        {
+            "id": "transport_preserved",
+            "passed": requested == observed,
+            "failure_code": "tool_transport_downgraded",
+        },
+        {
+            "id": "dispatch_completed",
+            "passed": outcome == "completed",
+            "failure_code": "tool_dispatch_incomplete",
+        },
+    ]
+    failure_codes = [check["failure_code"] for check in checks if not check["passed"]]
+    return {
+        "schema_version": TOOL_TRANSPORT_SCHEMA_VERSION,
+        "qualified": not failure_codes,
+        "failure_codes": failure_codes,
+        "checks": checks,
+        "required_contract": {
+            "admission_filter": "required_tool_transport",
+            "custom_tool_call": "preserve_raw_code_payload_and_item_type",
+            "on_no_eligible_provider": "fail_closed_before_first_output",
+        },
+        "responsible_layer": (
+            "provider_response_adapter"
+            if requested != observed
+            else "codex_app_tool_dispatch"
+        ),
+        "effect_boundary": "content_free_observation_only",
+    }
 
 
 def qualify_heartbeat_transport(observation: Mapping[str, Any]) -> dict[str, Any]:
@@ -375,11 +668,23 @@ def _compile_profiles(raw_profiles: Any) -> dict[str, dict[str, Any]]:
         )
         if not modalities or not set(modalities) <= ALLOWED_MODALITIES:
             raise ValueError(f"profile {profile_id} has unsupported input modalities")
+        default_tool_transports = (
+            ["function_call", "custom_tool_call"]
+            if provider == "codex"
+            else ["function_call"]
+        )
+        tool_transports = _string_list(
+            raw.get("tool_transports", default_tool_transports),
+            f"profiles[{index}].tool_transports",
+        )
+        if not tool_transports or not set(tool_transports) <= ALLOWED_TOOL_TRANSPORTS:
+            raise ValueError(f"profile {profile_id} has unsupported tool transports")
         profiles[profile_id] = {
             "id": profile_id,
             "provider": provider,
             "priority": priority,
             "input_modalities": modalities,
+            "tool_transports": tool_transports,
             "supports_fast": _boolean(
                 raw.get("supports_fast"),
                 f"profiles[{index}].supports_fast",
@@ -435,6 +740,7 @@ def _eligible_profiles(
     *,
     required_modalities: set[str],
     require_fast: bool = False,
+    required_tool_transport: str | None = None,
 ) -> list[str]:
     eligible: list[str] = []
     for profile_id in candidates:
@@ -442,6 +748,11 @@ def _eligible_profiles(
         if not required_modalities <= set(profile["input_modalities"]):
             continue
         if require_fast and not profile["supports_fast"]:
+            continue
+        if (
+            required_tool_transport is not None
+            and required_tool_transport not in profile["tool_transports"]
+        ):
             continue
         eligible.append(profile_id)
     return eligible
@@ -652,7 +963,9 @@ def compile_catalog(source: Mapping[str, Any]) -> dict[str, Any]:
                 if supports_fast and mode != "alias"
                 else [],
                 "routing_policy": {
-                    "candidate_filter": "required_modalities_and_service_tier",
+                    "candidate_filter": (
+                        "required_modalities_service_tier_and_tool_transport"
+                    ),
                     "on_no_eligible_provider": "fail_closed_before_first_output",
                     "session_affinity": "hint_revalidated_per_attempt"
                     if mode in {"auto", "preferred"}
@@ -745,7 +1058,12 @@ def normalize_selector_request(normalization: Mapping[str, Any]) -> dict[str, An
     reject_private_material(normalization)
     _reject_unexpected_keys(
         normalization,
-        {"catalog_source", "model_selector", "service_tier"},
+        {
+            "catalog_source",
+            "model_selector",
+            "service_tier",
+            "required_tool_transport",
+        },
         "normalization",
     )
     source = normalization.get("catalog_source")
@@ -778,6 +1096,26 @@ def normalize_selector_request(normalization: Mapping[str, Any]) -> dict[str, An
     )
     eligible_candidates = selector["candidates"]
     fallback_policy = selector["fallback_policy"]
+    required_tool_transport = normalization.get("required_tool_transport")
+    if required_tool_transport is not None:
+        required_tool_transport = _non_empty_string(
+            required_tool_transport, "normalization.required_tool_transport"
+        )
+        if required_tool_transport not in ALLOWED_TOOL_TRANSPORTS:
+            raise ValueError("normalization.required_tool_transport is unsupported")
+        profiles = {item["id"]: item for item in catalog["profiles"]}
+        eligible_candidates = _eligible_profiles(
+            eligible_candidates,
+            profiles,
+            required_modalities=set(),
+            required_tool_transport=required_tool_transport,
+        )
+        fallback_policy = "required_tool_transport_only"
+        if not eligible_candidates:
+            raise ValueError(
+                f"selector {selector_slug} has no provider for "
+                f"{required_tool_transport}"
+            )
     if effective_fast:
         profiles = {item["id"]: item for item in catalog["profiles"]}
         eligible_candidates = _eligible_profiles(
@@ -785,10 +1123,15 @@ def normalize_selector_request(normalization: Mapping[str, Any]) -> dict[str, An
             profiles,
             required_modalities=set(),
             require_fast=True,
+            required_tool_transport=required_tool_transport,
         )
         if not eligible_candidates:
             raise ValueError(f"selector {selector_slug} has no Fast-capable candidates")
-        fallback_policy = "fast_capable_only"
+        fallback_policy = (
+            "fast_and_required_tool_transport_only"
+            if required_tool_transport is not None
+            else "fast_capable_only"
+        )
 
     return {
         "original_model_selector": selector_slug,
@@ -797,6 +1140,7 @@ def normalize_selector_request(normalization: Mapping[str, Any]) -> dict[str, An
         "service_tier": tier_action,
         "fallback_policy": fallback_policy,
         "eligible_candidates": eligible_candidates,
+        "required_tool_transport": required_tool_transport,
     }
 
 
@@ -862,12 +1206,14 @@ def _eligible_route_order(
     *,
     modality: str,
     fast: bool,
+    required_tool_transport: str | None,
 ) -> list[str]:
     return _eligible_profiles(
         route["candidates"],
         profiles,
         required_modalities={modality},
         require_fast=fast,
+        required_tool_transport=required_tool_transport,
     )
 
 
@@ -878,8 +1224,15 @@ def _legal_attempt_orders(
     *,
     modality: str,
     fast: bool,
+    required_tool_transport: str | None,
 ) -> list[list[str]]:
-    eligible = _eligible_route_order(route, profiles, modality=modality, fast=fast)
+    eligible = _eligible_route_order(
+        route,
+        profiles,
+        modality=modality,
+        fast=fast,
+        required_tool_transport=required_tool_transport,
+    )
     if route["entrypoint"] != "affinity_then_first":
         return [eligible]
     ring = rings[route["ring_id"]]
@@ -948,6 +1301,7 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
             "attempted_profiles",
             "selected_profile",
             "outcome",
+            "required_tool_transport",
         },
         "status.execution_observation",
     )
@@ -972,6 +1326,16 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
         if selector_defaults_fast and not declared_fast:
             raise ValueError("a Fast selector cannot report a non-Fast execution")
         fast = declared_fast
+    required_tool_transport = observation.get("required_tool_transport")
+    if required_tool_transport is not None:
+        required_tool_transport = _non_empty_string(
+            required_tool_transport,
+            "status.execution_observation.required_tool_transport",
+        )
+        if required_tool_transport not in ALLOWED_TOOL_TRANSPORTS:
+            raise ValueError(
+                "status.execution_observation.required_tool_transport is unsupported"
+            )
     observed_at = _timestamp(
         observation.get("observed_at"), "status.execution_observation.observed_at"
     )
@@ -982,7 +1346,12 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
     if not attempted:
         raise ValueError("execution observation needs at least one attempted profile")
     legal_orders = _legal_attempt_orders(
-        route, rings, profiles, modality=modality, fast=fast
+        route,
+        rings,
+        profiles,
+        modality=modality,
+        fast=fast,
+        required_tool_transport=required_tool_transport,
     )
     matching_orders = [
         order for order in legal_orders if attempted == order[: len(attempted)]
@@ -1090,6 +1459,7 @@ def project_runtime_status(status: Mapping[str, Any]) -> dict[str, Any]:
             "routing_mode": route["routing_mode"],
             "modality": modality,
             "fast": fast,
+            "required_tool_transport": required_tool_transport,
             "legal_attempt_orders": legal_orders,
         },
         "execution": execution,
@@ -1314,6 +1684,14 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
             "foreign_reasoning",
             "tool_causality",
         ],
+        "desktop_runtime_patch": [
+            "versioned_anchor_unique",
+            "asar_member_integrity",
+            "asar_header_integrity",
+            "desktop_signature",
+            "desktop_launch",
+            "heartbeat_transport_readback",
+        ],
         "integration_candidate": [
             "exact_base_head",
             "exact_ordered_source_heads",
@@ -1322,11 +1700,23 @@ def build_upgrade_plan(upgrade: Mapping[str, Any]) -> dict[str, Any]:
         ],
         "sse_lifecycle": ["unique_terminal", "active_item_pairing"],
         "retry_policy": ["bounded_attempts", "ttfb_p50_p95", "commit_barrier"],
+        "quota_recovery": [
+            "reset_receipt_ordering",
+            "stale_cooldown_invalidation",
+            "post_reset_account_probe",
+            "fallback_probe_gate",
+        ],
         "transport_pool": [
             "h2_reuse",
             "tls_resumption",
             "draining_rebuild",
             "no_replay",
+        ],
+        "tool_transport": [
+            "custom_tool_candidate_admission",
+            "custom_tool_item_preserved",
+            "tool_dispatch_completed",
+            "incompatible_fallback_fail_closed",
         ],
         "model_catalog": [
             "visible_routes",

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -668,13 +668,8 @@ def _compile_profiles(raw_profiles: Any) -> dict[str, dict[str, Any]]:
         )
         if not modalities or not set(modalities) <= ALLOWED_MODALITIES:
             raise ValueError(f"profile {profile_id} has unsupported input modalities")
-        default_tool_transports = (
-            ["function_call", "custom_tool_call"]
-            if provider == "codex"
-            else ["function_call"]
-        )
         tool_transports = _string_list(
-            raw.get("tool_transports", default_tool_transports),
+            raw.get("tool_transports", ["function_call"]),
             f"profiles[{index}].tool_transports",
         )
         if not tool_transports or not set(tool_transports) <= ALLOWED_TOOL_TRANSPORTS:

--- a/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
+++ b/packages/loopx-codex-provider-routing/templates/cpa-config.public.yaml
@@ -28,6 +28,11 @@ routing:
   session-affinity: true
   session-affinity-ttl: "1h"
 
+# Runtime contract (adapter/CPA implementation, not a native YAML key): when a
+# successful account reset receipt is newer than the observation that created
+# a quota cooldown, invalidate that cooldown and re-probe the account before
+# selecting a fallback. A fresh quota-limited probe may create a new cooldown.
+
 codex:
   stream-bootstrap-buffering: true
   optimize-multi-agent-v2: false
@@ -38,3 +43,7 @@ codex:
 # members. Preserve both model and service tier for ordinary selectors; if an
 # ordinary selector already carries `priority`, apply the same Fast-capable-only
 # admission so the native Fast entry cannot reach a non-Fast fallback.
+# Also inspect the host-required tool item transport. A Code Mode request that
+# requires `custom_tool_call` may traverse only profiles that declare and
+# preserve that item type; a generic function-only compatibility provider must
+# fail closed before the first visible output or tool call.


### PR DESCRIPTION
## Summary

- add read-only desktop patch qualification for versioned anchors, ASAR member/header integrity, signing, launch, and heartbeat readback
- invalidate stale quota cooldowns after a newer reset receipt and require a bounded account probe before fallback
- model tool item transports as provider capabilities so Code Mode `custom_tool_call` requests fail closed before reaching a function-only fallback
- bump `loopx-codex-provider-routing` to 0.7.0 and document the operator/effect boundary

## Validation

- `ruff format --check` and `ruff check` on provider source and smokes
- `mypy --strict packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing`
- provider aggregate smoke and focused recovery-contract smoke
- `pytest -q tests/extensions/test_colocated_extension_layout.py`
- all request examples validated against the JSON Schema
- `loopx check --scan-path packages/loopx-codex-provider-routing`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` (18 selected checks passed, 0 holds)
- exact change-quality receipt `cqr_7cd5cda57987216db761`

## Boundaries

The extension remains read-only and credential-free. It does not patch or sign App bundles, consume account resets, mutate CPA state, read live IPC sockets, or touch Codex session stores. Those effects remain operator/CPA owned and submit only symbolic observations for qualification.

## Future-facing pass

Reused the existing compiler/normalizer/runtime/upgrade contracts. Recovery negative paths live in a focused smoke instead of further expanding the aggregate provider smoke.
