### PR TITLE
fix: keep unscheduled watch-only monitors quiet

### DIFF
--- a/loopx/control_plane/scheduler/monitor_todo.py
+++ b/loopx/control_plane/scheduler/monitor_todo.py
@@ -10,6 +10,7 @@ from ..todos.contract import (
     normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
+    normalize_todo_watch_only,
 )
 from .time import parse_scheduler_timestamp
 from .state_transition_rules import project_monitor_todo_schedule
@@ -118,5 +119,7 @@ def monitor_todo_missing_schedule(
     if monitor_todo_task_class(item, task_text=task_text) != TODO_TASK_CLASS_MONITOR:
         return False
     if monitor_todo_is_expired(item, now=now):
+        return False
+    if normalize_todo_watch_only(item.get("watch_only")) is True:
         return False
     return not monitor_todo_has_schedule(item)

--- a/tests/control_plane/test_scheduler_monitor_todo.py
+++ b/tests/control_plane/test_scheduler_monitor_todo.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from loopx.control_plane.scheduler.monitor_todo import monitor_todo_missing_schedule
+from loopx.control_plane.testing.quota_fixtures import quota_todo_summary
+
+
+def test_watch_only_monitor_without_schedule_is_not_a_schedule_gap() -> None:
+    monitor = {
+        "status": "open",
+        "task_class": "continuous_monitor",
+        "watch_only": "true",
+    }
+
+    assert monitor_todo_missing_schedule(monitor) is False
+
+    summary = quota_todo_summary([monitor])
+    assert summary["monitor_schedule_gap_count"] == 0
+    assert summary["monitor_schedule_gap_items"] == []
+
+
+def test_actionable_monitor_without_schedule_remains_a_schedule_gap() -> None:
+    monitor = {
+        "status": "open",
+        "task_class": "continuous_monitor",
+    }
+
+    assert monitor_todo_missing_schedule(monitor) is True


### PR DESCRIPTION
## Summary

- treat `watch_only=true` continuous monitors without a schedule as externally driven rather than misconfigured
- preserve the schedule-gap warning for ordinary unscheduled monitors
- add focused unit and todo-summary projection coverage

## Validation

- `python -m pytest tests/control_plane/test_scheduler_monitor_todo.py tests/control_plane/test_monitor_followthrough_contract.py tests/control_plane/test_monitor_poll_cli_projection.py tests/control_plane/test_monitor_replan_agent_scope.py tests/control_plane/test_quota_monitor_poll_runtime.py tests/control_plane/test_capability_monitor_repair_tool_behavior.py tests/control_plane/test_todo_list_thin.py tests/control_plane/test_quota_action_portfolio.py -q` (59 passed)
- source-entrypoint `canary premerge --from-git-diff` (17 selected checks passed; no manual holds)

## Scope review

The existing scheduler monitor helper owns the missing-schedule classification, so no new abstraction is needed. The change is limited to that rule and regression coverage.