### PR TITLE
feat(dashboard): add read-only benchmark study view

### DIFF
--- a/apps/presentation/dashboard/package.json
+++ b/apps/presentation/dashboard/package.json
@@ -30,6 +30,8 @@
     "smoke:status-source-switch-browser": "node ../../../examples/status-source-switch-browser-smoke.mjs",
     "smoke:status-source-switch-packaged": "LOOPX_STATUS_SOURCE_SWITCH_PACKAGED=1 LOOPX_STATUS_SOURCE_SWITCH_PORT=5198 node ../../../examples/status-source-switch-browser-smoke.mjs",
     "smoke:status-sources": "rm -rf /tmp/loopx-status-source-smoke && tsc --ignoreConfig --target ES2022 --module CommonJS --moduleResolution Node --ignoreDeprecations 6.0 --skipLibCheck --strict --resolveJsonModule --esModuleInterop --outDir /tmp/loopx-status-source-smoke smoke/status-source-catalog-smoke.ts src/data/ssh-host-catalog.ts src/data/status-source-catalog.ts src/data/local-status-query.ts src/data/status.ts && NODE_PATH=\"$PWD/node_modules\" node /tmp/loopx-status-source-smoke/apps/presentation/dashboard/smoke/status-source-catalog-smoke.js",
+    "smoke:benchmark-study": "rm -rf node_modules/.cache/loopx-benchmark-study-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --resolveJsonModule --outDir node_modules/.cache/loopx-benchmark-study-smoke smoke/benchmark-study-contract-smoke.ts src/data/benchmark-study.ts && node node_modules/.cache/loopx-benchmark-study-smoke/smoke/benchmark-study-contract-smoke.js",
+    "smoke:benchmark-study-browser": "node ../../../examples/dashboard-benchmark-study-browser-smoke.mjs",
     "smoke:usage-progress": "rm -rf /tmp/loopx-usage-progress-smoke && tsc --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck --strict --outDir /tmp/loopx-usage-progress-smoke smoke/usage-progress-smoke.ts && node /tmp/loopx-usage-progress-smoke/usage-progress-smoke.js"
   },
   "dependencies": {

--- a/apps/presentation/dashboard/public/benchmark-study.example.json
+++ b/apps/presentation/dashboard/public/benchmark-study.example.json
@@ -1,0 +1,161 @@
+{
+  "ok": true,
+  "schema_version": "benchmark_study_dashboard_v0",
+  "benchmark_id": "example-swe@1",
+  "study_id": "four-arm-demo-v1",
+  "status": "provisional",
+  "design": {
+    "protocol_id": "solver-v1",
+    "comparison_protocol_id": "paired-v1",
+    "baseline_arm_id": "goal_plain",
+    "case_set": { "case_set_id": "public-demo-cases", "case_ids": ["case-api-contract", "case-state-transition"] },
+    "metric_catalog": [
+      { "metric_name": "feature", "role": "primary", "unit": "tests", "higher_is_better": true, "binary": false },
+      { "metric_name": "preservation", "role": "guardrail", "unit": "tests", "higher_is_better": true, "binary": false },
+      { "metric_name": "reward", "role": "guardrail", "higher_is_better": true, "binary": true }
+    ],
+    "labels": { "title": "Four-arm software-engineering study" }
+  },
+  "campaign": {
+    "intended_case_count": 2,
+    "intended_arm_count": 4,
+    "intended_cell_denominator": 8,
+    "selected_score_countable_cell_count": 6,
+    "selected_score_countable_coverage_rate": 0.75,
+    "complete_declared_design_case_count": 1,
+    "ambiguous_score_countable_cell_count": 0,
+    "in_flight_run_count": 2,
+    "matched_pair_countable_count": 3,
+    "factorial_contrast_count": 1,
+    "factorial_contrast_countable_count": 1,
+    "runtime_observation_count": 6,
+    "runtime_classification_counts": { "running_qualified": 2, "terminal_qualified": 4 }
+  },
+  "arms": [
+    {
+      "arm_id": "goal_plain", "arm_role": "baseline", "factor_assignments": { "orchestrator": "goal", "domain_hint": "none" },
+      "protocol_counts": { "goal-v1": 2 }, "runner_revision_counts": { "runner-demo-1": 2 }, "orchestrator_runtime_counts": {},
+      "intended_case_count": 2, "run_count": 2, "terminal_run_count": 2, "selected_score_countable_case_count": 2, "coverage_rate": 1,
+      "metrics": {
+        "feature": { "case_denominator": 2, "value_sum": 17, "value_mean": 8.5, "value_median": 8.5, "value_min": 7, "value_max": 10, "case_macro_rate": 0.85, "suite_micro_rate": 0.85, "suite_micro_numerator": 17, "suite_micro_denominator": 20 },
+        "preservation": { "case_denominator": 2, "value_sum": 40, "value_mean": 20, "value_median": 20, "value_min": 20, "value_max": 20, "case_macro_rate": 1, "suite_micro_rate": 1, "suite_micro_numerator": 40, "suite_micro_denominator": 40 },
+        "reward": { "case_denominator": 2, "value_sum": 1, "value_mean": 0.5, "value_median": 0.5, "value_min": 0, "value_max": 1 }
+      },
+      "binary_outcomes": { "reward": { "success_count": 1, "case_denominator": 2, "success_rate": 0.5 } },
+      "effort": { "duration_ms": { "denominator": 2, "mean": 5400000, "median": 5400000 } }, "failure_class_counts": { "contract_miss": 1 }
+    },
+    {
+      "arm_id": "loopx_plain", "arm_role": "treatment", "factor_assignments": { "orchestrator": "loopx", "domain_hint": "none" },
+      "protocol_counts": { "loopx-v1": 2 }, "runner_revision_counts": { "runner-demo-1": 2 }, "orchestrator_runtime_counts": { "{\"provider_id\": \"loopx\", \"revision\": \"loopx-demo-1\"}": 2 },
+      "intended_case_count": 2, "run_count": 2, "terminal_run_count": 1, "selected_score_countable_case_count": 1, "coverage_rate": 0.5,
+      "metrics": {
+        "feature": { "case_denominator": 1, "value_sum": 10, "value_mean": 10, "value_median": 10, "value_min": 10, "value_max": 10, "case_macro_rate": 1, "suite_micro_rate": 1, "suite_micro_numerator": 10, "suite_micro_denominator": 10 },
+        "preservation": { "case_denominator": 1, "value_sum": 20, "value_mean": 20, "value_median": 20, "value_min": 20, "value_max": 20, "case_macro_rate": 1, "suite_micro_rate": 1, "suite_micro_numerator": 20, "suite_micro_denominator": 20 },
+        "reward": { "case_denominator": 1, "value_sum": 1, "value_mean": 1, "value_median": 1, "value_min": 1, "value_max": 1 }
+      },
+      "binary_outcomes": { "reward": { "success_count": 1, "case_denominator": 1, "success_rate": 1 } },
+      "effort": { "duration_ms": { "denominator": 1, "mean": 7200000, "median": 7200000 } }, "failure_class_counts": {}
+    },
+    {
+      "arm_id": "goal_hint", "arm_role": "control", "factor_assignments": { "orchestrator": "goal", "domain_hint": "swe" },
+      "protocol_counts": { "goal-hint-v1": 2 }, "runner_revision_counts": { "runner-demo-1": 2 }, "orchestrator_runtime_counts": {},
+      "intended_case_count": 2, "run_count": 2, "terminal_run_count": 2, "selected_score_countable_case_count": 2, "coverage_rate": 1,
+      "metrics": {
+        "feature": { "case_denominator": 2, "value_sum": 19, "value_mean": 9.5, "value_median": 9.5, "value_min": 9, "value_max": 10, "case_macro_rate": 0.95, "suite_micro_rate": 0.95, "suite_micro_numerator": 19, "suite_micro_denominator": 20 },
+        "preservation": { "case_denominator": 2, "value_sum": 40, "value_mean": 20, "value_median": 20, "value_min": 20, "value_max": 20, "case_macro_rate": 1, "suite_micro_rate": 1, "suite_micro_numerator": 40, "suite_micro_denominator": 40 },
+        "reward": { "case_denominator": 2, "value_sum": 1, "value_mean": 0.5, "value_median": 0.5, "value_min": 0, "value_max": 1 }
+      },
+      "binary_outcomes": { "reward": { "success_count": 1, "case_denominator": 2, "success_rate": 0.5 } },
+      "effort": { "duration_ms": { "denominator": 2, "mean": 6000000, "median": 6000000 } }, "failure_class_counts": { "edge_case_miss": 1 }
+    },
+    {
+      "arm_id": "loopx_hint", "arm_role": "treatment", "factor_assignments": { "orchestrator": "loopx", "domain_hint": "swe" },
+      "protocol_counts": { "loopx-hint-v1": 1 }, "runner_revision_counts": { "runner-demo-1": 1 }, "orchestrator_runtime_counts": { "{\"provider_id\": \"loopx\", \"revision\": \"loopx-demo-1\"}": 1 },
+      "intended_case_count": 2, "run_count": 1, "terminal_run_count": 1, "selected_score_countable_case_count": 1, "coverage_rate": 0.5,
+      "metrics": {
+        "feature": { "case_denominator": 1, "value_sum": 10, "value_mean": 10, "value_median": 10, "value_min": 10, "value_max": 10, "case_macro_rate": 1, "suite_micro_rate": 1, "suite_micro_numerator": 10, "suite_micro_denominator": 10 },
+        "preservation": { "case_denominator": 1, "value_sum": 20, "value_mean": 20, "value_median": 20, "value_min": 20, "value_max": 20, "case_macro_rate": 1, "suite_micro_rate": 1, "suite_micro_numerator": 20, "suite_micro_denominator": 20 },
+        "reward": { "case_denominator": 1, "value_sum": 1, "value_mean": 1, "value_median": 1, "value_min": 1, "value_max": 1 }
+      },
+      "binary_outcomes": { "reward": { "success_count": 1, "case_denominator": 1, "success_rate": 1 } },
+      "effort": { "duration_ms": { "denominator": 1, "mean": 7800000, "median": 7800000 } }, "failure_class_counts": {}
+    }
+  ],
+  "contrasts": {
+    "loopx_plain": { "matched_pair_denominator": 1, "primary_metric_directions": { "improved": 0, "flat": 1, "regressed": 0 }, "binary_metric_transitions": { "reward": { "0_to_1": 0, "1_to_0": 0, "same": 1 } } },
+    "goal_hint": { "matched_pair_denominator": 2, "primary_metric_directions": { "improved": 1, "flat": 1, "regressed": 0 }, "binary_metric_transitions": { "reward": { "0_to_1": 0, "1_to_0": 0, "same": 2 } } }
+  },
+  "factorial_contrasts": [],
+  "cases": [
+    {
+      "case_id": "case-api-contract", "complete_declared_design": true,
+      "eligible_comparisons": [
+        { "comparison_id": "run-goal-api->run-loopx-api", "comparison_anchor_run_id": "run-goal-api", "candidate_run_id": "run-loopx-api", "candidate_arm_id": "loopx_plain", "primary_metric": "feature", "matched_pair_countable": true, "metric_deltas": { "feature": { "baseline_value": 10, "candidate_value": 10, "delta": 0, "direction": "flat" }, "preservation": { "baseline_value": 20, "candidate_value": 20, "delta": 0, "direction": "flat" }, "reward": { "baseline_value": 1, "candidate_value": 1, "delta": 0, "direction": "flat" } } },
+        { "comparison_id": "run-goal-api->run-goal-hint-api", "comparison_anchor_run_id": "run-goal-api", "candidate_run_id": "run-goal-hint-api", "candidate_arm_id": "goal_hint", "primary_metric": "feature", "matched_pair_countable": true, "metric_deltas": { "feature": { "baseline_value": 10, "candidate_value": 10, "delta": 0, "direction": "flat" }, "preservation": { "baseline_value": 20, "candidate_value": 20, "delta": 0, "direction": "flat" }, "reward": { "baseline_value": 1, "candidate_value": 1, "delta": 0, "direction": "flat" } } }
+      ],
+      "largest_eligible_primary_contrast": { "comparison_id": "run-goal-api->run-loopx-api", "comparison_anchor_run_id": "run-goal-api", "candidate_run_id": "run-loopx-api", "candidate_arm_id": "loopx_plain", "primary_metric": "feature", "matched_pair_countable": true, "metric_deltas": { "feature": { "baseline_value": 10, "candidate_value": 10, "delta": 0, "direction": "flat" }, "preservation": { "baseline_value": 20, "candidate_value": 20, "delta": 0, "direction": "flat" }, "reward": { "baseline_value": 1, "candidate_value": 1, "delta": 0, "direction": "flat" } } },
+      "arms": [
+        { "arm_id": "goal_plain", "selected_run_id": "run-goal-api", "score_countable": true, "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } }, "effort": { "duration_ms": 3600000 }, "insight": null },
+        { "arm_id": "loopx_plain", "selected_run_id": "run-loopx-api", "score_countable": true, "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } }, "effort": { "duration_ms": 7200000 }, "insight": null },
+        { "arm_id": "goal_hint", "selected_run_id": "run-goal-hint-api", "score_countable": true, "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } }, "effort": { "duration_ms": 4800000 }, "insight": null },
+        { "arm_id": "loopx_hint", "selected_run_id": "run-loopx-hint-api", "score_countable": true, "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } }, "effort": { "duration_ms": 7800000 }, "insight": null }
+      ]
+    },
+    {
+      "case_id": "case-state-transition", "complete_declared_design": false,
+      "eligible_comparisons": [
+        { "comparison_id": "run-goal-state->run-goal-hint-state", "comparison_anchor_run_id": "run-goal-state", "candidate_run_id": "run-goal-hint-state", "candidate_arm_id": "goal_hint", "primary_metric": "feature", "matched_pair_countable": true, "metric_deltas": { "feature": { "baseline_value": 7, "candidate_value": 9, "delta": 2, "direction": "improved" }, "preservation": { "baseline_value": 20, "candidate_value": 20, "delta": 0, "direction": "flat" }, "reward": { "baseline_value": 0, "candidate_value": 0, "delta": 0, "direction": "flat" } } }
+      ],
+      "largest_eligible_primary_contrast": { "comparison_id": "run-goal-state->run-goal-hint-state", "comparison_anchor_run_id": "run-goal-state", "candidate_run_id": "run-goal-hint-state", "candidate_arm_id": "goal_hint", "primary_metric": "feature", "matched_pair_countable": true, "metric_deltas": { "feature": { "baseline_value": 7, "candidate_value": 9, "delta": 2, "direction": "improved" }, "preservation": { "baseline_value": 20, "candidate_value": 20, "delta": 0, "direction": "flat" }, "reward": { "baseline_value": 0, "candidate_value": 0, "delta": 0, "direction": "flat" } } },
+      "arms": [
+        { "arm_id": "goal_plain", "selected_run_id": "run-goal-state", "score_countable": true, "metrics": { "feature": { "value": 7, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 0, "higher_is_better": true } }, "effort": { "duration_ms": 7200000 }, "insight": null },
+        { "arm_id": "loopx_plain", "selected_run_id": null, "score_countable": false, "metrics": {}, "effort": {}, "insight": null },
+        { "arm_id": "goal_hint", "selected_run_id": "run-goal-hint-state", "score_countable": true, "metrics": { "feature": { "value": 9, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 0, "higher_is_better": true } }, "effort": { "duration_ms": 7200000 }, "insight": null },
+        { "arm_id": "loopx_hint", "selected_run_id": null, "score_countable": false, "metrics": {}, "effort": {}, "insight": null }
+      ]
+    }
+  ],
+  "runs": [
+    {
+      "run_id": "run-goal-api", "case_id": "case-api-contract", "arm_id": "goal_plain", "arm_role": "baseline", "status": "completed", "protocol_id": "goal-v1", "runner_revision": "runner-demo-1", "observed_at": "2026-09-02T12:00:00+00:00",
+      "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } },
+      "countability": { "integrity_qualified": true, "official_result_present": true, "score_countable": true }, "treatment_fidelity": "not_applicable", "effort": { "duration_ms": 3600000, "agent_steps": 42, "token_count": 120000 },
+      "redacted_insight": { "failure_class": "none", "causal_summary": "The implementation matched the declared public API from an external caller.", "expectedness": "expected", "implication": "Keep the external contract check.", "next_probe": "Repeat on the state-transition case.", "confidence": "high", "evidence_refs": ["public-receipt:demo123"] },
+      "upload_provenance": { "producer_id": "example-adapter", "producer_version": "1.0.0", "observed_at": "2026-09-02T12:00:00+00:00", "source_revision": "demo-source-1" }
+    },
+    {
+      "run_id": "run-loopx-api", "case_id": "case-api-contract", "arm_id": "loopx_plain", "arm_role": "treatment", "status": "completed", "protocol_id": "loopx-v1", "runner_revision": "runner-demo-1", "observed_at": "2026-09-02T14:00:00+00:00",
+      "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } },
+      "countability": { "integrity_qualified": true, "official_result_present": true, "score_countable": true }, "treatment_fidelity": "qualified", "effort": { "duration_ms": 7200000 }, "redacted_insight": null,
+      "upload_provenance": { "producer_id": "example-adapter", "producer_version": "1.0.0", "observed_at": "2026-09-02T14:00:00+00:00", "source_revision": "demo-source-1" }
+    },
+    {
+      "run_id": "run-goal-state", "case_id": "case-state-transition", "arm_id": "goal_plain", "arm_role": "baseline", "status": "completed", "protocol_id": "goal-v1", "runner_revision": "runner-demo-1", "observed_at": "2026-09-02T16:00:00+00:00",
+      "metrics": { "feature": { "value": 7, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 0, "higher_is_better": true } },
+      "countability": { "integrity_qualified": true, "official_result_present": true, "score_countable": true }, "treatment_fidelity": "not_applicable", "effort": { "duration_ms": 7200000 }, "redacted_insight": null,
+      "upload_provenance": { "producer_id": "example-adapter", "producer_version": "1.0.0", "observed_at": "2026-09-02T16:00:00+00:00", "source_revision": "demo-source-1" }
+    },
+    {
+      "run_id": "run-goal-hint-api", "case_id": "case-api-contract", "arm_id": "goal_hint", "arm_role": "control", "status": "completed", "protocol_id": "goal-hint-v1", "runner_revision": "runner-demo-1", "observed_at": "2026-09-02T17:00:00+00:00",
+      "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } },
+      "countability": { "integrity_qualified": true, "official_result_present": true, "score_countable": true }, "treatment_fidelity": "qualified", "effort": { "duration_ms": 4800000 }, "redacted_insight": null,
+      "upload_provenance": { "producer_id": "example-adapter", "producer_version": "1.0.0", "observed_at": "2026-09-02T17:00:00+00:00", "source_revision": "demo-source-1" }
+    },
+    {
+      "run_id": "run-loopx-hint-api", "case_id": "case-api-contract", "arm_id": "loopx_hint", "arm_role": "treatment", "status": "completed", "protocol_id": "loopx-hint-v1", "runner_revision": "runner-demo-1", "observed_at": "2026-09-02T18:00:00+00:00",
+      "metrics": { "feature": { "value": 10, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 1, "higher_is_better": true } },
+      "countability": { "integrity_qualified": true, "official_result_present": true, "score_countable": true }, "treatment_fidelity": "qualified", "effort": { "duration_ms": 7800000 }, "redacted_insight": null,
+      "upload_provenance": { "producer_id": "example-adapter", "producer_version": "1.0.0", "observed_at": "2026-09-02T18:00:00+00:00", "source_revision": "demo-source-1" }
+    },
+    {
+      "run_id": "run-goal-hint-state", "case_id": "case-state-transition", "arm_id": "goal_hint", "arm_role": "control", "status": "completed", "protocol_id": "goal-hint-v1", "runner_revision": "runner-demo-1", "observed_at": "2026-09-02T19:00:00+00:00",
+      "metrics": { "feature": { "value": 9, "total": 10, "unit": "tests", "higher_is_better": true }, "preservation": { "value": 20, "total": 20, "unit": "tests", "higher_is_better": true }, "reward": { "value": 0, "higher_is_better": true } },
+      "countability": { "integrity_qualified": true, "official_result_present": true, "score_countable": true }, "treatment_fidelity": "qualified", "effort": { "duration_ms": 7200000 }, "redacted_insight": null,
+      "upload_provenance": { "producer_id": "example-adapter", "producer_version": "1.0.0", "observed_at": "2026-09-02T19:00:00+00:00", "source_revision": "demo-source-1" }
+    }
+  ],
+  "authority": { "score_source": "benchmark_experiment_board_row_v0", "matched_comparison_source": "benchmark_experiment_board_v0", "factorial_comparison_source": null, "manifest_changes_scores": false, "dashboard_is_execution_authority": false },
+  "public_boundary": { "raw_task_recorded": false, "raw_trajectory_recorded": false, "hidden_evaluation_recorded": false, "raw_verifier_output_recorded": false, "credentials_recorded": false, "local_paths_recorded": false },
+  "write_performed": false,
+  "network_access_performed": false
+}

--- a/apps/presentation/dashboard/smoke/benchmark-study-contract-smoke.ts
+++ b/apps/presentation/dashboard/smoke/benchmark-study-contract-smoke.ts
@@ -1,0 +1,36 @@
+import fixture from "../public/benchmark-study.example.json" with { type: "json" };
+import {
+  parseBenchmarkStudyDashboard,
+  resolveBenchmarkStudyDashboardUrl,
+} from "../src/data/benchmark-study.js";
+
+const packet = parseBenchmarkStudyDashboard(fixture);
+if (packet.status !== "provisional") throw new Error("fixture must expose provisional coverage");
+if (packet.campaign.intended_cell_denominator !== 8) throw new Error("campaign denominator drifted");
+if (packet.campaign.selected_score_countable_cell_count !== 6) throw new Error("countable numerator drifted");
+if (packet.arms.some((arm) => arm.intended_case_count !== 2)) throw new Error("arm denominator missing");
+if (packet.cases[1]?.complete_declared_design !== false) throw new Error("case provisional state missing");
+if (!packet.runs.every((run) => typeof run.countability.score_countable === "boolean")) throw new Error("run countability missing");
+if (packet.contrasts.loopx_plain?.primary_metric_directions.flat !== 1) throw new Error("matched direction drifted from run metrics");
+if (packet.contrasts.goal_hint?.binary_metric_transitions.reward?.same !== 2) throw new Error("binary transition drifted from run metrics");
+if (packet.cases[1]?.largest_eligible_primary_contrast?.metric_deltas.feature?.delta !== 2) throw new Error("case-level eligible contrast missing");
+if (packet.cases[0]?.arms.some((cell) => cell.score_countable && !cell.metrics.preservation)) throw new Error("countable cell guardrail missing");
+
+const resolved = resolveBenchmarkStudyDashboardUrl("/study.json", "http://127.0.0.1:5173/benchmarks/study");
+if (resolved !== "http://127.0.0.1:5173/study.json") throw new Error("local readback URL drifted");
+const packaged = resolveBenchmarkStudyDashboardUrl("/chat/benchmark-study.example.json", "http://127.0.0.1:5173/chat/benchmarks/study");
+if (packaged !== "http://127.0.0.1:5173/chat/benchmark-study.example.json") throw new Error("packaged-base readback URL drifted");
+try {
+  resolveBenchmarkStudyDashboardUrl("file:///private/study.json", "http://127.0.0.1:5173/");
+  throw new Error("file source must be rejected");
+} catch (error) {
+  if (error instanceof Error && error.message === "file source must be rejected") throw error;
+}
+try {
+  resolveBenchmarkStudyDashboardUrl("https://example.com/study.json", "http://127.0.0.1:5173/");
+  throw new Error("cross-origin source must be rejected");
+} catch (error) {
+  if (error instanceof Error && error.message === "cross-origin source must be rejected") throw error;
+}
+
+console.log("benchmark study dashboard contract smoke passed");

--- a/apps/presentation/dashboard/src/data/benchmark-study.ts
+++ b/apps/presentation/dashboard/src/data/benchmark-study.ts
@@ -1,0 +1,213 @@
+import { z } from "zod";
+
+const metricValueSchema = z.object({
+  value: z.number().finite(),
+  total: z.number().finite().positive().optional(),
+  unit: z.string().optional(),
+  higher_is_better: z.boolean(),
+}).passthrough();
+
+const effortSchema = z.record(z.string(), z.number().finite()).default({});
+
+const insightSchema = z.object({
+  outcome_status: z.string().optional(),
+  failure_class: z.string(),
+  causal_summary: z.string(),
+  expectedness: z.string(),
+  implication: z.string(),
+  next_probe: z.string(),
+  confidence: z.string(),
+  evidence_refs: z.array(z.string()).optional(),
+}).passthrough();
+
+const armCellSchema = z.object({
+  arm_id: z.string(),
+  selected_run_id: z.string().nullable(),
+  score_countable: z.boolean(),
+  metrics: z.record(z.string(), metricValueSchema),
+  effort: effortSchema,
+  insight: insightSchema.nullable().optional(),
+});
+
+const runSchema = z.object({
+  run_id: z.string(),
+  case_id: z.string(),
+  arm_id: z.string(),
+  arm_role: z.string(),
+  status: z.string(),
+  protocol_id: z.string(),
+  runner_revision: z.string().optional(),
+  observed_at: z.string(),
+  metrics: z.record(z.string(), metricValueSchema),
+  countability: z.object({
+    integrity_qualified: z.boolean(),
+    official_result_present: z.boolean(),
+    score_countable: z.boolean(),
+  }).passthrough(),
+  treatment_fidelity: z.string(),
+  effort: effortSchema,
+  redacted_insight: insightSchema.nullable().optional(),
+  upload_provenance: z.object({
+    producer_id: z.string(),
+    producer_version: z.string(),
+    observed_at: z.string(),
+    source_revision: z.string(),
+  }).passthrough(),
+}).passthrough();
+
+const metricAggregateSchema = z.object({
+  case_denominator: z.number().int().nonnegative(),
+  value_sum: z.number().finite(),
+  value_mean: z.number().finite().nullable(),
+  value_median: z.number().finite().nullable(),
+  value_min: z.number().finite().nullable(),
+  value_max: z.number().finite().nullable(),
+  case_macro_rate: z.number().finite().optional(),
+  suite_micro_rate: z.number().finite().optional(),
+  suite_micro_numerator: z.number().finite().optional(),
+  suite_micro_denominator: z.number().finite().positive().optional(),
+}).passthrough();
+
+const armSchema = z.object({
+  arm_id: z.string(),
+  arm_role: z.string(),
+  factor_assignments: z.record(z.string(), z.string()),
+  protocol_counts: z.record(z.string(), z.number().int().nonnegative()).default({}),
+  runner_revision_counts: z.record(z.string(), z.number().int().nonnegative()).default({}),
+  orchestrator_runtime_counts: z.record(z.string(), z.number().int().nonnegative()).default({}),
+  intended_case_count: z.number().int().positive(),
+  run_count: z.number().int().nonnegative(),
+  terminal_run_count: z.number().int().nonnegative(),
+  selected_score_countable_case_count: z.number().int().nonnegative(),
+  coverage_rate: z.number().finite().min(0).max(1),
+  metrics: z.record(z.string(), metricAggregateSchema),
+  binary_outcomes: z.record(z.string(), z.object({
+    success_count: z.number().int().nonnegative(),
+    case_denominator: z.number().int().nonnegative(),
+    success_rate: z.number().finite().min(0).max(1).nullable(),
+  })),
+  effort: z.record(z.string(), z.object({
+    denominator: z.number().int().nonnegative(),
+    mean: z.number().finite().nullable(),
+    median: z.number().finite().nullable(),
+  })),
+  failure_class_counts: z.record(z.string(), z.number().int().nonnegative()),
+}).passthrough();
+
+const metricDeltaSchema = z.object({
+  baseline_value: z.number().finite(),
+  candidate_value: z.number().finite(),
+  delta: z.number().finite(),
+  direction: z.enum(["improved", "flat", "regressed"]).optional(),
+}).passthrough();
+
+const matchedComparisonSchema = z.object({
+  comparison_id: z.string(),
+  comparison_anchor_run_id: z.string(),
+  candidate_run_id: z.string(),
+  candidate_arm_id: z.string(),
+  primary_metric: z.string(),
+  matched_pair_countable: z.literal(true),
+  metric_deltas: z.record(z.string(), metricDeltaSchema),
+}).passthrough();
+
+export const benchmarkStudyDashboardSchema = z.object({
+  ok: z.literal(true),
+  schema_version: z.literal("benchmark_study_dashboard_v0"),
+  benchmark_id: z.string(),
+  study_id: z.string(),
+  status: z.enum(["complete", "provisional"]),
+  design: z.object({
+    protocol_id: z.string(),
+    comparison_protocol_id: z.string(),
+    baseline_arm_id: z.string(),
+    case_set: z.object({
+      case_set_id: z.string(),
+      case_ids: z.array(z.string()),
+    }),
+    metric_catalog: z.array(z.object({
+      metric_name: z.string(),
+      role: z.enum(["primary", "guardrail", "supporting"]),
+      unit: z.string().optional(),
+      higher_is_better: z.boolean(),
+      binary: z.boolean(),
+    })),
+    labels: z.record(z.string(), z.string()),
+  }).passthrough(),
+  campaign: z.object({
+    intended_case_count: z.number().int().positive(),
+    intended_arm_count: z.number().int().positive(),
+    intended_cell_denominator: z.number().int().positive(),
+    selected_score_countable_cell_count: z.number().int().nonnegative(),
+    selected_score_countable_coverage_rate: z.number().finite().min(0).max(1),
+    complete_declared_design_case_count: z.number().int().nonnegative(),
+    ambiguous_score_countable_cell_count: z.number().int().nonnegative(),
+    in_flight_run_count: z.number().int().nonnegative(),
+    matched_pair_countable_count: z.number().int().nonnegative(),
+    factorial_contrast_count: z.number().int().nonnegative(),
+    factorial_contrast_countable_count: z.number().int().nonnegative(),
+    runtime_observation_count: z.number().int().nonnegative(),
+    runtime_classification_counts: z.record(z.string(), z.number().int().nonnegative()),
+  }),
+  arms: z.array(armSchema),
+  contrasts: z.record(z.string(), z.object({
+    matched_pair_denominator: z.number().int().nonnegative(),
+    primary_metric_directions: z.object({
+      improved: z.number().int().nonnegative(),
+      flat: z.number().int().nonnegative(),
+      regressed: z.number().int().nonnegative(),
+    }),
+    binary_metric_transitions: z.record(z.string(), z.object({
+      "0_to_1": z.number().int().nonnegative(),
+      "1_to_0": z.number().int().nonnegative(),
+      same: z.number().int().nonnegative(),
+    })),
+  })),
+  cases: z.array(z.object({
+    case_id: z.string(),
+    complete_declared_design: z.boolean(),
+    arms: z.array(armCellSchema),
+    eligible_comparisons: z.array(matchedComparisonSchema),
+    largest_eligible_primary_contrast: matchedComparisonSchema.nullable(),
+  })),
+  runs: z.array(runSchema),
+  authority: z.object({
+    score_source: z.string(),
+    matched_comparison_source: z.string(),
+    factorial_comparison_source: z.string().nullable(),
+    manifest_changes_scores: z.literal(false),
+    dashboard_is_execution_authority: z.literal(false),
+  }),
+  public_boundary: z.object({
+    raw_task_recorded: z.literal(false),
+    raw_trajectory_recorded: z.literal(false),
+    hidden_evaluation_recorded: z.literal(false),
+    raw_verifier_output_recorded: z.literal(false),
+    credentials_recorded: z.literal(false),
+    local_paths_recorded: z.literal(false),
+  }),
+  write_performed: z.literal(false),
+  network_access_performed: z.literal(false),
+});
+
+export type BenchmarkStudyDashboard = z.infer<typeof benchmarkStudyDashboardSchema>;
+export type BenchmarkStudyArm = BenchmarkStudyDashboard["arms"][number];
+export type BenchmarkStudyCase = BenchmarkStudyDashboard["cases"][number];
+export type BenchmarkStudyRun = BenchmarkStudyDashboard["runs"][number];
+export type BenchmarkStudyView = "campaign" | "arms" | "cases" | "runs";
+
+export function parseBenchmarkStudyDashboard(value: unknown): BenchmarkStudyDashboard {
+  return benchmarkStudyDashboardSchema.parse(value);
+}
+
+export function resolveBenchmarkStudyDashboardUrl(value: string, baseUrl: string): string {
+  const base = new URL(baseUrl);
+  const resolved = new URL(value || "/benchmark-study.example.json", base);
+  if (!new Set(["http:", "https:"]).has(resolved.protocol)) {
+    throw new Error("Benchmark dashboard source must use HTTP or HTTPS");
+  }
+  if (resolved.origin !== base.origin) {
+    throw new Error("Benchmark dashboard source must use same-origin local readback");
+  }
+  return resolved.toString();
+}

--- a/apps/presentation/dashboard/src/router.tsx
+++ b/apps/presentation/dashboard/src/router.tsx
@@ -11,6 +11,7 @@ import { DashboardPage } from "./views/dashboard-page";
 import { DeprecatedFrontstageOpsPage } from "./views/deprecated/frontstage-ops-page";
 import { FrontstageDeveloperPage } from "./views/frontstage-developer-page";
 import { FrontstagePage } from "./views/frontstage-page";
+import { BenchmarkStudyPage } from "./views/benchmark-study-page";
 
 const searchSchema = z.object({
   goalId: z.string().optional().default(""),
@@ -26,6 +27,12 @@ const frontstageSearchSchema = z.object({
 });
 
 const deprecatedFrontstageOpsSearchSchema = frontstageSearchSchema.omit({ mode: true });
+
+const benchmarkStudySearchSchema = z.object({
+  dashboardUrl: z.string().optional().default(""),
+  view: z.enum(["campaign", "arms", "cases", "runs"]).optional().default("campaign"),
+  runId: z.string().optional().default(""),
+});
 
 function FrontstageRoutePage() {
   const search = frontstageRoute.useSearch();
@@ -94,11 +101,19 @@ export const frontstageDeveloperRoute = createRoute({
   component: FrontstageDeveloperPage,
 });
 
+export const benchmarkStudyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/benchmarks/study",
+  validateSearch: (search) => benchmarkStudySearchSchema.parse(search),
+  component: BenchmarkStudyPage,
+});
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   frontstageRoute,
   deprecatedFrontstageOpsRoute,
   frontstageDeveloperRoute,
+  benchmarkStudyRoute,
 ]);
 
 function routerBasepathFromViteBase(baseUrl: string) {

--- a/apps/presentation/dashboard/src/views/benchmark-study-page.tsx
+++ b/apps/presentation/dashboard/src/views/benchmark-study-page.tsx
@@ -1,0 +1,374 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Activity,
+  ArrowRight,
+  CheckCircle2,
+  CircleAlert,
+  Database,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react";
+
+import { benchmarkStudyRoute } from "../router";
+import {
+  parseBenchmarkStudyDashboard,
+  resolveBenchmarkStudyDashboardUrl,
+  type BenchmarkStudyArm,
+  type BenchmarkStudyCase,
+  type BenchmarkStudyDashboard,
+  type BenchmarkStudyRun,
+  type BenchmarkStudyView,
+} from "../data/benchmark-study";
+import "./benchmark-study.css";
+
+const views: Array<{ id: BenchmarkStudyView; label: string }> = [
+  { id: "campaign", label: "Campaign" },
+  { id: "arms", label: "Arms" },
+  { id: "cases", label: "Cases" },
+  { id: "runs", label: "Runs" },
+];
+
+function percent(value: number | null | undefined) {
+  return value == null ? "—" : `${(value * 100).toFixed(value >= 0.995 ? 0 : 1)}%`;
+}
+
+function compactNumber(value: number | null | undefined) {
+  if (value == null) return "—";
+  return new Intl.NumberFormat("en", { maximumFractionDigits: 2, notation: "compact" }).format(value);
+}
+
+function durationLabel(value: number | null | undefined) {
+  if (value == null) return "—";
+  const minutes = value / 60000;
+  return minutes >= 120 ? `${(minutes / 60).toFixed(1)} h` : `${compactNumber(minutes)} min`;
+}
+
+function countList(values: Record<string, number>) {
+  const entries = Object.entries(values);
+  return entries.length ? entries.map(([name, count]) => `${name} (${count})`).join(", ") : "—";
+}
+
+function metricValue(metric: { value: number; total?: number; unit?: string } | undefined) {
+  if (!metric) return "—";
+  const value = metric.total == null ? compactNumber(metric.value) : `${compactNumber(metric.value)}/${compactNumber(metric.total)}`;
+  return metric.unit ? `${value} ${metric.unit}` : value;
+}
+
+function metricAggregate(arm: BenchmarkStudyArm, metricName: string) {
+  const metric = arm.metrics[metricName];
+  if (!metric || metric.case_denominator === 0) return "—";
+  if (metric.suite_micro_rate != null) {
+    return `${percent(metric.suite_micro_rate)} · ${compactNumber(metric.suite_micro_numerator)}/${compactNumber(metric.suite_micro_denominator)}`;
+  }
+  return `${compactNumber(metric.value_mean)} mean`;
+}
+
+function largestContrastLabel(item: BenchmarkStudyCase, primaryMetric: string) {
+  const contrast = item.largest_eligible_primary_contrast;
+  const metric = contrast?.metric_deltas[primaryMetric];
+  if (!contrast || !metric) return null;
+  const prefix = metric.delta > 0 ? "+" : "";
+  return {
+    direction: metric.direction,
+    text: `${contrast.candidate_arm_id}: ${prefix}${compactNumber(metric.delta)}`,
+  };
+}
+
+function StateBadge({ children, tone = "neutral" }: { children: React.ReactNode; tone?: "neutral" | "success" | "warning" | "info" }) {
+  return <span className={`benchmark-state benchmark-state-${tone}`}>{children}</span>;
+}
+
+function CampaignView({ packet, primaryMetric }: { packet: BenchmarkStudyDashboard; primaryMetric: string }) {
+  return (
+    <div className="benchmark-view-stack">
+      <section aria-labelledby="arm-summary-title">
+        <div className="benchmark-section-heading">
+          <div>
+            <p className="benchmark-kicker">ARM SUMMARY</p>
+            <h2 id="arm-summary-title">Comparable outcomes, denominator first</h2>
+          </div>
+          <p>Only one score-countable run per declared case × arm cell is selected.</p>
+        </div>
+        <div className="benchmark-arm-grid">
+          {packet.arms.map((arm) => {
+            const reward = Object.values(arm.binary_outcomes)[0];
+            return (
+              <article className="benchmark-arm-card" key={arm.arm_id}>
+                <div className="benchmark-card-heading">
+                  <div>
+                    <span className="benchmark-mono">{arm.arm_role}</span>
+                    <h3>{arm.arm_id}</h3>
+                  </div>
+                  <StateBadge tone={arm.coverage_rate === 1 ? "success" : "warning"}>
+                    {arm.coverage_rate === 1 ? "Complete" : "Provisional"}
+                  </StateBadge>
+                </div>
+                <dl className="benchmark-stat-list">
+                  <div><dt>Primary · {primaryMetric}</dt><dd>{metricAggregate(arm, primaryMetric)}</dd></div>
+                  <div><dt>Score-countable coverage</dt><dd>{arm.selected_score_countable_case_count}/{arm.intended_case_count}</dd></div>
+                  <div><dt>Binary success</dt><dd>{reward ? `${reward.success_count}/${reward.case_denominator}` : "Not declared"}</dd></div>
+                </dl>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section aria-labelledby="contrast-title">
+        <div className="benchmark-section-heading">
+          <div>
+            <p className="benchmark-kicker">MATCHED CONTRASTS</p>
+            <h2 id="contrast-title">Direction counts on eligible pairs</h2>
+          </div>
+          <p>Raw run volume is never used as a comparison denominator.</p>
+        </div>
+        <div className="benchmark-table-shell">
+          <table>
+            <thead><tr><th>Candidate arm</th><th>Matched denominator</th><th>Improved</th><th>Flat</th><th>Regressed</th><th>Binary transitions</th></tr></thead>
+            <tbody>
+              {Object.entries(packet.contrasts).map(([armId, contrast]) => (
+                <tr key={armId}>
+                  <td><strong>{armId}</strong></td>
+                  <td>{contrast.matched_pair_denominator}</td>
+                  <td className="benchmark-positive">{contrast.primary_metric_directions.improved}</td>
+                  <td>{contrast.primary_metric_directions.flat}</td>
+                  <td className="benchmark-negative">{contrast.primary_metric_directions.regressed}</td>
+                  <td>{Object.entries(contrast.binary_metric_transitions).map(([metric, transitions]) => `${metric}: 0→1 ${transitions["0_to_1"]}, 1→0 ${transitions["1_to_0"]}, same ${transitions.same}`).join(" · ") || "—"}</td>
+                </tr>
+              ))}
+              {Object.keys(packet.contrasts).length === 0 && <tr><td colSpan={6}>No matched comparisons are countable yet.</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section aria-labelledby="runtime-health-title">
+        <div className="benchmark-section-heading">
+          <div>
+            <p className="benchmark-kicker">RUNTIME HEALTH</p>
+            <h2 id="runtime-health-title">Qualified observations, without execution authority</h2>
+          </div>
+          <p>{packet.campaign.runtime_observation_count} public-safe runtime observations.</p>
+        </div>
+        <div className="benchmark-runtime-list">
+          {Object.entries(packet.campaign.runtime_classification_counts).map(([classification, count]) => (
+            <div key={classification}><span>{classification}</span><strong>{count}</strong></div>
+          ))}
+          {packet.campaign.runtime_observation_count === 0 && <p className="benchmark-muted">No runtime observations uploaded.</p>}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function ArmsView({ packet }: { packet: BenchmarkStudyDashboard }) {
+  return (
+    <div className="benchmark-detail-grid">
+      {packet.arms.map((arm) => (
+        <article className="benchmark-detail-card" key={arm.arm_id}>
+          <div className="benchmark-card-heading">
+            <div><span className="benchmark-mono">{arm.arm_role}</span><h2>{arm.arm_id}</h2></div>
+            <StateBadge tone={arm.coverage_rate === 1 ? "success" : "warning"}>{arm.selected_score_countable_case_count}/{arm.intended_case_count} countable</StateBadge>
+          </div>
+          <div className="benchmark-factor-row">
+            {Object.entries(arm.factor_assignments).map(([factor, level]) => <span key={factor}>{factor}: <strong>{level}</strong></span>)}
+          </div>
+          <dl className="benchmark-stat-list">
+            {packet.design.metric_catalog.map((metric) => (
+              <div key={metric.metric_name}><dt>{metric.role} · {metric.metric_name}</dt><dd>{metricAggregate(arm, metric.metric_name)}</dd></div>
+            ))}
+            <div><dt>Runs terminal / observed</dt><dd>{arm.terminal_run_count}/{arm.run_count}</dd></div>
+            <div><dt>Median duration</dt><dd>{durationLabel(arm.effort.duration_ms?.median)}</dd></div>
+            <div><dt>Protocols</dt><dd>{countList(arm.protocol_counts)}</dd></div>
+            <div><dt>Runner revisions</dt><dd>{countList(arm.runner_revision_counts)}</dd></div>
+            <div><dt>Orchestrator runtimes</dt><dd>{Object.keys(arm.orchestrator_runtime_counts).length || 0} distinct</dd></div>
+            <div><dt>Failure classes</dt><dd>{countList(arm.failure_class_counts)}</dd></div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function CasesView({ packet, primaryMetric, onOpenRun }: { packet: BenchmarkStudyDashboard; primaryMetric: string; onOpenRun: (runId: string) => void }) {
+  return (
+    <div className="benchmark-table-shell benchmark-wide-table">
+      <table>
+        <thead><tr><th>Case</th><th>Design status</th><th>Largest eligible delta</th>{packet.arms.map((arm) => <th key={arm.arm_id}>{arm.arm_id}</th>)}</tr></thead>
+        <tbody>
+          {packet.cases.map((item) => {
+            const largestContrast = largestContrastLabel(item, primaryMetric);
+            return (
+              <tr key={item.case_id}>
+                <td><strong>{item.case_id}</strong></td>
+                <td><StateBadge tone={item.complete_declared_design ? "success" : "warning"}>{item.complete_declared_design ? "Complete" : "Provisional"}</StateBadge></td>
+                <td className={largestContrast?.direction === "improved" ? "benchmark-positive" : largestContrast?.direction === "regressed" ? "benchmark-negative" : undefined}>
+                  {largestContrast?.text ?? "—"}
+                </td>
+                {item.arms.map((cell) => (
+                  <td key={cell.arm_id}>
+                    {cell.selected_run_id && cell.score_countable ? (
+                      <button className="benchmark-cell-link" onClick={() => onOpenRun(cell.selected_run_id!)} type="button">
+                        <span>{primaryMetric}: {metricValue(cell.metrics[primaryMetric])}</span>
+                        {packet.design.metric_catalog.filter((metric) => metric.metric_name !== primaryMetric).map((metric) => (
+                          <small className="benchmark-cell-metric" key={metric.metric_name}>{metric.metric_name}: {metricValue(cell.metrics[metric.metric_name])}</small>
+                        ))}
+                        <small>Countable · {durationLabel(cell.effort.duration_ms)} <ArrowRight aria-hidden="true" size={12} /></small>
+                        {cell.insight && <small>{cell.insight.failure_class} · {cell.insight.confidence}</small>}
+                      </button>
+                    ) : <span className="benchmark-muted">Not countable</span>}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RunDetail({ run, packet }: { run: BenchmarkStudyRun; packet: BenchmarkStudyDashboard }) {
+  return (
+    <aside aria-label={`Run detail for ${run.run_id}`} className="benchmark-run-detail">
+      <div className="benchmark-card-heading">
+        <div><span className="benchmark-mono">RUN DETAIL</span><h2>{run.run_id}</h2></div>
+        <StateBadge tone={run.countability.score_countable ? "success" : "warning"}>{run.countability.score_countable ? "Score-countable" : "Diagnostic only"}</StateBadge>
+      </div>
+      <dl className="benchmark-stat-list benchmark-run-facts">
+        <div><dt>Case / arm</dt><dd>{run.case_id} · {run.arm_id}</dd></div>
+        <div><dt>Lifecycle</dt><dd>{run.status} · {run.observed_at}</dd></div>
+        <div><dt>Protocol</dt><dd>{run.protocol_id}</dd></div>
+        <div><dt>Qualification</dt><dd>Integrity {run.countability.integrity_qualified ? "qualified" : "not qualified"} · result {run.countability.official_result_present ? "present" : "missing"}</dd></div>
+        <div><dt>Treatment fidelity</dt><dd>{run.treatment_fidelity}</dd></div>
+        <div><dt>Effort</dt><dd>{durationLabel(run.effort.duration_ms)} · {compactNumber(run.effort.agent_steps)} steps · {compactNumber(run.effort.token_count)} tokens</dd></div>
+        <div><dt>Runner revision</dt><dd>{run.runner_revision ?? "—"}</dd></div>
+        <div><dt>Upload provenance</dt><dd>{run.upload_provenance.producer_id} · {run.upload_provenance.source_revision}</dd></div>
+      </dl>
+      <div className="benchmark-run-metrics">
+        {packet.design.metric_catalog.map((metric) => <div key={metric.metric_name}><span>{metric.metric_name}</span><strong>{metricValue(run.metrics[metric.metric_name])}</strong></div>)}
+      </div>
+      {run.redacted_insight && (
+        <div className="benchmark-insight">
+          <span className="benchmark-mono">REDACTED CASE INSIGHT · {run.redacted_insight.confidence}</span>
+          <p>{run.redacted_insight.causal_summary}</p>
+          <small>Implication: {run.redacted_insight.implication}</small><br />
+          <small>Next probe: {run.redacted_insight.next_probe}</small>
+          {!!run.redacted_insight.evidence_refs?.length && <><br /><small>Evidence: {run.redacted_insight.evidence_refs.join(", ")}</small></>}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function RunsView({ packet, selectedRunId, onSelectRun }: { packet: BenchmarkStudyDashboard; selectedRunId: string; onSelectRun: (runId: string) => void }) {
+  const selected = packet.runs.find((run) => run.run_id === selectedRunId) ?? packet.runs[0];
+  return (
+    <div className="benchmark-runs-layout">
+      <div className="benchmark-table-shell">
+        <table>
+          <thead><tr><th>Run</th><th>Case</th><th>Arm</th><th>Status</th><th>Countability</th></tr></thead>
+          <tbody>{packet.runs.map((run) => (
+            <tr aria-selected={run.run_id === selected?.run_id} key={run.run_id}>
+              <td><button className="benchmark-run-link" onClick={() => onSelectRun(run.run_id)} type="button">{run.run_id}</button></td>
+              <td>{run.case_id}</td><td>{run.arm_id}</td><td>{run.status}</td>
+              <td>{run.countability.score_countable ? "Score-countable" : "Diagnostic only"}</td>
+            </tr>
+          ))}</tbody>
+        </table>
+      </div>
+      {selected && <RunDetail packet={packet} run={selected} />}
+    </div>
+  );
+}
+
+export function BenchmarkStudyPage() {
+  const search = benchmarkStudyRoute.useSearch();
+  const navigate = benchmarkStudyRoute.useNavigate();
+  const [packet, setPacket] = useState<BenchmarkStudyDashboard | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const source = useMemo(() => {
+    const configuredSource = search.dashboardUrl || `${import.meta.env.BASE_URL}benchmark-study.example.json`;
+    try { return { url: resolveBenchmarkStudyDashboardUrl(configuredSource, window.location.href), error: null }; }
+    catch (nextError) { return { url: "", error: nextError instanceof Error ? nextError.message : "Invalid dashboard source" }; }
+  }, [search.dashboardUrl]);
+
+  useEffect(() => {
+    let active = true;
+    setPacket(null);
+    setError(null);
+    if (source.error) {
+      setError(source.error);
+      return () => { active = false; };
+    }
+    fetch(source.url, { cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status} while loading the dashboard packet`);
+        return parseBenchmarkStudyDashboard(await response.json());
+      })
+      .then((nextPacket) => { if (active) setPacket(nextPacket); })
+      .catch((nextError: unknown) => { if (active) setError(nextError instanceof Error ? nextError.message : "Unable to load dashboard packet"); });
+    return () => { active = false; };
+  }, [reloadKey, source]);
+
+  useEffect(() => {
+    if (packet) document.title = `${packet.design.labels.title ?? packet.study_id} · LoopX Benchmark`;
+  }, [packet]);
+
+  if (error) {
+    return <main className="benchmark-page benchmark-loading"><CircleAlert aria-hidden="true" /><h1>Dashboard packet unavailable</h1><p>{error}</p><button onClick={() => setReloadKey((value) => value + 1)} type="button"><RefreshCw aria-hidden="true" size={16} /> Retry readback</button></main>;
+  }
+  if (!packet) return <main aria-busy="true" className="benchmark-page benchmark-loading"><Activity aria-hidden="true" /><h1>Reading benchmark study</h1><p>Validating the public-safe dashboard packet…</p></main>;
+
+  const primaryMetric = packet.design.metric_catalog.find((metric) => metric.role === "primary")?.metric_name ?? "primary";
+  const setView = (view: BenchmarkStudyView, runId = search.runId) => navigate({ search: (current) => ({ ...current, view, runId }) });
+  const sourcePath = new URL(source.url).pathname;
+
+  return (
+    <main className="benchmark-page">
+      <header className="benchmark-hero">
+        <div className="benchmark-hero-topline">
+          <a className="benchmark-wordmark" href={import.meta.env.BASE_URL}>LoopX</a>
+          <div className="benchmark-readonly"><ShieldCheck aria-hidden="true" size={15} /> Derived read-only projection</div>
+        </div>
+        <div className="benchmark-hero-grid">
+          <div>
+            <p className="benchmark-kicker">BENCHMARK STUDY / {packet.benchmark_id}</p>
+            <div className="benchmark-title-row"><h1>{packet.design.labels.title ?? packet.study_id}</h1><StateBadge tone={packet.status === "complete" ? "success" : "warning"}>{packet.status}</StateBadge></div>
+            <p className="benchmark-lead">One declared study, explicit denominators, and the same countability rules from campaign summary to exact run.</p>
+          </div>
+          <dl className="benchmark-identity">
+            <div><dt>Study</dt><dd>{packet.study_id}</dd></div>
+            <div><dt>Protocol</dt><dd>{packet.design.protocol_id}</dd></div>
+            <div><dt>Case set</dt><dd>{packet.design.case_set.case_set_id}</dd></div>
+          </dl>
+        </div>
+        <div className="benchmark-kpi-grid">
+          <article><Database aria-hidden="true" /><span>Score-countable cells</span><strong>{packet.campaign.selected_score_countable_cell_count}<small> / {packet.campaign.intended_cell_denominator}</small></strong><p>{percent(packet.campaign.selected_score_countable_coverage_rate)} declared coverage</p></article>
+          <article><CheckCircle2 aria-hidden="true" /><span>Complete designs</span><strong>{packet.campaign.complete_declared_design_case_count}<small> / {packet.campaign.intended_case_count}</small></strong><p>Cases with every declared arm</p></article>
+          <article><ArrowRight aria-hidden="true" /><span>Matched comparisons</span><strong>{packet.campaign.matched_pair_countable_count}</strong><p>Eligible pairs only</p></article>
+          <article><Activity aria-hidden="true" /><span>In flight</span><strong>{packet.campaign.in_flight_run_count}</strong><p>{packet.status === "provisional" ? "Coverage remains provisional" : "Declared coverage complete"}</p></article>
+        </div>
+      </header>
+
+      <nav aria-label="Benchmark dashboard views" className="benchmark-tabs">
+        {views.map((view) => <button aria-current={search.view === view.id ? "page" : undefined} key={view.id} onClick={() => setView(view.id)} type="button">{view.label}</button>)}
+        <button className="benchmark-refresh" onClick={() => setReloadKey((value) => value + 1)} type="button"><RefreshCw aria-hidden="true" size={14} /> Refresh local readback</button>
+      </nav>
+
+      <div className="benchmark-content">
+        {search.view === "campaign" && <CampaignView packet={packet} primaryMetric={primaryMetric} />}
+        {search.view === "arms" && <ArmsView packet={packet} />}
+        {search.view === "cases" && <CasesView onOpenRun={(runId) => setView("runs", runId)} packet={packet} primaryMetric={primaryMetric} />}
+        {search.view === "runs" && <RunsView onSelectRun={(runId) => setView("runs", runId)} packet={packet} selectedRunId={search.runId} />}
+      </div>
+
+      <footer className="benchmark-footer">
+        <div><ShieldCheck aria-hidden="true" size={16} /><span>Scores: {packet.authority.score_source}</span><span>Dashboard cannot launch, grade, or mutate runs.</span></div>
+        <code title={sourcePath}>local{sourcePath}</code>
+      </footer>
+    </main>
+  );
+}

--- a/apps/presentation/dashboard/src/views/benchmark-study.css
+++ b/apps/presentation/dashboard/src/views/benchmark-study.css
@@ -1,0 +1,138 @@
+.benchmark-page {
+  --benchmark-ink: #171717;
+  --benchmark-body: #4d4d4d;
+  --benchmark-muted: #767676;
+  --benchmark-canvas: #fafafa;
+  --benchmark-surface: #fff;
+  --benchmark-soft: #f2f2f2;
+  --benchmark-border: #e5e5e5;
+  --benchmark-link: #0068d7;
+  min-height: 100vh;
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: clip;
+  color: var(--benchmark-ink);
+  background: var(--benchmark-canvas);
+  font-family: "Geist", "Inter", "Helvetica Neue", Arial, sans-serif;
+}
+
+.benchmark-page,
+.benchmark-page * {
+  box-sizing: border-box;
+}
+
+.benchmark-hero { padding: 24px max(24px, calc((100vw - 1200px) / 2)); border-bottom: 1px solid var(--benchmark-border); background: var(--benchmark-surface); }
+.benchmark-hero-topline, .benchmark-title-row, .benchmark-card-heading, .benchmark-footer > div { display: flex; align-items: center; }
+.benchmark-hero-topline { justify-content: space-between; margin-bottom: 64px; }
+.benchmark-wordmark { color: var(--benchmark-ink); font-weight: 650; letter-spacing: -0.04em; text-decoration: none; }
+.benchmark-readonly { display: inline-flex; align-items: center; gap: 8px; color: var(--benchmark-muted); font-size: 12px; }
+.benchmark-hero-grid { display: grid; grid-template-columns: minmax(0, 1.5fr) minmax(260px, .5fr); gap: 64px; align-items: end; }
+.benchmark-kicker, .benchmark-mono { margin: 0 0 8px; color: var(--benchmark-muted); font: 500 11px/16px "Geist Mono", "JetBrains Mono", monospace; letter-spacing: .08em; text-transform: uppercase; }
+.benchmark-title-row { gap: 16px; align-items: baseline; }
+.benchmark-title-row h1 { max-width: 780px; margin: 0; font-size: clamp(32px, 4.5vw, 48px); line-height: 1; font-weight: 600; letter-spacing: -.05em; }
+.benchmark-lead { max-width: 680px; margin: 20px 0 0; color: var(--benchmark-body); font-size: 16px; line-height: 24px; }
+.benchmark-identity, .benchmark-stat-list { margin: 0; }
+.benchmark-identity > div { display: grid; grid-template-columns: 80px minmax(0, 1fr); gap: 16px; padding: 10px 0; border-top: 1px solid var(--benchmark-border); }
+.benchmark-identity dt, .benchmark-stat-list dt { color: var(--benchmark-muted); font-size: 12px; }
+.benchmark-identity dd { overflow: hidden; margin: 0; font: 500 12px/18px "Geist Mono", monospace; text-overflow: ellipsis; white-space: nowrap; }
+.benchmark-kpi-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-top: 64px; border: 1px solid var(--benchmark-border); border-radius: 12px; overflow: hidden; }
+.benchmark-kpi-grid article { min-width: 0; padding: 20px 24px; border-right: 1px solid var(--benchmark-border); }
+.benchmark-kpi-grid article:last-child { border-right: 0; }
+.benchmark-kpi-grid svg { color: var(--benchmark-muted); }
+.benchmark-kpi-grid span { display: block; margin-top: 16px; color: var(--benchmark-muted); font-size: 12px; }
+.benchmark-kpi-grid strong { display: block; margin-top: 6px; font-size: 30px; font-weight: 600; letter-spacing: -.04em; font-variant-numeric: tabular-nums; }
+.benchmark-kpi-grid strong small { color: var(--benchmark-muted); font-size: 14px; font-weight: 400; letter-spacing: 0; }
+.benchmark-kpi-grid p { margin: 8px 0 0; color: var(--benchmark-body); font-size: 12px; }
+.benchmark-state { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--benchmark-border); border-radius: 999px; padding: 3px 8px; color: var(--benchmark-body); background: var(--benchmark-soft); font: 500 11px/16px "Geist Mono", monospace; text-transform: capitalize; }
+.benchmark-state-success { color: #087a44; border-color: #b8e7ce; background: #ecf9f2; }
+.benchmark-state-warning { color: #8a5100; border-color: #f0d2a3; background: #fff8e8; }
+.benchmark-state-info { color: #0057b8; border-color: #b9d7f5; background: #eef6ff; }
+.benchmark-tabs { position: sticky; z-index: 3; top: 0; display: flex; gap: 4px; align-items: center; padding: 12px max(24px, calc((100vw - 1200px) / 2)); border-bottom: 1px solid var(--benchmark-border); background: rgb(250 250 250 / .94); backdrop-filter: blur(12px); }
+.benchmark-tabs button, .benchmark-loading button { min-height: 40px; border: 0; border-radius: 6px; padding: 0 14px; color: var(--benchmark-body); background: transparent; font-size: 13px; font-weight: 500; cursor: pointer; }
+.benchmark-tabs button[aria-current="page"] { color: #fff; background: var(--benchmark-ink); }
+.benchmark-tabs .benchmark-refresh { display: inline-flex; gap: 7px; align-items: center; margin-left: auto; border: 1px solid var(--benchmark-border); background: var(--benchmark-surface); }
+.benchmark-tabs button:focus-visible, .benchmark-cell-link:focus-visible, .benchmark-run-link:focus-visible, .benchmark-loading button:focus-visible { outline: 2px solid var(--benchmark-link); outline-offset: 2px; }
+.benchmark-content { width: min(calc(100vw - 48px), 1200px); min-width: 0; margin: 0 auto; padding: 40px 0 64px; }
+.benchmark-view-stack { display: grid; min-width: 0; gap: 48px; }
+.benchmark-view-stack > section { min-width: 0; }
+.benchmark-section-heading { display: flex; gap: 24px; align-items: end; justify-content: space-between; margin-bottom: 16px; }
+.benchmark-section-heading h2, .benchmark-detail-card h2, .benchmark-run-detail h2 { margin: 0; font-size: 20px; line-height: 28px; letter-spacing: -.02em; }
+.benchmark-section-heading > p { max-width: 420px; margin: 0; color: var(--benchmark-muted); font-size: 12px; line-height: 18px; text-align: right; }
+.benchmark-arm-grid, .benchmark-detail-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+.benchmark-arm-card, .benchmark-detail-card, .benchmark-run-detail { border: 1px solid var(--benchmark-border); border-radius: 12px; padding: 24px; background: var(--benchmark-surface); }
+.benchmark-card-heading { justify-content: space-between; gap: 24px; align-items: start; }
+.benchmark-card-heading h3 { margin: 0; font-size: 16px; line-height: 24px; letter-spacing: -.02em; }
+.benchmark-stat-list { margin-top: 24px; }
+.benchmark-stat-list > div { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 16px; padding: 11px 0; border-top: 1px solid var(--benchmark-border); }
+.benchmark-stat-list dd { margin: 0; font: 500 12px/18px "Geist Mono", monospace; font-variant-numeric: tabular-nums; text-align: right; }
+.benchmark-factor-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 20px; }
+.benchmark-factor-row span { border-radius: 6px; padding: 5px 8px; color: var(--benchmark-muted); background: var(--benchmark-soft); font-size: 11px; }
+.benchmark-runtime-list { display: flex; flex-wrap: wrap; gap: 8px; }
+.benchmark-runtime-list > div { display: inline-flex; align-items: center; gap: 20px; border: 1px solid var(--benchmark-border); border-radius: 6px; padding: 9px 11px; background: var(--benchmark-surface); font: 500 11px/16px "Geist Mono", monospace; }
+.benchmark-runtime-list > div span { color: var(--benchmark-muted); }
+.benchmark-runtime-list > div strong { font-weight: 600; }
+.benchmark-table-shell { width: 100%; max-width: 100%; overflow: auto; border: 1px solid var(--benchmark-border); border-radius: 12px; background: var(--benchmark-surface); }
+.benchmark-table-shell table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.benchmark-table-shell th, .benchmark-table-shell td { padding: 14px 16px; border-bottom: 1px solid var(--benchmark-border); text-align: left; white-space: nowrap; }
+.benchmark-table-shell tr:last-child td { border-bottom: 0; }
+.benchmark-table-shell th { color: var(--benchmark-muted); background: var(--benchmark-soft); font-size: 11px; font-weight: 500; letter-spacing: .03em; text-transform: uppercase; }
+.benchmark-table-shell td { color: var(--benchmark-body); }
+.benchmark-positive { color: #087a44 !important; }
+.benchmark-negative { color: #b42318 !important; }
+.benchmark-muted { color: var(--benchmark-muted); }
+.benchmark-wide-table { min-height: 300px; }
+.benchmark-cell-link, .benchmark-run-link { border: 0; padding: 0; color: var(--benchmark-ink); background: transparent; font: inherit; text-align: left; cursor: pointer; }
+.benchmark-cell-link span { display: block; font-family: "Geist Mono", monospace; }
+.benchmark-cell-link small { display: flex; gap: 4px; align-items: center; margin-top: 5px; color: var(--benchmark-link); }
+.benchmark-cell-link small + small { color: var(--benchmark-muted); }
+.benchmark-cell-link .benchmark-cell-metric { color: var(--benchmark-body); font-family: "Geist Mono", monospace; }
+.benchmark-run-link { max-width: 280px; overflow: hidden; color: var(--benchmark-link); text-overflow: ellipsis; }
+.benchmark-runs-layout { display: grid; grid-template-columns: minmax(0, 1.3fr) minmax(340px, .7fr); gap: 16px; align-items: start; }
+.benchmark-table-shell tr[aria-selected="true"] td { background: #f3f7fb; }
+.benchmark-run-detail { position: sticky; top: 82px; }
+.benchmark-run-detail h2 { max-width: 340px; overflow-wrap: anywhere; }
+.benchmark-run-facts dd { max-width: 310px; overflow-wrap: anywhere; white-space: normal; }
+.benchmark-run-metrics { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin-top: 20px; }
+.benchmark-run-metrics > div { border-radius: 6px; padding: 10px; background: var(--benchmark-soft); }
+.benchmark-run-metrics span, .benchmark-run-metrics strong { display: block; }
+.benchmark-run-metrics span { color: var(--benchmark-muted); font-size: 10px; }
+.benchmark-run-metrics strong { margin-top: 5px; font: 600 12px/18px "Geist Mono", monospace; }
+.benchmark-insight { margin-top: 20px; border-left: 2px solid var(--benchmark-link); padding: 4px 0 4px 14px; }
+.benchmark-insight p { margin: 8px 0; color: var(--benchmark-body); font-size: 13px; line-height: 20px; }
+.benchmark-insight small { color: var(--benchmark-muted); line-height: 18px; }
+.benchmark-footer { display: flex; gap: 24px; justify-content: space-between; padding: 20px max(24px, calc((100vw - 1200px) / 2)); border-top: 1px solid var(--benchmark-border); color: var(--benchmark-muted); background: var(--benchmark-surface); font-size: 11px; }
+.benchmark-footer > div { flex-wrap: wrap; gap: 12px; }
+.benchmark-footer code { max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.benchmark-loading { display: grid; min-height: 100vh; place-content: center; text-align: center; }
+.benchmark-loading svg { margin: 0 auto; color: var(--benchmark-muted); }
+.benchmark-loading h1 { margin: 18px 0 0; font-size: 24px; }
+.benchmark-loading p { max-width: 520px; margin: 8px auto 0; color: var(--benchmark-muted); }
+.benchmark-loading button { display: inline-flex; gap: 8px; align-items: center; margin: 20px auto 0; border: 1px solid var(--benchmark-border); background: var(--benchmark-surface); }
+
+@media (max-width: 900px) {
+  .benchmark-hero-grid, .benchmark-runs-layout { grid-template-columns: 1fr; }
+  .benchmark-hero-grid { gap: 32px; }
+  .benchmark-kpi-grid { grid-template-columns: repeat(2, 1fr); }
+  .benchmark-kpi-grid article:nth-child(2) { border-right: 0; }
+  .benchmark-kpi-grid article:nth-child(-n + 2) { border-bottom: 1px solid var(--benchmark-border); }
+  .benchmark-run-detail { position: static; }
+}
+
+@media (max-width: 640px) {
+  .benchmark-hero { padding-inline: 20px; }
+  .benchmark-hero-topline { margin-bottom: 40px; }
+  .benchmark-title-row, .benchmark-section-heading, .benchmark-footer { align-items: flex-start; flex-direction: column; }
+  .benchmark-title-row h1 { font-size: 34px; }
+  .benchmark-kpi-grid, .benchmark-arm-grid, .benchmark-detail-grid { grid-template-columns: 1fr; }
+  .benchmark-kpi-grid article { border-right: 0; border-bottom: 1px solid var(--benchmark-border); }
+  .benchmark-kpi-grid article:last-child { border-bottom: 0; }
+  .benchmark-tabs { overflow-x: auto; padding-inline: 20px; }
+  .benchmark-tabs .benchmark-refresh { display: none; }
+  .benchmark-content { width: calc(100vw - 40px); padding-top: 28px; }
+  .benchmark-section-heading > p { text-align: left; }
+  .benchmark-footer code { max-width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .benchmark-page *, .benchmark-page *::before, .benchmark-page *::after { scroll-behavior: auto !important; transition: none !important; }
+}

--- a/examples/dashboard-benchmark-study-browser-smoke.mjs
+++ b/examples/dashboard-benchmark-study-browser-smoke.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Browser-level smoke for the public-safe, read-only benchmark study route.
+
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const dashboardDir = resolve(repoRoot, "apps/presentation/dashboard");
+const port = Number(process.env.LOOPX_BENCHMARK_STUDY_SMOKE_PORT ?? "5199");
+
+function loadPlaywright() {
+  const candidates = [
+    process.env.LOOPX_PLAYWRIGHT_PACKAGE,
+    resolve(dashboardDir, "node_modules/playwright"),
+    resolve(homedir(), ".cache/codex-runtimes/codex-primary-runtime/dependencies/node/node_modules/playwright"),
+  ].filter(Boolean);
+  try {
+    return require("playwright");
+  } catch {
+    // Try the explicitly configured or bundled runtime below.
+  }
+  for (const candidate of candidates) {
+    if (!candidate || !existsSync(candidate)) continue;
+    try {
+      return require(candidate);
+    } catch {
+      // Keep looking.
+    }
+  }
+  throw new Error("Playwright package not found; install playwright or set LOOPX_PLAYWRIGHT_PACKAGE");
+}
+
+async function launchBrowser(chromium) {
+  try {
+    return await chromium.launch({ channel: "chrome", headless: true });
+  } catch {
+    return chromium.launch({ headless: true });
+  }
+}
+
+function startDashboardServer() {
+  const viteBin = resolve(dashboardDir, "node_modules/vite/bin/vite.js");
+  if (!existsSync(viteBin)) throw new Error(`Vite package not installed: ${viteBin}`);
+  return spawn(process.execPath, [viteBin, "--host", "127.0.0.1", "--port", String(port), "--strictPort"], {
+    cwd: dashboardDir,
+    stdio: "ignore",
+  });
+}
+
+async function waitForDashboard(url) {
+  const deadline = Date.now() + 20_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = new Error(`HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveTimeout) => setTimeout(resolveTimeout, 250));
+  }
+  throw lastError ?? new Error(`Timed out waiting for ${url}`);
+}
+
+async function assertNoHorizontalOverflow(page, label) {
+  const dimensions = await page.evaluate(() => ({
+    viewport: window.innerWidth,
+    scroll: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+  }));
+  if (dimensions.scroll > dimensions.viewport + 2) {
+    throw new Error(`${label} horizontal overflow: viewport=${dimensions.viewport} scroll=${dimensions.scroll}`);
+  }
+}
+
+async function assertCommonSurface(page, label) {
+  await page.waitForSelector("main.benchmark-page", { timeout: 10_000 });
+  const body = await page.locator("body").innerText();
+  for (const required of [
+    "Four-arm software-engineering study",
+    "Derived read-only projection",
+    "Score-countable cells",
+    "RUNTIME HEALTH",
+    "Dashboard cannot launch, grade, or mutate runs.",
+  ]) {
+    if (!body.includes(required)) throw new Error(`${label} missing text: ${required}`);
+  }
+  if (await page.locator("form").count()) throw new Error(`${label} unexpectedly exposes a form`);
+  if (await page.locator('input, textarea, select, [contenteditable="true"]').count()) {
+    throw new Error(`${label} unexpectedly exposes editable controls`);
+  }
+  await assertNoHorizontalOverflow(page, label);
+}
+
+async function main() {
+  const { chromium } = loadPlaywright();
+  const server = startDashboardServer();
+  let browser;
+  const pageErrors = [];
+  try {
+    const url = `http://127.0.0.1:${port}/benchmarks/study`;
+    await waitForDashboard(url);
+    browser = await launchBrowser(chromium);
+
+    const desktop = await browser.newPage({ viewport: { width: 1440, height: 1100 } });
+    desktop.on("pageerror", (error) => pageErrors.push(error.message));
+    await desktop.goto(url, { waitUntil: "networkidle" });
+    await assertCommonSurface(desktop, "desktop campaign");
+    if ((await desktop.getByRole("navigation", { name: "Benchmark dashboard views" }).count()) !== 1) {
+      throw new Error("benchmark view navigation must expose one accessible label");
+    }
+    if ((await desktop.getByText("6 / 8", { exact: true }).count()) !== 1) {
+      throw new Error("campaign countability denominator is not rendered exactly once");
+    }
+
+    await desktop.getByRole("button", { name: "Arms", exact: true }).click();
+    await desktop.getByText("2/2 countable", { exact: true }).first().waitFor();
+    await desktop.getByText("goal-v1 (2)", { exact: true }).waitFor();
+    await desktop.getByText("contract_miss (1)", { exact: true }).waitFor();
+    await desktop.getByRole("button", { name: "Cases", exact: true }).click();
+    await desktop.getByRole("columnheader", { name: "Largest eligible delta", exact: true }).waitFor();
+    await desktop.getByText("goal_hint: +2", { exact: true }).waitFor();
+    await desktop.getByText("preservation: 20/20 tests", { exact: true }).first().waitFor();
+    await desktop.getByText("reward: 0", { exact: true }).first().waitFor();
+    await desktop.getByRole("button", { name: /Countable/ }).first().click();
+    await desktop.getByRole("complementary", { name: /Run detail for/ }).waitFor();
+    await desktop.getByText("Upload provenance", { exact: true }).waitFor();
+    await desktop.getByText("Implication: Keep the external contract check.", { exact: true }).waitFor();
+    await desktop.getByText("Evidence: public-receipt:demo123", { exact: true }).waitFor();
+
+    const refresh = desktop.getByRole("button", { name: "Refresh local readback", exact: true });
+    if ((await refresh.count()) !== 1) throw new Error("readback refresh must be a real accessible button");
+    await refresh.focus();
+    if (!(await refresh.evaluate((element) => element === document.activeElement))) {
+      throw new Error("readback refresh is not keyboard focusable");
+    }
+
+    const mobile = await browser.newPage({ viewport: { width: 390, height: 844 } });
+    mobile.on("pageerror", (error) => pageErrors.push(error.message));
+    await mobile.goto(url, { waitUntil: "networkidle" });
+    await assertCommonSurface(mobile, "mobile campaign");
+
+    const rejected = await browser.newPage({ viewport: { width: 800, height: 700 } });
+    await rejected.goto(`${url}?dashboardUrl=${encodeURIComponent("https://example.com/study.json")}`, { waitUntil: "networkidle" });
+    await rejected.getByText("Benchmark dashboard source must use same-origin local readback", { exact: true }).waitFor();
+
+    if (pageErrors.length) throw new Error(`browser errors: ${pageErrors.join(" | ")}`);
+    console.log("benchmark study browser smoke passed");
+  } finally {
+    await browser?.close();
+    server.kill("SIGTERM");
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- add a read-only `/benchmarks/study` dashboard route for the public-safe `benchmark_study_dashboard_v0` packet
- show campaign denominators, arm aggregates, matched contrasts, case cells, exact run provenance, and redacted case insights
- enforce schema validation and same-origin HTTP(S) readback; the surface cannot launch, grade, upload, or mutate benchmark runs
- include a generic example packet plus contract and desktop/mobile browser smokes

## Validation

- `npm --prefix apps/presentation/dashboard run smoke:benchmark-study`
- `npm --prefix apps/presentation/dashboard run smoke:benchmark-study-browser`
- `npm --prefix apps/presentation/dashboard run build`
- `loopx canary premerge --from-git-diff` (10 selected checks, 0 failures, no manual holds)
- DCO sign-off present
- public/private scan clean; no credentials, raw task text, raw trajectories, verifier output, or local paths

## Review notes

Changed surfaces: dashboard routing, schema/readback boundary, benchmark operator presentation, and focused validation. The owner reviewed and approved the first-screen preview before finalization. This is display-only plumbing over the existing public-safe study packet; scoring, runner behavior, task semantics, permissions, and benchmark execution are unchanged.