### PR TITLE
provider(routing): qualify recovery boundaries and outage-end revalidation

### DIFF
--- a/packages/loopx-codex-provider-routing/CONTRACT.md
+++ b/packages/loopx-codex-provider-routing/CONTRACT.md
@@ -18,6 +18,8 @@ Desktop patch qualification: `codex_desktop_patch_qualification_v0`
 
 Quota recovery qualification: `codex_quota_recovery_qualification_v0`
 
+Outage recovery qualification: `codex_outage_recovery_qualification_v0`
+
 Tool transport qualification: `codex_tool_transport_qualification_v0`
 
 The provider accepts exactly one public-safe operation per invocation and
@@ -112,6 +114,15 @@ invalidate it and probe that account before selecting a fallback. A fresh probe
 may either succeed or return a new quota limit; only the latter permits a new
 cooldown and fallback. This contract prevents a reset account from remaining
 unreachable until an obsolete expiry.
+
+An observed provider-incident end is ordered the same way. A cooldown created
+by incident errors (for example repeated 4xx/5xx across every native profile)
+is stale once a recovery signal newer than its source is observed. CPA must
+invalidate that cooldown, complete a bounded probe and revalidate any degraded
+fallback affinity before admitting a request that needs native capabilities.
+The fallback may keep serving text-only traffic only while the probe still
+reports an outage; a native-capability request must fail closed rather than
+travel through an unqualified fallback binding.
 
 Patched desktop builds have a separate post-build gate. The patch anchor must
 be unique for the current build, every changed ASAR member must have matching

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -83,6 +83,14 @@ qualification.
   bounded account probe before fallback is admitted; only a fresh quota-limited
   probe may create a replacement cooldown.
 
+`qualify_outage_recovery`
+: Orders the end of a provider-wide incident against the stale native cooldown
+  and degraded fallback affinity it created. A recovery signal newer than the
+  cooldown source must invalidate the cooldown, run a bounded probe and clear
+  or revalidate the fallback binding before a native-capability request is
+  admitted. Text-only traffic may remain on the fallback only while the probe
+  still reports an outage.
+
 `qualify_tool_transport`
 : Checks that a requested tool item type survives provider adaptation and that
   host dispatch completes. In particular, Code Mode `custom_tool_call` must not
@@ -142,6 +150,10 @@ loopx extension run loopx-codex-provider-routing \
   --execute \
   --format json
 loopx extension run loopx-codex-provider-routing \
+  --input-json packages/loopx-codex-provider-routing/examples/outage-recovery.json \
+  --execute \
+  --format json
+loopx extension run loopx-codex-provider-routing \
   --input-json packages/loopx-codex-provider-routing/examples/tool-transport.json \
   --execute \
   --format json
@@ -167,6 +179,7 @@ The earlier operator scripts split into three classes:
 | App/CPA model readback assertions | Migrated as the content-free `qualify_snapshot` contract |
 | Patched desktop ASAR/signature/launch checks | Migrated as `qualify_desktop_patch`; the effectful bundle patcher stays operator-owned |
 | Quota reset versus cached cooldown reconciliation | Migrated as `qualify_quota_recovery`; live cooldown invalidation and probing stay CPA-owned |
+| Provider incident end versus stale native cooldown and degraded fallback affinity | Migrated as `qualify_outage_recovery`; live invalidation, bounded probe and binding revalidation stay CPA-owned |
 | Ordered PR/patch candidate inventory and drift detection | Migrated as `reconcile_integration_candidate`; Git composition remains owned by LoopX core `integration-branch` |
 | Upgrade matrix, snapshot order and rollback triggers | Migrated as `upgrade_plan`; effect execution remains operator-owned |
 | CPA process launcher, OAuth login/reconcile, Ark key loading | Excluded; these are provider runtime and credential lifecycle, not LoopX state |

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -14,6 +14,7 @@ ports, accounts or private receipts.
 | Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
 | Verify a patched desktop runtime across versioned anchors, ASAR member/header integrity, signature, launch and heartbeat readback | Migrated as a read-only qualification | `qualify_desktop_patch`; patching, signing and process lifecycle remain operator-owned effects |
 | Invalidate a provider cooldown after a newer successful quota reset | Migrated as a recovery ordering contract | `qualify_quota_recovery`; CPA owns the live invalidation and bounded reprobe |
+| Invalidate incident cooldown and revalidate degraded fallback affinity after a provider-wide outage ends | Migrated as a recovery ordering contract | `qualify_outage_recovery`; CPA owns the live invalidation, bounded probe and binding revalidation |
 | Preserve Code Mode tool item shape across heterogeneous fallback | Migrated as admission plus qualification | profile `tool_transports`, `normalize_selector_request` and `qualify_tool_transport`; adapters must prove custom-item preservation before declaring support |
 | Reconcile an ordered multi-PR candidate against exact heads and required seams | Migrated as a public-safe planning contract | `reconcile_integration_candidate` returns core `integration-branch` inputs; Git effects remain outside the extension |
 | Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
@@ -49,6 +50,8 @@ The package keeps credential-free examples for every operation, including:
   signature, launch and heartbeat qualification;
 - [`examples/quota-recovery.json`](examples/quota-recovery.json): reset/cooldown
   ordering with bounded reprobe;
+- [`examples/outage-recovery.json`](examples/outage-recovery.json): incident-end
+  ordering with stale cooldown invalidation, bounded probe and affinity revalidation;
 - [`examples/tool-transport.json`](examples/tool-transport.json): requested and
   observed tool item transport plus dispatch outcome.
 

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -146,6 +146,7 @@ merge commit，并重新运行本文矩阵。
 | Codex App selector projection | 本机与 SSH App Server readback 通过 | `model/list` 暴露三组 Standard/Fast Sol 行、Luna、Ark 共八个可见 selector，并保留隐藏 `gpt-5.6-sol` 兼容 alias；C 不存在 |
 | 图片能力投影 | 正向 E2E 通过，Auto 负向路径有已复现缺口 | Auto、Prefer A、Prefer B、Luna 声明 `text + image`，Ark 保持 `text`；健康 A/B 下图片到达 Codex。A/B 失败后，当前 Auto affinity 可能错误粘到 Ark，尚未做到 modality-aware fail closed |
 | 模型切换快照 | 已复现设置落盘与新 turn 启动竞态 | UI 显示已选择 B 不足以证明正在运行或重试的 turn 已采用 B；旧 turn 可能继续携带 Auto 快照。需要 durable settings revision / readback 后再启动新 turn |
+| Provider incident 恢复 | 真实故障链已复现；in-memory restart 已恢复，待 CPA 固化 | incident 期间 Ark affinity 粘住后，Code Mode exec 以 incompatible payload 失败；恢复后必须先失效 incident cooldown、完成 bounded probe 并清 degraded affinity；Ark HTTP 200 不能作为 native 已恢复的证据 |
 | Fast tier 投影 | 本机与 SSH App Server readback 通过 | Auto、Prefer A、Prefer B 各有显式 `fast/` sibling 行，默认 tier 为 `fast` 并在请求规整时强制 `priority`；普通行与 Luna 保持 `default`，Fast 行不进入 Ark |
 | SSH CPA 远端 | reverse-loopback 与 App Server 通过 | 远端只连接 loopback tunnel，不保存本机 OAuth/Ark secret；同一 SSH alias 与同一远端 `CODEX_HOME` 可继续原 task，新建 task 不删除旧 session |
 | CPA upstream review | quota PR 已合并；四个分发 PR 等待 maintainer review | #5211 merge `ca601db0`；#5410 head `566da3b`、#5261 head `c8e76e1`、#5336 head `cc16e38`、#5435 head `6f16121` 的 CI 已通过 |
@@ -615,6 +616,28 @@ failover 队列前进；session affinity 随后粘到 text-only Ark；App 又对
 资格通过标准。AgentSwap 也不参与这条在线路径；它无法修复 settings race 或
 modality-blind affinity。
 
+### Provider incident 结束后的恢复边界
+
+2026-09-03 的公开 ChatGPT/Codex incident 暴露了一个与图片无关的等价失败链：
+
+1. native A/B 在 provider incident 中全部返回 4xx/5xx（`model_not_found` 或
+   `no healthy upstream`），CPA 因此把 session 粘到 text-only Ark tail；
+2. incident 结束、native 上游恢复后，Ark affinity 仍被当作普通 1h 亲和保留；
+   native 账号在 incident 中进入的 cooldown 也没有 half-open 探测；
+3. 文本请求经 Ark 返回 HTTP 200，看起来已经恢复，但需要 Code Mode
+   `custom_tool_call`（如 exec）的请求仍走 Ark，最终以 incompatible payload
+   失败；新的冷 session 又优先撞在已耗尽配额的 native 账号上。
+
+结论与图片路径一致：affinity 只是 hint，fallback binding 必须标记 degraded。
+一旦观察到晚于 cooldown 来源的 recovery signal，先失效 incident cooldown 并
+执行 bounded probe，再把 native-capability 请求重绑到 A/B。fallback 返回的
+HTTP 200 不能作为 native 已恢复的证据。
+
+`qualify_outage_recovery` 用 symbolic、content-free 观察固化这条恢复顺序；
+手工重启 in-memory runtime 只是 operator remedy，不是资格通过标准。要根治需要
+CPA 在在线 selector 中实现 incident 错误分类、恢复后自动失效/probe 与 degraded
+affinity 重绑，LoopX 只维护 contract 和验收门。
+
 ## 一键切模型时如何切轨迹
 
 “切轨迹”不应理解成修改或覆盖本地 rollout。安全的抽象是：一个逻辑 task 保留一份
@@ -777,17 +800,19 @@ in-band SSE error、客户端取消和 handler 自己补出的 lifecycle event�
 
 ## 运行时恢复与兼容门
 
-在把异构 provider 纳入自动 fallback 前，还要过三类独立恢复门。它们不能被“HTTP 200”
+在把异构 provider 纳入自动 fallback 前，还要过四类独立恢复门。它们不能被“HTTP 200”
 或“进程已经启动”替代：
 
 | 故障面 | 必须观察 | fail-closed 行为 |
 | --- | --- | --- |
 | 桌面补丁升级 | 当前构建只有一个已应用锚点；所有改动文件的 ASAR integrity 匹配；header digest 与 bundle metadata 匹配；签名、启动、heartbeat readback 均成功 | 停留在旧 runtime 或回滚，不把未知构建投入使用 |
 | quota reset | reset receipt 晚于 cooldown 来源；旧 cooldown 已失效；目标账号先完成一次 bounded probe | probe 前不得因旧 cooldown 直接选择 fallback；新 probe 明确 quota-limited 后才允许新 cooldown |
+| provider incident 结束 | recovery signal（官方状态恢复或 bounded probe success）晚于 cooldown 来源；旧 incident cooldown 已失效；目标账号先完成一次 bounded probe；degraded fallback affinity 已清或按能力重绑 | 未完成 probe 前不得继续 fallback；native-capability 请求（Code Mode `custom_tool_call`、图片、Fast）不得留在只支持文本的 degraded binding 上，无 eligible native 时 fail closed |
 | Code Mode 工具 | selector normalization 声明 `required_tool_transport=custom_tool_call`；实际响应仍为 `custom_tool_call`；host dispatch 完成 | function-only provider 在遍历前被过滤；适配层若降级 item type，qualification 失败 |
 
-这三类证据分别由 `qualify_desktop_patch`、`qualify_quota_recovery`、
-`qualify_tool_transport` 接收。它们只处理 symbolic、content-free observation。
+这四类证据分别由 `qualify_desktop_patch`、`qualify_quota_recovery`、
+`qualify_outage_recovery`、`qualify_tool_transport` 接收。它们只处理 symbolic、
+content-free observation。
 本机 bundle 路径、账号身份、task ID、原始日志、OAuth 和 reset token 都不得进入
 LoopX state 或公开 PR。
 
@@ -814,6 +839,7 @@ LoopX state 或公开 PR。
 | hidden bare alias | 旧 task 或跨 host metadata 使用 `gpt-5.6-sol` 时按 Auto 路由，不在 selector 重复显示 |
 | Auto / A / B 图片输入 | App admission 通过，图片实际到达 A/B；A/B 均不可用时明确失败，不降级为 Ark 文本请求 |
 | Auto affinity + 图片 + Codex 故障 | 每个 attempt 重算 required modalities；旧 Ark affinity 失效；A/B 无 eligible target 时首字节前返回 typed error |
+| Provider incident 结束 | recovery signal 晚于 cooldown 来源；incident cooldown 已失效；bounded probe 完成；degraded Ark affinity 不得用于 Code Mode / 图片 / Fast；text-only 只在 still-outage probe 后保留 |
 | Ark 图片输入 | App 或 provider 明确拒绝；不把 Ark catalog 伪装为 image-capable |
 | Fast selector rows | Auto/Prefer A/Prefer B 各有 Standard 与 Fast 行；普通行和 Luna 默认 `default`，Fast 行强制 `priority`；Fast A/B 都失败时不落 Ark |
 | Fast request normalization | 在 alias mapping 前捕获原始 `fast/` selector；剥离前缀后保持同一底层 route；普通 selector 的 model/tier 不被误改 |
@@ -835,7 +861,7 @@ LoopX state 或公开 PR。
 | Upstream | 计划 | 合并门槛 |
 | --- | --- | --- |
 | CPA | **公共分发 PR**：[history / SSE normalization #5410](https://github.com/router-for-me/CLIProxyAPI/pull/5410) head `566da3b`；[ChatGPT uTLS HTTP/2 连接复用与 TLS session resumption #5261](https://github.com/router-for-me/CLIProxyAPI/pull/5261) head `c8e76e1`；[route priority #5336](https://github.com/router-for-me/CLIProxyAPI/pull/5336) head `cc16e38`；[OpenAI-compatible bounded rate-limit waits #5435](https://github.com/router-for-me/CLIProxyAPI/pull/5435) head `6f16121` | 截至 2026-09-03，四者 CI 均通过并等待 review；self-use 锁定 integrated fork SHA，但不得把它表述为 upstream release |
-| CPA modality-aware Auto | **待提交公共 PR**：required-modality admission、affinity invalidation、无 eligible provider 的 typed error | 先用 text-only fallback + image history 复现；验证 A/B 正常、B 网络失败、A/B 全不可用与旧 Ark affinity 四类路径；不得把图片剥离后继续文本请求 |
+| CPA modality-aware Auto + incident recovery | **待提交公共 PR**：required-modality / required-tool-transport admission、affinity invalidation、incident 错误分类与恢复后自动失效/probe/重绑、无 eligible provider 的 typed error | 先用 text-only fallback + image history 与 2026-09-03 provider incident 恢复链复现；验证 A/B 正常、B 网络失败、A/B 全不可用、旧 Ark affinity 与官方故障结束后 stale cooldown 五类路径；不得把图片剥离后继续文本请求，也不得让 Code Mode exec 走 text-only degraded binding |
 | AgentSwap | **条件 PR**：只有 locked commit 的 Codex writer 不能保持 multipart tool-result 1:1，或需要 provider-neutral checkpoint export 时才提交 | round-trip test 先复现真实缺口；不增加在线 retry、模型选择或第二 data plane |
 | Codex App / App Server | **待验证上游 seam**：settings revision 持久化/readback 与 turn-start 原子顺序；compaction barrier 仍只需要 fork + navigate host hook | 新 turn 必须证明采用新 revision；旧 turn 的 retry 不得被 UI 显示伪装为新模型；hook 不获得 provider 路由、凭据或 LoopX authority |
 | CC Switch | 当前无 PR | 只保留 bootstrap、credential import、snapshot 和 rollback；不重新进入 per-turn 在线切换 |
@@ -863,9 +889,12 @@ commit 作为升级候选并重跑 qualification。#5261 已进入 integrated se
 5. **本机与 SSH selector（self-use 已完成）**：八个可见 selector、hidden bare alias、图片
    能力、逐行 tier 与 Fast request-normalizer contract 已在两端 App Server readback 通过；
    上游 release 升级仍要重启对应 App Server 并重复 readback。
-6. **多模态 Auto 负向路径（待修复）**：健康 A/B 的图片 E2E 已通过；modality-aware
-   affinity、A/B 全不可用时的 typed fail-closed，以及 settings revision / turn-start 竞态仍要
-   修复并重跑矩阵。在此之前不宣称 Auto 图片 failover 已完整资格化。
+6. **Provider incident 恢复与多模态 Auto 负向路径（待修复）**：健康 A/B 的图片
+   E2E 已通过；2026-09-03 incident 复现了 provider incident 结束后 stale
+   cooldown + degraded Ark affinity 的失败链。modality-aware affinity、incident
+   错误分类与恢复后自动失效/probe/重绑、A/B 全不可用时的 typed fail-closed，以及
+   settings revision / turn-start 竞态仍要修复并重跑矩阵。在此之前不宣称 Auto
+   failover 已完整资格化。
 7. **连接复用升级（self-use 已完成，上游待 review）**：#5261 已通过公共 CI 与 integrated
    self-use matrix，覆盖 HTTP/2 reuse、TLS resumed、draining transport close、异常重建和
    已提交输出不重放；上游合并后仍要以 merge commit 重新验证。

--- a/packages/loopx-codex-provider-routing/examples/outage-recovery.json
+++ b/packages/loopx-codex-provider-routing/examples/outage-recovery.json
@@ -1,0 +1,15 @@
+{
+  "operation": "qualify_outage_recovery",
+  "outage_recovery": {
+    "cooldown_expires_at": "2026-09-03T18:00:00Z",
+    "cooldown_invalidated": true,
+    "cooldown_source_observed_at": "2026-09-03T14:00:00Z",
+    "degraded_fallback_binding_cleared": true,
+    "fallback_attempted": false,
+    "native_capability_requested": true,
+    "outage_ended": true,
+    "outage_ended_observed_at": "2026-09-03T15:00:00Z",
+    "post_recovery_probe": "success"
+  },
+  "schema_version": "loopx_codex_provider_routing_request_v0"
+}

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.7.0"
+version = "0.8.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.7.0"
+version = "0.8.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/schemas/request.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/request.schema.json
@@ -7,6 +7,7 @@
         "operation": {
           "const": "qualify_heartbeat_transport"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "host_control_recovery": false,
         "integration": false,
@@ -27,6 +28,7 @@
         "operation": {
           "const": "qualify_host_control_recovery"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "integration": false,
@@ -47,6 +49,7 @@
         "operation": {
           "const": "reconcile_integration_candidate"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -67,6 +70,7 @@
         "operation": {
           "const": "project_runtime_status"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -87,6 +91,7 @@
         "operation": {
           "const": "compile_catalog"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -107,6 +112,7 @@
         "operation": {
           "const": "normalize_selector_request"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -127,6 +133,7 @@
         "operation": {
           "const": "qualify_snapshot"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -147,6 +154,7 @@
         "operation": {
           "const": "upgrade_plan"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -167,6 +175,7 @@
         "operation": {
           "const": "qualify_desktop_patch"
         },
+        "outage_recovery": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
         "integration": false,
@@ -187,6 +196,7 @@
         "operation": {
           "const": "qualify_quota_recovery"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -207,6 +217,7 @@
         "operation": {
           "const": "qualify_tool_transport"
         },
+        "outage_recovery": false,
         "desktop_patch": false,
         "heartbeat_transport": false,
         "host_control_recovery": false,
@@ -221,6 +232,27 @@
       "required": [
         "tool_transport"
       ]
+    },
+    {
+      "properties": {
+        "operation": {
+          "const": "qualify_outage_recovery"
+        },
+        "desktop_patch": false,
+        "heartbeat_transport": false,
+        "host_control_recovery": false,
+        "integration": false,
+        "normalization": false,
+        "quota_recovery": false,
+        "snapshot": false,
+        "source": false,
+        "status": false,
+        "tool_transport": false,
+        "upgrade": false
+      },
+      "required": [
+        "outage_recovery"
+      ]
     }
   ],
   "properties": {
@@ -231,6 +263,9 @@
       "type": "object"
     },
     "host_control_recovery": {
+      "type": "object"
+    },
+    "outage_recovery": {
       "type": "object"
     },
     "quota_recovery": {
@@ -247,6 +282,7 @@
         "qualify_desktop_patch",
         "qualify_heartbeat_transport",
         "qualify_host_control_recovery",
+        "qualify_outage_recovery",
         "qualify_quota_recovery",
         "qualify_snapshot",
         "qualify_tool_transport",

--- a/packages/loopx-codex-provider-routing/schemas/response.schema.json
+++ b/packages/loopx-codex-provider-routing/schemas/response.schema.json
@@ -48,6 +48,7 @@
         "qualify_desktop_patch",
         "qualify_heartbeat_transport",
         "qualify_host_control_recovery",
+        "qualify_outage_recovery",
         "qualify_quota_recovery",
         "qualify_snapshot",
         "qualify_tool_transport",

--- a/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
@@ -840,6 +840,7 @@ def main() -> int:
         "desktop-patch.json",
         "heartbeat-transport.json",
         "host-control-recovery.json",
+        "outage-recovery.json",
         "quota-recovery.json",
         "tool-transport.json",
         "integration-candidate.json",

--- a/packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(PACKAGE_ROOT / "src"))
 
 contract = importlib.import_module("loopx_codex_provider_routing.contract")
 qualify_desktop_patch = contract.qualify_desktop_patch
+qualify_outage_recovery = contract.qualify_outage_recovery
 qualify_quota_recovery = contract.qualify_quota_recovery
 qualify_tool_transport = contract.qualify_tool_transport
 
@@ -48,6 +49,45 @@ def main() -> int:
         "desktop_launch_failed",
         "heartbeat_transport_readback_failed",
     } <= set(stale_asar["failure_codes"])
+
+    outage_recovery = qualify_outage_recovery(
+        {
+            "outage_ended": True,
+            "outage_ended_observed_at": "2026-09-03T16:00:00Z",
+            "cooldown_source_observed_at": "2026-09-03T14:50:00Z",
+            "cooldown_expires_at": "2026-09-03T18:50:00Z",
+            "cooldown_invalidated": True,
+            "post_recovery_probe": "success",
+            "degraded_fallback_binding_cleared": True,
+            "native_capability_requested": True,
+            "fallback_attempted": False,
+        }
+    )
+    assert outage_recovery["qualified"] is True
+    assert outage_recovery["expected_action"] == (
+        "invalidate_cooldown_and_revalidate_affinity"
+    )
+
+    stale_outage_state = qualify_outage_recovery(
+        {
+            "outage_ended": True,
+            "outage_ended_observed_at": "2026-09-03T16:00:00Z",
+            "cooldown_source_observed_at": "2026-09-03T14:50:00Z",
+            "cooldown_expires_at": "2026-09-03T18:50:00Z",
+            "cooldown_invalidated": False,
+            "post_recovery_probe": "not_attempted",
+            "degraded_fallback_binding_cleared": False,
+            "native_capability_requested": True,
+            "fallback_attempted": True,
+        }
+    )
+    assert stale_outage_state["qualified"] is False
+    assert set(stale_outage_state["failure_codes"]) == {
+        "stale_outage_cooldown_retained",
+        "recovery_probe_missing",
+        "fallback_selected_after_recovery_probe",
+        "degraded_fallback_binding_used_for_native_request",
+    }
 
     quota_recovery = qualify_quota_recovery(
         {

--- a/packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
@@ -89,6 +89,24 @@ def main() -> int:
         "degraded_fallback_binding_used_for_native_request",
     }
 
+    ongoing_outage_native_fallback = qualify_outage_recovery(
+        {
+            "outage_ended": False,
+            "outage_ended_observed_at": None,
+            "cooldown_source_observed_at": "2026-09-03T14:50:00Z",
+            "cooldown_expires_at": "2026-09-03T18:50:00Z",
+            "cooldown_invalidated": False,
+            "post_recovery_probe": "not_attempted",
+            "degraded_fallback_binding_cleared": False,
+            "native_capability_requested": True,
+            "fallback_attempted": True,
+        }
+    )
+    assert ongoing_outage_native_fallback["qualified"] is False
+    assert ongoing_outage_native_fallback["failure_codes"] == [
+        "degraded_fallback_binding_used_for_native_request"
+    ]
+
     quota_recovery = qualify_quota_recovery(
         {
             "reset_outcome": "applied",

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/cli.py
@@ -16,6 +16,7 @@ from .contract import (
     qualify_desktop_patch,
     qualify_heartbeat_transport,
     qualify_host_control_recovery,
+    qualify_outage_recovery,
     qualify_quota_recovery,
     qualify_snapshot,
     qualify_tool_transport,
@@ -53,6 +54,7 @@ def _doctor() -> int:
                 "qualify_desktop_patch",
                 "qualify_heartbeat_transport",
                 "qualify_host_control_recovery",
+                "qualify_outage_recovery",
                 "qualify_quota_recovery",
                 "qualify_snapshot",
                 "qualify_tool_transport",
@@ -79,6 +81,7 @@ def _run_request(request: Any) -> dict[str, Any]:
         "qualify_desktop_patch": "desktop_patch",
         "qualify_heartbeat_transport": "heartbeat_transport",
         "qualify_host_control_recovery": "host_control_recovery",
+        "qualify_outage_recovery": "outage_recovery",
         "qualify_quota_recovery": "quota_recovery",
         "qualify_snapshot": "snapshot",
         "qualify_tool_transport": "tool_transport",
@@ -129,6 +132,13 @@ def _run_request(request: Any) -> dict[str, Any]:
                 "qualify_host_control_recovery requires object `host_control_recovery`"
             )
         result = qualify_host_control_recovery(host_control_recovery)
+    elif operation == "qualify_outage_recovery":
+        outage_recovery = request.get("outage_recovery")
+        if not isinstance(outage_recovery, Mapping):
+            raise ValueError(
+                "qualify_outage_recovery requires object `outage_recovery`"
+            )
+        result = qualify_outage_recovery(outage_recovery)
     elif operation == "qualify_quota_recovery":
         quota_recovery = request.get("quota_recovery")
         if not isinstance(quota_recovery, Mapping):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -16,6 +16,7 @@ HOST_CONTROL_RECOVERY_SCHEMA_VERSION = "codex_host_control_recovery_qualificatio
 DESKTOP_PATCH_SCHEMA_VERSION = "codex_desktop_patch_qualification_v0"
 QUOTA_RECOVERY_SCHEMA_VERSION = "codex_quota_recovery_qualification_v0"
 TOOL_TRANSPORT_SCHEMA_VERSION = "codex_tool_transport_qualification_v0"
+OUTAGE_RECOVERY_SCHEMA_VERSION = "codex_outage_recovery_qualification_v0"
 
 RECOVERABLE_HOST_CONTROL_NAMES = {
     "automation_update",
@@ -236,6 +237,132 @@ def qualify_desktop_patch(observation: Mapping[str, Any]) -> dict[str, Any]:
             "read_back_heartbeat_transport",
         ],
         "responsible_layer": "codex_desktop_runtime_builder",
+        "effect_boundary": "content_free_observation_only",
+    }
+
+
+def qualify_outage_recovery(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Qualify state transitions after a provider-wide outage ends.
+
+    A provider incident (for example repeated 4xx/5xx across every native
+    profile) creates two kinds of state: a cooldown on native profiles and a
+    degraded affinity to a text-only fallback. Once a recovery signal newer
+    than the cooldown source is observed, both must be revalidated before a
+    request that needs native capabilities is admitted.
+    """
+
+    reject_private_material(observation)
+    _reject_unexpected_keys(
+        observation,
+        {
+            "outage_ended",
+            "outage_ended_observed_at",
+            "cooldown_source_observed_at",
+            "cooldown_expires_at",
+            "cooldown_invalidated",
+            "post_recovery_probe",
+            "degraded_fallback_binding_cleared",
+            "native_capability_requested",
+            "fallback_attempted",
+        },
+        "outage_recovery",
+    )
+    outage_ended = _boolean(
+        observation.get("outage_ended"), "outage_recovery.outage_ended"
+    )
+    cooldown_source_at = _utc_datetime(
+        observation.get("cooldown_source_observed_at"),
+        "outage_recovery.cooldown_source_observed_at",
+    )
+    cooldown_expires_at = _utc_datetime(
+        observation.get("cooldown_expires_at"),
+        "outage_recovery.cooldown_expires_at",
+    )
+    if cooldown_expires_at <= cooldown_source_at:
+        raise ValueError("outage_recovery cooldown expiry must follow its source")
+    invalidated = _boolean(
+        observation.get("cooldown_invalidated"),
+        "outage_recovery.cooldown_invalidated",
+    )
+    probe = _non_empty_string(
+        observation.get("post_recovery_probe"),
+        "outage_recovery.post_recovery_probe",
+    )
+    if probe not in {"not_attempted", "success", "still_outage", "transport_failed"}:
+        raise ValueError("outage_recovery.post_recovery_probe is unsupported")
+    degraded_cleared = _boolean(
+        observation.get("degraded_fallback_binding_cleared"),
+        "outage_recovery.degraded_fallback_binding_cleared",
+    )
+    native_requested = _boolean(
+        observation.get("native_capability_requested"),
+        "outage_recovery.native_capability_requested",
+    )
+    fallback_attempted = _boolean(
+        observation.get("fallback_attempted"),
+        "outage_recovery.fallback_attempted",
+    )
+
+    if outage_ended:
+        outage_ended_at = _utc_datetime(
+            observation.get("outage_ended_observed_at"),
+            "outage_recovery.outage_ended_observed_at",
+        )
+        if outage_ended_at <= cooldown_source_at:
+            raise ValueError("outage end must follow the cooldown source")
+        checks = [
+            {
+                "id": "stale_cooldown_invalidated",
+                "passed": invalidated,
+                "failure_code": "stale_outage_cooldown_retained",
+            },
+            {
+                "id": "recovery_probe_performed",
+                "passed": probe in {"success", "still_outage"},
+                "failure_code": "recovery_probe_missing",
+            },
+            {
+                "id": "fallback_gated_by_probe",
+                "passed": not fallback_attempted or probe == "still_outage",
+                "failure_code": "fallback_selected_after_recovery_probe",
+            },
+            {
+                "id": "degraded_binding_not_used_for_native",
+                "passed": not native_requested
+                or (
+                    degraded_cleared
+                    and not (fallback_attempted and probe == "still_outage")
+                ),
+                "failure_code": "degraded_fallback_binding_used_for_native_request",
+            },
+        ]
+        expected_action = "invalidate_cooldown_and_revalidate_affinity"
+    else:
+        checks = [
+            {
+                "id": "cooldown_retained_without_outage_end",
+                "passed": not invalidated,
+                "failure_code": "cooldown_invalidated_without_outage_end",
+            }
+        ]
+        expected_action = "retain_cooldown_until_recovery_observed"
+    failure_codes = [check["failure_code"] for check in checks if not check["passed"]]
+    return {
+        "schema_version": OUTAGE_RECOVERY_SCHEMA_VERSION,
+        "qualified": not failure_codes,
+        "failure_codes": failure_codes,
+        "outage_ended": outage_ended,
+        "expected_action": expected_action,
+        "checks": checks,
+        "required_contract": {
+            "incident_cooldown": "outage_end_newer_than_source_invalidates_cooldown",
+            "recovery_gate": "bounded_probe_before_fallback_admission",
+            "degraded_affinity": (
+                "fallback_binding_revalidated_before_native_capability_request"
+            ),
+            "native_capability": "fail_closed_when_no_eligible_native_provider",
+        },
+        "responsible_layer": "cpa_provider_health_state_and_selector",
         "effect_boundary": "content_free_observation_only",
     }
 

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -326,15 +326,6 @@ def qualify_outage_recovery(observation: Mapping[str, Any]) -> dict[str, Any]:
                 "passed": not fallback_attempted or probe == "still_outage",
                 "failure_code": "fallback_selected_after_recovery_probe",
             },
-            {
-                "id": "degraded_binding_not_used_for_native",
-                "passed": not native_requested
-                or (
-                    degraded_cleared
-                    and not (fallback_attempted and probe == "still_outage")
-                ),
-                "failure_code": "degraded_fallback_binding_used_for_native_request",
-            },
         ]
         expected_action = "invalidate_cooldown_and_revalidate_affinity"
     else:
@@ -346,6 +337,17 @@ def qualify_outage_recovery(observation: Mapping[str, Any]) -> dict[str, Any]:
             }
         ]
         expected_action = "retain_cooldown_until_recovery_observed"
+    checks.append(
+        {
+            "id": "degraded_binding_not_used_for_native",
+            "passed": not native_requested
+            or (
+                not fallback_attempted
+                and (not outage_ended or degraded_cleared)
+            ),
+            "failure_code": "degraded_fallback_binding_used_for_native_request",
+        }
+    )
     failure_codes = [check["failure_code"] for check in checks if not check["passed"]]
     return {
         "schema_version": OUTAGE_RECOVERY_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary

Extends the optional `loopx-codex-provider-routing` extension with a content-free outage-recovery qualification contract.

After a provider-wide incident ends, the contract requires the stale cooldown to be invalidated, a bounded post-recovery probe to succeed, and degraded fallback affinity to be cleared before a native-capability request is admitted. While an outage is still ongoing, a native request may fail closed, but it must never be attempted through a degraded fallback.

LoopX only qualifies supplied observations here. It does not invalidate provider state, perform probes, select providers, or acquire credentials.

## Changed surfaces

- `contract.py`: adds `qualify_outage_recovery` with typed checks and failure codes.
- request/response schemas and CLI dispatch: expose the new `outage_recovery` operation.
- example and package metadata: publish the 0.8.0 contract.
- smoke coverage: proves successful recovery, stale cooldown, failed probes, uncleared affinity, and native fallback attempts during both ongoing and ended outages.
- README, CONTRACT, REFERENCES, and RUNBOOK: document the recovery sequence and operator boundary.

The branch was rebased onto the current main containing #3892, so the PR now contains only the outage-recovery increment rather than duplicating the previously merged runtime recovery contracts.

## Validation

- provider recovery contracts smoke: passed
- provider routing CLI smoke: passed
- colocated extension layout: 2 tests passed
- request/response schemas and examples parse under Python 3.13
- Ruff and Python compilation: passed
- public/private boundary scan and `git diff --check`: passed
- exact-diff change-quality receipt: valid
- LoopX standard premerge canary: 17 checks passed, no failures or manual holds
