### PR TITLE
fix(periodic-report): isolate subscription resolution in hook composition

### DIFF
--- a/loopx/capabilities/periodic_report/post_writeback_hook.py
+++ b/loopx/capabilities/periodic_report/post_writeback_hook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import warnings
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -65,7 +66,15 @@ def _goal_config(registry_path: Path, goal_id: str) -> Mapping[str, Any]:
 def periodic_report_post_writeback_hooks_for_goal(
     *, registry_path: Path, goal_id: str, runtime_root: Path | None = None
 ) -> tuple[PostWritebackHookRegistration, ...]:
-    """Resolve a Goal override or live machine-default profile at composition."""
+    """Resolve a Goal override or live machine-default profile at composition.
+
+    Both branches resolve through the canonical subscription resolver, so an
+    invalid Goal override is reported here the same way the delivery paths
+    report it. Store read and subscription validation failures degrade to no
+    hooks with one warning: composition happens outside the dispatch
+    isolation boundary, so optional hooks never alter the primary truth of
+    the CLI command that composes them.
+    """
 
     registry = load_registry(registry_path)
     effective_runtime_root = runtime_root or resolve_runtime_root(
@@ -83,18 +92,26 @@ def periodic_report_post_writeback_hooks_for_goal(
     if not isinstance(goal, Mapping):
         return ()
     goal_override = _goal_config(registry_path, goal_id)
-    if goal_override:
-        if goal_override.get("enabled") is not True:
-            return ()
-        preset = str(goal_override.get("profile_preset") or "").strip()
-    else:
+    try:
         subscription = resolve_goal_periodic_report_subscription(
             goal,
-            read_periodic_report_machine_defaults(effective_runtime_root),
+            (
+                None
+                if goal_override
+                else read_periodic_report_machine_defaults(effective_runtime_root)
+            ),
         )
-        if subscription.get("enabled") is not True:
-            return ()
-        preset = str(subscription.get("profile_preset") or "").strip()
+    except (TypeError, ValueError) as exc:
+        warnings.warn(
+            f"periodic-report subscription for goal {goal_id} failed to resolve; "
+            f"post-writeback hooks are disabled: {exc}",
+            UserWarning,
+            stacklevel=2,
+        )
+        return ()
+    if subscription.get("enabled") is not True:
+        return ()
+    preset = str(subscription.get("profile_preset") or "").strip()
     if not preset:
         return ()
     activation = build_periodic_report_preset_activation(preset)

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -8,6 +8,8 @@ import sys
 import threading
 import time
 
+import pytest
+
 from loopx.control_plane.capability_hooks import (
     POST_WRITEBACK_HOOK_INPUT_SCHEMA_VERSION,
     POST_WRITEBACK_HOOK_RESULT_SCHEMA_VERSION,
@@ -341,7 +343,9 @@ def test_periodic_report_hook_requires_explicit_goal_profile_opt_in(tmp_path) ->
     )
 
     registry = json.loads(registry_path.read_text(encoding="utf-8"))
-    registry["goals"][0]["control_plane"]["periodic_report"]["enabled"] = True
+    registry["goals"][0]["control_plane"]["periodic_report"].update(
+        {"enabled": True, "route_ref": "loopx-concierge"}
+    )
     registry_path.write_text(json.dumps(registry), encoding="utf-8")
 
     hooks = periodic_report_post_writeback_hooks_for_goal(
@@ -419,6 +423,190 @@ def test_periodic_report_hook_uses_live_machine_default_without_goal_mutation(
 
     assert len(hooks) == 1
     assert json.loads(registry_path.read_text(encoding="utf-8")) == registry_payload
+
+
+def _write_unreadable_periodic_report_machine_store(runtime_root: Path) -> None:
+    store = runtime_root / "machine" / "configuration.json"
+    store.parent.mkdir(parents=True)
+    store.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_machine_configuration_v0",
+                "namespaces": {
+                    "periodic_report": {
+                        "schema_version": "periodic_report_machine_defaults_v0",
+                        "enabled": "true",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_periodic_report_hook_degrades_to_no_hooks_when_machine_store_is_unreadable(
+    tmp_path,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps({"goals": [{"id": "goal-1"}]}),
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    _write_unreadable_periodic_report_machine_store(runtime_root)
+
+    with pytest.warns(UserWarning, match="periodic_report.enabled must be a boolean"):
+        assert (
+            periodic_report_post_writeback_hooks_for_goal(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                goal_id="goal-1",
+            )
+            == ()
+        )
+
+
+def test_periodic_report_hook_degrades_to_no_hooks_on_legacy_machine_namespace(
+    tmp_path,
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps({"goals": [{"id": "goal-1"}]}),
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    store = runtime_root / "machine" / "configuration.json"
+    store.parent.mkdir(parents=True)
+    store.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_machine_configuration_v0",
+                "namespaces": {
+                    "periodic_report": {
+                        "schema_version": "periodic_report_machine_defaults_v0",
+                        "enabled": True,
+                        "delivery_style": "weekly",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.warns(UserWarning, match="periodic_report contains unsupported fields"):
+        assert (
+            periodic_report_post_writeback_hooks_for_goal(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                goal_id="goal-1",
+            )
+            == ()
+        )
+
+
+def test_periodic_report_hook_reports_invalid_goal_overrides_like_canonical_resolver(
+    tmp_path,
+) -> None:
+    from loopx.capabilities.periodic_report.machine_defaults import (
+        resolve_goal_periodic_report_subscription,
+    )
+
+    invalid_overrides = [
+        (
+            {"enabled": True},
+            "goal periodic_report.profile_preset is required",
+        ),
+        (
+            {
+                "enabled": "true",
+                "profile_preset": "weekly-progress",
+                "route_ref": "loopx-concierge",
+            },
+            "goal periodic_report.enabled must be a boolean",
+        ),
+    ]
+    for override, expected_error in invalid_overrides:
+        goal = {"id": "goal-1", "control_plane": {"periodic_report": override}}
+        with pytest.raises((TypeError, ValueError), match=expected_error):
+            resolve_goal_periodic_report_subscription(goal)
+
+        registry_path = tmp_path / "registry.json"
+        registry_path.write_text(
+            json.dumps({"goals": [goal]}),
+            encoding="utf-8",
+        )
+        with pytest.warns(UserWarning, match=expected_error):
+            assert (
+                periodic_report_post_writeback_hooks_for_goal(
+                    registry_path=registry_path,
+                    runtime_root=tmp_path / "runtime",
+                    goal_id="goal-1",
+                )
+                == ()
+            )
+
+
+def test_todo_complete_survives_unreadable_periodic_report_machine_store(
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from loopx.cli import main as cli_main
+
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    state = tmp_path / "STATE.md"
+    state.write_text(
+        "# Goal\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] demo work item\n"
+        "  <!-- loopx:todo status=open task_class=advancement_task "
+        "claimed_by=agent-a todo_id=todo_dem0item -->\n",
+        encoding="utf-8",
+    )
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "goal-1",
+                        "repo": str(tmp_path),
+                        "state_file": "STATE.md",
+                        "agents": [{"id": "agent-a"}],
+                    }
+                ],
+                "common_runtime_root": str(runtime_root),
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_unreadable_periodic_report_machine_store(runtime_root)
+
+    with pytest.warns(UserWarning, match="periodic_report.enabled must be a boolean"):
+        exit_code = cli_main(
+            [
+                "--registry",
+                str(registry_path),
+                "--format",
+                "json",
+                "todo",
+                "complete",
+                "--goal-id",
+                "goal-1",
+                "--todo-id",
+                "todo_dem0item",
+                "--agent-id",
+                "agent-a",
+                "--evidence",
+                "demo",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["completed"] is True
 
 
 def test_periodic_report_projection_reduces_durable_successor_transition(

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -3491,6 +3491,7 @@ def test_read_only_settlement_omits_non_causal_delivery_workspace(
         "periodic_report": {
             "enabled": True,
             "profile_preset": "weekly",
+            "route_ref": "project-room",
         }
     }
     registry_path.write_text(


### PR DESCRIPTION
## Summary

- The post-writeback hook composition (`periodic_report_post_writeback_hooks_for_goal`) runs during CLI argument evaluation, outside the dispatch isolation boundary, so a machine-configuration store that fails normalization (a bad value or a legacy namespace field surfacing after an upgrade) crashed `loopx todo complete` and `loopx refresh-state` with a bare traceback for every goal without a `periodic_report` override — violating the dispatch contract that optional hooks never alter the primary truth of the composing command.
- The goal-override branch also kept its own lenient predicate: invalid overrides were silently treated as disabled, while the canonical `resolve_goal_periodic_report_subscription` raises for the same configuration.
- Both branches now resolve through the canonical subscription resolver, and `TypeError`/`ValueError` from the store read and validation degrade to no hooks with one `UserWarning` carrying the original typed message. Programming/environment errors (`OSError` etc.) still propagate, so the isolation does not swallow real defects.

## Issue Or Task

- Closes #
- Contributor task ID: found by an independent bug hunt during the #3871 review cycle; CLI-level reproductions (bad store value, legacy upgrade fields) available on request.

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [x] `loopx check --scan-root .` (0 errors; 3 pre-existing local-runtime warnings unrelated to this change)
- [x] Other: 4 new red/green-verified tests in `tests/control_plane/test_post_writeback_capability_hooks.py` (crash before, structured warning + exit 0 after; invalid override now reported consistently); CLI-level reproduction flips from `CRASH` to `CLI exited 0`; `tests/capabilities/` 902 passed with only the 9 pre-existing `test_repository_change_window.py` env failures that reproduce on a clean baseline; output-budget regression smoke passes (warnings go to stderr, not the measured stdout payload); ruff check + format clean; m6 gates passed; architecture import-boundary tests passed.

## Type of Change

- [x] Bug fix

## LoopX Area

- [x] Capability or extension (providers, adapters, skills)

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
