### PR TITLE
fix(coordination): route the legacy todo write transaction through the effective runtime root

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -1153,6 +1153,7 @@ def assert_writeback_helper_preview_contract() -> None:
         generated_at = "2026-01-01T00:05:00+00:00"
         preview = write_monitor_poll_todo_state(
             registry_path=registry_path,
+            runtime_root=runtime_root_from_registry(registry_path),
             goal_id=GOAL_ID,
             generated_at=generated_at,
             execute=False,

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -51,6 +51,9 @@ from .capabilities.periodic_report.post_writeback_hook import (
     build_periodic_report_post_writeback_projection,
     periodic_report_post_writeback_hooks_for_goal,
 )
+from .control_plane.coordination.local_authority_shadow_adapter import (
+    effective_runtime_root,
+)
 from .capabilities.semantic_preference.cli import (
     handle_semantic_preference_command,
     register_semantic_preference_commands,
@@ -675,6 +678,10 @@ def main(argv: list[str] | None = None) -> int:
             periodic_report_post_writeback_hooks_for_goal(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
+                runtime_root=effective_runtime_root(
+                    registry_path,
+                    args.runtime_root,
+                ),
             )
             if args.command == "refresh-state"
             else ()

--- a/loopx/cli_commands/turn.py
+++ b/loopx/cli_commands/turn.py
@@ -73,6 +73,66 @@ PrintPayload = Callable[
 FormatSelector = Callable[..., str]
 
 
+def write_turn_repair_update(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    todo_id: str,
+    note: str,
+    evidence: str,
+    agent_id: str | None,
+) -> None:
+    """Record one repair-required Todo note under the effective runtime root.
+
+    ``runtime_root_arg`` is required on purpose: the Turn settlement must
+    hand down the same ``--runtime-root`` override the dispatch resolved, so
+    the legacy writer fence and the todo mutex of a promotion cannot split
+    from the Turn writeback path.
+    """
+
+    update_goal_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        role="agent",
+        note=note,
+        evidence=evidence,
+        agent_id=agent_id,
+        project=None,
+        dry_run=False,
+        runtime_root_arg=runtime_root_arg,
+    )
+
+
+def write_turn_validated_completion(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    todo_id: str,
+    completion_turn_key: str,
+    evidence: str,
+    note: str,
+    agent_id: str | None,
+) -> dict[str, Any]:
+    """Complete one validated Todo under the effective runtime root."""
+
+    return complete_goal_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        role="agent",
+        completion_turn_key=completion_turn_key,
+        evidence=evidence,
+        note=note,
+        agent_id=agent_id,
+        project=None,
+        dry_run=False,
+        runtime_root_arg=runtime_root_arg,
+    )
+
+
 def handle_turn_command(
     args: argparse.Namespace,
     *,
@@ -406,16 +466,14 @@ def handle_turn_command(
                         raise ValueError(
                             f"{result_kind} requires one selected todo for typed writeback"
                         )
-                    update_goal_todo(
+                    write_turn_repair_update(
                         registry_path=registry_path,
+                        runtime_root_arg=runtime_root_arg,
                         goal_id=args.goal_id,
                         todo_id=todo_id,
-                        role="agent",
                         note=str(result.get("summary") or result["classification"]),
                         evidence=f"LoopX Turn {result_kind}: {result['next_action']}",
                         agent_id=args.agent_id,
-                        project=state_project,
-                        dry_run=False,
                     )
                 refresh = refresh_state_run(
                     registry_path=registry_path,
@@ -494,11 +552,11 @@ def handle_turn_command(
                     raise ValueError(
                         "validated_completion requires one selected todo for lifecycle writeback"
                     )
-                completion = complete_goal_todo(
+                completion = write_turn_validated_completion(
                     registry_path=registry_path,
+                    runtime_root_arg=runtime_root_arg,
                     goal_id=args.goal_id,
                     todo_id=todo_id,
-                    role="agent",
                     completion_turn_key=settlement_identity.turn_instance_id,
                     evidence=(
                         "LoopX Turn validated completion: "
@@ -506,8 +564,6 @@ def handle_turn_command(
                     ),
                     note=str(result["next_action"]),
                     agent_id=args.agent_id,
-                    project=None,
-                    dry_run=False,
                 )
                 # Project the continuation the Todo lifecycle durably recorded,
                 # never a host-normalized continuation. Contradictory or

--- a/loopx/cli_runtime.py
+++ b/loopx/cli_runtime.py
@@ -271,6 +271,9 @@ def dispatch_common_command(
 		)
 		from .cli_commands.todo import handle_todo_command
 		from .cli_rollout import append_cli_rollout_event
+		from .control_plane.coordination.local_authority_shadow_adapter import (
+			effective_runtime_root,
+		)
 
 		return handle_todo_command(
 			args,
@@ -283,6 +286,10 @@ def dispatch_common_command(
 				periodic_report_post_writeback_hooks_for_goal(
 					registry_path=registry_path,
 					goal_id=args.goal_id,
+					runtime_root=effective_runtime_root(
+						registry_path,
+						args.runtime_root,
+					),
 				)
 				if args.todo_command == "complete"
 				else ()

--- a/loopx/control_plane/coordination/legacy_writer_fence.py
+++ b/loopx/control_plane/coordination/legacy_writer_fence.py
@@ -121,17 +121,25 @@ def legacy_todo_write_transaction(
     agent_id: str | None,
     operation: str,
     dry_run: bool,
+    *,
+    runtime_root: Path | None = None,
 ) -> Iterator[None]:
-    """Serialize promotion with one complete legacy Todo mutation."""
+    """Serialize promotion with one complete legacy Todo mutation.
 
-    runtime_root = resolve_runtime_root(
+    ``runtime_root`` is the effective runtime root of the CLI call (the
+    ``--runtime-root`` override when given) so the mutex and the fence check
+    share the same root as promotion and the observation hooks.  Callers that
+    omit it keep the registry-derived root.
+    """
+
+    resolved_runtime_root = runtime_root or resolve_runtime_root(
         load_registry(registry_path),
         None,
         registry_path=registry_path,
     )
     with exclusive_file_lock(
         legacy_coordination_todo_lock_path(
-            runtime_root=runtime_root,
+            runtime_root=resolved_runtime_root,
             goal_id=goal_id,
         ),
         agent_id=agent_id,
@@ -143,7 +151,7 @@ def legacy_todo_write_transaction(
     ):
         if not dry_run:
             require_legacy_coordination_write_allowed(
-                runtime_root=runtime_root,
+                runtime_root=resolved_runtime_root,
                 goal_id=goal_id,
             )
         yield

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -555,9 +555,11 @@ def _provider_writeback(
     plan: Mapping[str, Any],
     *,
     registry_path: Path,
+    runtime_root: Path,
 ) -> dict[str, Any]:
     result = write_monitor_poll_todo_state(
         registry_path=registry_path,
+        runtime_root=runtime_root,
         goal_id=str(plan.get("goal_id") or ""),
         generated_at=str(plan.get("generated_at") or ""),
         execute=plan.get("execute") is True,
@@ -716,7 +718,11 @@ def record_quota_monitor_poll_for_decision(
             raise TypeError("TypeScript monitor-poll preflight omitted provider plan")
         if registry_path is None:
             raise ValueError("monitor todo writeback requires registry_path")
-        provider_receipt = _provider_writeback(plan, registry_path=registry_path)
+        provider_receipt = _provider_writeback(
+            plan,
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+        )
         status_warning = None
         if execute:
             after_status, status_warning = _reload_status_after_monitor_writeback(

--- a/loopx/control_plane/scheduler/monitor_poll_writeback.py
+++ b/loopx/control_plane/scheduler/monitor_poll_writeback.py
@@ -168,6 +168,7 @@ def resolve_monitor_todo_item(
 def write_monitor_poll_todo_state(
     *,
     registry_path: Path,
+    runtime_root: Path,
     goal_id: str,
     generated_at: str,
     execute: bool,
@@ -190,6 +191,16 @@ def write_monitor_poll_todo_state(
     next_claimed_by: str | None = None,
     agent_id: str | None = None,
 ) -> dict[str, Any] | None:
+    """Apply one monitor poll observation as a complete Todo writeback.
+
+    ``runtime_root`` is the effective runtime root of the calling CLI
+    composition (the ``--runtime-root`` override when given).  Every legacy
+    Todo mutation below shares that root, so the writer fence and the todo
+    mutex of a promotion cannot split from the writeback path.  The parameter
+    is required on purpose: callers must compose the root instead of relying
+    on a registry-derived fallback that promotion cannot fence.
+    """
+
     from ...todos import add_goal_todo, update_goal_todo
 
     if not todo_id and not target_key:
@@ -237,6 +248,7 @@ def write_monitor_poll_todo_state(
         todo_id=resolved_todo_id,
         role="agent",
         reason=reason_summary,
+        runtime_root_arg=str(runtime_root),
         monitor_metadata=MonitorPollObservation(
             generated_at=generated_at,
             result_hash=safe_result_hash,
@@ -268,6 +280,7 @@ def write_monitor_poll_todo_state(
                 goal_id=goal_id,
                 role="agent",
                 text=next_agent_todo,
+                runtime_root_arg=str(runtime_root),
                 task_class=TODO_TASK_CLASS_ADVANCEMENT,
                 action_kind=successor_route["action_kind"],
                 task_repository=successor_route["task_repository"],
@@ -286,6 +299,7 @@ def write_monitor_poll_todo_state(
                 goal_id=goal_id,
                 role="user",
                 text=next_user_todo,
+                runtime_root_arg=str(runtime_root),
                 task_class=effective_next_user_task_class,
                 action_kind=(
                     "gate"

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -725,6 +725,7 @@ def add_goal_todo(
 
     with legacy_todo_write_transaction(
         registry_path, goal_id, resolved_state_file, agent_id or claimed_by, "todo_add", dry_run,
+        runtime_root=shadow_runtime_root,
     ), ExitStack() as handoff_gate_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -1044,6 +1045,7 @@ def update_goal_todo(
     resume_monitor_generation: int | None = None
     with legacy_todo_write_transaction(
         registry_path, goal_id, resolved_state_file, agent_id or claimed_by, "todo_update", dry_run,
+        runtime_root=shadow_runtime_root,
     ), ExitStack() as handoff_gate_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -1472,6 +1474,7 @@ def complete_goal_todo(
         return validation_failure
     with legacy_todo_write_transaction(
         registry_path, goal_id, resolved_state_file, agent_id or claimed_by, "todo_complete", dry_run,
+        runtime_root=shadow_runtime_root,
     ), ExitStack() as lease_fence_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -1832,6 +1835,7 @@ def supersede_goal_todo(
     )
     with legacy_todo_write_transaction(
         registry_path, goal_id, resolved_state_file, agent_id, "todo_supersede", dry_run,
+        runtime_root=shadow_runtime_root,
     ), ExitStack() as lease_fence_stack:
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
@@ -2029,6 +2033,7 @@ def archive_completed_todos(
 
     with legacy_todo_write_transaction(
         registry_path, goal_id, resolved_state_file, None, "todo_archive_completed", dry_run,
+        runtime_root=shadow_runtime_root,
     ):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()

--- a/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
+++ b/tests/capabilities/test_issue_fix_grouped_monitor_materialization.py
@@ -251,6 +251,7 @@ def test_grouped_monitor_keeps_creator_ownership_across_turns_and_due_poll(
     with pytest.raises(ValueError, match=f"claimed_by={AGENT_ID!r}"):
         write_monitor_poll_todo_state(
             registry_path=registry,
+            runtime_root=tmp_path / "runtime",
             goal_id=GOAL_ID,
             todo_id=todo_id,
             result_hash=monitor["result_hash"],
@@ -262,6 +263,7 @@ def test_grouped_monitor_keeps_creator_ownership_across_turns_and_due_poll(
 
     polled = write_monitor_poll_todo_state(
         registry_path=registry,
+        runtime_root=tmp_path / "runtime",
         goal_id=GOAL_ID,
         todo_id=todo_id,
         result_hash=monitor["result_hash"],

--- a/tests/control_plane/test_legacy_coordination_writer_fence.py
+++ b/tests/control_plane/test_legacy_coordination_writer_fence.py
@@ -7,9 +7,89 @@ import pytest
 
 from loopx.control_plane.coordination.legacy_writer_fence import (
     LegacyCoordinationWriterFenced,
+    legacy_coordination_todo_lock_path,
     legacy_coordination_writer_fence_path,
+    legacy_todo_write_transaction,
     require_legacy_coordination_write_allowed,
 )
+from loopx.file_lock import lock_holder_path
+from loopx.todos import add_goal_todo
+
+SPLIT_ROOT_GOAL_ID = "legacy-fence-split-root"
+SPLIT_ROOT_AGENT = "codex-author"
+
+
+def _write_split_root_fixture(
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path]:
+    """A registry whose common_runtime_root differs from the CLI override root."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "\n".join(
+            [
+                "---",
+                f"goal_id: {SPLIT_ROOT_GOAL_ID}",
+                "updated_at: 2026-09-04T00:00:00+00:00",
+                "---",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime_registry = tmp_path / "runtime-registry"
+    runtime_override = tmp_path / "runtime-override"
+    runtime_registry.mkdir()
+    runtime_override.mkdir()
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_registry),
+                "goals": [
+                    {
+                        "id": SPLIT_ROOT_GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [SPLIT_ROOT_AGENT],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state, runtime_registry, runtime_override
+
+
+def _engage_fence(runtime_root: Path) -> None:
+    fence_path = legacy_coordination_writer_fence_path(
+        runtime_root=runtime_root,
+        goal_id=SPLIT_ROOT_GOAL_ID,
+    )
+    fence_path.parent.mkdir(parents=True)
+    fence_path.write_text(json.dumps({"state": "present"}), encoding="utf-8")
+
+
+def _blocked_effect_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.legacy_writer_fence.effect_runtime_result",
+        lambda *_args, **_kwargs: {
+            "status": "blocked",
+            "reason_code": "legacy_coordination_writer_fenced",
+            "authority_mode": "file_v0",
+        },
+    )
 
 
 def test_missing_fence_preserves_default_without_starting_typescript(
@@ -60,3 +140,107 @@ def test_present_fence_delegates_to_typescript_and_blocks(
 
     assert exc_info.value.code == "legacy_coordination_writer_fenced"
     assert captured["method"] == "coordination.local_authority.legacy_write_check"
+
+
+def test_todo_write_transaction_fences_under_the_effective_runtime_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A fence engaged under --runtime-root must fence the legacy writer."""
+
+    registry, state, _runtime_registry, runtime_override = _write_split_root_fixture(
+        tmp_path
+    )
+    _engage_fence(runtime_override)
+    _blocked_effect_runtime(monkeypatch)
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        with legacy_todo_write_transaction(
+            registry,
+            SPLIT_ROOT_GOAL_ID,
+            state,
+            SPLIT_ROOT_AGENT,
+            "todo_add",
+            False,
+            runtime_root=runtime_override,
+        ):
+            pytest.fail("transaction body must not run while fenced")
+
+
+def test_todo_write_transaction_keeps_registry_root_without_runtime_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Omitting runtime_root keeps the registry-derived root (backward compat)."""
+
+    registry, state, runtime_registry, _runtime_override = _write_split_root_fixture(
+        tmp_path
+    )
+    _engage_fence(runtime_registry)
+    _blocked_effect_runtime(monkeypatch)
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        with legacy_todo_write_transaction(
+            registry,
+            SPLIT_ROOT_GOAL_ID,
+            state,
+            SPLIT_ROOT_AGENT,
+            "todo_add",
+            False,
+        ):
+            pytest.fail("transaction body must not run while fenced")
+
+
+def test_todo_write_lock_lands_under_the_effective_runtime_root(
+    tmp_path: Path,
+) -> None:
+    """The todo mutex must serialize with promotion under the override root."""
+
+    registry, state, runtime_registry, runtime_override = _write_split_root_fixture(
+        tmp_path
+    )
+    override_lock = legacy_coordination_todo_lock_path(
+        runtime_root=runtime_override,
+        goal_id=SPLIT_ROOT_GOAL_ID,
+    )
+
+    registry_lock = legacy_coordination_todo_lock_path(
+        runtime_root=runtime_registry,
+        goal_id=SPLIT_ROOT_GOAL_ID,
+    )
+
+    with legacy_todo_write_transaction(
+        registry,
+        SPLIT_ROOT_GOAL_ID,
+        state,
+        SPLIT_ROOT_AGENT,
+        "todo_add",
+        False,
+        runtime_root=runtime_override,
+    ):
+        assert lock_holder_path(override_lock).exists()
+        assert not lock_holder_path(registry_lock).exists()
+
+
+def test_goal_todo_add_is_fenced_when_the_override_root_holds_the_fence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """End to end: todo add shares the CLI override root with the fence."""
+
+    registry, _state, _runtime_registry, runtime_override = _write_split_root_fixture(
+        tmp_path
+    )
+    _engage_fence(runtime_override)
+    _blocked_effect_runtime(monkeypatch)
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        add_goal_todo(
+            registry_path=registry,
+            goal_id=SPLIT_ROOT_GOAL_ID,
+            role="agent",
+            text="Deliver one bounded control-plane change.",
+            task_class="advancement_task",
+            claimed_by=SPLIT_ROOT_AGENT,
+            runtime_root_arg=str(runtime_override),
+        )

--- a/tests/control_plane/test_monitor_followthrough_contract.py
+++ b/tests/control_plane/test_monitor_followthrough_contract.py
@@ -281,6 +281,7 @@ def test_runtime_writeback_can_read_legacy_unbounded_monitor(tmp_path: Path) -> 
 
     result = write_monitor_poll_todo_state(
         registry_path=registry,
+        runtime_root=tmp_path / "runtime",
         goal_id=GOAL_ID,
         generated_at="2026-08-11T00:00:00Z",
         execute=False,

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -8,6 +8,8 @@ import sys
 import threading
 import time
 
+import pytest
+
 from loopx.control_plane.capability_hooks import (
     POST_WRITEBACK_HOOK_INPUT_SCHEMA_VERSION,
     POST_WRITEBACK_HOOK_RESULT_SCHEMA_VERSION,
@@ -918,3 +920,110 @@ with journal.execution_lease(sys.argv[3]):
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=3)
+
+
+def _split_root_registry(tmp_path: Path) -> tuple[Path, Path, Path]:
+    runtime_registry = tmp_path / "runtime-registry"
+    runtime_override = tmp_path / "runtime-override"
+    runtime_registry.mkdir()
+    runtime_override.mkdir()
+    registry_path = tmp_path / "registry.global.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_registry),
+                "goals": [{"id": "goal-1"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry_path, runtime_registry, runtime_override
+
+
+def test_todo_complete_composition_passes_effective_runtime_root_to_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The todo complete hook composition reads machine defaults under the override."""
+
+    import argparse
+
+    from loopx.cli_runtime import dispatch_common_command
+
+    registry_path, _runtime_registry, runtime_override = _split_root_registry(tmp_path)
+    captured: dict[str, object] = {}
+
+    def capture_hooks(
+        *, registry_path: Path, goal_id: str, runtime_root: Path | None
+    ) -> tuple[PostWritebackHookRegistration, ...]:
+        captured["runtime_root"] = runtime_root
+        return ()
+
+    monkeypatch.setattr(
+        "loopx.capabilities.periodic_report.post_writeback_hook"
+        ".periodic_report_post_writeback_hooks_for_goal",
+        capture_hooks,
+    )
+    monkeypatch.setattr(
+        "loopx.cli_commands.todo.handle_todo_command",
+        lambda *_args, **_kwargs: 0,
+    )
+    args = argparse.Namespace(
+        command="todo",
+        todo_command="complete",
+        goal_id="goal-1",
+        runtime_root=str(runtime_override),
+    )
+
+    result = dispatch_common_command(
+        args,
+        registry_path=registry_path,
+        allow_missing_registry=False,
+    )
+
+    assert result == 0
+    assert captured["runtime_root"] == runtime_override
+
+
+def test_refresh_state_composition_passes_effective_runtime_root_to_hooks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The refresh-state hook composition reads machine defaults under the override."""
+
+    from loopx import cli as cli_module
+
+    registry_path, _runtime_registry, runtime_override = _split_root_registry(tmp_path)
+    captured: dict[str, object] = {}
+
+    def capture_hooks(
+        *, registry_path: Path, goal_id: str, runtime_root: Path | None
+    ) -> tuple[PostWritebackHookRegistration, ...]:
+        captured["runtime_root"] = runtime_root
+        return ()
+
+    monkeypatch.setattr(
+        cli_module,
+        "periodic_report_post_writeback_hooks_for_goal",
+        capture_hooks,
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "handle_project_lifecycle_command",
+        lambda *_args, **_kwargs: 7,
+    )
+
+    exit_code = cli_module.main(
+        [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime_override),
+            "refresh-state",
+            "--goal-id",
+            "goal-1",
+        ]
+    )
+
+    assert exit_code == 7
+    assert captured["runtime_root"] == runtime_override

--- a/tests/control_plane/test_split_root_todo_writeback_fence.py
+++ b/tests/control_plane/test_split_root_todo_writeback_fence.py
@@ -1,0 +1,276 @@
+"""Split-root fence regressions for the monitor-poll and Turn writebacks.
+
+A promotion engages the legacy writer fence under the CLI ``--runtime-root``
+override.  Every Python Todo writeback of the same composition must resolve
+its fence and mutex from that same override root, never from the registry's
+``common_runtime_root``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from loopx.cli_commands.turn import (
+    write_turn_repair_update,
+    write_turn_validated_completion,
+)
+from loopx.control_plane.coordination.legacy_writer_fence import (
+    LegacyCoordinationWriterFenced,
+    legacy_coordination_writer_fence_path,
+)
+from loopx.control_plane.quota import monitor_poll
+from loopx.control_plane.scheduler.monitor_poll_writeback import (
+    write_monitor_poll_todo_state,
+)
+
+GOAL_ID = "split-root-writeback-goal"
+AGENT_ID = "turn-writeback-author"
+ADVANCE_ID = "todo_splitroot_advance"
+MONITOR_ID = "todo_splitroot_monitor"
+OVERRIDE_POLL_HASH = "split-v2"
+LEGACY_POLL_HASH = "split-v1"
+
+
+def _write_split_root_goal(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    state = repo / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "---\n"
+        f"goal_id: {GOAL_ID}\n"
+        "updated_at: 2026-09-04T00:00:00+00:00\n"
+        "---\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Advance the fenced writeback slice.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={ADVANCE_ID} status=open task_class=advancement_task "
+        f"claimed_by={AGENT_ID} -->\n"
+        "- [ ] [P2] Watch the fenced writeback channel.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={MONITOR_ID} status=open task_class=continuous_monitor "
+        f"claimed_by={AGENT_ID} target_key=splitroot-review cadence=30m "
+        f"result_hash={LEGACY_POLL_HASH} material_change=false -->\n",
+        encoding="utf-8",
+    )
+    runtime_registry = tmp_path / "registry-runtime"
+    runtime_override = tmp_path / "override-runtime"
+    runtime_registry.mkdir()
+    runtime_override.mkdir()
+    registry = tmp_path / "registry.global.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_registry),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "harness_self_improvement",
+                        "status": "active",
+                        "repo": str(repo),
+                        "state_file": state.name,
+                        "adapter": {"kind": "harness_self_improvement"},
+                        "coordination": {
+                            "agent_model": "peer_v1",
+                            "registered_agents": [AGENT_ID],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state, runtime_registry, runtime_override
+
+
+def _engage_fence_at(runtime_root: Path) -> None:
+    fence = legacy_coordination_writer_fence_path(
+        runtime_root=runtime_root,
+        goal_id=GOAL_ID,
+    )
+    fence.parent.mkdir(parents=True, exist_ok=True)
+    fence.write_text(
+        json.dumps({"state": "present", "engaged_by": "promotion"}),
+        encoding="utf-8",
+    )
+
+
+def _fence_check_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.legacy_writer_fence."
+        "effect_runtime_result",
+        lambda *_args, **_kwargs: {
+            "status": "blocked",
+            "reason_code": "legacy_coordination_writer_fenced",
+            "authority_mode": "file_v0",
+        },
+    )
+
+
+def _poll_kwargs(
+    registry: Path,
+    runtime_root: Path,
+    *,
+    result_hash: str = OVERRIDE_POLL_HASH,
+) -> dict[str, Any]:
+    return {
+        "registry_path": registry,
+        "runtime_root": runtime_root,
+        "goal_id": GOAL_ID,
+        "generated_at": "2026-09-04T01:00:00+00:00",
+        "execute": True,
+        "todo_id": MONITOR_ID,
+        "result_hash": result_hash,
+        "material_change": False,
+        "next_due_at": "2026-09-04T02:00:00+00:00",
+        "agent_id": AGENT_ID,
+    }
+
+
+def test_monitor_poll_writeback_blocked_when_override_root_is_fenced(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry, state, _runtime_registry, runtime_override = (
+        _write_split_root_goal(tmp_path)
+    )
+    _engage_fence_at(runtime_override)
+    _fence_check_blocks(monkeypatch)
+    state_before = state.read_text(encoding="utf-8")
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        write_monitor_poll_todo_state(**_poll_kwargs(registry, runtime_override))
+
+    assert LEGACY_POLL_HASH in state.read_text(encoding="utf-8")
+    assert OVERRIDE_POLL_HASH not in state.read_text(encoding="utf-8")
+    assert state.read_text(encoding="utf-8") == state_before
+
+
+def test_monitor_poll_writeback_allows_when_only_registry_root_is_fenced(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The override root alone decides; a registry-root fence must not block."""
+
+    registry, state, runtime_registry, runtime_override = (
+        _write_split_root_goal(tmp_path)
+    )
+    _engage_fence_at(runtime_registry)
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.legacy_writer_fence."
+        "effect_runtime_result",
+        lambda *_args, **_kwargs: pytest.fail(
+            "an override-root writeback must not consult another root's fence"
+        ),
+    )
+
+    receipt = write_monitor_poll_todo_state(
+        **_poll_kwargs(registry, runtime_override)
+    )
+
+    assert receipt is not None
+    assert receipt["result_hash"] == OVERRIDE_POLL_HASH
+    assert receipt["last_checked_at"] == "2026-09-04T01:00:00+00:00"
+    active = state.read_text(encoding="utf-8")
+    assert f"result_hash={OVERRIDE_POLL_HASH}" in active
+
+
+def test_quota_monitor_poll_provider_writeback_blocked_under_override_fence(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The record path must hand its effective root to the provider writeback."""
+
+    registry, state, _runtime_registry, runtime_override = (
+        _write_split_root_goal(tmp_path)
+    )
+    _engage_fence_at(runtime_override)
+    _fence_check_blocks(monkeypatch)
+
+    def native(_method: str, request: dict[str, Any]) -> dict[str, Any]:
+        assert request["phase"] == "preflight"
+        return {
+            "schema_version": monitor_poll.QUOTA_MONITOR_POLL_COMMIT_RESULT_SCHEMA,
+            "status": "provider_required",
+            "provider_plan": {
+                "goal_id": GOAL_ID,
+                "generated_at": "2026-09-04T01:00:00+00:00",
+                "execute": True,
+                "todo_id": MONITOR_ID,
+                "result_hash": OVERRIDE_POLL_HASH,
+                "material_change": False,
+                "next_due_at": "2026-09-04T02:00:00+00:00",
+            },
+        }
+
+    monkeypatch.setattr(monitor_poll, "effect_runtime_result", native)
+    before = {
+        "goal_id": GOAL_ID,
+        "should_run": False,
+        "effective_action": "monitor_quiet_skip",
+        "agent_identity": {"agent_id": AGENT_ID},
+    }
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        monitor_poll.record_quota_monitor_poll_for_decision(
+            before,
+            {"runtime_root": str(runtime_override)},
+            goal_id=GOAL_ID,
+            after_decision=lambda _status: before,
+            render_markdown=lambda _record: "unused",
+            registry_path=registry,
+            execute=True,
+            todo_id=MONITOR_ID,
+            result_hash=OVERRIDE_POLL_HASH,
+            agent_id=AGENT_ID,
+        )
+
+    assert OVERRIDE_POLL_HASH not in state.read_text(encoding="utf-8")
+
+
+def test_turn_repair_update_blocked_when_override_root_is_fenced(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry, _state, _runtime_registry, runtime_override = (
+        _write_split_root_goal(tmp_path)
+    )
+    _engage_fence_at(runtime_override)
+    _fence_check_blocks(monkeypatch)
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        write_turn_repair_update(
+            registry_path=registry,
+            runtime_root_arg=str(runtime_override),
+            goal_id=GOAL_ID,
+            todo_id=ADVANCE_ID,
+            note="host repair reported a bounded retry",
+            evidence="LoopX Turn repair_required: rerun the slice",
+            agent_id=AGENT_ID,
+        )
+
+
+def test_turn_validated_completion_blocked_when_override_root_is_fenced(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry, _state, _runtime_registry, runtime_override = (
+        _write_split_root_goal(tmp_path)
+    )
+    _engage_fence_at(runtime_override)
+    _fence_check_blocks(monkeypatch)
+
+    with pytest.raises(LegacyCoordinationWriterFenced):
+        write_turn_validated_completion(
+            registry_path=registry,
+            runtime_root_arg=str(runtime_override),
+            goal_id=GOAL_ID,
+            todo_id=ADVANCE_ID,
+            completion_turn_key="turn_splitroot_0001",
+            evidence="LoopX Turn validated completion: slice merged",
+            note="advance to the next bounded slice",
+            agent_id=AGENT_ID,
+        )

--- a/tests/control_plane/test_todo_external_wait.py
+++ b/tests/control_plane/test_todo_external_wait.py
@@ -106,6 +106,7 @@ def test_monitor_change_wait_binds_generation_and_resumes_only_after_increment(
 
     unchanged = write_monitor_poll_todo_state(
         registry_path=registry,
+        runtime_root=tmp_path / "runtime",
         goal_id=GOAL_ID,
         execute=True,
         reason_summary="external review remains unchanged",
@@ -121,6 +122,7 @@ def test_monitor_change_wait_binds_generation_and_resumes_only_after_increment(
 
     changed = write_monitor_poll_todo_state(
         registry_path=registry,
+        runtime_root=tmp_path / "runtime",
         goal_id=GOAL_ID,
         execute=True,
         reason_summary="external review produced a typed material change",
@@ -139,6 +141,7 @@ def test_monitor_change_wait_binds_generation_and_resumes_only_after_increment(
 
     replay = write_monitor_poll_todo_state(
         registry_path=registry,
+        runtime_root=tmp_path / "runtime",
         goal_id=GOAL_ID,
         execute=True,
         reason_summary="replay the same material observation",
@@ -243,6 +246,7 @@ def test_monitor_provider_effect_replay_does_not_advance_counters(
     registry, state_file = _write_fixture(tmp_path)
     kwargs = {
         "registry_path": registry,
+        "runtime_root": tmp_path / "runtime",
         "goal_id": GOAL_ID,
         "execute": True,
         "generated_at": "2026-08-25T01:00:00Z",
@@ -298,6 +302,7 @@ def test_monitor_provider_effect_replay_reuses_material_successor(
     successor_text = "Advance the material monitor transition."
     kwargs = {
         "registry_path": registry,
+        "runtime_root": tmp_path / "runtime",
         "goal_id": GOAL_ID,
         "execute": True,
         "generated_at": "2026-08-25T01:00:00Z",
@@ -352,6 +357,7 @@ def test_overlapping_material_polls_recompute_generation_after_wait_baseline(
         second_poll = executor.submit(
             write_monitor_poll_todo_state,
             registry_path=registry,
+            runtime_root=tmp_path / "runtime",
             goal_id=GOAL_ID,
             execute=True,
             generated_at="2026-08-25T02:01:00Z",
@@ -364,6 +370,7 @@ def test_overlapping_material_polls_recompute_generation_after_wait_baseline(
 
         first_poll = write_monitor_poll_todo_state(
             registry_path=registry,
+            runtime_root=tmp_path / "runtime",
             goal_id=GOAL_ID,
             execute=True,
             generated_at="2026-08-25T02:00:00Z",

--- a/tests/control_plane/test_todo_mutation_authority.py
+++ b/tests/control_plane/test_todo_mutation_authority.py
@@ -1693,6 +1693,7 @@ def test_monitor_writeback_propagates_multi_agent_actor(tmp_path: Path) -> None:
 
     result = write_monitor_poll_todo_state(
         registry_path=registry,
+        runtime_root=tmp_path / "runtime",
         goal_id=GOAL_ID,
         generated_at="2026-07-18T00:15:00+00:00",
         execute=False,


### PR DESCRIPTION
## Summary

- `legacy_todo_write_transaction` (added in d2b5842e) resolved its runtime root from the registry alone, dropping the `--runtime-root` override that ea15267f had unified for observation, lease, and follow-up hooks.
- With an override root different from the registry-derived root, a promotion that engaged the legacy writer fence under the override root was invisible to the Python legacy todo writer (it checked the registry root), so the write was allowed — fail-open — and the per-goal todo mutex serialized on a different root than the promotion transaction.
- The transaction now accepts the effective runtime root and uses it for both the todo mutex and the fence check; the five todo write paths (add/update/complete/supersede/archive) pass the shadow runtime root they already resolve, and the two periodic-report post-writeback compositions in `cli.py`/`cli_runtime.py` pass the effective root so the machine-default lookup no longer splits from the dispatch root. Non-CLI callers that omit the argument keep the registry-derived root.

## Issue Or Task

- Closes #
- Contributor task ID: found by an independent bug hunt during the #3871 review cycle; reproduction and analysis available on request.

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other: new `tests/control_plane/test_legacy_coordination_writer_fence.py` (6 tests) — the override-root fence case fails open before the fix (DID NOT RAISE) and fences after; end-to-end todo add raises `LegacyCoordinationWriterFenced`; focused suites fence 6 passed + hooks 18 passed; `mypy` full run `Success: no issues found in 15 source files`; `ruff` clean; `test_m6_quality_gates.py` passed; ~460 related todos/coordination/hooks tests green (one pre-existing pydantic-missing env failure reproduces on a clean baseline).

## Type of Change

- [x] Bug fix

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
