### PR TITLE
feat(control-plane): fence legacy coordination writers

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -1336,6 +1336,18 @@ cutover machinery rather than a production authority flip. The follow-up must
 wire every legacy writer, make configuration and rollback explicit, and prove
 default legacy compatibility before the local promotion can be enabled.
 
+The first production fencing integration now closes the write side of that
+follow-up. Every Python Todo mutation checks the TypeScript-owned durable fence
+while holding the existing active-state mutation lock, and native TypeScript
+task-lease acquire/renew/transfer/release check the same fence while holding the
+lease lock. The absent-fence path remains a zero-runtime-call compatibility
+path; a present, unreadable, or invalid fence fails closed. The promotion
+orchestrator must acquire those same two legacy locks before engaging the fence,
+so no legacy write can pass its check and commit after cutover. Provider-first
+CLI routing and the lock-owning promotion operation remain the next slice; until
+they land, this integration deliberately blocks split-brain writes rather than
+silently falling back.
+
 Durable completion continuation read-back
 (`durable_completion.py`: `read_persisted_todo_record` /
 `project_durable_completion_outcome`) is a provider read point: it re-reads

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -1078,6 +1078,15 @@ fail-closed write-check hook；promotion 可按 operation receipt 重放，provi
 后续必须接齐所有 legacy writer、显式配置与 rollback，并证明默认 legacy 兼容性，
 才能启用本地 promotion。
 
+第一块生产 fencing 集成现在已经收口了上述工作中的写入侧：所有 Python Todo mutation
+都会在持有现有 active-state mutation lock 时检查 TypeScript 权威拥有的 durable fence；
+原生 TypeScript task-lease 的 acquire / renew / transfer / release 也会在持有 lease lock
+时检查同一个 fence。fence 不存在时保持零 runtime 调用的默认兼容路径；fence 存在、
+不可读或不合法时一律 fail closed。后续 promotion orchestrator 必须先取得这两把 legacy
+lock，再 engage fence，从而保证不存在某次 legacy write 已通过检查、却在 cutover 后才
+提交。provider-first CLI 路由和持锁 promotion operation 仍是下一切片；在它们落地前，
+本集成选择阻断 split-brain 写入，而不会静默回退。
+
 完成续接（continuation）的持久化读回
 （`durable_completion.py`：`read_persisted_todo_record` /
 `project_durable_completion_outcome`）是一个 provider read point：它在完成写入之后、

--- a/loopx/control_plane/coordination/legacy_writer_fence.py
+++ b/loopx/control_plane/coordination/legacy_writer_fence.py
@@ -1,0 +1,149 @@
+"""Cheap Python entry guard for the TypeScript-owned coordination fence.
+
+Legacy Todo writes still happen in Python during Stage 2C.  The durable fence
+itself and its validation semantics remain owned by the TypeScript control
+plane; this module only avoids starting that runtime while no fence exists and
+delegates every present-fence decision to the canonical handler.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import hashlib
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..effect_runtime import effect_runtime_result
+from ...file_lock import exclusive_file_lock
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+
+
+LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA = (
+    "loopx_legacy_coordination_write_check_request_v0"
+)
+LEGACY_COORDINATION_WRITE_CHECK_METHOD = (
+    "coordination.local_authority.legacy_write_check"
+)
+
+
+class LegacyCoordinationWriterFenced(RuntimeError):
+    """Raised when a legacy writer is no longer an authority."""
+
+    def __init__(self, message: str, *, code: str, payload: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.code = code
+        self.payload = payload
+
+
+def legacy_coordination_writer_fence_path(
+    *, runtime_root: Path, goal_id: str
+) -> Path:
+    digest = hashlib.sha256(goal_id.encode("utf-8")).hexdigest()[:16]
+    return (
+        runtime_root
+        / "authority-transition"
+        / "file-v0"
+        / f"legacy-writer-fence-{digest}.json"
+    )
+
+
+def legacy_coordination_todo_lock_path(*, runtime_root: Path, goal_id: str) -> Path:
+    digest = hashlib.sha256(goal_id.encode("utf-8")).hexdigest()[:16]
+    return (
+        runtime_root
+        / "authority-transition"
+        / "file-v0"
+        / f"legacy-todo-writer-{digest}"
+    )
+
+
+def require_legacy_coordination_write_allowed(
+    *, runtime_root: Path, goal_id: str
+) -> None:
+    """Allow the default path cheaply; delegate a present fence fail-closed.
+
+    A future promotion transaction must acquire the legacy writer's existing
+    mutation lock before engaging the fence.  Calling this function while that
+    lock is held then closes the check/write race without introducing a second
+    Python authority for fence contents.
+    """
+
+    fence_path = legacy_coordination_writer_fence_path(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+    )
+    try:
+        fence_path.stat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise LegacyCoordinationWriterFenced(
+            "legacy coordination writer fence cannot be inspected",
+            code="legacy_writer_fence_read_failed",
+            payload={"authority_mode": "unknown_fail_closed"},
+        ) from exc
+
+    result = effect_runtime_result(
+        LEGACY_COORDINATION_WRITE_CHECK_METHOD,
+        {
+            "schema_version": LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA,
+            "runtime_root": str(runtime_root.expanduser().resolve(strict=False)),
+            "goal_id": goal_id,
+        },
+    )
+    if not isinstance(result, dict):
+        raise LegacyCoordinationWriterFenced(
+            "legacy coordination writer fence returned an invalid result",
+            code="legacy_writer_fence_invalid_result",
+            payload={"authority_mode": "unknown_fail_closed"},
+        )
+    if (
+        result.get("status") == "allowed"
+        and result.get("authority_mode") == "legacy_canonical"
+    ):
+        return
+
+    code = str(result.get("reason_code") or "legacy_writer_fence_check_failed")
+    message = (
+        "legacy coordination writer is fenced; use the canonical file authority"
+        if result.get("status") == "blocked"
+        else str(result.get("reason") or "legacy coordination writer fence check failed")
+    )
+    raise LegacyCoordinationWriterFenced(message, code=code, payload=result)
+
+
+@contextmanager
+def legacy_todo_write_transaction(
+    registry_path: Path,
+    goal_id: str,
+    state_file: Path,
+    agent_id: str | None,
+    operation: str,
+    dry_run: bool,
+) -> Iterator[None]:
+    """Serialize promotion with one complete legacy Todo mutation."""
+
+    runtime_root = resolve_runtime_root(
+        load_registry(registry_path),
+        None,
+        registry_path=registry_path,
+    )
+    with exclusive_file_lock(
+        legacy_coordination_todo_lock_path(
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+        ),
+        agent_id=agent_id,
+        operation="legacy_coordination_todo_write",
+    ), exclusive_file_lock(
+        state_file,
+        agent_id=agent_id,
+        operation=operation,
+    ):
+        if not dry_run:
+            require_legacy_coordination_write_allowed(
+                runtime_root=runtime_root,
+                goal_id=goal_id,
+            )
+        yield

--- a/loopx/control_plane/coordination/legacy_writer_fence.ts
+++ b/loopx/control_plane/coordination/legacy_writer_fence.ts
@@ -21,6 +21,8 @@ export const LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA =
   "loopx_legacy_coordination_write_check_request_v0";
 export const LEGACY_COORDINATION_WRITE_CHECK_RESULT_SCHEMA =
   "loopx_legacy_coordination_write_check_result_v0";
+export const LEGACY_COORDINATION_TODO_LOCK_KEY = "legacy-todo-writer";
+export const LEGACY_COORDINATION_LEASE_LOCK_KEY = "legacy-task-lease-writer";
 
 function runtimeRoot(value: unknown): string {
   if (typeof value !== "string" || value.trim() !== value || !isAbsolute(value)) {
@@ -29,9 +31,19 @@ function runtimeRoot(value: unknown): string {
   return value;
 }
 
-function fencePath(root: string, goalId: string): string {
+export function legacyCoordinationWriterFencePath(root: string, goalId: string): string {
   const digest = createHash("sha256").update(goalId, "utf8").digest("hex").slice(0, 16);
   return join(root, "authority-transition", "file-v0", `legacy-writer-fence-${digest}.json`);
+}
+
+export function legacyCoordinationTodoLockPath(root: string, goalId: string): string {
+  const digest = createHash("sha256").update(goalId, "utf8").digest("hex").slice(0, 16);
+  return join(root, "authority-transition", "file-v0", `legacy-todo-writer-${digest}`);
+}
+
+export function legacyCoordinationLeaseLockPath(root: string, goalId: string): string {
+  const digest = createHash("sha256").update(goalId, "utf8").digest("hex").slice(0, 16);
+  return join(root, "authority-transition", "file-v0", `legacy-task-lease-writer-${digest}`);
 }
 
 export function decodeLegacyCoordinationWriterFence(value: unknown): JsonObject {
@@ -69,7 +81,7 @@ export async function loadLegacyCoordinationWriterFence(
   reason: string;
 }> {
   try {
-    const raw = await readFile(fencePath(runtimeRoot(root), goalId), "utf8");
+    const raw = await readFile(legacyCoordinationWriterFencePath(runtimeRoot(root), goalId), "utf8");
     const fence = decodeLegacyCoordinationWriterFence(JSON.parse(raw));
     if (fence.goal_id !== goalId) throw new Error("legacy writer fence goal mismatch");
     return { status: "loaded", fence };
@@ -94,7 +106,7 @@ export async function engageLegacyCoordinationWriterFence(value: unknown): Promi
     const goalId = requireAuthorityStoreId(input.goal_id, "goal id");
     const fence = decodeLegacyCoordinationWriterFence(input.fence);
     if (fence.goal_id !== goalId) throw new Error("legacy writer fence goal mismatch");
-    const path = fencePath(root, goalId);
+    const path = legacyCoordinationWriterFencePath(root, goalId);
     return await withFileMutationLock(path, async () => {
       const existing = await loadLegacyCoordinationWriterFence(root, goalId);
       if (existing.status === "loaded") {

--- a/loopx/control_plane/work_items/task_lease_acquire.ts
+++ b/loopx/control_plane/work_items/task_lease_acquire.ts
@@ -8,6 +8,11 @@ import {
 } from "../effect_runtime_errors.ts";
 import { atomicWriteJson, withFileMutationLock } from "../effect_runtime_io.ts";
 import {
+  checkLegacyCoordinationWriteAllowed,
+  legacyCoordinationLeaseLockPath,
+  LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA,
+} from "../coordination/legacy_writer_fence.ts";
+import {
   settlementIdentity,
   type JsonObject,
 } from "../effect_program.ts";
@@ -1355,8 +1360,24 @@ export async function executeTaskLeaseAcquire(
 
   try {
     return await withFileMutationLock(
-      taskLeaseLockPath(request),
-      () => commitAcquire(request, dependencies),
+      legacyCoordinationLeaseLockPath(request.runtime_root, request.goal_id),
+      () => withFileMutationLock(taskLeaseLockPath(request), async () => {
+        const writerGuard = await checkLegacyCoordinationWriteAllowed({
+          schema_version: LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA,
+          runtime_root: request.runtime_root,
+          goal_id: request.goal_id,
+        });
+        if (writerGuard.status !== "allowed") {
+          throw new TaskLeaseAcquireError(
+            writerGuard.status === "blocked"
+              ? "legacy task-lease writer is fenced; use the canonical file authority"
+              : String(writerGuard.reason ?? "legacy writer fence check failed"),
+            String(writerGuard.reason_code ?? "legacy_writer_fence_check_failed"),
+            writerGuard,
+          );
+        }
+        return await commitAcquire(request, dependencies);
+      }),
     );
   } catch (error) {
     if (error instanceof TaskLeaseAcquireError) {

--- a/loopx/control_plane/work_items/task_lease_lifecycle.ts
+++ b/loopx/control_plane/work_items/task_lease_lifecycle.ts
@@ -20,6 +20,11 @@ import {
   type FileMutationLockClaim,
 } from "../effect_runtime_io.ts";
 import {
+  checkLegacyCoordinationWriteAllowed,
+  legacyCoordinationLeaseLockPath,
+  LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA,
+} from "../coordination/legacy_writer_fence.ts";
+import {
   settlementIdentity,
   type JsonObject,
 } from "../effect_program.ts";
@@ -2679,7 +2684,26 @@ export async function executeTaskLeaseLifecycle(
       const fence = await fenceVerify(request, dependencies);
       return { ok: true, schema_version: "task_lease_v0", action: request.operation, fence, settlement: lifecycleSettlement(request, "committed") };
     }
-    return await withFileMutationLock(lockPathFor(request), () => ordinaryOperation(request!, dependencies));
+    return await withFileMutationLock(
+      legacyCoordinationLeaseLockPath(request.runtime_root, request.goal_id),
+      () => withFileMutationLock(lockPathFor(request!), async () => {
+        const writerGuard = await checkLegacyCoordinationWriteAllowed({
+          schema_version: LEGACY_COORDINATION_WRITE_CHECK_REQUEST_SCHEMA,
+          runtime_root: request!.runtime_root,
+          goal_id: request!.goal_id,
+        });
+        if (writerGuard.status !== "allowed") {
+          throw new TaskLeaseLifecycleError(
+            writerGuard.status === "blocked"
+              ? "legacy task-lease writer is fenced; use the canonical file authority"
+              : String(writerGuard.reason ?? "legacy writer fence check failed"),
+            String(writerGuard.reason_code ?? "legacy_writer_fence_check_failed"),
+            writerGuard,
+          );
+        }
+        return await ordinaryOperation(request!, dependencies);
+      }),
+    );
   } catch (error) {
     const info = errorInfo(error);
     return failureEnvelope(request ?? failureRequestContext(value), info);

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 from .agent_registry import registered_agent_ids_from_registry, require_registered_agent_id
-from .file_lock import exclusive_file_lock
 from .history import load_registry
 from .paths import resolve_runtime_root
 from .rollout_event_log import load_rollout_events, rollout_event_log_path
@@ -121,6 +120,7 @@ from .control_plane.todos.write_policy import (
     require_user_todo_task_class,
     resolve_user_gate_global_gate_update,
 )
+from .control_plane.coordination.legacy_writer_fence import legacy_todo_write_transaction
 from .control_plane.todos.handoff_mode import (
     enter_added_todo_ownership_handoff_gate,
     enter_todo_ownership_handoff_gate,
@@ -956,10 +956,8 @@ def add_goal_todo(
         state_file=state_file,
     )
 
-    with exclusive_file_lock(
-        resolved_state_file,
-        agent_id=agent_id or claimed_by,
-        operation="todo_add",
+    with legacy_todo_write_transaction(
+        registry_path, goal_id, resolved_state_file, agent_id or claimed_by, "todo_add", dry_run,
     ), ExitStack() as handoff_gate_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -1273,10 +1271,8 @@ def update_goal_todo(
             return validation_failure
     external_wait_transition: dict[str, Any] | None = None
     resume_monitor_generation: int | None = None
-    with exclusive_file_lock(
-        resolved_state_file,
-        agent_id=agent_id or claimed_by,
-        operation="todo_update",
+    with legacy_todo_write_transaction(
+        registry_path, goal_id, resolved_state_file, agent_id or claimed_by, "todo_update", dry_run,
     ), ExitStack() as handoff_gate_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -1699,10 +1695,8 @@ def complete_goal_todo(
     validation_failure = validation_gate.get("failure")
     if validation_failure is not None:
         return validation_failure
-    with exclusive_file_lock(
-        resolved_state_file,
-        agent_id=agent_id or claimed_by,
-        operation="todo_complete",
+    with legacy_todo_write_transaction(
+        registry_path, goal_id, resolved_state_file, agent_id or claimed_by, "todo_complete", dry_run,
     ), ExitStack() as lease_fence_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -2055,8 +2049,8 @@ def supersede_goal_todo(
         project=project,
         state_file=state_file,
     )
-    with exclusive_file_lock(
-        resolved_state_file, agent_id=agent_id, operation="todo_supersede",
+    with legacy_todo_write_transaction(
+        registry_path, goal_id, resolved_state_file, agent_id, "todo_supersede", dry_run,
     ), ExitStack() as lease_fence_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -2248,7 +2242,9 @@ def archive_completed_todos(
         state_file=state_file,
     )
 
-    with exclusive_file_lock(resolved_state_file, operation="todo_archive_completed"):
+    with legacy_todo_write_transaction(
+        registry_path, goal_id, resolved_state_file, None, "todo_archive_completed", dry_run,
+    ):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         archive_result = archive_completed_todo_lines(

--- a/tests/control_plane/test_legacy_coordination_writer_fence.py
+++ b/tests/control_plane/test_legacy_coordination_writer_fence.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.coordination.legacy_writer_fence import (
+    LegacyCoordinationWriterFenced,
+    legacy_coordination_writer_fence_path,
+    require_legacy_coordination_write_allowed,
+)
+
+
+def test_missing_fence_preserves_default_without_starting_typescript(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.legacy_writer_fence.effect_runtime_result",
+        lambda *_args, **_kwargs: pytest.fail("default path must not start runtime"),
+    )
+
+    require_legacy_coordination_write_allowed(
+        runtime_root=tmp_path,
+        goal_id="goal-a",
+    )
+
+
+def test_present_fence_delegates_to_typescript_and_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    path = legacy_coordination_writer_fence_path(
+        runtime_root=tmp_path,
+        goal_id="goal-a",
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"state": "present"}), encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def invoke(method: str, params: dict[str, object]) -> dict[str, object]:
+        captured.update(method=method, params=params)
+        return {
+            "status": "blocked",
+            "reason_code": "legacy_coordination_writer_fenced",
+            "authority_mode": "file_v0",
+        }
+
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.legacy_writer_fence.effect_runtime_result",
+        invoke,
+    )
+
+    with pytest.raises(LegacyCoordinationWriterFenced) as exc_info:
+        require_legacy_coordination_write_allowed(
+            runtime_root=tmp_path,
+            goal_id="goal-a",
+        )
+
+    assert exc_info.value.code == "legacy_coordination_writer_fenced"
+    assert captured["method"] == "coordination.local_authority.legacy_write_check"

--- a/tests/control_plane_ts/local_authority_runtime.test.ts
+++ b/tests/control_plane_ts/local_authority_runtime.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -28,6 +28,11 @@ import {
   COORDINATION_RUNTIME_SHADOW_BOOTSTRAP_REQUEST_SCHEMA,
   COORDINATION_RUNTIME_SHADOW_REQUEST_SCHEMA,
 } from "../../loopx/control_plane/coordination/runtime_shadow.ts";
+import { executeTaskLeaseAcquire } from "../../loopx/control_plane/work_items/task_lease_acquire.ts";
+import {
+  TASK_LEASE_LIFECYCLE_REQUEST_SCHEMA_VERSION,
+  executeTaskLeaseLifecycle,
+} from "../../loopx/control_plane/work_items/task_lease_lifecycle.ts";
 
 function sha256(value: unknown): string {
   return createHash("sha256").update(canonicalAuthorityBytes(value)).digest("hex");
@@ -274,4 +279,64 @@ test("local canonical runtime never falls back when provider state is missing", 
   assert.equal(result.status, "missing");
   assert.equal(result.decision_read_from_provider, true);
   assert.equal(result.legacy_fallback_used, false);
+});
+
+test("engaged promotion fence blocks every native legacy task-lease writer", async () => {
+  const root = await mkdtemp(join(tmpdir(), "loopx-local-authority-lease-fence-"));
+  const shadow = await qualifiedShadow(root);
+  const request = promotionRequest(root, shadow.projection, shadow.providerRevision);
+  await engageFence(request);
+
+  const authorityPath = join(root, "authority-source.json");
+  const authorityContent = "authority-v1";
+  await writeFile(authorityPath, authorityContent, "utf8");
+  const authority = {
+    handoff_mode: "hard_lease",
+    registered_agent_candidates: [["agent-a"]],
+    todos: [{
+      todo_id: "todo_abc",
+      status: "open",
+      claimed_by: "agent-a",
+      role: "agent",
+      task_class: "advancement_task",
+    }],
+    todo_projection_error: null,
+    source_receipts: [{
+      source_id: "authority",
+      path: authorityPath,
+      state: "file",
+      sha256: createHash("sha256").update(authorityContent).digest("hex"),
+    }],
+  };
+  const acquire = await executeTaskLeaseAcquire({
+    schema_version: "loopx_task_lease_acquire_native_v0",
+    runtime_root: root,
+    goal_id: "goal-a",
+    todo_id: "todo_abc",
+    owner: "agent-a",
+    idempotency_key: "lease:fenced-acquire",
+    write_scopes: [],
+    ttl_seconds: 60,
+    expected_version: null,
+    authority,
+  });
+  assert.equal(acquire.ok, false);
+  assert.equal(acquire.error_code, "legacy_coordination_writer_fenced");
+
+  const renew = await executeTaskLeaseLifecycle({
+    schema_version: TASK_LEASE_LIFECYCLE_REQUEST_SCHEMA_VERSION,
+    operation: "renew",
+    runtime_root: root,
+    goal_id: "goal-a",
+    todo_id: "todo_abc",
+    owner: "agent-a",
+    idempotency_key: "lease:fenced-renew",
+    expected_version: 1,
+    ttl_seconds: 60,
+    new_owner: null,
+    new_idempotency_key: null,
+    authority,
+  });
+  assert.equal(renew.ok, false);
+  assert.equal(renew.error_code, "legacy_coordination_writer_fenced");
 });


### PR DESCRIPTION
## Summary

- serialize every legacy Python Todo mutation with the Stage 2C cutover lock and delegate present-fence validation to the TypeScript control plane
- fence native TypeScript task-lease acquire and lifecycle mutations under the matching promotion lock
- preserve the pre-promotion legacy default while proving all Todo/lease writes fail closed after FileAuthorityStore promotion
- clarify the Stage 2C atomic cutover contract in the bilingual Shared Authority RFC

## Validation

- `npm run typecheck:control-plane`
- focused Node local-authority and task-lease suites: 59 passed
- focused Python Todo and writer-fence suites: 63 passed
- Ruff and focused mypy passed
- `loopx check` public/private scan passed (unrelated registry warnings only)
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 risk-selected checks passed
- exact-diff change-quality receipt: `cqr_a57aa3000717c362472d`

## Review notes

- The behavior is unchanged until a durable promotion fence exists.
- The Python adapter contains only the absent-fence fast path and the lock/check bridge; TypeScript remains the fence semantic owner.
- Future-facing pass: applied by centralizing both Todo and task-lease mutation boundaries on the shared promotion lock; no broader provider migration was added.