### PR TITLE
fix(control-plane): fence goal-scoped event log paths

### DIFF
--- a/loopx/control_plane/agents/supervisor_events.py
+++ b/loopx/control_plane/agents/supervisor_events.py
@@ -39,7 +39,13 @@ class SupervisorRollbackMode(str, Enum):
 
 
 def supervisor_event_log_path(runtime_root: Path, goal_id: str) -> Path:
-    return runtime_root.expanduser() / "goals" / str(goal_id) / SUPERVISOR_EVENT_LOG_NAME
+    # Supervisor events share the same goal-scoped storage boundary as rollout
+    # events; validate before constructing a path so CLI reads and writes cannot
+    # escape the runtime goals directory.
+    from ...history import validate_goal_id_path_segment
+
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
+    return runtime_root.expanduser() / "goals" / safe_goal_id / SUPERVISOR_EVENT_LOG_NAME
 
 
 def _tokens(values: Any, *, field: str, required: bool) -> list[str]:
@@ -78,13 +84,16 @@ def build_supervisor_proposal_event(
     decision: Mapping[str, Any],
     recorded_at: str | None = None,
 ) -> dict[str, Any]:
+    from ...history import validate_goal_id_path_segment
+
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
     normalized = normalize_supervisor_decision(decision, supervisor=supervisor)
     _reject_inline_secrets(normalized, field="decision")
     decision_id = str(normalized["decision_id"])
     supervisor_agent_id = str(supervisor.get("agent_id") or "")
     return make_state_event(
         event_id=f"supervisor-proposal-{decision_id}",
-        goal_id=goal_id,
+        goal_id=safe_goal_id,
         event_type=SUPERVISOR_PROPOSED,
         refs={
             "decision_id": decision_id,
@@ -189,6 +198,9 @@ def build_supervisor_receipt_event(
     host_capabilities: list[str] | tuple[str, ...] | None = None,
     recorded_at: str | None = None,
 ) -> dict[str, Any]:
+    from ...history import validate_goal_id_path_segment
+
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
     proposal = proposal_event.get("payload")
     if not isinstance(proposal, Mapping):
         raise ValueError("proposal event is missing payload")
@@ -199,7 +211,7 @@ def build_supervisor_receipt_event(
     )
     return make_state_event(
         event_id=f"supervisor-receipt-{normalized['receipt_id']}",
-        goal_id=goal_id,
+        goal_id=safe_goal_id,
         event_type=SUPERVISOR_RECEIPT_RECORDED,
         refs={
             "decision_id": normalized["decision_id"],

--- a/loopx/rollout_event_log.py
+++ b/loopx/rollout_event_log.py
@@ -186,10 +186,16 @@ def _idempotency_body(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def rollout_event_log_path(runtime_root: Path, goal_id: str) -> Path:
+    # Goal ids are used as directory names throughout the control plane. Keep
+    # this shared path helper fail-closed so every reader and writer inherits
+    # the same single-segment boundary.
+    from .history import validate_goal_id_path_segment
+
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
     return (
         runtime_root.expanduser()
         / "goals"
-        / str(goal_id)
+        / safe_goal_id
         / DEFAULT_ROLLOUT_EVENT_LOG_NAME
     )
 
@@ -235,8 +241,9 @@ def build_rollout_event(
     local paths out of the payload.
     """
 
-    if not str(goal_id).strip():
-        raise ValueError("goal_id is required")
+    from .history import validate_goal_id_path_segment
+
+    safe_goal_id = validate_goal_id_path_segment(goal_id)
     private_kind = (
         str(private_source_kind).strip()
         if private_source_kind
@@ -259,7 +266,7 @@ def build_rollout_event(
     ]
     payload: dict[str, Any] = {
         "schema_version": ROLLOUT_EVENT_SCHEMA_VERSION,
-        "goal_id": str(goal_id).strip(),
+        "goal_id": safe_goal_id,
         "event_kind": _normalized_event_kind(event_kind),
         "recorded_at": recorded_at or _now_iso(),
         "boundary": {

--- a/tests/control_plane/test_goal_scoped_log_paths.py
+++ b/tests/control_plane/test_goal_scoped_log_paths.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.agents.supervisor_events import (
+    build_supervisor_proposal_event,
+    supervisor_event_log_path,
+)
+from loopx.rollout_event_log import build_rollout_event, rollout_event_log_path
+
+
+UNSAFE_GOAL_IDS = ("../escape", "a/b", "/tmp/outside", "..", ".", r"..\escape")
+
+
+@pytest.mark.parametrize("path_builder", [rollout_event_log_path, supervisor_event_log_path])
+@pytest.mark.parametrize("goal_id", UNSAFE_GOAL_IDS)
+def test_goal_scoped_log_paths_reject_path_traversal(
+    tmp_path: Path,
+    path_builder,
+    goal_id: str,
+) -> None:
+    with pytest.raises(ValueError, match="single path segment"):
+        path_builder(tmp_path, goal_id)
+
+    assert not (tmp_path / "goals").exists()
+
+
+@pytest.mark.parametrize(
+    ("path_builder", "file_name"),
+    [
+        (rollout_event_log_path, "rollout-event-log.jsonl"),
+        (supervisor_event_log_path, "supervisor-events.jsonl"),
+    ],
+)
+def test_goal_scoped_log_paths_preserve_valid_goal_layout(
+    tmp_path: Path,
+    path_builder,
+    file_name: str,
+) -> None:
+    assert path_builder(tmp_path, "goal-123") == (
+        tmp_path / "goals" / "goal-123" / file_name
+    )
+
+
+def test_rollout_event_builder_rejects_unsafe_goal_id() -> None:
+    with pytest.raises(ValueError, match="single path segment"):
+        build_rollout_event(goal_id="../escape", event_kind="validation")
+
+
+def test_supervisor_event_builder_rejects_unsafe_goal_id() -> None:
+    with pytest.raises(ValueError, match="single path segment"):
+        build_supervisor_proposal_event(
+            goal_id="../escape",
+            supervisor={"agent_id": "supervisor", "supervised_agents": []},
+            decision={
+                "kind": "observe",
+                "decision_id": "decision-1",
+                "reason_codes": ["inspect"],
+                "evidence_refs": ["run:1"],
+            },
+        )
+
+
+def test_evidence_log_cli_rejects_unsafe_goal_without_writing_outside_root(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import json
+
+    from loopx.cli import main
+
+    runtime_root = tmp_path / "runtime"
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps({"common_runtime_root": str(runtime_root), "goals": []}) + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            "evidence-log",
+            "--goal-id",
+            "../escape",
+            "--agent-id",
+            "agent-a",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"] == "goal id must be a single path segment"
+    assert not (runtime_root / "escape").exists()
+
+
+def test_cli_rollout_event_does_not_create_path_outside_goals_root(tmp_path: Path) -> None:
+    from loopx.cli_rollout import append_cli_rollout_event
+
+    runtime_root = tmp_path / "runtime"
+    payload = append_cli_rollout_event(
+        {"ok": True, "goal_id": "../escape", "runtime_root": str(runtime_root)},
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        event_kind="validation",
+        summary="path boundary regression",
+    )
+
+    assert payload["rollout_event_log_error"]["error_type"] == "ValueError"
+    assert not (runtime_root / "escape").exists()


### PR DESCRIPTION
## Summary
- validate Goal IDs before constructing rollout and supervisor event-log paths
- reject traversal and absolute/separator-bearing IDs in rollout and supervisor event builders
- add CLI and cross-platform regression coverage for the runtime goals boundary

## Validation
- `uv run --extra test pytest -q tests/control_plane/test_goal_scoped_log_paths.py tests/control_plane/test_heartbeat_receipt.py tests/control_plane/test_todo_decision_scope_cli_validation.py tests/test_feedback_goal_id_validation.py tests/test_history_chronology.py` (55 passed)
- `uv run python -m loopx.cli canary premerge --from-git-diff --format json --no-progress` (17 checks passed)
- `git diff --cached --check`

The change is limited to public control-plane path handling and does not alter valid Goal ID directory layout.
