### PR TITLE
fix(periodic-report): admit last_report into the post-writeback read scope

### DIFF
--- a/loopx/capabilities/periodic_report/post_writeback_hook.py
+++ b/loopx/capabilities/periodic_report/post_writeback_hook.py
@@ -352,7 +352,7 @@ def periodic_report_post_writeback_hook(
         capability_id="periodic-report",
         event_kinds=("refresh_state", "todo_complete"),
         intent_kinds=(PERIODIC_REPORT_TRIGGER_EVALUATION_INTENT,),
-        requested_read_scope=("stage_completion", "project_progress"),
+        requested_read_scope=("stage_completion", "project_progress", "last_report"),
         producer=producer,
         policy_version=policy_version,
     )

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -16,6 +16,10 @@ from loopx.control_plane.capability_hooks import (
     _post_writeback_dispatch_id,
     dispatch_post_writeback_hooks,
 )
+from loopx.capabilities.periodic_report.incremental import (
+    build_periodic_report_publication_candidate,
+    commit_periodic_report_publication_cursor,
+)
 from loopx.capabilities.periodic_report.post_writeback_hook import (
     build_periodic_report_post_writeback_projection,
     evaluate_periodic_report_trigger_evaluation_intent,
@@ -591,6 +595,128 @@ def test_periodic_report_projection_reduces_terminal_after_todo_completion(
     receipt = projection["stage_completion"]
     assert receipt["transition"] == "goal_terminal"
     assert receipt["frontier_identity"] == "validated-goal-terminal"
+
+
+def _published_report_goal_fixtures(
+    tmp_path,
+    *,
+    runs,
+) -> tuple[Path, Path, Path]:
+    """Materialize the state file, registry, and runs index for goal-1.
+
+    The projection-under-test only needs one open advancement todo on the
+    active state; the runs rows below drive the stage-completion receipt.
+    """
+
+    state_path = tmp_path / "goal.md"
+    state_path.write_text(
+        "# Goal\n\n## User Todo\n\n## Agent Todo\n\n"
+        "- [ ] Pick the next bounded slice of follow-up work.\n"
+        "  <!-- loopx:todo todo_id=todo-followup status=open "
+        "task_class=advancement_task claimed_by=agent-1 -->\n",
+        encoding="utf-8",
+    )
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {"goals": [{"id": "goal-1", "repo": str(tmp_path), "state_file": "goal.md"}]}
+        ),
+        encoding="utf-8",
+    )
+    runtime_root = tmp_path / "runtime"
+    (runtime_root / "goals" / "goal-1" / "runs").mkdir(parents=True)
+    return runtime_root, registry_path, state_path
+
+
+def test_periodic_report_hook_accepts_projection_after_a_published_report(
+    tmp_path,
+) -> None:
+    runs = [
+        {
+            "generated_at": "2026-08-30T11:00:00Z",
+            "goal_id": "goal-1",
+            "agent_vision": {
+                "schema_version": "goal_vision_replan_contract_v0",
+                "agent_id": "agent-1",
+                "state": "active",
+                "vision_patch": {"acceptance_summary": "Follow-up slice is scoped."},
+            },
+            "autonomous_replan_ack": {
+                "recorded": True,
+                "frontier_identity": "frontier-followup",
+                "semantic_delta": {
+                    "accepted": True,
+                    "outcomes": ["fresh_vision_path_outcome"],
+                    "trigger_kinds": ["vision_successor_required"],
+                    "obligation_id": "replan-2",
+                },
+            },
+        },
+        {
+            "generated_at": "2026-08-30T10:00:00Z",
+            "goal_id": "goal-1",
+            "agent_vision": {
+                "schema_version": "goal_vision_replan_contract_v0",
+                "agent_id": "agent-1",
+                "state": "vision_closed",
+                "vision_patch": {"acceptance_summary": "Initial slice accepted and reported."},
+            },
+            "vision_checkpoint": {
+                "schema_version": "vision_checkpoint_v0",
+                "satisfied": True,
+                "decision": "patched",
+                "triggers": [
+                    {
+                        "kind": "material_delivery_outcome",
+                        "delivery_outcome": "outcome_progress",
+                    }
+                ],
+            },
+        },
+    ]
+    runtime_root, registry_path, state_path = _published_report_goal_fixtures(
+        tmp_path, runs=runs
+    )
+    ((runtime_root / "goals" / "goal-1" / "runs") / "index.jsonl").write_text(
+        "".join(json.dumps(run) + "\n" for run in runs), encoding="utf-8"
+    )
+    candidate = build_periodic_report_publication_candidate(
+        goal_id="goal-1",
+        agent_id="agent-1",
+        generation_id="report_generation_first",
+        trigger_receipt={"coalesced_trigger_ids": ["trigger_first"]},
+        facts=[],
+        baseline=None,
+    )
+    commit_periodic_report_publication_cursor(
+        runtime_root=runtime_root,
+        candidate=candidate,
+        publication_id="goal-channel:first",
+        delivered_at="2026-08-30T12:00:00Z",
+        covered_until="2026-08-30T11:00:00Z",
+    )
+
+    projection = build_periodic_report_post_writeback_projection(
+        payload={"state": {"path": str(state_path)}},
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id="goal-1",
+        agent_id="agent-1",
+    )
+
+    assert projection["last_report"]["covered_trigger_ids"] == ["trigger_first"]
+
+    hook_input = _input()
+    hook_input["projection"] = projection  # type: ignore[assignment]
+    dispatch = dispatch_post_writeback_hooks(
+        [periodic_report_post_writeback_hook()],
+        hook_input=hook_input,
+    )
+
+    assert dispatch["failures"] == []
+    assert dispatch["intent_count"] == 1
+    intent = dispatch["intents"][0]
+    assert intent["payload"]["last_report"]["covered_trigger_ids"] == ["trigger_first"]
 
 
 def test_post_writeback_concurrent_exact_dispatch_single_flight(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- `build_periodic_report_post_writeback_projection` injects a `last_report` key into the projection whenever a publication cursor exists (i.e. after the first periodic report has been published), and the hook producer already consumes it for incremental suppression.
- But the registration declared `requested_read_scope=("stage_completion", "project_progress")` without `last_report`, so the control-plane input validation rejected **every dispatch after the first publication** with `registration_or_input_rejected` — silently: no journal entry, no intent, and the primary command still succeeds.
- The incremental-report loop is therefore broken after its first delivery: subsequent stage settlements never produce a follow-up report intent. This adds `last_report` to the read scope (the TS side enforces only a bounded-tokens limit, no enum) and pins the fix with an integration test that drives the real cursor commit path and feeds the projection into dispatch unmodified.

## Issue Or Task

- Closes #
- Contributor task ID: found by an independent review of the #3691 refinement commits; function-level reproduction available on request.

## Validation

- [x] `python3 -m py_compile loopx/*.py`
- [ ] `loopx check --scan-root .`
- [x] Other: new integration test `test_periodic_report_hook_accepts_projection_after_a_published_report` fails with `registration_or_input_rejected` before the one-line fix and passes after (red/green-verified both directions, re-verified post-commit by checking out the old file); `tests/control_plane/test_post_writeback_capability_hooks.py` 17 passed; periodic capability tests 98 passed; m6 gates 3 passed; TS `capability_hooks.test.ts` 12 pass; ruff check + format clean.

## Type of Change

- [x] Bug fix

## LoopX Area

- [x] Capability or extension (providers, adapters, skills)

## Technical Direction

- [x] Core control-plane hardening

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
