### PR TITLE
fix(codex): preserve scheduler fallback host context

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -549,10 +549,11 @@ If `automation_update` is unavailable in the session and
 `fallback_hint.cli_args` (`loopx-apply-rrule`) once instead. It backs up
 `codex-dev.db`, syncs the automation TOML and SQLite row, and runs the bound
 ACK; direct SQLite edits bypass the app API, so this is a bounded fallback and
-never the routine path. The bridge treats the provided turn id as its parent
-and derives a stable child receipt id for the internal quota query, so it does
-not reuse the already-settled heartbeat receipt. When the automation id could
-not be resolved,
+never the routine path. The bridge reuses the provided parent Turn for its
+internal `quota should-run` query. That same-Turn replay preserves the committed
+receipt's bound Todo, observed capabilities, and settlement identity; an
+explicitly conflicting identity still fails closed. When the automation id
+could not be resolved,
 `fallback_hint.available=false` and the pasteable heartbeat gate is the correct
 stop - never guess an automation id.
 

--- a/scripts/codex_app_apply_rrule.py
+++ b/scripts/codex_app_apply_rrule.py
@@ -19,8 +19,8 @@ overridden for tests or alternate installations.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
+import os
 import re
 import sqlite3
 import subprocess
@@ -60,7 +60,7 @@ def _subprocess_failure_detail(completed: subprocess.CompletedProcess[str]) -> s
 
 
 def _scheduler_hint_turn_instance_id(parent_turn_instance_id: str) -> str:
-    """Derive one replay-safe child receipt identity for the fallback query."""
+    """Reuse the host Turn so the fallback query replays its quota receipt."""
 
     try:
         normalized = normalize_turn_instance_id(parent_turn_instance_id)
@@ -68,8 +68,14 @@ def _scheduler_hint_turn_instance_id(parent_turn_instance_id: str) -> str:
         raise SystemExit(str(exc)) from exc
     if not normalized:
         raise SystemExit("--turn-instance-id must not be empty")
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
-    return f"apply-rrule:{digest}"
+    return normalized
+
+
+def _codex_home() -> Path:
+    """Resolve the active Codex App home without changing LoopX registry roots."""
+
+    configured = os.environ.get("CODEX_HOME", "").strip()
+    return Path(configured).expanduser() if configured else Path.home() / ".codex"
 
 
 def _load_registry_goal(registry: Path, goal_id: str) -> dict[str, Any]:
@@ -445,25 +451,25 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--automations-root",
         type=Path,
-        default=Path.home() / ".codex/automations",
+        default=_codex_home() / "automations",
     )
     parser.add_argument(
         "--db-path",
         type=Path,
-        default=Path.home() / ".codex/sqlite/codex-dev.db",
+        default=_codex_home() / "sqlite/codex-dev.db",
     )
     parser.add_argument("--loopx", default="loopx")
     parser.add_argument(
         "--capability",
         action="append",
-        default=["network", "external_evidence_poll"],
+        default=[],
     )
     parser.add_argument(
         "--turn-instance-id",
         default=f"apply-rrule-{_now_ms()}",
         help=(
-            "outer host turn identity; the bridge derives a stable child identity "
-            "for its internal quota query"
+            "outer host turn identity; the bridge reuses it when replaying the "
+            "scheduler hint"
         ),
     )
     parser.add_argument("--dry-run", action="store_true")

--- a/tests/test_codex_app_apply_rrule.py
+++ b/tests/test_codex_app_apply_rrule.py
@@ -156,6 +156,19 @@ def test_default_app_stores_follow_codex_home_and_capabilities_are_explicit(
     assert explicit.capability == ["network"]
 
 
+def test_heartbeat_guide_matches_parent_turn_replay_contract() -> None:
+    guide = (
+        Path(__file__).parents[1] / "docs/heartbeat-automation-prompt.md"
+    ).read_text(encoding="utf-8")
+
+    assert "reuses the provided parent Turn" in guide
+    assert "same-Turn replay preserves the committed" in guide
+    assert "bound Todo, observed capabilities, and settlement identity" in guide
+    assert "explicitly conflicting identity still fails closed" in guide
+    assert "derives a stable child receipt id" not in guide
+    assert "does not reuse the already-settled heartbeat receipt" not in guide
+
+
 def test_should_run_failure_reports_structured_stdout(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_codex_app_apply_rrule.py
+++ b/tests/test_codex_app_apply_rrule.py
@@ -9,6 +9,7 @@ import pytest
 
 from scripts.codex_app_apply_rrule import (
     _now_ms,
+    _parse_args,
     _scheduler_hint_turn_instance_id,
     _update_sqlite,
     _update_toml,
@@ -102,7 +103,7 @@ class _FakeCompleted:
         self.stderr = stderr
 
 
-def test_scheduler_hint_uses_stable_child_turn_identity(
+def test_scheduler_hint_replays_parent_turn_without_synthetic_capabilities(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -131,12 +132,28 @@ def test_scheduler_hint_uses_stable_child_turn_identity(
         == 0
     )
 
-    child_turn = calls[0][calls[0].index("--turn-instance-id") + 1]
-    assert child_turn == _scheduler_hint_turn_instance_id(parent_turn)
-    assert child_turn == _scheduler_hint_turn_instance_id(parent_turn)
-    assert child_turn != parent_turn
-    assert len(child_turn) <= 128
-    assert re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]*", child_turn)
+    replay_turn = calls[0][calls[0].index("--turn-instance-id") + 1]
+    assert replay_turn == _scheduler_hint_turn_instance_id(parent_turn)
+    assert replay_turn == parent_turn
+    assert len(replay_turn) <= 128
+    assert re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]*", replay_turn)
+    assert "--available-capability" not in calls[0]
+
+
+def test_default_app_stores_follow_codex_home_and_capabilities_are_explicit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    codex_home = tmp_path / "codex-home"
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    defaults = _parse_args([])
+    assert defaults.automations_root == codex_home / "automations"
+    assert defaults.db_path == codex_home / "sqlite/codex-dev.db"
+    assert defaults.capability == []
+
+    explicit = _parse_args(["--capability", "network"])
+    assert explicit.capability == ["network"]
 
 
 def test_should_run_failure_reports_structured_stdout(


### PR DESCRIPTION
## Summary

- resolve Codex App automation stores from the active `CODEX_HOME` while keeping the LoopX registry default unchanged
- replay scheduler hints with the parent Turn identity so the fallback cannot supersede its host receipt
- stop injecting unobserved capabilities; callers may still pass explicitly verified capabilities

## Validation

- `pytest -q tests/test_codex_app_apply_rrule.py tests/control_plane/test_scheduler_fallback_hint.py` — 15 passed
- `ruff check scripts/codex_app_apply_rrule.py tests/test_codex_app_apply_rrule.py`
- `loopx canary premerge --from-git-diff` — passed, 2 changed files, no manual holds
- `git diff --check`

## Boundary

No local state, credentials, raw logs, private URLs, or generated artifacts are included. The related future-facing pass found no broader refactor necessary: the existing fallback script remains the nearest owner.