### PR TITLE
fix(change-window): allow read-only SSH transport

### DIFF
--- a/loopx/capabilities/repository_change_window/git_hook.py
+++ b/loopx/capabilities/repository_change_window/git_hook.py
@@ -1047,6 +1047,19 @@ def run_git_hook_provider(
     hook_stdin: bytes = b"",
     now: datetime | None = None,
 ) -> dict[str, Any]:
+    if event == SSH_TRANSPORT_EVENT and not _ssh_transport_is_push(hook_args):
+        return {
+            "ok": True,
+            "schema_version": "repository_change_window_hook_result_v1",
+            "status": "allowed",
+            "event": event,
+            "exit_code": 0,
+            "guarded_change": False,
+            "previous_hook_invoked": False,
+            "policy_evaluated": False,
+            "reason": "read_only_ssh_transport",
+        }
+
     context = resolve_repository_context(repo_path)
     state = _read_state(_state_path(context.common_dir))
     enforcement = _state_enforcement_level(state)
@@ -1078,8 +1091,6 @@ def run_git_hook_provider(
             hook_args=hook_args,
             hook_stdin=hook_stdin,
         )
-    elif event == SSH_TRANSPORT_EVENT:
-        guarded_change = _ssh_transport_is_push(hook_args)
     else:
         guarded_change = True
     if guarded_change and not decision["allowed"]:

--- a/tests/capabilities/test_repository_change_window.py
+++ b/tests/capabilities/test_repository_change_window.py
@@ -484,6 +484,8 @@ def test_reference_guard_uses_fake_clock_and_shared_linked_worktree_state(
     assert allowed_ssh["status"] == "allowed"
     assert allowed_ssh["guarded_change"] is False
     assert allowed_ssh["previous_hook_invoked"] is False
+    assert allowed_ssh["policy_evaluated"] is False
+    assert allowed_ssh["reason"] == "read_only_ssh_transport"
     with pytest.raises(ValueError, match="unsupported Git SSH service"):
         run_git_hook_provider(
             repo_path=linked,
@@ -537,6 +539,51 @@ def test_reference_guard_uses_fake_clock_and_shared_linked_worktree_state(
         and item["status"] == "unexpected_managed_hook"
         for item in drifted_status["checks"]
     )
+
+
+def test_read_only_ssh_transport_survives_provider_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = _repository(tmp_path, monkeypatch)
+    runtime_root = tmp_path / "runtime"
+    install_git_hook_provider(
+        repo_path=repo,
+        policy=_weekday_policy(),
+        enforcement_level=EnforcementLevel.REFERENCE_GUARD,
+        execute=True,
+    )
+    _git(repo, "config", "--local", "--unset", "core.hooksPath")
+    assert git_hook_provider_status(repo_path=repo)["status"] == "drifted"
+
+    for service in ("git-upload-pack", "git-upload-archive"):
+        allowed = run_git_hook_provider(
+            repo_path=repo,
+            runtime_root=runtime_root,
+            event="ssh-transport",
+            hook_args=("git@github.com", f"{service} 'example/repo.git'"),
+            now=datetime.fromisoformat("2026-08-18T12:00:00+08:00"),
+        )
+        assert allowed == {
+            "ok": True,
+            "schema_version": "repository_change_window_hook_result_v1",
+            "status": "allowed",
+            "event": "ssh-transport",
+            "exit_code": 0,
+            "guarded_change": False,
+            "previous_hook_invoked": False,
+            "policy_evaluated": False,
+            "reason": "read_only_ssh_transport",
+        }
+
+    guarded = run_git_hook_provider(
+        repo_path=repo,
+        runtime_root=runtime_root,
+        event="ssh-transport",
+        hook_args=("git@github.com", "git-receive-pack 'example/repo.git'"),
+        now=datetime.fromisoformat("2026-08-18T12:00:00+08:00"),
+    )
+    assert guarded["status"] == "provider_drift"
 
 
 def test_provider_detects_incompatible_hook_runtime(


### PR DESCRIPTION
## Summary

- classify Git SSH services before repository-provider health checks
- allow read-only `git-upload-pack` and `git-upload-archive` even when the local change-window provider has drifted
- keep `git-receive-pack` fail-closed behind provider health and the configured time policy

## Why

The change-window capability governs public repository writes. A drifted local provider was rejecting every SSH transport before it determined whether the service was a write, so a harmless `git fetch` failed with the same message as a blocked push. That made recovery harder and caused agents to misreport an open nighttime window as closed.

## Validation

- focused read-only/provider-drift regression: passed
- live hook invocation against the drifted checkout: returned `reason=read_only_ssh_transport`, exit 0
- Ruff, Python compile, and `git diff --check`: passed

The broader change-window test file still has pre-existing failures caused by the machine-wide Git hook layout leaking into its temporary-repository fixtures; the two SSH-focused cases pass and the unrelated fixture issue is not changed here.
