### PR TITLE
feat(control-plane): route promoted Todo reads to file authority

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -1062,7 +1062,10 @@ The sequence is:
    it for decisions. Prove parity, crash recovery, migration, and one-command
    rollback; then, in a separately reviewed promotion, make the file aggregate
    the local coordination authority and fence the legacy writers. Markdown and
-   task-lease files become projections only after that promotion.
+   task-lease files become projections only after that promotion. Projection
+   shape or head-digest parity alone is insufficient: promotion must also prove
+   that the provider reproduces the complete consumer-visible Todo semantics at
+   the exact qualified revision.
 5. **Stage 3 - one-way remote shadow parity.** The promoted local
    `FileAuthorityStore` remains the only authority while committed observations
    are projected to a NoKV or PostgreSQL candidate. Provider parity compares
@@ -1265,9 +1268,12 @@ disabled evidence. When enabled, the runtime obeys the following boundary:
 - the legacy Markdown Todo writer or task-lease writer commits first and
   remains canonical; only a successful primary mutation dispatches the
   shadow;
-- the Python adapter reduces the committed Todo and lease read models to the
-  coordination-owned fields, sorts them by stable Todo identity, and sends one
-  post-commit projection through the existing TypeScript effect runtime;
+- the Python adapter projects the committed Todo view through the same shared
+  canonical read-record contract used by `todo list`, retains every
+  consumer-visible identity, text, priority, filtering, continuation, resume,
+  scheduling, archival, completion, note, and evidence field, sorts records by
+  stable Todo identity, and sends that view plus compact leases through the
+  existing TypeScript effect runtime;
 - the TypeScript owner writes that projection and its operation receipt in one
   `AuthorityStore` transaction. It checks an existing receipt before writing,
   rejects reuse of an operation id with different normalized content, retries
@@ -1337,6 +1343,29 @@ and reports `qualified`, `insufficient_evidence`, or `drifted`. Replays do not
 increase the operation count, missing coverage fails the gate, and every result
 continues to declare `decision_read_from_shadow=false`.
 
+Structural parity is not consumer semantic parity. A promotable projection
+therefore also carries a versioned Todo read-model receipt containing the exact
+field contract, record count, and canonical record digest. TypeScript validates
+that receipt against deterministic provider records during qualification,
+promotion, and every provider-first collection read; a missing schema, stale
+digest, truncated field contract, count mismatch, or unstable order fails
+closed. Provider-first mutations regenerate the receipt atomically with the
+head. Adding a Todo consumer field is a contract change and requires a new
+qualification rather than a permissive fallback.
+
+Before any real Goal is promoted, qualification must additionally execute the
+existing consumer pipeline on both the legacy source and the provider
+round-trip at the same revision. The semantic matrix covers user and agent
+roles; open, done, blocked, and deferred status; priority and ordering; claim,
+exclusion, bound-agent, and global-gate filtering; resume conditions;
+successor/continuation behavior; continuous-monitor cadence, due time,
+watch-only and material-generation state; notes, evidence, completion, and
+archival; and provider-only reads after the Markdown file is unavailable. Any
+difference blocks promotion and leaves legacy authority in place. Synthetic
+stubs remain useful unit tests but cannot substitute for this real complex-Goal
+qualification. Real Goal content stays local; public evidence contains only
+redacted coverage, counts, exact revision identifiers, and digests.
+
 The next read-only seam exercises the provider shape needed by the future
 read flip without granting it authority:
 
@@ -1385,6 +1414,13 @@ so no legacy write can pass its check and commit after cutover. Provider-first
 CLI routing and the lock-owning promotion operation remain the next slice; until
 they land, this integration deliberately blocks split-brain writes rather than
 silently falling back.
+
+The Todo collection-read slice routes `loopx todo list` to `FileAuthorityStore`
+only after the durable fence exists. It reuses the same filtering, ordering,
+resume, and summary pipeline as the legacy path, permits provider-only reads
+when Markdown is absent, and carries an authority receipt in the response.
+Provider missing, corruption, protocol drift, or Todo read-model semantic drift
+all fail closed; no post-cutover Markdown fallback is permitted.
 
 Durable completion continuation read-back
 (`durable_completion.py`: `read_persisted_todo_record` /

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -853,7 +853,9 @@ Stage 3/4 qualification 必须保持以下 ownership 与 proof 边界：
    把现有 Markdown/task-lease writer shadow 到 `FileAuthorityStore`；验证 parity、
    crash recovery、migration 与一键 rollback。随后通过一个单独评审的 promotion，
    让 file aggregate 成为本地 coordination authority，并 fence legacy writer；
-   只有晋升后 Markdown 与 task-lease 文件才退为 projection。
+   只有晋升后 Markdown 与 task-lease 文件才退为 projection。仅证明 projection
+   结构或 head digest 相等仍然不够；promotion 还必须在精确的 qualified revision
+   上证明 provider 完整复现 Todo 消费方可见语义。
 5. **Stage 3——远端单向 shadow parity。** 晋升后的本地 `FileAuthorityStore` 仍是
    唯一 authority；将已提交观察投影到 NoKV 或 PostgreSQL 候选。Provider parity
    只对比 Todo/claim、lease fence、
@@ -1022,9 +1024,10 @@ task-lease writer。
 
 - legacy Markdown Todo writer 或 task-lease writer 先成功提交且继续作为 canonical；
   只有 primary mutation 成功后才派发 shadow；
-- Python adapter 把已提交的 Todo 与 lease read model 收敛为 coordination 自有字段，
-  按稳定 Todo identity 排序，再通过既有 TypeScript effect runtime 发送一份提交后
-  projection；
+- Python adapter 通过 `todo list` 共用的 canonical read-record 合同投影已提交 Todo
+  view，完整保留消费方可见的 identity、文本、优先级、过滤、continuation、resume、
+  调度、归档、完成、note 与 evidence 字段；随后按稳定 Todo identity 排序，并把该
+  view 与紧凑 lease 一起通过既有 TypeScript effect runtime 发送；
 - TypeScript owner 在同一笔 `AuthorityStore` transaction 中写 projection 与 operation
   receipt。写前先查询既有 receipt；同一 operation id 搭配不同 normalized content
   会被拒绝；provider-revision contention 只做固定次数重试；ambiguous commit 只能
@@ -1080,6 +1083,23 @@ event/receipt/projection identity，以及当前 legacy/file head digest，并�
 `qualified`、`insufficient_evidence` 或 `drifted`。replay 不增加 operation 计数，缺少
 覆盖会让 gate 失败，所有结果仍明确声明 `decision_read_from_shadow=false`。
 
+结构 parity 不等于消费语义 parity。因此，可 promotion 的 projection 还必须携带一个
+版本化 Todo read-model receipt，其中包含精确字段合同、记录数和 canonical record
+digest。TypeScript 会在 qualification、promotion 以及每次 provider-first collection
+read 时，对 deterministic provider records 校验该 receipt；schema 缺失、digest 过期、
+字段合同被截断、记录数不符或顺序不稳定都会 fail closed。provider-first mutation 必须
+在同一原子 head 更新中重算 receipt。新增 Todo 消费字段属于合同变更，必须重新
+qualification，不能宽松 fallback。
+
+任何真实 Goal promotion 前，还必须在同一个 revision 上分别让 legacy source 与
+provider round-trip 经过既有消费 pipeline。语义矩阵至少覆盖：user/agent role；open、
+done、blocked、deferred；优先级与排序；claim、exclusion、bound-agent、global-gate
+过滤；resume condition；successor/continuation；continuous monitor 的 cadence、due、
+watch-only 与 material generation；note、evidence、completion、archival；以及 Markdown
+文件不可用后的 provider-only read。任一差异都阻止 promotion，并保持 legacy authority。
+synthetic stub 可作为单元测试，但不能替代真实复杂 Goal qualification。真实 Goal 内容
+只保留在本机；公开证据只包含脱敏 coverage、计数、精确 revision 标识与 digest。
+
 下一个只读 seam 会演练未来 read flip 所需的 provider 读取形态，但不授予它 authority：
 
 ```bash
@@ -1118,6 +1138,12 @@ fail-closed write-check hook；promotion 可按 operation receipt 重放，provi
 lock，再 engage fence，从而保证不存在某次 legacy write 已通过检查、却在 cutover 后才
 提交。provider-first CLI 路由和持锁 promotion operation 仍是下一切片；在它们落地前，
 本集成选择阻断 split-brain 写入，而不会静默回退。
+
+Todo collection-read 切片只在 durable fence 已存在时把 `loopx todo list` 路由到
+`FileAuthorityStore`。它与 legacy 路径复用同一套过滤、排序、resume 和 summary
+pipeline；Markdown 缺失时仍可执行 provider-only read，并在响应中携带 authority
+receipt。provider 缺失、损坏、协议漂移或 Todo read-model 语义漂移都会 fail closed；
+cutover 后禁止回退 Markdown。
 
 完成续接（continuation）的持久化读回
 （`durable_completion.py`：`read_persisted_todo_record` /

--- a/loopx/control_plane/coordination/coordination_projection.ts
+++ b/loopx/control_plane/coordination/coordination_projection.ts
@@ -177,31 +177,39 @@ export function validateCoordinationTodoReadModel(
   }
   const allowedFields = new Set<string>(TODO_CANONICAL_READ_RECORD_FIELDS);
   for (const [recordIndex, record] of records.entries()) {
-    const unknownField = Object.keys(record).find((field) => !allowedFields.has(field));
-    if (unknownField !== undefined) {
+    validateCoordinationTodoReadRecord(record, recordIndex, allowedFields);
+  }
+  return readModel;
+}
+
+function validateCoordinationTodoReadRecord(
+  record: JsonObject,
+  recordIndex: number,
+  allowedFields: ReadonlySet<string>,
+): void {
+  const unknownField = Object.keys(record).find((field) => !allowedFields.has(field));
+  if (unknownField !== undefined) {
+    throw new AuthorityStoreProtocolError(
+      `coordination Todo read record ${recordIndex} has an unversioned field`,
+    );
+  }
+  for (const field of TODO_CANONICAL_REQUIRED_READ_FIELDS) {
+    if (!(field in record)) {
       throw new AuthorityStoreProtocolError(
-        `coordination Todo read record ${recordIndex} has an unversioned field`,
-      );
-    }
-    for (const field of TODO_CANONICAL_REQUIRED_READ_FIELDS) {
-      if (!(field in record)) {
-        throw new AuthorityStoreProtocolError(
-          `coordination Todo read record ${recordIndex} omits required ${field}`,
-        );
-      }
-    }
-    if (record.schema_version !== "todo_item_v0" ||
-        (record.role !== "user" && record.role !== "agent") ||
-        typeof record.status !== "string" || record.status.length === 0 ||
-        typeof record.done !== "boolean" || typeof record.text !== "string" ||
-        typeof record.archive_state !== "string" || record.archive_state.length === 0 ||
-        typeof record.source_section !== "string" || record.source_section.length === 0) {
-      throw new AuthorityStoreProtocolError(
-        `coordination Todo read record ${recordIndex} has invalid required semantics`,
+        `coordination Todo read record ${recordIndex} omits required ${field}`,
       );
     }
   }
-  return readModel;
+  if (record.schema_version !== "todo_item_v0" ||
+      (record.role !== "user" && record.role !== "agent") ||
+      typeof record.status !== "string" || record.status.length === 0 ||
+      typeof record.done !== "boolean" || typeof record.text !== "string" ||
+      typeof record.archive_state !== "string" || record.archive_state.length === 0 ||
+      typeof record.source_section !== "string" || record.source_section.length === 0) {
+    throw new AuthorityStoreProtocolError(
+      `coordination Todo read record ${recordIndex} has invalid required semantics`,
+    );
+  }
 }
 
 function todoReadModel(records: readonly JsonObject[]): JsonObject {
@@ -221,11 +229,68 @@ function requireCompleteTodoReplacement(
   if (previous === undefined) return;
   const omittedFields = Object.keys(previous)
     .filter((field) => !(field in replacement))
-    .sort();
+    .sort(authorityUnicodeCompare);
   if (omittedFields.length > 0) {
     throw new AuthorityStoreProtocolError(
       `coordination Todo replacement ${index} omits existing fields: ${omittedFields.join(", ")}`,
     );
+  }
+}
+
+function applyCoordinationMutation(
+  mutation: CoordinationProjectionMutation,
+  index: number,
+  todos: Map<string, JsonObject>,
+  leases: Map<string, JsonObject>,
+  claimMutationTarget: (kind: "todo" | "lease", todoId: string) => void,
+  requireCompleteReplacement: boolean,
+): void {
+  switch (mutation.kind) {
+    case "todo_upsert": {
+      const todo = canonicalAuthorityObject(mutation.todo, `mutations[${index}].todo`);
+      const todoId = requireAuthorityStoreId(todo.todo_id, `mutations[${index}].todo_id`);
+      claimMutationTarget("todo", todoId);
+      if (requireCompleteReplacement) {
+        requireCompleteTodoReplacement(todos.get(todoId), todo, index);
+      }
+      todos.set(todoId, todo);
+      return;
+    }
+    case "todo_remove": {
+      const todoId = requireAuthorityStoreId(
+        mutation.todo_id,
+        `mutations[${index}].todo_id`,
+      );
+      claimMutationTarget("todo", todoId);
+      if (!todos.delete(todoId)) {
+        throw new AuthorityStoreProtocolError("coordination projection todo remove target missing");
+      }
+      return;
+    }
+    case "lease_upsert": {
+      const lease = canonicalAuthorityObject(mutation.lease, `mutations[${index}].lease`);
+      const todoId = requireAuthorityStoreId(lease.todo_id, `mutations[${index}].todo_id`);
+      claimMutationTarget("lease", todoId);
+      leases.set(todoId, lease);
+      return;
+    }
+    case "lease_remove": {
+      const todoId = requireAuthorityStoreId(
+        mutation.todo_id,
+        `mutations[${index}].todo_id`,
+      );
+      claimMutationTarget("lease", todoId);
+      if (!leases.delete(todoId)) {
+        throw new AuthorityStoreProtocolError("coordination projection lease remove target missing");
+      }
+      return;
+    }
+    default: {
+      const unreachable: never = mutation;
+      throw new AuthorityStoreProtocolError(
+        `unsupported coordination projection mutation: ${String(unreachable)}`,
+      );
+    }
   }
 }
 
@@ -280,53 +345,14 @@ export function reduceCoordinationProjection(
   };
 
   for (const [index, mutation] of mutations.entries()) {
-    switch (mutation.kind) {
-      case "todo_upsert": {
-        const todo = canonicalAuthorityObject(mutation.todo, `mutations[${index}].todo`);
-        const todoId = requireAuthorityStoreId(todo.todo_id, `mutations[${index}].todo_id`);
-        claimMutationTarget("todo", todoId);
-        if (value.todo_read_model !== undefined) {
-          requireCompleteTodoReplacement(todos.get(todoId), todo, index);
-        }
-        todos.set(todoId, todo);
-        break;
-      }
-      case "todo_remove": {
-        const todoId = requireAuthorityStoreId(
-          mutation.todo_id,
-          `mutations[${index}].todo_id`,
-        );
-        claimMutationTarget("todo", todoId);
-        if (!todos.delete(todoId)) {
-          throw new AuthorityStoreProtocolError("coordination projection todo remove target missing");
-        }
-        break;
-      }
-      case "lease_upsert": {
-        const lease = canonicalAuthorityObject(mutation.lease, `mutations[${index}].lease`);
-        const todoId = requireAuthorityStoreId(lease.todo_id, `mutations[${index}].todo_id`);
-        claimMutationTarget("lease", todoId);
-        leases.set(todoId, lease);
-        break;
-      }
-      case "lease_remove": {
-        const todoId = requireAuthorityStoreId(
-          mutation.todo_id,
-          `mutations[${index}].todo_id`,
-        );
-        claimMutationTarget("lease", todoId);
-        if (!leases.delete(todoId)) {
-          throw new AuthorityStoreProtocolError("coordination projection lease remove target missing");
-        }
-        break;
-      }
-      default: {
-        const unreachable: never = mutation;
-        throw new AuthorityStoreProtocolError(
-          `unsupported coordination projection mutation: ${String(unreachable)}`,
-        );
-      }
-    }
+    applyCoordinationMutation(
+      mutation,
+      index,
+      todos,
+      leases,
+      claimMutationTarget,
+      value.todo_read_model !== undefined,
+    );
   }
 
   for (const todoId of leases.keys()) {

--- a/loopx/control_plane/coordination/coordination_projection.ts
+++ b/loopx/control_plane/coordination/coordination_projection.ts
@@ -19,6 +19,36 @@ export const COORDINATION_PROJECTION_MUTATION_EVENT_SCHEMA =
   "loopx_coordination_projection_mutation_event_v0";
 export const COORDINATION_PROJECTION_MUTATION_RECEIPT_SCHEMA =
   "loopx_coordination_projection_mutation_receipt_v0";
+export const TODO_CANONICAL_READ_RECORD_SCHEMA = "loopx_todo_canonical_read_record_v0";
+export const TODO_CANONICAL_READ_RECORD_FIELDS = [
+  "index", "done", "text", "schema_version", "todo_id", "role", "status",
+  "priority", "title", "archive_state", "source_section", "task_class",
+  "action_kind", "task_domain", "capability_binding_ref", "task_repository",
+  "continuation_policy", "removed_continuation_policy", "required_write_scopes",
+  "required_capabilities", "target_capabilities", "explore_result_node_refs",
+  "decision_scope", "required_decision_scopes", "decision_outcome",
+  "decision_scope_outcomes", "claimed_by", "created_by", "last_actor_agent_id",
+  "bound_agent", "goal_bound", "blocks_agent", "excluded_agents", "global_gate",
+  "unblocks_todo_id", "resume_when", "resume_monitor_generation",
+  "resume_condition", "resume_ready", "no_followup", "successor_todo_ids",
+  "completion_continuation", "completion_recovery", "replan_obligation_id",
+  "target_key", "cadence", "next_due_at", "expires_at", "watch_only",
+  "last_checked_at", "result_hash", "consecutive_no_change", "material_change",
+  "material_change_generation", "max_no_change_before_replan", "monitor_effect_id",
+  "note", "evidence", "reason", "completed_at", "completion_turn_key", "updated_at", "superseded_by",
+  "completion_validation_required",
+  "handoff_note",
+] as const;
+const TODO_CANONICAL_REQUIRED_READ_FIELDS = [
+  "schema_version",
+  "todo_id",
+  "role",
+  "status",
+  "done",
+  "text",
+  "archive_state",
+  "source_section",
+] as const;
 
 export interface CoordinationTodoProjectionIndex {
   readonly todos: ReadonlyMap<string, JsonObject>;
@@ -106,6 +136,80 @@ export function indexCoordinationProjectionTodos(
   return {
     todos,
     todo_ids: sortedIds(todos.keys()),
+  };
+}
+
+/**
+ * Validate the revision-bound Todo consumer contract carried by a promotable
+ * projection. This is intentionally stricter than identity indexing: a head
+ * that can coordinate claims but cannot reproduce the existing Todo list is
+ * not eligible to become the read authority.
+ */
+export function validateCoordinationTodoReadModel(
+  value: JsonObject,
+  expectedGoalId: string,
+): JsonObject {
+  const index = indexCoordinationProjectionTodos(value, expectedGoalId);
+  const records = index.todo_ids.map((todoId) => index.todos.get(todoId)!);
+  if (!Array.isArray(value.todos) ||
+      !canonicalAuthorityBytes(value.todos).equals(canonicalAuthorityBytes(records))) {
+    throw new AuthorityStoreProtocolError(
+      "coordination Todo read records must use deterministic todo_id order",
+    );
+  }
+  const readModel = canonicalAuthorityObject(
+    value.todo_read_model,
+    "projection.todo_read_model",
+  );
+  if (readModel.schema_version !== TODO_CANONICAL_READ_RECORD_SCHEMA) {
+    throw new AuthorityStoreProtocolError("coordination Todo read-model schema mismatch");
+  }
+  if (readModel.todo_count !== records.length) {
+    throw new AuthorityStoreProtocolError("coordination Todo read-model count mismatch");
+  }
+  if (readModel.records_sha256 !== canonicalAuthoritySha256(records)) {
+    throw new AuthorityStoreProtocolError("coordination Todo read-model digest mismatch");
+  }
+  if (!canonicalAuthorityBytes(readModel.contract_fields).equals(
+    canonicalAuthorityBytes(TODO_CANONICAL_READ_RECORD_FIELDS)
+  )) {
+    throw new AuthorityStoreProtocolError("coordination Todo read-model field contract mismatch");
+  }
+  const allowedFields = new Set<string>(TODO_CANONICAL_READ_RECORD_FIELDS);
+  for (const [recordIndex, record] of records.entries()) {
+    const unknownField = Object.keys(record).find((field) => !allowedFields.has(field));
+    if (unknownField !== undefined) {
+      throw new AuthorityStoreProtocolError(
+        `coordination Todo read record ${recordIndex} has an unversioned field`,
+      );
+    }
+    for (const field of TODO_CANONICAL_REQUIRED_READ_FIELDS) {
+      if (!(field in record)) {
+        throw new AuthorityStoreProtocolError(
+          `coordination Todo read record ${recordIndex} omits required ${field}`,
+        );
+      }
+    }
+    if (record.schema_version !== "todo_item_v0" ||
+        (record.role !== "user" && record.role !== "agent") ||
+        typeof record.status !== "string" || record.status.length === 0 ||
+        typeof record.done !== "boolean" || typeof record.text !== "string" ||
+        typeof record.archive_state !== "string" || record.archive_state.length === 0 ||
+        typeof record.source_section !== "string" || record.source_section.length === 0) {
+      throw new AuthorityStoreProtocolError(
+        `coordination Todo read record ${recordIndex} has invalid required semantics`,
+      );
+    }
+  }
+  return readModel;
+}
+
+function todoReadModel(records: readonly JsonObject[]): JsonObject {
+  return {
+    schema_version: TODO_CANONICAL_READ_RECORD_SCHEMA,
+    todo_count: records.length,
+    records_sha256: canonicalAuthoritySha256(records),
+    contract_fields: [...TODO_CANONICAL_READ_RECORD_FIELDS],
   };
 }
 
@@ -213,10 +317,14 @@ export function reduceCoordinationProjection(
       );
     }
   }
+  const nextTodos = sortedIds(todos.keys()).map((todoId) => todos.get(todoId)!);
   return canonicalAuthorityObject({
     ...value,
-    todos: sortedIds(todos.keys()).map((todoId) => todos.get(todoId)!),
+    todos: nextTodos,
     leases: sortedIds(leases.keys()).map((todoId) => leases.get(todoId)!),
+    ...(value.todo_read_model === undefined
+      ? {}
+      : { todo_read_model: todoReadModel(nextTodos) }),
   }, "coordination projection");
 }
 
@@ -251,6 +359,9 @@ export function prepareCoordinationProjectionCommit(
     goalId,
     input.mutations,
   );
+  if (currentProjection.todo_read_model !== undefined) {
+    validateCoordinationTodoReadModel(nextProjection, goalId);
+  }
   const targets = input.mutations.map(mutationTarget).sort(authorityUnicodeCompare);
   const mutationKinds = input.mutations.map((mutation) => mutation.kind).sort(
     authorityUnicodeCompare,

--- a/loopx/control_plane/coordination/coordination_projection.ts
+++ b/loopx/control_plane/coordination/coordination_projection.ts
@@ -213,6 +213,22 @@ function todoReadModel(records: readonly JsonObject[]): JsonObject {
   };
 }
 
+function requireCompleteTodoReplacement(
+  previous: JsonObject | undefined,
+  replacement: JsonObject,
+  index: number,
+): void {
+  if (previous === undefined) return;
+  const omittedFields = Object.keys(previous)
+    .filter((field) => !(field in replacement))
+    .sort();
+  if (omittedFields.length > 0) {
+    throw new AuthorityStoreProtocolError(
+      `coordination Todo replacement ${index} omits existing fields: ${omittedFields.join(", ")}`,
+    );
+  }
+}
+
 /** Validate the complete Todo/lease identity graph of one coordination head. */
 export function indexCoordinationProjection(
   value: JsonObject,
@@ -269,6 +285,9 @@ export function reduceCoordinationProjection(
         const todo = canonicalAuthorityObject(mutation.todo, `mutations[${index}].todo`);
         const todoId = requireAuthorityStoreId(todo.todo_id, `mutations[${index}].todo_id`);
         claimMutationTarget("todo", todoId);
+        if (value.todo_read_model !== undefined) {
+          requireCompleteTodoReplacement(todos.get(todoId), todo, index);
+        }
         todos.set(todoId, todo);
         break;
       }

--- a/loopx/control_plane/coordination/local_authority.py
+++ b/loopx/control_plane/coordination/local_authority.py
@@ -1,0 +1,263 @@
+"""Python adapter for provider-first local coordination reads.
+
+TypeScript remains the semantic owner of canonical projection validation.  The
+Python CLI only detects whether cutover is engaged, invokes that owner, and
+fails closed instead of consulting the legacy Markdown projection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ..effect_runtime import effect_runtime_result
+from .legacy_writer_fence import legacy_coordination_writer_fence_path
+
+
+LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA = (
+    "loopx_local_coordination_todo_list_request_v0"
+)
+LOCAL_COORDINATION_TODO_LIST_METHOD = "coordination.local_authority.todo_list"
+
+
+class LocalCoordinationAuthorityUnavailable(RuntimeError):
+    """Canonical coordination state cannot safely answer a post-cutover read."""
+
+    def __init__(self, message: str, *, code: str, payload: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.code = code
+        self.payload = dict(payload)
+
+
+def read_canonical_todos_if_promoted(
+    *, runtime_root: Path, goal_id: str
+) -> dict[str, Any] | None:
+    """Return canonical Todos after cutover, or ``None`` before cutover.
+
+    Presence of the durable writer fence is the mode switch. Once present,
+    every malformed, missing, or unavailable provider response is terminal for
+    this read; callers must never recover by reading Markdown.
+    """
+
+    fence_path = legacy_coordination_writer_fence_path(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+    )
+    try:
+        fence_path.stat()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise LocalCoordinationAuthorityUnavailable(
+            "local coordination authority mode cannot be inspected",
+            code="local_authority_mode_read_failed",
+            payload={"source_authority": "unknown_fail_closed"},
+        ) from exc
+
+    result = effect_runtime_result(
+        LOCAL_COORDINATION_TODO_LIST_METHOD,
+        {
+            "schema_version": LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+            "runtime_root": str(runtime_root.expanduser().resolve(strict=False)),
+            "goal_id": goal_id,
+        },
+    )
+    if not isinstance(result, Mapping):
+        raise LocalCoordinationAuthorityUnavailable(
+            "local coordination authority returned an invalid Todo list",
+            code="local_authority_todo_list_invalid_result",
+            payload={"source_authority": "file_v0"},
+        )
+    payload = dict(result)
+    todos = payload.get("todos")
+    if (
+        payload.get("status") != "loaded"
+        or payload.get("source_authority") != "file_v0"
+        or payload.get("decision_read_from_provider") is not True
+        or payload.get("legacy_fallback_used") is not False
+        or not isinstance(todos, list)
+        or any(not isinstance(item, Mapping) for item in todos)
+    ):
+        raise LocalCoordinationAuthorityUnavailable(
+            str(payload.get("reason") or "canonical Todo authority is unavailable"),
+            code=str(payload.get("reason_code") or "local_authority_todo_list_unavailable"),
+            payload=payload,
+        )
+    payload["todos"] = [dict(item) for item in todos]
+    return payload
+
+
+def canonical_todo_summary_fields(
+    todos: list[dict[str, Any]],
+    *,
+    rollout_events: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Adapt canonical records into the existing Todo summary read model."""
+
+    from ..todos.active_state_editing import TODO_SECTION_HEADINGS
+    from ..todos.todo_summary import compact_todo_group
+
+    fields: dict[str, Any] = {}
+    for role in ("user", "agent"):
+        items = [
+            item
+            for item in todos
+            if ("user" if item.get("role") == "user" else "agent") == role
+        ]
+        summary = compact_todo_group(
+            items,
+            source_section=TODO_SECTION_HEADINGS[role],
+            role=role,
+            resume_source_items=todos,
+            rollout_events=rollout_events,
+            item_limit=None,
+        )
+        if summary:
+            fields[f"{role}_todos"] = summary
+    return fields
+
+
+def todo_summary_items(fields: dict[str, Any], role: str) -> list[dict[str, Any]]:
+    summary = fields.get(f"{role}_todos") if isinstance(fields, dict) else None
+    if not isinstance(summary, dict):
+        return []
+    return [item for item in summary.get("items") or [] if isinstance(item, dict)]
+
+
+def merge_legacy_todo_projection_fields(
+    *, markdown_fields: dict[str, Any], event_fields: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Preserve the pre-cutover event-over-Markdown compatibility projection."""
+
+    from ..todos.active_state_editing import TODO_SECTION_HEADINGS
+    from ..todos.contract import build_todo_id, normalize_todo_id
+    from ..todos.todo_summary import compact_todo_group
+
+    merged: dict[str, Any] = {}
+    merged_items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
+    overlay: dict[str, Any] = {
+        "schema_version": "todo_list_projection_overlay_v0",
+        "base": "markdown_active_state",
+        "overlay": "event_projection",
+    }
+    by_id: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+    markdown_ids: set[str] = set()
+    markdown_ids_by_role: dict[str, set[str]] = {"user": set(), "agent": set()}
+    event_ids: set[str] = set()
+    event_order: list[str] = []
+    for role in ("user", "agent"):
+        for item in todo_summary_items(markdown_fields, role):
+            todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
+                role=role,
+                source_section=item.get("source_section"),
+                index=item.get("index"),
+                text=item.get("text"),
+            )
+            if todo_id not in by_id:
+                order.append(todo_id)
+            markdown_ids.add(todo_id)
+            markdown_ids_by_role[role].add(todo_id)
+            by_id[todo_id] = dict(item)
+    for role in ("user", "agent"):
+        for item in todo_summary_items(event_fields, role):
+            todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
+                role=role,
+                source_section=item.get("source_section"),
+                index=item.get("index"),
+                text=item.get("text"),
+            )
+            if todo_id not in by_id:
+                order.append(todo_id)
+            if todo_id not in event_ids:
+                event_order.append(todo_id)
+                event_ids.add(todo_id)
+            by_id[todo_id] = dict(item)
+    overlay.update(
+        markdown_only_todo_ids=[
+            todo_id
+            for role in ("user", "agent")
+            for todo_id in sorted(markdown_ids_by_role[role] - event_ids)
+        ],
+        event_only_todo_ids=[todo_id for todo_id in event_order if todo_id not in markdown_ids],
+        overlaid_todo_ids=[todo_id for todo_id in event_order if todo_id in markdown_ids],
+    )
+    for todo_id in order:
+        item = by_id[todo_id]
+        merged_items["user" if item.get("role") == "user" else "agent"].append(item)
+    resume_items = [*merged_items["user"], *merged_items["agent"]]
+    for role in ("user", "agent"):
+        source_section = str(
+            (markdown_fields.get(f"{role}_todos") or {}).get("source_section")
+            or (event_fields.get(f"{role}_todos") or {}).get("source_section")
+            or TODO_SECTION_HEADINGS[role]
+        )
+        summary = compact_todo_group(
+            merged_items[role],
+            source_section=source_section,
+            role=role,
+            resume_source_items=resume_items,
+            item_limit=None,
+        )
+        if summary:
+            merged[f"{role}_todos"] = summary
+    return merged, overlay
+
+
+def legacy_or_canonical_todo_fields(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    goal: dict[str, Any],
+    state_file: Path,
+    rollout_events: list[dict[str, Any]],
+) -> tuple[dict[str, Any], str, dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
+    """Select the Todo authority and build its existing CLI read model."""
+
+    from ...status import active_state_event_projection_fields
+    from ..todos.active_state_todo_parser import parse_active_state_todos
+
+    canonical = read_canonical_todos_if_promoted(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+    )
+    if canonical is not None:
+        return (
+            canonical_todo_summary_fields(
+                canonical["todos"],
+                rollout_events=rollout_events,
+            ),
+            "file_authority",
+            {},
+            None,
+            canonical,
+        )
+    if not state_file.exists():
+        raise ValueError(f"active state file does not exist: {state_file}")
+    event_fields = active_state_event_projection_fields(
+        goal,
+        state_path=state_file,
+        item_limit=None,
+        rollout_events=rollout_events,
+    )
+    markdown_fields = parse_active_state_todos(
+        state_file.read_text(encoding="utf-8"),
+        goal=goal,
+        state_path=state_file,
+        item_limit=None,
+        rollout_events=rollout_events,
+    )
+    event_has_todos = bool(event_fields.get("user_todos") or event_fields.get("agent_todos"))
+    markdown_has_todos = bool(
+        markdown_fields.get("user_todos") or markdown_fields.get("agent_todos")
+    )
+    if event_has_todos and markdown_has_todos:
+        fields, overlay = merge_legacy_todo_projection_fields(
+            markdown_fields=markdown_fields,
+            event_fields=event_fields,
+        )
+        return fields, "event_projection_with_markdown_overlay", event_fields, overlay, None
+    if event_has_todos:
+        return event_fields, "event_projection", event_fields, None, None
+    return markdown_fields, "markdown_active_state", event_fields, None, None

--- a/loopx/control_plane/coordination/local_authority.py
+++ b/loopx/control_plane/coordination/local_authority.py
@@ -71,6 +71,7 @@ def read_canonical_todos_if_promoted(
         )
     payload = dict(result)
     todos = payload.get("todos")
+    todo_read_model = payload.get("todo_read_model")
     if (
         payload.get("status") != "loaded"
         or payload.get("source_authority") != "file_v0"
@@ -78,6 +79,10 @@ def read_canonical_todos_if_promoted(
         or payload.get("legacy_fallback_used") is not False
         or not isinstance(todos, list)
         or any(not isinstance(item, Mapping) for item in todos)
+        or not isinstance(todo_read_model, Mapping)
+        or todo_read_model.get("schema_version")
+        != "loopx_todo_canonical_read_record_v0"
+        or todo_read_model.get("todo_count") != len(todos)
     ):
         raise LocalCoordinationAuthorityUnavailable(
             str(payload.get("reason") or "canonical Todo authority is unavailable"),
@@ -116,148 +121,3 @@ def canonical_todo_summary_fields(
         if summary:
             fields[f"{role}_todos"] = summary
     return fields
-
-
-def todo_summary_items(fields: dict[str, Any], role: str) -> list[dict[str, Any]]:
-    summary = fields.get(f"{role}_todos") if isinstance(fields, dict) else None
-    if not isinstance(summary, dict):
-        return []
-    return [item for item in summary.get("items") or [] if isinstance(item, dict)]
-
-
-def merge_legacy_todo_projection_fields(
-    *, markdown_fields: dict[str, Any], event_fields: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Preserve the pre-cutover event-over-Markdown compatibility projection."""
-
-    from ..todos.active_state_editing import TODO_SECTION_HEADINGS
-    from ..todos.contract import build_todo_id, normalize_todo_id
-    from ..todos.todo_summary import compact_todo_group
-
-    merged: dict[str, Any] = {}
-    merged_items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
-    overlay: dict[str, Any] = {
-        "schema_version": "todo_list_projection_overlay_v0",
-        "base": "markdown_active_state",
-        "overlay": "event_projection",
-    }
-    by_id: dict[str, dict[str, Any]] = {}
-    order: list[str] = []
-    markdown_ids: set[str] = set()
-    markdown_ids_by_role: dict[str, set[str]] = {"user": set(), "agent": set()}
-    event_ids: set[str] = set()
-    event_order: list[str] = []
-    for role in ("user", "agent"):
-        for item in todo_summary_items(markdown_fields, role):
-            todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
-                role=role,
-                source_section=item.get("source_section"),
-                index=item.get("index"),
-                text=item.get("text"),
-            )
-            if todo_id not in by_id:
-                order.append(todo_id)
-            markdown_ids.add(todo_id)
-            markdown_ids_by_role[role].add(todo_id)
-            by_id[todo_id] = dict(item)
-    for role in ("user", "agent"):
-        for item in todo_summary_items(event_fields, role):
-            todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
-                role=role,
-                source_section=item.get("source_section"),
-                index=item.get("index"),
-                text=item.get("text"),
-            )
-            if todo_id not in by_id:
-                order.append(todo_id)
-            if todo_id not in event_ids:
-                event_order.append(todo_id)
-                event_ids.add(todo_id)
-            by_id[todo_id] = dict(item)
-    overlay.update(
-        markdown_only_todo_ids=[
-            todo_id
-            for role in ("user", "agent")
-            for todo_id in sorted(markdown_ids_by_role[role] - event_ids)
-        ],
-        event_only_todo_ids=[todo_id for todo_id in event_order if todo_id not in markdown_ids],
-        overlaid_todo_ids=[todo_id for todo_id in event_order if todo_id in markdown_ids],
-    )
-    for todo_id in order:
-        item = by_id[todo_id]
-        merged_items["user" if item.get("role") == "user" else "agent"].append(item)
-    resume_items = [*merged_items["user"], *merged_items["agent"]]
-    for role in ("user", "agent"):
-        source_section = str(
-            (markdown_fields.get(f"{role}_todos") or {}).get("source_section")
-            or (event_fields.get(f"{role}_todos") or {}).get("source_section")
-            or TODO_SECTION_HEADINGS[role]
-        )
-        summary = compact_todo_group(
-            merged_items[role],
-            source_section=source_section,
-            role=role,
-            resume_source_items=resume_items,
-            item_limit=None,
-        )
-        if summary:
-            merged[f"{role}_todos"] = summary
-    return merged, overlay
-
-
-def legacy_or_canonical_todo_fields(
-    *,
-    runtime_root: Path,
-    goal_id: str,
-    goal: dict[str, Any],
-    state_file: Path,
-    rollout_events: list[dict[str, Any]],
-) -> tuple[dict[str, Any], str, dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
-    """Select the Todo authority and build its existing CLI read model."""
-
-    from ...status import active_state_event_projection_fields
-    from ..todos.active_state_todo_parser import parse_active_state_todos
-
-    canonical = read_canonical_todos_if_promoted(
-        runtime_root=runtime_root,
-        goal_id=goal_id,
-    )
-    if canonical is not None:
-        return (
-            canonical_todo_summary_fields(
-                canonical["todos"],
-                rollout_events=rollout_events,
-            ),
-            "file_authority",
-            {},
-            None,
-            canonical,
-        )
-    if not state_file.exists():
-        raise ValueError(f"active state file does not exist: {state_file}")
-    event_fields = active_state_event_projection_fields(
-        goal,
-        state_path=state_file,
-        item_limit=None,
-        rollout_events=rollout_events,
-    )
-    markdown_fields = parse_active_state_todos(
-        state_file.read_text(encoding="utf-8"),
-        goal=goal,
-        state_path=state_file,
-        item_limit=None,
-        rollout_events=rollout_events,
-    )
-    event_has_todos = bool(event_fields.get("user_todos") or event_fields.get("agent_todos"))
-    markdown_has_todos = bool(
-        markdown_fields.get("user_todos") or markdown_fields.get("agent_todos")
-    )
-    if event_has_todos and markdown_has_todos:
-        fields, overlay = merge_legacy_todo_projection_fields(
-            markdown_fields=markdown_fields,
-            event_fields=event_fields,
-        )
-        return fields, "event_projection_with_markdown_overlay", event_fields, overlay, None
-    if event_has_todos:
-        return event_fields, "event_projection", event_fields, None, None
-    return markdown_fields, "markdown_active_state", event_fields, None, None

--- a/loopx/control_plane/coordination/local_authority_runtime.ts
+++ b/loopx/control_plane/coordination/local_authority_runtime.ts
@@ -6,6 +6,7 @@ import {
   commitCoordinationProjectionMutation,
   indexCoordinationProjection,
   indexCoordinationProjectionTodos,
+  validateCoordinationTodoReadModel,
   type CoordinationProjectionMutation,
 } from "./coordination_projection.ts";
 import type { AuthorityStore, AuthorityStoreReceiptResult } from "./authority_store.ts";
@@ -517,6 +518,7 @@ export async function readLocalCoordinationTodo(
       };
     }
     const projection = indexCoordinationProjectionTodos(head.head, goalId);
+    validateCoordinationTodoReadModel(head.head, goalId);
     const todo = projection.todos.get(todoId);
     return {
       schema_version: LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA,
@@ -568,11 +570,13 @@ export async function listLocalCoordinationTodos(
       };
     }
     const projection = indexCoordinationProjectionTodos(head.head, goalId);
+    const todoReadModel = validateCoordinationTodoReadModel(head.head, goalId);
     return {
       schema_version: LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA,
       status: "loaded",
       todos: projection.todo_ids.map((todoId) => projection.todos.get(todoId)!),
       todo_ids: projection.todo_ids,
+      todo_read_model: todoReadModel,
       provider_revision: head.provider_revision,
       cursor: head.cursor,
       source_authority: "file_v0",

--- a/loopx/control_plane/coordination/local_authority_runtime.ts
+++ b/loopx/control_plane/coordination/local_authority_runtime.ts
@@ -34,6 +34,10 @@ export const LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_read_request_v0";
 export const LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA =
   "loopx_local_coordination_todo_read_result_v0";
+export const LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA =
+  "loopx_local_coordination_todo_list_request_v0";
+export const LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA =
+  "loopx_local_coordination_todo_list_result_v0";
 export const LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA =
   "loopx_local_coordination_promotion_request_v0";
 export const LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA =
@@ -532,6 +536,55 @@ export async function readLocalCoordinationTodo(
       status: "failed",
       reason_code: "invalid_local_coordination_todo_read_request",
       reason: error instanceof Error ? error.message : "invalid Todo read request",
+      source_authority: "file_v0",
+      decision_read_from_provider: true,
+      legacy_fallback_used: false,
+    };
+  }
+}
+
+/** Provider-first Todo collection read. Missing/unavailable state never falls back. */
+export async function listLocalCoordinationTodos(
+  value: unknown,
+  dependencies: LocalAuthorityRuntimeDependencies = {},
+): Promise<JsonObject> {
+  try {
+    const input = requireJsonObject(value, "local coordination Todo list request");
+    if (input.schema_version !== LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA) {
+      throw new Error("local coordination Todo list request schema mismatch");
+    }
+    const root = runtimeRoot(input.runtime_root);
+    const goalId = requireAuthorityStoreId(input.goal_id, "goal id");
+    const store = dependencies.createStore?.(authorityDirectory(root), goalId) ??
+      new FileAuthorityStore(authorityDirectory(root), goalId);
+    const head = await store.loadAuthority();
+    if (head.status !== "loaded") {
+      return {
+        schema_version: LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA,
+        ...head,
+        source_authority: "file_v0",
+        decision_read_from_provider: true,
+        legacy_fallback_used: false,
+      };
+    }
+    const projection = indexCoordinationProjectionTodos(head.head, goalId);
+    return {
+      schema_version: LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA,
+      status: "loaded",
+      todos: projection.todo_ids.map((todoId) => projection.todos.get(todoId)!),
+      todo_ids: projection.todo_ids,
+      provider_revision: head.provider_revision,
+      cursor: head.cursor,
+      source_authority: "file_v0",
+      decision_read_from_provider: true,
+      legacy_fallback_used: false,
+    };
+  } catch (error) {
+    return {
+      schema_version: LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA,
+      status: "failed",
+      reason_code: "invalid_local_coordination_todo_list_request",
+      reason: error instanceof Error ? error.message : "invalid Todo list request",
       source_authority: "file_v0",
       decision_read_from_provider: true,
       legacy_fallback_used: false,

--- a/loopx/control_plane/coordination/runtime_shadow.py
+++ b/loopx/control_plane/coordination/runtime_shadow.py
@@ -8,6 +8,7 @@ returned as evidence and must not change the primary command result.
 from __future__ import annotations
 
 import json
+import hashlib
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -75,28 +76,6 @@ def resolve_coordination_runtime_shadow_config(
 
 RuntimeInvoker = Callable[..., object]
 
-_TODO_PROJECTION_FIELDS = (
-    "todo_id",
-    "role",
-    "status",
-    "task_class",
-    "action_kind",
-    "task_domain",
-    "task_repository",
-    "continuation_policy",
-    "claimed_by",
-    "bound_agent",
-    "goal_bound",
-    "blocks_agent",
-    "excluded_agents",
-    "global_gate",
-    "required_write_scopes",
-    "successor_todo_ids",
-    "superseding_todo_id",
-    "no_followup",
-    "updated_at",
-)
-
 _LEASE_PROJECTION_FIELDS = (
     "todo_id",
     "owner",
@@ -146,7 +125,13 @@ def build_todo_runtime_shadow_projection(
     todos: object,
     leases: object = None,
 ) -> dict[str, object]:
-    """Reduce the legacy Todo read model to coordination-owned JSON fields."""
+    """Persist the complete canonical Todo consumer record for provider cutover."""
+
+    from ..todos.todo_summary import (
+        TODO_CANONICAL_READ_RECORD_FIELDS,
+        TODO_CANONICAL_READ_RECORD_SCHEMA_VERSION,
+        canonical_todo_read_record,
+    )
 
     compact: list[dict[str, object]] = []
     if isinstance(todos, list):
@@ -156,11 +141,7 @@ def build_todo_runtime_shadow_projection(
             todo_id = item.get("todo_id")
             if not isinstance(todo_id, str) or not todo_id:
                 continue
-            projected = {
-                field: item[field]
-                for field in _TODO_PROJECTION_FIELDS
-                if field in item and item[field] is not None
-            }
+            projected = canonical_todo_read_record(dict(item))
             compact.append(projected)
     compact.sort(key=lambda item: str(item["todo_id"]))
     compact_leases: list[dict[str, object]] = []
@@ -179,12 +160,26 @@ def build_todo_runtime_shadow_projection(
                 }
             )
     compact_leases.sort(key=lambda item: str(item["todo_id"]))
+    todo_records_sha256 = hashlib.sha256(
+        json.dumps(
+            compact,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
     return {
         "schema_version": "loopx_coordination_runtime_shadow_projection_v0",
         "goal_id": goal_id,
         "source_authority": "legacy_markdown_and_task_lease",
         "todos": compact,
         "leases": compact_leases,
+        "todo_read_model": {
+            "schema_version": TODO_CANONICAL_READ_RECORD_SCHEMA_VERSION,
+            "todo_count": len(compact),
+            "records_sha256": todo_records_sha256,
+            "contract_fields": list(TODO_CANONICAL_READ_RECORD_FIELDS),
+        },
     }
 
 

--- a/loopx/control_plane/coordination/runtime_shadow.ts
+++ b/loopx/control_plane/coordination/runtime_shadow.ts
@@ -13,7 +13,10 @@ import {
   canonicalAuthoritySha256,
   requireAuthorityStoreId,
 } from "./authority_store_codec.ts";
-import { indexCoordinationProjectionTodos } from "./coordination_projection.ts";
+import {
+  indexCoordinationProjectionTodos,
+  validateCoordinationTodoReadModel,
+} from "./coordination_projection.ts";
 import { FileAuthorityStore } from "./file_authority_store.ts";
 
 export const COORDINATION_RUNTIME_SHADOW_REQUEST_SCHEMA =
@@ -955,6 +958,27 @@ export async function qualifyCoordinationRuntimeShadow(
     }
     const expectedProjectionSha256 = canonicalAuthoritySha256(request.projection);
     const observedProjectionSha256 = canonicalAuthoritySha256(head.head);
+    let todoReadModel: JsonObject;
+    try {
+      validateCoordinationTodoReadModel(request.projection, request.goal_id);
+      todoReadModel = validateCoordinationTodoReadModel(head.head, request.goal_id);
+    } catch (error) {
+      return {
+        schema_version: COORDINATION_RUNTIME_SHADOW_QUALIFY_RESULT_SCHEMA,
+        status: "drifted",
+        reason_code: "shadow_todo_consumer_semantics_invalid",
+        reason: error instanceof Error ? error.message : "Todo read-model validation failed",
+        policy,
+        qualified: false,
+        parity_matches: false,
+        expected_projection_sha256: expectedProjectionSha256,
+        observed_projection_sha256: observedProjectionSha256,
+        provider_revision: head.provider_revision,
+        cursor: head.cursor,
+        primary_writeback_preserved: true,
+        decision_read_from_shadow: false,
+      };
+    }
     const lineage = await scanShadowLineage(store);
     if (lineage.status === "failed") {
       return {
@@ -1011,6 +1035,8 @@ export async function qualifyCoordinationRuntimeShadow(
         missing_required_event_kinds: missingRequiredEventKinds,
         enough_operations: enoughOperations,
         coverage_complete: coverageComplete,
+        todo_consumer_semantics_verified: true,
+        todo_read_model: todoReadModel,
         ...(transactionFailure === null ? {} : { reason_code: transactionFailure }),
       },
       primary_writeback_preserved: true,

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -109,6 +109,7 @@ import {
 } from "./coordination/runtime_shadow.ts";
 import {
   mutateLocalCoordinationAuthority,
+  listLocalCoordinationTodos,
   promoteLocalCoordinationAuthority,
   readLocalCoordinationTodo,
 } from "./coordination/local_authority_runtime.ts";
@@ -387,6 +388,7 @@ export function createEffectRuntimeHandlers(
     ["coordination.local_authority.promote", promoteLocalCoordinationAuthority],
     ["coordination.local_authority.mutate", mutateLocalCoordinationAuthority],
     ["coordination.local_authority.todo_read", readLocalCoordinationTodo],
+    ["coordination.local_authority.todo_list", listLocalCoordinationTodos],
     [
       "coordination.local_authority.legacy_writer_fence.engage",
       engageLegacyCoordinationWriterFence,

--- a/loopx/control_plane/todos/goal_todo_projection.py
+++ b/loopx/control_plane/todos/goal_todo_projection.py
@@ -294,6 +294,35 @@ def goal_todo_summaries(
         fields = markdown_fields
         source = "markdown_active_state"
 
+    return todo_summaries_from_fields(
+        fields=fields,
+        source=source,
+        projection_fields=projection_fields,
+        projection_overlay=projection_overlay,
+        rollout_events=rollout_events,
+        roles=roles,
+        status=status,
+        todo_id=todo_id,
+        agent_id=agent_id,
+        limit=limit,
+    )
+
+
+def todo_summaries_from_fields(
+    *,
+    fields: dict[str, Any],
+    source: str,
+    projection_fields: dict[str, Any] | None,
+    projection_overlay: dict[str, Any] | None,
+    rollout_events: list[dict[str, Any]],
+    roles: list[str],
+    status: str | None,
+    todo_id: str | None,
+    agent_id: str | None,
+    limit: int | None,
+) -> GoalTodoSummaries:
+    """Apply the shared Todo consumer semantics to an authority read model."""
+
     resume_source_items = [
         *summary_items(fields, "user"),
         *summary_items(fields, "agent"),
@@ -327,7 +356,7 @@ def goal_todo_summaries(
         uncapped_todo_count += int(summary.get("total_count") or 0)
     return GoalTodoSummaries(
         source=source,
-        projection_fields=projection_fields,
+        projection_fields=projection_fields or {},
         projection_overlay=projection_overlay,
         summaries=summaries,
         todos=todos,
@@ -342,4 +371,5 @@ __all__ = [
     "goal_todo_summaries",
     "merge_todo_projection_fields",
     "summary_items",
+    "todo_summaries_from_fields",
 ]

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -84,6 +84,84 @@ TODO_CLOSURE_INTENT_SCHEMA_VERSION = "todo_closure_intent_v0"
 TODO_TERMINAL_CLOSURE_PROOF_SCHEMA_VERSION = "todo_terminal_closure_proof_v0"
 TASK_ORCHESTRATION_AUTHORITY_SCHEMA_VERSION = "task_orchestration_authority_v0"
 TODO_ARCHIVE_STATE_ACTIVE = "active"
+TODO_CANONICAL_READ_RECORD_SCHEMA_VERSION = "loopx_todo_canonical_read_record_v0"
+TODO_CANONICAL_READ_RECORD_FIELDS = (
+    "index",
+    "done",
+    "text",
+    "schema_version",
+    "todo_id",
+    "role",
+    "status",
+    "priority",
+    "title",
+    "archive_state",
+    "source_section",
+    "task_class",
+    "action_kind",
+    "task_domain",
+    "capability_binding_ref",
+    "task_repository",
+    "continuation_policy",
+    "removed_continuation_policy",
+    "required_write_scopes",
+    "required_capabilities",
+    "target_capabilities",
+    "explore_result_node_refs",
+    "decision_scope",
+    "required_decision_scopes",
+    "decision_outcome",
+    "decision_scope_outcomes",
+    "claimed_by",
+    "created_by",
+    "last_actor_agent_id",
+    "bound_agent",
+    "goal_bound",
+    "blocks_agent",
+    "excluded_agents",
+    "global_gate",
+    "unblocks_todo_id",
+    "resume_when",
+    "resume_monitor_generation",
+    "resume_condition",
+    "resume_ready",
+    "no_followup",
+    "successor_todo_ids",
+    "completion_continuation",
+    "completion_recovery",
+    "replan_obligation_id",
+    "target_key",
+    "cadence",
+    "next_due_at",
+    "expires_at",
+    "watch_only",
+    "last_checked_at",
+    "result_hash",
+    "consecutive_no_change",
+    "material_change",
+    "material_change_generation",
+    "max_no_change_before_replan",
+    "monitor_effect_id",
+    "note",
+    "evidence",
+    "reason",
+    "completed_at",
+    "completion_turn_key",
+    "updated_at",
+    "superseded_by",
+    "completion_validation_required",
+    "handoff_note",
+)
+TODO_CANONICAL_REQUIRED_READ_FIELDS = (
+    "schema_version",
+    "todo_id",
+    "role",
+    "status",
+    "done",
+    "text",
+    "archive_state",
+    "source_section",
+)
 AttentionItemBuilder = Callable[..., dict[str, Any]]
 GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
 PublicSafeText = Callable[..., Optional[str]]
@@ -441,72 +519,43 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "done": bool(item.get("done")),
         "text": item.get("text"),
     }
-    for key in (
-        "schema_version",
-        "todo_id",
-        "role",
-        "status",
-        "priority",
-        "title",
-        "archive_state",
-        "source_section",
-        "task_class",
-        "action_kind",
-        "task_domain",
-        "capability_binding_ref",
-        "task_repository",
-        "continuation_policy",
-        "removed_continuation_policy",
-        "required_write_scopes",
-        "required_capabilities",
-        "target_capabilities",
-        "explore_result_node_refs",
-        "decision_scope",
-        "required_decision_scopes",
-        "decision_outcome",
-        "decision_scope_outcomes",
-        "claimed_by",
-        "created_by",
-        "last_actor_agent_id",
-        "bound_agent",
-        "goal_bound",
-        "blocks_agent",
-        "excluded_agents",
-        "global_gate",
-        "unblocks_todo_id",
-        "resume_when",
-        "resume_monitor_generation",
-        "resume_condition",
-        "resume_ready",
-        "no_followup",
-        "successor_todo_ids",
-        "completion_continuation",
-        "completion_recovery",
-        "replan_obligation_id",
-        "target_key",
-        "cadence",
-        "next_due_at",
-        "expires_at",
-        "watch_only",
-        "last_checked_at",
-        "result_hash",
-        "consecutive_no_change",
-        "material_change",
-        "material_change_generation",
-        "max_no_change_before_replan",
-        "note",
-        "evidence",
-        "reason",
-        "completed_at",
-        "completion_turn_key",
-        "updated_at",
-        "superseded_by",
-        "completion_validation_required",
-    ):
+    for key in TODO_CANONICAL_READ_RECORD_FIELDS:
+        if key in compact:
+            continue
         if item.get(key) is not None:
             compact[key] = item.get(key)
     attach_todo_handoff_note(compact)
     return compact
+
+
+def canonical_todo_read_record(item: dict[str, Any]) -> dict[str, Any]:
+    """Copy one already-normalized Todo consumer record without re-deriving it."""
+
+    record = {
+        field: item[field]
+        for field in TODO_CANONICAL_READ_RECORD_FIELDS
+        if field in item and item[field] is not None
+    }
+    missing = [field for field in TODO_CANONICAL_REQUIRED_READ_FIELDS if field not in record]
+    if missing:
+        raise ValueError(
+            "canonical Todo read record omits required fields: " + ", ".join(missing)
+        )
+    if (
+        record["schema_version"] != TODO_ITEM_SCHEMA_VERSION
+        or not isinstance(record["role"], str)
+        or record["role"] not in {"user", "agent"}
+        or not isinstance(record["status"], str)
+        or not record["status"]
+        or not isinstance(record["done"], bool)
+        or not isinstance(record["text"], str)
+        or not isinstance(record["archive_state"], str)
+        or not record["archive_state"]
+        or not isinstance(record["source_section"], str)
+        or not record["source_section"]
+    ):
+        raise ValueError("canonical Todo read record has invalid required semantics")
+    return record
 
 
 def _task_orchestration_authority(

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -304,6 +304,7 @@ def list_goal_todos(
             "source_authority": canonical_read["source_authority"],
             "provider_revision": canonical_read.get("provider_revision"),
             "cursor": canonical_read.get("cursor"),
+            "todo_read_model": canonical_read.get("todo_read_model"),
             "decision_read_from_provider": True,
             "legacy_fallback_used": False,
         }

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -91,7 +91,10 @@ from .control_plane.todos.list_projection import (
     todo_item_relations,
     todo_list_projection_contract,
 )
-from .control_plane.todos.goal_todo_projection import goal_todo_summaries
+from .control_plane.todos.goal_todo_projection import (
+    goal_todo_summaries,
+    todo_summaries_from_fields,
+)
 from .control_plane.todos import monitor_metadata as todo_monitor_metadata
 from .control_plane.todos.external_wait_writeback import plan_todo_external_wait_update
 from .control_plane.todos.mutation_authority import authorize_todo_lifecycle_mutation, todo_update_authority_action
@@ -116,6 +119,10 @@ from .control_plane.todos.write_policy import (
     resolve_user_gate_global_gate_update,
 )
 from .control_plane.coordination.legacy_writer_fence import legacy_todo_write_transaction
+from .control_plane.coordination.local_authority import (
+    canonical_todo_summary_fields,
+    read_canonical_todos_if_promoted,
+)
 from .control_plane.todos.handoff_mode import (
     enter_added_todo_ownership_handoff_gate,
     enter_todo_ownership_handoff_gate,
@@ -205,8 +212,6 @@ def list_goal_todos(
     )
     if goal is None:
         raise ValueError(f"goal {goal_id!r} is not present in the registry")
-    if not resolved_state_file.exists():
-        raise ValueError(f"active state file does not exist: {resolved_state_file}")
 
     runtime_root = resolve_runtime_root(registry, runtime_root_arg)
     rollout_events = load_rollout_events(
@@ -215,17 +220,40 @@ def list_goal_todos(
     )
 
     roles = [role] if role else ["user", "agent"]
-    projected = goal_todo_summaries(
-        goal,
-        state_text=resolved_state_file.read_text(encoding="utf-8"),
-        state_path=resolved_state_file,
-        rollout_events=rollout_events,
-        roles=roles,
-        status=status,
-        todo_id=normalized_todo_id,
-        agent_id=normalized_agent_id,
-        limit=limit,
+    canonical_read = read_canonical_todos_if_promoted(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
     )
+    if canonical_read is not None:
+        projected = todo_summaries_from_fields(
+            fields=canonical_todo_summary_fields(
+                canonical_read["todos"],
+                rollout_events=rollout_events,
+            ),
+            source="file_authority",
+            projection_fields={},
+            projection_overlay=None,
+            rollout_events=rollout_events,
+            roles=roles,
+            status=status,
+            todo_id=normalized_todo_id,
+            agent_id=normalized_agent_id,
+            limit=limit,
+        )
+    else:
+        if not resolved_state_file.exists():
+            raise ValueError(f"active state file does not exist: {resolved_state_file}")
+        projected = goal_todo_summaries(
+            goal,
+            state_text=resolved_state_file.read_text(encoding="utf-8"),
+            state_path=resolved_state_file,
+            rollout_events=rollout_events,
+            roles=roles,
+            status=status,
+            todo_id=normalized_todo_id,
+            agent_id=normalized_agent_id,
+            limit=limit,
+        )
     source = projected.source
     projection_fields = projected.projection_fields
     projection_overlay = projected.projection_overlay
@@ -271,6 +299,14 @@ def list_goal_todos(
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
     }
+    if canonical_read is not None:
+        payload["authority_read"] = {
+            "source_authority": canonical_read["source_authority"],
+            "provider_revision": canonical_read.get("provider_revision"),
+            "cursor": canonical_read.get("cursor"),
+            "decision_read_from_provider": True,
+            "legacy_fallback_used": False,
+        }
     if normalized_agent_id:
         payload["agent_id_filter"] = normalized_agent_id
         payload["unfiltered_todo_count"] = unfiltered_count

--- a/tests/control_plane/test_coordination_runtime_shadow_adapter.py
+++ b/tests/control_plane/test_coordination_runtime_shadow_adapter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from loopx.cli_commands import todo as todo_command
 from loopx.cli_commands import task_lease as task_lease_command
 from loopx.control_plane import effect_runtime
@@ -23,6 +25,26 @@ from loopx.control_plane.coordination.runtime_shadow import (
     resolve_coordination_runtime_shadow_config,
     rollback_coordination_runtime_shadow,
 )
+
+
+def _canonical_todo(
+    *,
+    todo_id: str = "todo_one",
+    role: str = "agent",
+    status: str = "open",
+    **fields: object,
+) -> dict[str, object]:
+    return {
+        "schema_version": "todo_item_v0",
+        "todo_id": todo_id,
+        "role": role,
+        "status": status,
+        "done": status == "done",
+        "text": f"{status} {todo_id}",
+        "archive_state": "active",
+        "source_section": "User Todo" if role == "user" else "Agent Todo",
+        **fields,
+    }
 
 
 def test_runtime_shadow_todo_read_candidate_is_default_off_and_typed(
@@ -412,22 +434,32 @@ def test_runtime_shadow_qualification_is_default_off_and_forwards_policy(
     ]
 
 
-def test_todo_projection_is_compact_stable_and_excludes_private_fields() -> None:
+def test_todo_projection_is_complete_stable_and_declares_read_model_contract() -> None:
     projection = build_todo_runtime_shadow_projection(
         goal_id="goal-a",
         todos=[
             {
+                "schema_version": "todo_item_v0",
                 "todo_id": "todo_b",
                 "role": "agent",
                 "status": "open",
+                "done": False,
+                "text": "Qualify provider cutover",
+                "archive_state": "active",
+                "source_section": "Agent Todo",
                 "claimed_by": "agent-a",
-                "note": "private narrative must not enter coordination",
-                "evidence": "large evidence must stay in its owning ledger",
+                "note": "operator note retained by local canonical authority",
+                "evidence": "durable evidence retained for Todo list semantics",
             },
             {
+                "schema_version": "todo_item_v0",
                 "todo_id": "todo_a",
                 "role": "user",
                 "status": "done",
+                "done": True,
+                "text": "Approve provider cutover",
+                "archive_state": "active",
+                "source_section": "User Todo",
                 "successor_todo_ids": ["todo_b"],
             },
             {"status": "open"},
@@ -438,9 +470,20 @@ def test_todo_projection_is_compact_stable_and_excludes_private_fields() -> None
         "todo_a",
         "todo_b",
     ]
-    assert "note" not in projection["todos"][1]
-    assert "evidence" not in projection["todos"][1]
+    assert projection["todos"][1]["note"] == "operator note retained by local canonical authority"
+    assert projection["todos"][1]["evidence"] == "durable evidence retained for Todo list semantics"
     assert projection["leases"] == []
+    assert projection["todo_read_model"]["todo_count"] == 2
+    assert "text" in projection["todo_read_model"]["contract_fields"]
+    assert "resume_when" in projection["todo_read_model"]["contract_fields"]
+
+
+def test_todo_projection_rejects_incomplete_consumer_semantics() -> None:
+    with pytest.raises(ValueError, match="omits required fields"):
+        build_todo_runtime_shadow_projection(
+            goal_id="goal-a",
+            todos=[{"todo_id": "todo_incomplete", "status": "open"}],
+        )
 
 
 def test_committed_todo_hook_has_no_default_output_or_runtime_call(
@@ -504,9 +547,7 @@ def test_committed_todo_hook_dispatches_after_explicit_opt_in(
     monkeypatch.setattr(
         todo_command,
         "list_goal_todos",
-        lambda **_kwargs: {
-            "todos": [{"todo_id": "todo_one", "role": "agent", "status": "done"}]
-        },
+        lambda **_kwargs: {"todos": [_canonical_todo(status="done")]},
     )
     captured: dict[str, object] = {}
 
@@ -536,9 +577,7 @@ def test_committed_todo_hook_dispatches_after_explicit_opt_in(
     assert result == {"status": "applied"}
     assert captured["operation_id"] == "todo-shadow:event-a"
     assert captured["event_kind"] == "todo_complete"
-    assert captured["projection"]["todos"] == [
-        {"todo_id": "todo_one", "role": "agent", "status": "done"}
-    ]
+    assert captured["projection"]["todos"] == [_canonical_todo(status="done")]
 
 
 def test_committed_todo_hook_reaches_the_file_shadow_through_typescript(
@@ -569,14 +608,7 @@ def test_committed_todo_hook_reaches_the_file_shadow_through_typescript(
         todo_command,
         "list_goal_todos",
         lambda **_kwargs: {
-            "todos": [
-                {
-                    "todo_id": "todo_one",
-                    "role": "agent",
-                    "status": "open",
-                    "claimed_by": "agent-a",
-                }
-            ]
+            "todos": [_canonical_todo(claimed_by="agent-a")]
         },
     )
     monkeypatch.setattr(
@@ -627,12 +659,21 @@ def test_runtime_shadow_inspection_reaches_file_store_through_typescript(
             }
         },
     }
-    projection = {
-        "schema_version": "projection_v0",
-        "goal_id": "goal-a",
-        "todos": [{"todo_id": "todo_one", "status": "open"}],
-        "leases": [],
-    }
+    projection = build_todo_runtime_shadow_projection(
+        goal_id="goal-a",
+        todos=[
+            {
+                "schema_version": "todo_item_v0",
+                "todo_id": "todo_one",
+                "role": "agent",
+                "status": "open",
+                "done": False,
+                "text": "qualify",
+                "archive_state": "active",
+                "source_section": "Agent Todo",
+            }
+        ],
+    )
     runtime_root = tmp_path / "state"
     monkeypatch.setattr(
         effect_runtime,
@@ -687,12 +728,21 @@ def test_runtime_shadow_qualification_reaches_file_store_through_typescript(
             }
         },
     }
-    projection = {
-        "schema_version": "projection_v0",
-        "goal_id": "goal-a",
-        "todos": [{"todo_id": "todo_one", "status": "open"}],
-        "leases": [],
-    }
+    projection = build_todo_runtime_shadow_projection(
+        goal_id="goal-a",
+        todos=[
+            {
+                "schema_version": "todo_item_v0",
+                "todo_id": "todo_one",
+                "role": "agent",
+                "status": "open",
+                "done": False,
+                "text": "qualify",
+                "archive_state": "active",
+                "source_section": "Agent Todo",
+            }
+        ],
+    )
     runtime_root = tmp_path / "state"
     monkeypatch.setattr(
         effect_runtime,
@@ -791,9 +841,7 @@ def test_committed_task_lease_hook_dispatches_full_coordination_snapshot(
     monkeypatch.setattr(
         task_lease_command,
         "list_goal_todos",
-        lambda **_kwargs: {
-            "todos": [{"todo_id": "todo_one", "role": "agent", "status": "open"}]
-        },
+        lambda **_kwargs: {"todos": [_canonical_todo()]},
     )
     monkeypatch.setattr(
         task_lease_command,
@@ -876,9 +924,7 @@ def test_committed_task_lease_hook_reaches_file_shadow_through_typescript(
     monkeypatch.setattr(
         task_lease_command,
         "list_goal_todos",
-        lambda **_kwargs: {
-            "todos": [{"todo_id": "todo_one", "role": "agent", "status": "open"}]
-        },
+        lambda **_kwargs: {"todos": [_canonical_todo()]},
     )
     lease_dir = tmp_path / "state" / "goals" / "goal-a" / "task-leases"
     lease_dir.mkdir(parents=True)

--- a/tests/control_plane/test_coordination_shadow_command.py
+++ b/tests/control_plane/test_coordination_shadow_command.py
@@ -20,6 +20,19 @@ def _goal() -> dict[str, object]:
     }
 
 
+def _canonical_todo(todo_id: str, *, status: str) -> dict[str, object]:
+    return {
+        "schema_version": "todo_item_v0",
+        "todo_id": todo_id,
+        "role": "agent",
+        "status": status,
+        "done": status == "done",
+        "text": f"{status} {todo_id}",
+        "archive_state": "active",
+        "source_section": "Agent Todo",
+    }
+
+
 def _run(
     monkeypatch,
     tmp_path: Path,
@@ -40,8 +53,8 @@ def _run(
         "list_goal_todos",
         lambda **_kwargs: {
             "todos": [
-                {"todo_id": "todo_b", "status": "open"},
-                {"todo_id": "todo_a", "status": "done"},
+                _canonical_todo("todo_b", status="open"),
+                _canonical_todo("todo_a", status="done"),
             ]
         },
     )
@@ -152,8 +165,8 @@ def test_coordination_shadow_bootstrap_requires_execute_and_reads_back_parity(
     assert str(bootstrap_request["operation_id"]).startswith("shadow-bootstrap:goal-a:")
     assert str(bootstrap_request["source_version"]).startswith("legacy-projection:")
     assert bootstrap_request["projection"]["todos"] == [
-        {"todo_id": "todo_a", "status": "done"},
-        {"todo_id": "todo_b", "status": "open"},
+        _canonical_todo("todo_a", status="done"),
+        _canonical_todo("todo_b", status="open"),
     ]
 
 
@@ -262,8 +275,8 @@ def test_coordination_shadow_reads_parity_matched_todo_candidate(
     assert payload["read_candidate"]["todo_id"] == "todo_b"
     assert request["todo_id"] == "todo_b"
     assert request["projection"]["todos"] == [
-        {"todo_id": "todo_a", "status": "done"},
-        {"todo_id": "todo_b", "status": "open"},
+        _canonical_todo("todo_a", status="done"),
+        _canonical_todo("todo_b", status="open"),
     ]
 
 

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.coordination.local_authority import (
+    LocalCoordinationAuthorityUnavailable,
+    read_canonical_todos_if_promoted,
+)
+from loopx.control_plane.coordination.legacy_writer_fence import (
+    legacy_coordination_writer_fence_path,
+)
+from loopx.todos import list_goal_todos
+
+
+def _engage_fence(runtime_root: Path, goal_id: str = "goal-a") -> None:
+    path = legacy_coordination_writer_fence_path(
+        runtime_root=runtime_root,
+        goal_id=goal_id,
+    )
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"state": "engaged"}), encoding="utf-8")
+
+
+def test_absent_fence_preserves_legacy_path_without_starting_typescript(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.local_authority.effect_runtime_result",
+        lambda *_args, **_kwargs: pytest.fail("pre-cutover read must stay legacy"),
+    )
+    assert read_canonical_todos_if_promoted(
+        runtime_root=tmp_path,
+        goal_id="goal-a",
+    ) is None
+
+
+def test_engaged_fence_reads_typescript_provider_result(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _engage_fence(tmp_path)
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.local_authority.effect_runtime_result",
+        lambda method, params: {
+            "status": "loaded",
+            "todos": [{"todo_id": "todo_a", "role": "agent", "status": "open"}],
+            "provider_revision": "file:1",
+            "cursor": "1",
+            "source_authority": "file_v0",
+            "decision_read_from_provider": True,
+            "legacy_fallback_used": False,
+        },
+    )
+    result = read_canonical_todos_if_promoted(
+        runtime_root=tmp_path,
+        goal_id="goal-a",
+    )
+    assert result is not None
+    assert result["todos"][0]["todo_id"] == "todo_a"
+
+
+def test_engaged_fence_never_falls_back_when_provider_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _engage_fence(tmp_path)
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.local_authority.effect_runtime_result",
+        lambda method, params: {
+            "status": "missing",
+            "source_authority": "file_v0",
+            "decision_read_from_provider": True,
+            "legacy_fallback_used": False,
+        },
+    )
+    with pytest.raises(LocalCoordinationAuthorityUnavailable) as exc_info:
+        read_canonical_todos_if_promoted(runtime_root=tmp_path, goal_id="goal-a")
+    assert exc_info.value.code == "local_authority_todo_list_unavailable"
+
+
+def test_todo_list_uses_provider_after_cutover_even_when_markdown_disagrees(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    state_file = project / ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "# Goal\n\n## Agent Todos\n\n- [ ] stale Markdown Todo <!-- loopx:todo todo_id=todo_stale status=open -->\n",
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": "goal-a",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _engage_fence(runtime_root)
+    state_file.unlink()
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.local_authority.effect_runtime_result",
+        lambda method, params: {
+            "status": "loaded",
+            "todos": [
+                {
+                    "todo_id": "todo_provider",
+                    "role": "agent",
+                    "status": "open",
+                    "text": "provider Todo",
+                }
+            ],
+            "provider_revision": "file:2",
+            "cursor": "2",
+            "source_authority": "file_v0",
+            "decision_read_from_provider": True,
+            "legacy_fallback_used": False,
+        },
+    )
+
+    result = list_goal_todos(registry_path=registry_path, goal_id="goal-a")
+
+    assert result["source"] == "file_authority"
+    assert [item["todo_id"] for item in result["todos"]] == ["todo_provider"]
+    assert result["authority_read"]["legacy_fallback_used"] is False

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -9,6 +10,11 @@ from loopx.control_plane.coordination.local_authority import (
     LocalCoordinationAuthorityUnavailable,
     read_canonical_todos_if_promoted,
 )
+from loopx.control_plane.coordination.runtime_shadow import (
+    build_todo_runtime_shadow_projection,
+)
+from loopx.control_plane.effect_runtime import effect_runtime_result
+from loopx.control_plane.todos.active_state_editing import TODO_SECTION_HEADINGS
 from loopx.control_plane.coordination.legacy_writer_fence import (
     legacy_coordination_writer_fence_path,
 )
@@ -22,6 +28,13 @@ def _engage_fence(runtime_root: Path, goal_id: str = "goal-a") -> None:
     )
     path.parent.mkdir(parents=True)
     path.write_text(json.dumps({"state": "engaged"}), encoding="utf-8")
+
+
+def _todo_read_model(todo_count: int) -> dict[str, object]:
+    return {
+        "schema_version": "loopx_todo_canonical_read_record_v0",
+        "todo_count": todo_count,
+    }
 
 
 def test_absent_fence_preserves_legacy_path_without_starting_typescript(
@@ -48,6 +61,7 @@ def test_engaged_fence_reads_typescript_provider_result(
         lambda method, params: {
             "status": "loaded",
             "todos": [{"todo_id": "todo_a", "role": "agent", "status": "open"}],
+            "todo_read_model": _todo_read_model(1),
             "provider_revision": "file:1",
             "cursor": "1",
             "source_authority": "file_v0",
@@ -126,6 +140,7 @@ def test_todo_list_uses_provider_after_cutover_even_when_markdown_disagrees(
                     "text": "provider Todo",
                 }
             ],
+            "todo_read_model": _todo_read_model(1),
             "provider_revision": "file:2",
             "cursor": "2",
             "source_authority": "file_v0",
@@ -139,3 +154,180 @@ def test_todo_list_uses_provider_after_cutover_even_when_markdown_disagrees(
     assert result["source"] == "file_authority"
     assert [item["todo_id"] for item in result["todos"]] == ["todo_provider"]
     assert result["authority_read"]["legacy_fallback_used"] is False
+
+
+def test_real_shadow_projection_promotes_complete_complex_todo_semantics(
+    tmp_path: Path,
+) -> None:
+    """Exercise builder -> shadow -> promotion -> production Todo list."""
+
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    state_file = project / ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Goal\n", encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": "goal-a",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    complex_todo = {
+        "schema_version": "todo_item_v0",
+        "index": 7,
+        "done": False,
+        "text": "Qualify provider cutover on a complex Goal",
+        "title": "Provider semantic parity",
+        "todo_id": "todo_complex",
+        "role": "agent",
+        "status": "deferred",
+        "priority": "P0",
+        "archive_state": "active",
+        "source_section": TODO_SECTION_HEADINGS["agent"],
+        "task_class": "continuous_monitor",
+        "action_kind": "monitor",
+        "task_domain": "control_plane",
+        "task_repository": "loopx",
+        "continuation_policy": "continue_goal",
+        "claimed_by": "agent-a",
+        "excluded_agents": ["agent-b"],
+        "resume_when": "material_change",
+        "resume_ready": False,
+        "cadence": "weekly",
+        "next_due_at": "2026-09-07T09:00:00+08:00",
+        "expires_at": "2026-10-01T00:00:00+08:00",
+        "watch_only": True,
+        "material_change": False,
+        "material_change_generation": 4,
+        "consecutive_no_change": 2,
+        "max_no_change_before_replan": 3,
+        "successor_todo_ids": ["todo_successor"],
+        "note": "keep operator context",
+        "evidence": "semantic fixture evidence",
+        "updated_at": "2026-09-04T10:00:00+08:00",
+    }
+    successor = {
+        "schema_version": "todo_item_v0",
+        "index": 8,
+        "done": True,
+        "text": "Preserve completion semantics",
+        "title": "Completion evidence",
+        "todo_id": "todo_successor",
+        "role": "agent",
+        "status": "done",
+        "priority": "P1",
+        "archive_state": "active",
+        "source_section": TODO_SECTION_HEADINGS["agent"],
+        "completion_continuation": "no_followup",
+        "completed_at": "2026-09-03T18:00:00+08:00",
+        "completion_turn_key": "turn-complete",
+    }
+    projection = build_todo_runtime_shadow_projection(
+        goal_id="goal-a",
+        todos=[complex_todo, successor],
+    )
+    canonical_bytes = json.dumps(
+        projection,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    projection_sha256 = hashlib.sha256(canonical_bytes).hexdigest()
+
+    bootstrap = effect_runtime_result(
+        "coordination.runtime_shadow.bootstrap",
+        {
+            "schema_version": "loopx_coordination_runtime_shadow_bootstrap_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": "goal-a",
+            "operation_id": "bootstrap:goal-a:complex",
+            "source_version": "state:complex:0",
+            "projection": projection,
+        },
+    )
+    assert bootstrap["status"] == "applied"
+    mirrored = effect_runtime_result(
+        "coordination.runtime_shadow.commit",
+        {
+            "schema_version": "loopx_coordination_runtime_shadow_commit_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": "goal-a",
+            "operation_id": "todo:goal-a:complex:qualify",
+            "event_kind": "todo_update",
+            "source_version": "state:complex:1",
+            "projection": projection,
+        },
+    )
+    assert mirrored["status"] == "applied"
+    provider_revision = str(mirrored["provider_revision"])
+    fence = {
+        "schema_version": "loopx_legacy_coordination_writer_fence_v0",
+        "state": "engaged",
+        "goal_id": "goal-a",
+        "fence_id": "legacy-writer-fence:goal-a:complex",
+        "source_version": "state:complex:1",
+        "source_projection_sha256": projection_sha256,
+        "expected_shadow_provider_revision": provider_revision,
+    }
+    engaged = effect_runtime_result(
+        "coordination.local_authority.legacy_writer_fence.engage",
+        {
+            "schema_version": "loopx_legacy_coordination_writer_fence_engage_request_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": "goal-a",
+            "fence": fence,
+        },
+    )
+    assert engaged["status"] == "applied"
+    promoted = effect_runtime_result(
+        "coordination.local_authority.promote",
+        {
+            "schema_version": "loopx_local_coordination_promotion_request_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": "goal-a",
+            "operation_id": "promote:goal-a:complex",
+            "expected_shadow_provider_revision": provider_revision,
+            "expected_shadow_projection_sha256": projection_sha256,
+            "minimum_operations": 1,
+            "required_event_kinds": ["todo_update"],
+            "writer_fence": fence,
+        },
+    )
+    assert promoted["status"] == "applied"
+
+    state_file.unlink()
+    result = list_goal_todos(registry_path=registry_path, goal_id="goal-a")
+    by_id = {item["todo_id"]: item for item in result["todos"]}
+    for field in (
+        "text",
+        "title",
+        "priority",
+        "source_section",
+        "archive_state",
+        "continuation_policy",
+        "resume_when",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+        "watch_only",
+        "material_change_generation",
+        "successor_todo_ids",
+        "note",
+        "evidence",
+    ):
+        assert by_id["todo_complex"][field] == complex_todo[field]
+    assert by_id["todo_successor"]["completed_at"] == successor["completed_at"]
+    assert by_id["todo_successor"]["completion_continuation"] == "no_followup"
+    assert result["authority_read"]["todo_read_model"]["todo_count"] == 2

--- a/tests/control_plane_ts/coordination_projection.test.ts
+++ b/tests/control_plane_ts/coordination_projection.test.ts
@@ -8,12 +8,16 @@ import type {
   AuthorityStoreCommit,
   AuthorityStoreCommitResult,
 } from "../../loopx/control_plane/coordination/authority_store.ts";
+import { canonicalAuthoritySha256 } from "../../loopx/control_plane/coordination/authority_store_codec.ts";
+import type { JsonObject } from "../../loopx/control_plane/effect_program.ts";
 import {
   commitCoordinationProjectionMutation,
   indexCoordinationProjection,
   indexCoordinationProjectionTodos,
   prepareCoordinationProjectionCommit,
   reduceCoordinationProjection,
+  TODO_CANONICAL_READ_RECORD_FIELDS,
+  TODO_CANONICAL_READ_RECORD_SCHEMA,
 } from "../../loopx/control_plane/coordination/coordination_projection.ts";
 import { FileAuthorityStore } from "../../loopx/control_plane/coordination/file_authority_store.ts";
 
@@ -137,6 +141,89 @@ test("coordination projection reducer fails closed on partial or invalid batches
     ]),
     /more than once/,
   );
+});
+
+test("canonical Todo mutation rejects a replacement that drops existing consumer fields", () => {
+  const todo = {
+    schema_version: "todo_item_v0",
+    todo_id: "todo_a",
+    role: "agent",
+    status: "open",
+    done: false,
+    text: "Qualify provider cutover",
+    archive_state: "active",
+    source_section: "Agent Todo",
+    priority: "P0",
+    title: "Provider cutover",
+    resume_when: "material_change:todo_monitor",
+    evidence: "receipt:cqr_example",
+  };
+  const projection = {
+    goal_id: "goal-a",
+    todos: [todo],
+    leases: [],
+    todo_read_model: {
+      schema_version: TODO_CANONICAL_READ_RECORD_SCHEMA,
+      todo_count: 1,
+      records_sha256: canonicalAuthoritySha256([todo]),
+      contract_fields: [...TODO_CANONICAL_READ_RECORD_FIELDS],
+    },
+  };
+
+  assert.throws(
+    () => reduceCoordinationProjection(projection, "goal-a", [{
+      kind: "todo_upsert",
+      todo: {
+        schema_version: "todo_item_v0",
+        todo_id: "todo_a",
+        role: "agent",
+        status: "done",
+        done: true,
+        text: "Qualify provider cutover",
+        archive_state: "active",
+        source_section: "Agent Todo",
+      },
+    }]),
+    /omits existing fields: evidence, priority, resume_when, title/,
+  );
+
+  const reduced = reduceCoordinationProjection(projection, "goal-a", [{
+    kind: "todo_upsert",
+    todo: { ...todo, status: "done", done: true },
+  }]);
+  assert.deepEqual((reduced.todos as JsonObject[])[0], {
+    ...todo,
+    status: "done",
+    done: true,
+  });
+
+  const explicitlyCleared = reduceCoordinationProjection(projection, "goal-a", [{
+    kind: "todo_upsert",
+    todo: { ...todo, resume_when: null, evidence: null },
+  }]);
+  assert.deepEqual((explicitlyCleared.todos as JsonObject[])[0], {
+    ...todo,
+    resume_when: null,
+    evidence: null,
+  });
+
+  const inserted = reduceCoordinationProjection(projection, "goal-a", [{
+    kind: "todo_upsert",
+    todo: {
+      schema_version: "todo_item_v0",
+      todo_id: "todo_b",
+      role: "agent",
+      status: "open",
+      done: false,
+      text: "Review cutover evidence",
+      archive_state: "active",
+      source_section: "Agent Todo",
+    },
+  }]);
+  assert.deepEqual((inserted.todos as JsonObject[]).map((record) => record.todo_id), [
+    "todo_a",
+    "todo_b",
+  ]);
 });
 
 test("coordination projection commit derives one auditable atomic transaction", () => {

--- a/tests/control_plane_ts/coordination_runtime_shadow.test.ts
+++ b/tests/control_plane_ts/coordination_runtime_shadow.test.ts
@@ -1,8 +1,14 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { mkdtemp, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
+import { canonicalAuthorityBytes } from "../../loopx/control_plane/coordination/authority_store_codec.ts";
+import {
+  TODO_CANONICAL_READ_RECORD_FIELDS,
+  TODO_CANONICAL_READ_RECORD_SCHEMA,
+} from "../../loopx/control_plane/coordination/coordination_projection.ts";
 
 import type {
   AuthorityStoreCommit,
@@ -27,6 +33,19 @@ import {
   COORDINATION_RUNTIME_SHADOW_ROLLBACK_REQUEST_SCHEMA,
 } from "../../loopx/control_plane/coordination/runtime_shadow.ts";
 
+function withTodoReadModel<T extends Record<string, unknown>>(projection: T): T {
+  const todos = projection.todos as Record<string, unknown>[];
+  return {
+    ...projection,
+    todo_read_model: {
+      schema_version: TODO_CANONICAL_READ_RECORD_SCHEMA,
+      todo_count: todos.length,
+      records_sha256: createHash("sha256").update(canonicalAuthorityBytes(todos)).digest("hex"),
+      contract_fields: [...TODO_CANONICAL_READ_RECORD_FIELDS],
+    },
+  };
+}
+
 async function request(root: string, operationId = "todo:goal-a:todo_one:v1") {
   return {
     schema_version: COORDINATION_RUNTIME_SHADOW_REQUEST_SCHEMA,
@@ -35,12 +54,22 @@ async function request(root: string, operationId = "todo:goal-a:todo_one:v1") {
     operation_id: operationId,
     event_kind: "todo_claim",
     source_version: "state:1",
-    projection: {
+    projection: withTodoReadModel({
       schema_version: "loopx_coordination_shadow_projection_v0",
       goal_id: "goal-a",
-      todos: [{ todo_id: "todo_one", status: "open", claimed_by: "agent-a" }],
+      todos: [{
+        schema_version: "todo_item_v0",
+        todo_id: "todo_one",
+        role: "agent",
+        status: "open",
+        done: false,
+        text: "Qualify shadow semantics",
+        archive_state: "active",
+        source_section: "Agent Todo",
+        claimed_by: "agent-a",
+      }],
       leases: [],
-    },
+    }),
   };
 }
 

--- a/tests/control_plane_ts/local_authority_runtime.test.ts
+++ b/tests/control_plane_ts/local_authority_runtime.test.ts
@@ -196,6 +196,39 @@ test("explicit local promotion requires qualified shadow and creates replayable 
   });
   assert.equal(advanced.status, "applied");
 
+  const partialReplacement = await mutateLocalCoordinationAuthority({
+    schema_version: LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+    operation_id: "todo:goal-a:todo_a:partial-after-promotion",
+    expected_provider_revision: advanced.provider_revision,
+    mutations: [{
+      kind: "todo_upsert",
+      todo: {
+        schema_version: "todo_item_v0",
+        todo_id: "todo_a",
+        role: "agent",
+        status: "done",
+        done: true,
+        text: "Qualify canonical Todo semantics",
+        archive_state: "active",
+        source_section: "Agent Todo",
+      },
+    }],
+  });
+  assert.equal(partialReplacement.status, "failed");
+  assert.equal(partialReplacement.reason_code, "invalid_coordination_mutation");
+  assert.match(String(partialReplacement.reason ?? ""), /omits existing fields: claimed_by/);
+  const unchanged = await readLocalCoordinationTodo({
+    schema_version: LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+    todo_id: "todo_a",
+  });
+  assert.equal(unchanged.status, "found");
+  assert.equal((unchanged.todo as Record<string, unknown>).claimed_by, "agent-a");
+  assert.equal((unchanged.todo as Record<string, unknown>).status, "in_progress");
+
   const replayed = await promoteLocalCoordinationAuthority(request);
   assert.equal(replayed.status, "replayed");
   assert.equal(replayed.provider_revision, applied.provider_revision);

--- a/tests/control_plane_ts/local_authority_runtime.test.ts
+++ b/tests/control_plane_ts/local_authority_runtime.test.ts
@@ -11,6 +11,8 @@ import {
   LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA,
   LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA,
   LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+  listLocalCoordinationTodos,
   mutateLocalCoordinationAuthority,
   promoteLocalCoordinationAuthority,
   readLocalCoordinationTodo,
@@ -266,6 +268,17 @@ test("local canonical runtime reads and mutates only the provider head", async (
     todo_id: "todo_a",
   });
   assert.equal((after.todo as Record<string, unknown>).claimed_by, "agent-a");
+
+  const listed = await listLocalCoordinationTodos({
+    schema_version: LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+  });
+  assert.equal(listed.status, "loaded");
+  assert.deepEqual(listed.todo_ids, ["todo_a"]);
+  assert.equal((listed.todos as Record<string, unknown>[])[0]?.claimed_by, "agent-a");
+  assert.equal(listed.decision_read_from_provider, true);
+  assert.equal(listed.legacy_fallback_used, false);
 });
 
 test("local canonical runtime never falls back when provider state is missing", async () => {

--- a/tests/control_plane_ts/local_authority_runtime.test.ts
+++ b/tests/control_plane_ts/local_authority_runtime.test.ts
@@ -8,6 +8,10 @@ import test from "node:test";
 import { FileAuthorityStore } from "../../loopx/control_plane/coordination/file_authority_store.ts";
 import { canonicalAuthorityBytes } from "../../loopx/control_plane/coordination/authority_store_codec.ts";
 import {
+  TODO_CANONICAL_READ_RECORD_FIELDS,
+  TODO_CANONICAL_READ_RECORD_SCHEMA,
+} from "../../loopx/control_plane/coordination/coordination_projection.ts";
+import {
   LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA,
   LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA,
   LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA,
@@ -40,12 +44,39 @@ function sha256(value: unknown): string {
   return createHash("sha256").update(canonicalAuthorityBytes(value)).digest("hex");
 }
 
-async function qualifiedShadow(root: string) {
-  const baseline = {
-    goal_id: "goal-a",
-    todos: [{ todo_id: "todo_a", status: "open" }],
-    leases: [],
+function withTodoReadModel<T extends Record<string, unknown>>(projection: T): T {
+  const todos = projection.todos as Record<string, unknown>[];
+  return {
+    ...projection,
+    todo_read_model: {
+      schema_version: TODO_CANONICAL_READ_RECORD_SCHEMA,
+      todo_count: todos.length,
+      records_sha256: sha256(todos),
+      contract_fields: [...TODO_CANONICAL_READ_RECORD_FIELDS],
+    },
   };
+}
+
+function todoRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema_version: "todo_item_v0",
+    todo_id: "todo_a",
+    role: "agent",
+    status: "open",
+    done: false,
+    text: "Qualify canonical Todo semantics",
+    archive_state: "active",
+    source_section: "Agent Todo",
+    ...overrides,
+  };
+}
+
+async function qualifiedShadow(root: string) {
+  const baseline = withTodoReadModel({
+    goal_id: "goal-a",
+    todos: [todoRecord()],
+    leases: [],
+  });
   const bootstrapped = await bootstrapCoordinationRuntimeShadow({
     schema_version: COORDINATION_RUNTIME_SHADOW_BOOTSTRAP_REQUEST_SCHEMA,
     runtime_root: root,
@@ -55,10 +86,10 @@ async function qualifiedShadow(root: string) {
     projection: baseline,
   });
   assert.equal(bootstrapped.status, "applied");
-  const projection = {
+  const projection = withTodoReadModel({
     ...baseline,
-    todos: [{ todo_id: "todo_a", status: "open", claimed_by: "agent-a" }],
-  };
+    todos: [todoRecord({ claimed_by: "agent-a" })],
+  });
   const mirrored = await commitCoordinationRuntimeShadow({
     schema_version: COORDINATION_RUNTIME_SHADOW_REQUEST_SCHEMA,
     runtime_root: root,
@@ -160,7 +191,7 @@ test("explicit local promotion requires qualified shadow and creates replayable 
     expected_provider_revision: applied.provider_revision,
     mutations: [{
       kind: "todo_upsert",
-      todo: { todo_id: "todo_a", status: "in_progress", claimed_by: "agent-a" },
+      todo: todoRecord({ status: "in_progress", claimed_by: "agent-a" }),
     }],
   });
   assert.equal(advanced.status, "applied");
@@ -218,6 +249,57 @@ test("local promotion fences shadow revision, digest, and writer-fence identity"
   assert.equal((await canonical.loadAuthority()).status, "missing");
 });
 
+test("promotion and provider list fail closed without exact Todo consumer semantics", async () => {
+  const root = await mkdtemp(join(tmpdir(), "loopx-local-authority-semantic-fence-"));
+  const incomplete = {
+    goal_id: "goal-a",
+    todos: [{ todo_id: "todo_a", role: "agent", status: "open" }],
+    leases: [],
+  };
+  const bootstrapped = await bootstrapCoordinationRuntimeShadow({
+    schema_version: COORDINATION_RUNTIME_SHADOW_BOOTSTRAP_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+    operation_id: "bootstrap:goal-a:incomplete",
+    source_version: "state:0",
+    projection: incomplete,
+  });
+  assert.equal(bootstrapped.status, "applied");
+  const mirrored = await commitCoordinationRuntimeShadow({
+    schema_version: COORDINATION_RUNTIME_SHADOW_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+    operation_id: "todo:goal-a:incomplete",
+    event_kind: "todo_update",
+    source_version: "state:1",
+    projection: incomplete,
+  });
+  assert.equal(mirrored.status, "applied");
+  const request = promotionRequest(root, incomplete, String(mirrored.provider_revision));
+  request.required_event_kinds = ["todo_update"];
+  await engageFence(request);
+  const rejected = await promoteLocalCoordinationAuthority(request);
+  assert.equal(rejected.status, "failed");
+  assert.equal(rejected.reason_code, "local_authority_shadow_not_qualified");
+
+  const canonical = new FileAuthorityStore(join(root, "authority", "file-v0"), "goal-a");
+  const committed = await canonical.commitAuthority({
+    expected_provider_revision: null,
+    operation_id: "unsafe:test-only",
+    events: [{ schema_version: "test_v0" }],
+    next_projection: incomplete,
+    receipts: [],
+  });
+  assert.equal(committed.status, "applied");
+  const listed = await listLocalCoordinationTodos({
+    schema_version: LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+  });
+  assert.equal(listed.status, "failed");
+  assert.equal(listed.reason_code, "invalid_local_coordination_todo_list_request");
+});
+
 test("local canonical runtime reads and mutates only the provider head", async () => {
   const root = await mkdtemp(join(tmpdir(), "loopx-local-authority-runtime-"));
   const store = new FileAuthorityStore(join(root, "authority", "file-v0"), "goal-a");
@@ -225,12 +307,12 @@ test("local canonical runtime reads and mutates only the provider head", async (
     expected_provider_revision: null,
     operation_id: "promote:goal-a",
     events: [{ schema_version: "promotion_v0" }],
-    next_projection: {
+    next_projection: withTodoReadModel({
       goal_id: "goal-a",
       source_authority: "file_v0",
-      todos: [{ todo_id: "todo_a", status: "open" }],
+      todos: [todoRecord()],
       leases: [],
-    },
+    }),
     receipts: [],
   });
   assert.equal(initial.status, "applied");
@@ -254,7 +336,7 @@ test("local canonical runtime reads and mutates only the provider head", async (
     expected_provider_revision: initial.provider_revision,
     mutations: [{
       kind: "todo_upsert",
-      todo: { todo_id: "todo_a", status: "open", claimed_by: "agent-a" },
+      todo: todoRecord({ claimed_by: "agent-a" }),
     }],
   });
   assert.equal(mutation.status, "applied");


### PR DESCRIPTION
## Summary

- add a TypeScript-owned provider-first Todo collection read over `FileAuthorityStore`
- route `loopx todo list` to the canonical file authority only after the durable promotion fence is present
- fail closed when provider state, ordering, schema, field contract, count, digest, or required Todo semantics drift; never fall back to Markdown after promotion
- preserve the existing Markdown/event projection behavior before promotion
- route canonical and legacy records through the same Todo filtering, ordering, visibility, resume, and summary pipeline
- remove the duplicated legacy projection selector from `local_authority.py` and keep `todos.py` focused on authority selection

## Review blocker resolution

The promoted projection now persists the complete canonical Todo list read record rather than the earlier identity-only coordination subset. Each exact provider revision carries a versioned `todo_read_model` receipt with its field contract, record count, and canonical SHA-256 digest.

Validation is independent at the critical boundaries:

- Python refuses to build a canonical shadow projection from an incomplete or semantically invalid Todo record.
- TypeScript validates the receipt during runtime-shadow qualification, promotion, exact/collection reads, and provider-first mutation preparation.
- Provider-first mutations regenerate the receipt atomically with the next head and reject a truncated replacement record before commit.
- The production regression traverses builder → runtime shadow → mirrored operation → writer fence → promotion → Markdown removal → `list_goal_todos`, then verifies text, title, priority, source/archive state, continuation/resume, cadence/due/watch state, material generation, successor, note/evidence, and completion fields.

## Real complex-Goal qualification

A local, read-only qualification used the real `loopx-meta` Todo projection without changing its authority and without publishing Todo content:

- 312 Todo records at qualification time
- source and provider canonical record digests matched exactly
- 15/15 consumer slices matched: full list, user/agent roles, open/done/blocked/deferred statuses, and eight agent-visibility views
- 16/16 semantic field families had real coverage, including scheduling, continuation, monitor, archival, evidence, and completion data
- provider-only reads remained equivalent after the temporary qualification copy of Markdown was unavailable

Only redacted counts and coverage are reported here; the local qualification script, paths, raw records, and Goal content are not part of this PR.

## RFC

The English and Chinese RFCs now state that structural/head-digest parity is insufficient for promotion. A real Goal must pass exact-revision consumer-pipeline parity, new consumer fields require a versioned contract update and requalification, synthetic stubs cannot substitute for the real qualification, and public evidence must remain redacted.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 493 passed, 1 skipped
- `python -m mypy` — repository-declared strict targets passed
- focused Python Todo/provider semantic suite — 48 passed
- repository-change-window + runtime-shadow environment qualification — 36 passed
- control-plane maintainability/M6 suite — 12 passed
- Ruff and changed-file Python compilation
- `npm run test:postgresql-authority-store` — 2 passed, 1 live integration skipped because `LOOPX_TEST_POSTGRES_URL` is not configured
- `loopx check` — all 16 changed public paths clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18 selected checks passed, no manual holds
- exact-scope change-quality receipt `cqr_39cb83620e06dcf45f97` — valid, fingerprint `39cb83620e06dcf45f97d3f300010ca4d1c24aad593204e9a5fbff0595fd8311`

## Boundaries

- This slice promotes Todo list reads only. Remaining provider-first lifecycle and claim/lease read promotion stays in later Stage 2C work.
- No local runtime state, credentials, private evidence, raw Goal content, generated logs, or local qualification artifacts are included.
