### PR TITLE
ci: extend Python test timeout to 30 minutes

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -36,10 +36,10 @@ concurrency:
 jobs:
   pytest:
     runs-on: ubuntu-latest
-    # The parallel suite now reaches coverage collation at ~15 minutes on the
-    # hosted runner. Keep the fail-safe bounded while leaving enough headroom
-    # for collection and post-test coverage reporting.
-    timeout-minutes: 25
+    # The parallel suite can take more than 15 minutes through coverage
+    # collation on the hosted runner. Keep the fail-safe bounded while leaving
+    # enough headroom for runner variance and post-test coverage reporting.
+    timeout-minutes: 30
     steps:
       - name: Check out repository
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- raise the Linux `pytest` job timeout from 25 to 30 minutes
- retain the existing job-level fail-safe and test commands
- allow headroom for hosted-runner variance and coverage collation; PR #3869 has already completed the same required job in about 16 minutes 37 seconds

## Validation

- workflow YAML parse
- `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 2/2 selected checks passed, zero holds
- public/private boundary scan passed
- strict change-quality receipt: `cqr_fe94dc2f56af5fd03c2b`

## Scope

One workflow file only. No test selection, coverage threshold, permissions, production runtime, or application behavior changes.
