### PR TITLE
fix: dedupe human gate notifications by state

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -827,6 +827,15 @@ the open user todo visible in `user_todo_summary`, but do not force a repeated
 notification, make the turn a user-action gate, or leave the top-level
 `should_run` set for an otherwise quiet no-op.
 
+Cooldown suppression has precedence over both blocking asks and non-blocking
+`user_action` notices: the final `interaction_contract.user_channel` must be
+`action_required=false, notify=DONT_NOTIFY` and must not retain an action list.
+Goal Channel delivery adds a sink-local replay fence keyed by the gate identity,
+its material state generation, and (only when due) the explicit reminder-window
+generation. Copy changes, recommendation churn, and provider readback misses do
+not create a new send generation; a material Todo transition or a new explicit
+reminder window does.
+
 Monitor catch-up is also bounded across runnable lanes. After two consecutive
 unchanged monitor-only work turns, `monitor_debt_arbitration_v0` prefers a
 same- or higher-priority advancement todo over another overdue monitor,

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1399,6 +1399,13 @@ remain visible, while `interaction_contract.user_channel` becomes
 `action_required=false`, `notify=DONT_NOTIFY` until the bounded reminder window
 or a material gate/host change. Other blocker-push
 cases may still be de-duplicated when the same blocker was surfaced recently.
+
+The suppression decision also removes `actions` and `non_blocking` from the
+final user channel, so a remaining `user_action` cannot re-promote the same
+contract to `NOTIFY`. Provider sinks must deduplicate delivery by gate identity
+plus material state generation, with an additional reminder generation only
+for an explicitly due reminder window; presentation text is not delivery
+identity.
 Eligible monitor-only no-transition polls keep open user todos in
 `user_todo_summary`, but do not force repeated notification or set
 `requires_user_action=true`; they should surface as a quiet

--- a/examples/control_plane/interaction-contract-state-machine-smoke.py
+++ b/examples/control_plane/interaction-contract-state-machine-smoke.py
@@ -165,7 +165,9 @@ def base_payload(
             "first_open_items": [advancement_item()] if should_run else [],
         },
         "automation_liveness": {
-            "automation_action": "execute_bounded_work" if should_run else "keep_active_quiet",
+            "automation_action": "execute_bounded_work"
+            if should_run
+            else "keep_active_quiet",
             "pause_allowed": False,
         },
     }
@@ -188,7 +190,9 @@ def finalize(payload: dict[str, Any]) -> dict[str, Any]:
     payload["scheduler_hint"] = build_scheduler_hint(
         payload,
         user_action_required=user_channel_action_required(payload),
-        agent_scope_frontier_actions=[action.value for action in AgentScopeFrontierAction],
+        agent_scope_frontier_actions=[
+            action.value for action in AgentScopeFrontierAction
+        ],
         scheduler_execution_context=APP_SCHEDULER_CONTEXT,
     )
     payload["protocol_action_packet"] = build_protocol_action_packet(payload)
@@ -476,6 +480,40 @@ def assert_user_action_is_non_blocking_notice() -> None:
     assert "user_action_pending=true" in summary, summary
 
 
+def assert_gate_cooldown_suppresses_non_blocking_notice() -> None:
+    payload = base_payload(
+        should_run=False,
+        effective_action="monitor_quiet_skip",
+        work_lane=monitor_quiet_lane(),
+        heartbeat_mode="monitor_quiet_until_material_transition",
+    )
+    user_action = {
+        "todo_id": "todo_user_action_cooldown",
+        "status": "open",
+        "task_class": "user_action",
+        "text": "Confirm one bounded action.",
+    }
+    payload["user_todo_summary"] = {
+        "first_open_items": [user_action],
+        "user_action_items": [user_action],
+    }
+    payload["user_gate_notification_cooldown"] = {
+        "notification_due": False,
+        "notification_suppressed": True,
+        "reason": "the same gate is outside its explicit reminder window",
+    }
+    contract = build_interaction_contract(
+        payload,
+        scheduler_execution_context=APP_SCHEDULER_CONTEXT,
+    )
+    user_channel = contract["user_channel"]
+    assert contract["mode"] == "user_gate_cooldown_wait", contract
+    assert user_channel["action_required"] is False, contract
+    assert user_channel["notify"] == "DONT_NOTIFY", contract
+    assert "non_blocking" not in user_channel, contract
+    assert "actions" not in user_channel, contract
+
+
 def assert_monitor_quiet_skip_is_no_spend() -> None:
     payload = finalize(
         base_payload(
@@ -493,8 +531,12 @@ def assert_monitor_quiet_skip_is_no_spend() -> None:
     assert contract["cli_channel"]["spend_policy"] == (
         "no spend for unchanged heartbeat stall receipt"
     ), contract
-    assert "heartbeat_receipt" in contract["cli_channel"]["next_cli_actions"][0], contract
-    assert "--turn-instance-id" in contract["cli_channel"]["next_cli_actions"][0], contract
+    assert "heartbeat_receipt" in contract["cli_channel"]["next_cli_actions"][0], (
+        contract
+    )
+    assert "--turn-instance-id" in contract["cli_channel"]["next_cli_actions"][0], (
+        contract
+    )
     assert "LOOPX_TURN" in contract["cli_channel"]["next_cli_actions"][0], contract
 
 
@@ -514,7 +556,9 @@ def assert_autonomous_replan_projects_accountable_settlement() -> None:
     assert contract["mode"] == "autonomous_replan", payload
     assert contract["agent_channel"]["must_attempt"] is True, contract
     assert contract["cli_channel"]["spend_after_validation"] is True, contract
-    assert "accountable replan delta" in contract["cli_channel"]["spend_policy"], contract
+    assert "accountable replan delta" in contract["cli_channel"]["spend_policy"], (
+        contract
+    )
     assert "surface_only" in contract["cli_channel"]["spend_policy"], contract
     settlement = contract["cli_channel"]["settlement_plan"]
     assert settlement["identity"]["binding_kind"] == "autonomous_replan", contract
@@ -550,7 +594,9 @@ def assert_agent_scope_wait_is_quiet_noop() -> None:
 def assert_successor_replan_is_validated_spend_path() -> None:
     payload = _successor_replan_payload()
     contract = payload["interaction_contract"]
-    assert contract["mode"] == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value, payload
+    assert (
+        contract["mode"] == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value
+    ), payload
     assert contract["agent_channel"]["must_attempt"] is True, contract
     assert contract["cli_channel"]["spend_after_validation"] is True, contract
     assert contract["cli_channel"]["spend_policy"].startswith("spend once"), contract
@@ -590,6 +636,7 @@ def main() -> int:
     assert_bounded_delivery_bundle()
     assert_user_notice_can_coexist_with_bounded_delivery()
     assert_user_action_is_non_blocking_notice()
+    assert_gate_cooldown_suppresses_non_blocking_notice()
     assert_monitor_quiet_skip_is_no_spend()
     assert_autonomous_replan_projects_accountable_settlement()
     assert_agent_scope_wait_is_quiet_noop()

--- a/examples/lark-goal-channel-human-gate-delivery-smoke.py
+++ b/examples/lark-goal-channel-human-gate-delivery-smoke.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from loopx.extensions.bundled import bundled_extension_manifest
 from loopx.extensions.lark.goal_channel_contracts import (
     GOAL_CHANNEL_BINDING_SCHEMA_VERSION,
+    quota_human_gate_state_generation,
     read_goal_channel_binding,
     semantic_key,
     write_goal_channel_binding,
@@ -23,7 +24,6 @@ from loopx.extensions.runtime import (
     default_extension_state_file,
     install_extension,
 )
-from loopx.control_plane.runtime.public_safety import public_safe_compact_text
 from loopx.paths import registry_project_root
 from loopx.quota import build_quota_should_run
 from loopx.status import collect_status
@@ -33,6 +33,7 @@ GOAL_ID = "goal-channel-human-gate-smoke"
 GATE_TODO_ID = "todo_gate_fixture"
 CHAT_ID = "oc_public_fixture"
 MESSAGE_ID = "om_public_fixture"
+MESSAGE_SEND_COMMAND = "+messages-send"
 APP_ID = "cli_public_fixture"
 
 
@@ -71,12 +72,14 @@ def write_fake_lark_cli(root: Path) -> tuple[Path, Path]:
     return bin_dir, state_path
 
 
-def run_refresh(
+def run_loopx(
     *,
     registry_path: Path,
     runtime_root: Path,
     project: Path,
     bin_dir: Path,
+    args: list[str],
+    operation: str,
 ) -> dict[str, object]:
     environment = {
         **os.environ,
@@ -94,6 +97,35 @@ def run_refresh(
             str(runtime_root),
             "--format",
             "json",
+            *args,
+        ],
+        cwd=project,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"{operation} failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    return json.loads(completed.stdout)
+
+
+def run_refresh(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path,
+    bin_dir: Path,
+) -> dict[str, object]:
+    return run_loopx(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        bin_dir=bin_dir,
+        operation="refresh-state",
+        args=[
             "refresh-state",
             "--goal-id",
             GOAL_ID,
@@ -105,17 +137,35 @@ def run_refresh(
             "Wait for owner approval.",
             "--no-global-sync",
         ],
-        cwd=project,
-        env=environment,
-        check=False,
-        capture_output=True,
-        text=True,
     )
-    if completed.returncode != 0:
-        raise AssertionError(
-            f"refresh-state failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
-        )
-    return json.loads(completed.stdout)
+
+
+def update_gate(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    project: Path,
+    bin_dir: Path,
+) -> dict[str, object]:
+    return run_loopx(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        project=project,
+        bin_dir=bin_dir,
+        operation="todo update",
+        args=[
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "user",
+            "--todo-id",
+            GATE_TODO_ID,
+            "--text",
+            "[P0] Approve the bounded external write after reviewing the diff.",
+        ],
+    )
 
 
 def write_project(root: Path) -> tuple[Path, Path]:
@@ -212,9 +262,7 @@ def write_project(root: Path) -> tuple[Path, Path]:
 
 
 def main() -> None:
-    with tempfile.TemporaryDirectory(
-        prefix="loopx-goal-channel-human-gate-"
-    ) as raw:
+    with tempfile.TemporaryDirectory(prefix="loopx-goal-channel-human-gate-") as raw:
         registry_path, binding_path = write_project(Path(raw))
         bin_dir, fake_state_path = write_fake_lark_cli(Path(raw))
         project = registry_path.parent.parent
@@ -228,7 +276,7 @@ def main() -> None:
         first = first_refresh["goal_channel_gate_sync"]
         first_fake_state = json.loads(fake_state_path.read_text(encoding="utf-8"))
         send_count = sum(
-            "+messages-send" in args for args in first_fake_state["calls"]
+            MESSAGE_SEND_COMMAND in args for args in first_fake_state["calls"]
         )
         second_refresh = run_refresh(
             registry_path=registry_path,
@@ -238,11 +286,6 @@ def main() -> None:
         )
         second = second_refresh["goal_channel_gate_sync"]
         second_fake_state = json.loads(fake_state_path.read_text(encoding="utf-8"))
-
-        assert first["status"] == "sent_verified", first
-        assert first["external_write_performed"] is True, first
-        assert first["readback_verified"] is True, first
-        notification = first["notification"]
         status = collect_status(
             registry_path=registry_path,
             runtime_root_override=str(Path(raw) / "runtime"),
@@ -256,21 +299,54 @@ def main() -> None:
             "lark",
             "notify_gate",
             GATE_TODO_ID,
-            public_safe_compact_text(quota["gate_prompt"], limit=900),
+            quota_human_gate_state_generation(quota),
+            "material_state",
             CHAT_ID,
         )
+        gate_update = update_gate(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            bin_dir=bin_dir,
+        )
+        third_refresh = run_refresh(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            project=project,
+            bin_dir=bin_dir,
+        )
+        third = third_refresh["goal_channel_gate_sync"]
+        third_fake_state = json.loads(fake_state_path.read_text(encoding="utf-8"))
+
+        assert first["status"] == "sent_verified", first
+        assert first["external_write_performed"] is True, first
+        assert first["readback_verified"] is True, first
+        notification = first["notification"]
         assert notification["idempotency_key"] == expected_key, notification
         assert second["status"] == "already_sent", second
         assert (
-            sum("+messages-send" in args for args in second_fake_state["calls"])
+            sum(MESSAGE_SEND_COMMAND in args for args in second_fake_state["calls"])
             == send_count
+        )
+        assert gate_update["changed"] is True, gate_update
+        assert third["status"] == "sent_verified", third
+        assert (
+            sum(MESSAGE_SEND_COMMAND in args for args in third_fake_state["calls"])
+            == send_count + 1
         )
         receipts = read_goal_channel_binding(binding_path)["bindings"][GOAL_ID][
             "receipts"
         ]
         assert expected_key in receipts, receipts
-        assert "Approve the bounded external write." in second_fake_state["sent_text"]
-        assert "LoopX remains the source of truth" not in second_fake_state["sent_text"]
+        assert len(receipts) == 2, receipts
+        assert "Approve the bounded external write" in third_fake_state["sent_text"]
+        assert third_fake_state["sent_text"].startswith(
+            "LoopX · Action required\n\nGoal:"
+        )
+        assert "\n1. " in third_fake_state["sent_text"]
+        assert "\n- " not in third_fake_state["sent_text"]
+        assert "Next safe action while waiting" not in third_fake_state["sent_text"]
+        assert "LoopX remains the source of truth" not in third_fake_state["sent_text"]
         public_packet = json.dumps(first, ensure_ascii=False)
         assert CHAT_ID not in public_packet
         assert MESSAGE_ID not in public_packet

--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -183,7 +183,15 @@ def register_goal_channel_commands(
     add_subcommand_format(notify)
     _add_common_args(notify)
     notify.add_argument("--agent-id")
-    notify.add_argument("--cooldown-seconds", type=int, default=3600)
+    notify.add_argument(
+        "--cooldown-seconds",
+        type=int,
+        default=None,
+        help=(
+            "Accepted for compatibility; delivery repeats only for a material "
+            "gate-state generation or an explicit quota reminder window."
+        ),
+    )
     notify.add_argument("--execute", action="store_true")
 
     runtime = sub.add_parser(
@@ -561,9 +569,7 @@ def handle_goal_channel_command(
             goal_id=goal_id,
             binding_path_arg=getattr(args, "binding_path", None),
         )
-        default_binding_path = default_goal_channel_binding_path(
-            source_registry_path
-        )
+        default_binding_path = default_goal_channel_binding_path(source_registry_path)
     else:
         binding_path = None
         default_binding_path = None
@@ -760,7 +766,6 @@ def handle_goal_channel_command(
                             goal_id=goal_id,
                             agent_id=args.agent_id,
                         ),
-                        cooldown_seconds=max(0, args.cooldown_seconds),
                         execute=execute,
                     )
                 else:

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -1203,20 +1203,20 @@ def _build_interaction_user_channel(
     user_required: bool,
 ) -> dict[str, Any]:
     actions = projected_user_channel_actions(payload, limit=3)
+    notification_suppressed = _user_gate_notification_suppressed(payload)
     non_blocking_notice = bool(
         not user_required
+        and not notification_suppressed
         and user_channel_notice_todo_actions(payload.get("user_todo_summary"), limit=3)
     )
+    notify = heartbeat_recommendation.get("notify", "DONT_NOTIFY")
+    if user_required or non_blocking_notice:
+        notify = "NOTIFY"
+    if notification_suppressed or _user_gate_scope_projection_repair_active(payload):
+        notify = "DONT_NOTIFY"
     channel: dict[str, Any] = {
         "action_required": user_required,
-        "notify": "NOTIFY"
-        if user_required or non_blocking_notice
-        else "DONT_NOTIFY"
-        if (
-            _user_gate_notification_suppressed(payload)
-            or _user_gate_scope_projection_repair_active(payload)
-        )
-        else heartbeat_recommendation.get("notify", "DONT_NOTIFY"),
+        "notify": notify,
     }
     if actions:
         channel["max_items"] = 3

--- a/loopx/extensions/lark/goal_channel_contracts.py
+++ b/loopx/extensions/lark/goal_channel_contracts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,6 +15,8 @@ from .private_json import write_private_json_atomic
 
 GOAL_CHANNEL_BINDING_SCHEMA_VERSION = "loopx_goal_channel_lark_binding_v0"
 GOAL_CHANNEL_OPERATION_SCHEMA_VERSION = "loopx_goal_channel_operation_v0"
+# Compatibility export for older callers. Scheduler-projected reminder windows
+# now own repeat-notification timing.
 DEFAULT_GATE_COOLDOWN_SECONDS = 3600
 HUMAN_GATE_AUTO_NOTIFY_SETTING = "human_gate_auto_notify_enabled"
 HUMAN_GATE_AUTO_NOTIFY_MARKER_SCHEMA_VERSION = (
@@ -29,6 +32,9 @@ PRIVATE_PACKET_KEYS = {
     "sender_profile",
     "table_id",
 }
+GATE_ACTION_PREFIX = re.compile(
+    r"^(?:(?:[-*•]|\d+[.)])\s*)?(?:\[[ xX]\]\s*)?(?:\[P\d+\]\s*)?"
+)
 
 
 def default_goal_channel_binding_path(registry_path: Path) -> Path:
@@ -52,8 +58,7 @@ def read_goal_channel_binding(path: Path) -> dict[str, Any]:
         raise ValueError("Goal Channel binding root must be a JSON object")
     if payload.get("schema_version") != GOAL_CHANNEL_BINDING_SCHEMA_VERSION:
         raise ValueError(
-            "Goal Channel binding must use "
-            f"{GOAL_CHANNEL_BINDING_SCHEMA_VERSION}"
+            f"Goal Channel binding must use {GOAL_CHANNEL_BINDING_SCHEMA_VERSION}"
         )
     bindings = payload.get("bindings")
     if not isinstance(bindings, dict):
@@ -206,7 +211,142 @@ def quota_human_gate_identity(quota_packet: Mapping[str, Any]) -> str:
     ).strip()
 
 
+def _quota_human_gate_items(
+    quota_packet: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    summary = quota_packet.get("user_todo_summary")
+    summary = summary if isinstance(summary, Mapping) else {}
+    for key in ("gate_open_items", "first_open_items"):
+        raw_items = summary.get(key)
+        if not isinstance(raw_items, list):
+            continue
+        items = [dict(item) for item in raw_items if isinstance(item, Mapping)]
+        if items:
+            return items[:3]
+    return []
+
+
+def quota_human_gate_state_generation(
+    quota_packet: Mapping[str, Any],
+) -> str:
+    """Fingerprint the material state of the currently projected human gate."""
+
+    material_items = []
+    for item in _quota_human_gate_items(quota_packet):
+        material_items.append(
+            {
+                key: item.get(key)
+                for key in (
+                    "todo_id",
+                    "gate_id",
+                    "status",
+                    "task_class",
+                    "updated_at",
+                    "material_change_generation",
+                    "decision_scope",
+                    "decision_outcome",
+                    "blocks_agent",
+                    "global_gate",
+                    "unblocks_todo_id",
+                )
+                if item.get(key) is not None
+            }
+        )
+        text = public_safe_compact_text(
+            item.get("text") or item.get("title"),
+            limit=300,
+        )
+        if text:
+            material_items[-1]["text"] = text
+    material: dict[str, Any] = {
+        "gate_identity": quota_human_gate_identity(quota_packet),
+        "items": material_items,
+    }
+    interaction = quota_packet.get("interaction_contract")
+    interaction = interaction if isinstance(interaction, Mapping) else {}
+    user_channel = interaction.get("user_channel")
+    user_channel = user_channel if isinstance(user_channel, Mapping) else {}
+    raw_actions = user_channel.get("actions")
+    actions = (
+        [public_safe_compact_text(action, limit=300) for action in raw_actions[:3]]
+        if isinstance(raw_actions, list)
+        else []
+    )
+    if any(actions):
+        material["actions"] = [action for action in actions if action]
+    if not material_items:
+        material["state"] = str(quota_packet.get("state") or "")
+        material["question"] = public_safe_compact_text(
+            quota_packet.get("gate_prompt")
+            or quota_packet.get("operator_question")
+            or quota_packet.get("reason"),
+            limit=900,
+        )
+    return semantic_key(
+        "human_gate_state_v0",
+        json.dumps(
+            material,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+
+
+def quota_human_gate_reminder_generation(
+    quota_packet: Mapping[str, Any],
+) -> str | None:
+    cooldown = quota_packet.get("user_gate_notification_cooldown")
+    if (
+        not isinstance(cooldown, Mapping)
+        or cooldown.get("notification_due") is not True
+    ):
+        return None
+    reminder_identity = {
+        key: cooldown.get(key)
+        for key in (
+            "policy",
+            "failed_at",
+            "next_reminder_at",
+            "cooldown_minutes",
+            "reminder_window_minutes",
+        )
+        if cooldown.get(key) is not None
+    }
+    return semantic_key(
+        "human_gate_reminder_v0",
+        json.dumps(
+            reminder_identity,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+
+
+def quota_human_gate_notification_suppressed(
+    quota_packet: Mapping[str, Any],
+) -> bool:
+    cooldown = quota_packet.get("user_gate_notification_cooldown")
+    return bool(
+        isinstance(cooldown, Mapping)
+        and cooldown.get("notification_suppressed") is True
+    )
+
+
 def quota_selects_human_gate(quota_packet: Mapping[str, Any]) -> bool:
+    if quota_human_gate_notification_suppressed(quota_packet):
+        return False
+    interaction = quota_packet.get("interaction_contract")
+    if isinstance(interaction, Mapping):
+        user_channel = interaction.get("user_channel")
+        if isinstance(user_channel, Mapping):
+            if user_channel.get("notify") != "NOTIFY":
+                return False
+            if user_channel.get("action_required") is True or bool(
+                user_channel.get("actions")
+            ):
+                return True
     return bool(
         quota_packet.get("state") == "operator_gate"
         or quota_packet.get("notify_user_on_gate") is True
@@ -354,35 +494,47 @@ def gate_message(
         or "A human decision is required.",
         limit=900,
     )
-    summary = quota_packet.get("user_todo_summary")
-    summary = summary if isinstance(summary, Mapping) else {}
-    raw_items = summary.get("first_executable_items") or summary.get(
-        "first_open_items"
+    interaction = quota_packet.get("interaction_contract")
+    interaction = interaction if isinstance(interaction, Mapping) else {}
+    user_channel = interaction.get("user_channel")
+    user_channel = user_channel if isinstance(user_channel, Mapping) else {}
+    raw_actions = user_channel.get("actions")
+    action_lines = (
+        [public_safe_compact_text(action, limit=300) for action in raw_actions[:3]]
+        if isinstance(raw_actions, list)
+        else []
     )
-    items = raw_items if isinstance(raw_items, list) else []
-    todo_lines = [
-        public_safe_compact_text(
-            item.get("text") or item.get("title"),
-            limit=300,
-        )
-        for item in items[:3]
-        if isinstance(item, Mapping)
-    ]
+    if not any(action_lines):
+        action_lines = [
+            public_safe_compact_text(
+                item.get("text") or item.get("title"),
+                limit=300,
+            )
+            for item in _quota_human_gate_items(quota_packet)
+        ]
+    unique_actions: list[str] = []
+    for action in action_lines or [question]:
+        cleaned = GATE_ACTION_PREFIX.sub("", action.strip()).strip()
+        if cleaned and cleaned not in unique_actions:
+            unique_actions.append(cleaned)
     lines = [
-        f"LoopX human gate for {goal_id}",
-        f"Objective: {objective}",
-        f"Action required: {question}",
+        "LoopX · Action required",
+        "",
+        f"Goal: {goal_id}",
     ]
-    if todo_lines:
-        lines.append("Open user actions:")
-        lines.extend(f"- {line}" for line in todo_lines if line)
-    lines.append("Reply with the requested decision or context; LoopX will validate it.")
-    next_action = public_safe_compact_text(
-        quota_packet.get("recommended_action"),
-        limit=300,
+    if objective and objective != goal_id:
+        lines.append(f"Objective: {objective}")
+    lines.extend(["", "Please confirm:"])
+    lines.extend(
+        f"{index}. {action}" for index, action in enumerate(unique_actions, start=1)
     )
-    if next_action:
-        lines.append(f"Next safe action while waiting: {next_action}")
+    lines.extend(
+        [
+            "",
+            "Reply: approve / reject / done / still pending, plus a one-sentence reason.",
+            "Unchanged gate state will stay quiet until an explicit reminder window.",
+        ]
+    )
     if kanban_url:
-        lines.append(f"Kanban: {kanban_url}")
+        lines.extend(["", f"Kanban: {kanban_url}"])
     return "\n".join(lines), question

--- a/loopx/extensions/lark/goal_channel_contracts.py
+++ b/loopx/extensions/lark/goal_channel_contracts.py
@@ -262,18 +262,6 @@ def quota_human_gate_state_generation(
         "gate_identity": quota_human_gate_identity(quota_packet),
         "items": material_items,
     }
-    interaction = quota_packet.get("interaction_contract")
-    interaction = interaction if isinstance(interaction, Mapping) else {}
-    user_channel = interaction.get("user_channel")
-    user_channel = user_channel if isinstance(user_channel, Mapping) else {}
-    raw_actions = user_channel.get("actions")
-    actions = (
-        [public_safe_compact_text(action, limit=300) for action in raw_actions[:3]]
-        if isinstance(raw_actions, list)
-        else []
-    )
-    if any(actions):
-        material["actions"] = [action for action in actions if action]
     if not material_items:
         material["state"] = str(quota_packet.get("state") or "")
         material["question"] = public_safe_compact_text(

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .goal_channel_contracts import (
-    DEFAULT_GATE_COOLDOWN_SECONDS,
     binding_for_goal,
     clear_human_gate_auto_notify_marker,
     gate_message,
@@ -16,9 +14,11 @@ from .goal_channel_contracts import (
     human_gate_auto_notify_marker_path,
     now_iso,
     operation_packet,
-    parse_time,
     provider_idempotency_key,
     quota_human_gate_identity,
+    quota_human_gate_notification_suppressed,
+    quota_human_gate_reminder_generation,
+    quota_human_gate_state_generation,
     quota_selects_human_gate,
     read_goal_channel_binding,
     save_goal_binding,
@@ -266,7 +266,8 @@ def doctor_lark_goal_channel(
             cli_bin=cli_bin,
             profile=profile,
             identity="bot",
-            expected_bot_name=str(identity_config.get("bot_display_name") or "") or None,
+            expected_bot_name=str(identity_config.get("bot_display_name") or "")
+            or None,
         )
         and verified_app_id(
             runner=runner,
@@ -490,7 +491,6 @@ def notify_lark_goal_channel_gate(
     binding_path: Path,
     quota_packet: Mapping[str, Any],
     provider_target: Mapping[str, Any] | None = None,
-    cooldown_seconds: int = DEFAULT_GATE_COOLDOWN_SECONDS,
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
@@ -539,6 +539,16 @@ def notify_lark_goal_channel_gate(
             blocker="channel_binding_incomplete",
             public_summary="complete Goal Channel setup before notifying a human gate",
         )
+    if quota_human_gate_notification_suppressed(quota_packet):
+        return operation_packet(
+            ok=False,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="suppressed",
+            blocker="notification_cooldown_active",
+            public_summary="the current human gate notification is in cooldown",
+        )
     if not quota_selects_human_gate(quota_packet):
         return operation_packet(
             ok=False,
@@ -556,54 +566,39 @@ def notify_lark_goal_channel_gate(
     cli_bin = str(identity_config.get("cli_bin") or DEFAULT_CLI_BIN)
     identity = str(identity_config.get("sender_identity") or "")
     profile = str(identity_config.get("sender_profile") or "") or None
-    message, question = gate_message(
+    message, _question = gate_message(
         goal_id=goal_id,
         objective=goal_objective(goal),
         quota_packet=quota_packet,
         kanban_url=str(kanban.get("base_url") or ""),
     )
     gate_identity = quota_human_gate_identity(quota_packet)
+    state_generation = quota_human_gate_state_generation(quota_packet)
+    reminder_generation = quota_human_gate_reminder_generation(quota_packet)
+    delivery_generation = reminder_generation or "material_state"
     key = semantic_key(
         goal_id,
         "lark",
         "notify_gate",
         gate_identity,
-        question,
+        state_generation,
+        delivery_generation,
         chat_id,
     )
     receipts = _mapping(binding.get("receipts"))
     existing_receipt = _mapping(receipts.get(key))
     if existing_receipt:
-        existing_message_id = str(existing_receipt.get("message_id") or "")
-        existing_verified = bool(
-            identity == "bot"
-            and MESSAGE_ID_PATTERN.fullmatch(existing_message_id)
-            and message_readback_verified(
-                runner=runner,
-                cli_bin=cli_bin,
-                profile=profile,
-                identity="bot",
-                message_id=existing_message_id,
-                expected_text=message,
-            )
+        return operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="already_sent",
+            public_summary="the same human gate generation was already sent",
+            readback_verified=existing_receipt.get("readback_verified") is not False,
+            idempotency_key=key,
+            receipt_id=f"receipt_{key.removeprefix('sha256:')[:16]}",
         )
-        if existing_verified:
-            return operation_packet(
-                ok=True,
-                goal_id=goal_id,
-                operation="notify_gate",
-                execute=execute,
-                status="already_sent",
-                public_summary="the same human gate notification was already sent",
-                readback_verified=True,
-                idempotency_key=key,
-                receipt_id=f"receipt_{key.removeprefix('sha256:')[:16]}",
-            )
-        receipts = {
-            receipt_key: receipt
-            for receipt_key, receipt in receipts.items()
-            if receipt_key != key
-        }
     same_gate_receipts = [
         receipt
         for receipt in receipts.values()
@@ -611,42 +606,36 @@ def notify_lark_goal_channel_gate(
         and receipt.get("kind") == "gate_notification"
         and str(receipt.get("gate_identity") or "") == gate_identity
     ]
-    cooldown = quota_packet.get("user_gate_notification_cooldown")
-    if (
-        same_gate_receipts
-        and isinstance(cooldown, Mapping)
-        and cooldown.get("notification_suppressed") is True
-    ):
+    same_state_receipts = [
+        receipt
+        for receipt in same_gate_receipts
+        if str(receipt.get("state_generation") or "") == state_generation
+    ]
+    legacy_receipts = [
+        receipt for receipt in same_gate_receipts if not receipt.get("state_generation")
+    ]
+    if same_state_receipts and reminder_generation is None:
         return operation_packet(
-            ok=False,
+            ok=True,
             goal_id=goal_id,
             operation="notify_gate",
             execute=execute,
-            status="suppressed",
-            blocker="notification_cooldown_active",
-            public_summary="the current human gate notification is in cooldown",
+            status="already_sent",
+            public_summary="the unchanged human gate generation was already sent",
+            readback_verified=True,
+            idempotency_key=key,
         )
-    latest_gate_time = max(
-        (
-            parsed
-            for receipt in same_gate_receipts
-            if (parsed := parse_time(receipt.get("verified_at"))) is not None
-        ),
-        default=None,
-    )
-    if latest_gate_time is not None:
-        elapsed = (datetime.now(timezone.utc) - latest_gate_time).total_seconds()
-        if elapsed < max(0, cooldown_seconds):
-            return operation_packet(
-                ok=False,
-                goal_id=goal_id,
-                operation="notify_gate",
-                execute=execute,
-                status="suppressed",
-                blocker="notification_cooldown_active",
-                public_summary="a recent human gate notification is still in cooldown",
-                idempotency_key=key,
-            )
+    if legacy_receipts and reminder_generation is None:
+        return operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="already_sent",
+            public_summary="a legacy receipt already covers this human gate",
+            readback_verified=True,
+            idempotency_key=key,
+        )
     if not execute:
         return operation_packet(
             ok=True,
@@ -667,7 +656,8 @@ def notify_lark_goal_channel_gate(
             cli_bin=cli_bin,
             profile=profile,
             identity="bot",
-            expected_bot_name=str(identity_config.get("bot_display_name") or "") or None,
+            expected_bot_name=str(identity_config.get("bot_display_name") or "")
+            or None,
         )
         and verified_app_id(
             runner=runner,
@@ -751,6 +741,24 @@ def notify_lark_goal_channel_gate(
         message_id=message_id,
         expected_text=message,
     )
+    mutable_receipts = dict(receipts)
+    mutable_receipts[key] = {
+        "kind": "gate_notification",
+        "gate_identity": gate_identity,
+        "state_generation": state_generation,
+        "delivery_generation": delivery_generation,
+        "message_id": message_id,
+        "verified_at": now_iso(),
+        "readback_verified": verified,
+    }
+    mutable_binding = dict(raw_binding)
+    mutable_binding["receipts"] = mutable_receipts
+    save_goal_binding(
+        binding_path=binding_path,
+        payload=payload,
+        goal_id=goal_id,
+        binding=mutable_binding,
+    )
     if not verified:
         return operation_packet(
             ok=False,
@@ -763,21 +771,6 @@ def notify_lark_goal_channel_gate(
             external_write_performed=True,
             idempotency_key=key,
         )
-    mutable_receipts = dict(receipts)
-    mutable_receipts[key] = {
-        "kind": "gate_notification",
-        "gate_identity": gate_identity,
-        "message_id": message_id,
-        "verified_at": now_iso(),
-    }
-    mutable_binding = dict(raw_binding)
-    mutable_binding["receipts"] = mutable_receipts
-    save_goal_binding(
-        binding_path=binding_path,
-        payload=payload,
-        goal_id=goal_id,
-        binding=mutable_binding,
-    )
     return operation_packet(
         ok=True,
         goal_id=goal_id,

--- a/loopx/extensions/lark/goal_channel_runtime.py
+++ b/loopx/extensions/lark/goal_channel_runtime.py
@@ -566,7 +566,7 @@ def notify_lark_goal_channel_gate(
     cli_bin = str(identity_config.get("cli_bin") or DEFAULT_CLI_BIN)
     identity = str(identity_config.get("sender_identity") or "")
     profile = str(identity_config.get("sender_profile") or "") or None
-    message, _question = gate_message(
+    message, question = gate_message(
         goal_id=goal_id,
         objective=goal_objective(goal),
         quota_packet=quota_packet,
@@ -576,6 +576,7 @@ def notify_lark_goal_channel_gate(
     state_generation = quota_human_gate_state_generation(quota_packet)
     reminder_generation = quota_human_gate_reminder_generation(quota_packet)
     delivery_generation = reminder_generation or "material_state"
+    target_generation = semantic_key("lark_goal_channel_target_v0", chat_id)
     key = semantic_key(
         goal_id,
         "lark",
@@ -599,22 +600,42 @@ def notify_lark_goal_channel_gate(
             idempotency_key=key,
             receipt_id=f"receipt_{key.removeprefix('sha256:')[:16]}",
         )
+    legacy_key = semantic_key(
+        goal_id,
+        "lark",
+        "notify_gate",
+        gate_identity,
+        question,
+        chat_id,
+    )
+    legacy_receipt = _mapping(receipts.get(legacy_key))
+    if legacy_receipt and not legacy_receipt.get("state_generation"):
+        return operation_packet(
+            ok=True,
+            goal_id=goal_id,
+            operation="notify_gate",
+            execute=execute,
+            status="already_sent",
+            public_summary="the exact legacy human gate delivery was already sent",
+            readback_verified=legacy_receipt.get("readback_verified") is not False,
+            idempotency_key=key,
+            receipt_id=f"receipt_{legacy_key.removeprefix('sha256:')[:16]}",
+        )
     same_gate_receipts = [
         receipt
         for receipt in receipts.values()
         if isinstance(receipt, Mapping)
         and receipt.get("kind") == "gate_notification"
         and str(receipt.get("gate_identity") or "") == gate_identity
+        and str(receipt.get("target_generation") or "") == target_generation
     ]
     same_state_receipts = [
         receipt
         for receipt in same_gate_receipts
         if str(receipt.get("state_generation") or "") == state_generation
     ]
-    legacy_receipts = [
-        receipt for receipt in same_gate_receipts if not receipt.get("state_generation")
-    ]
     if same_state_receipts and reminder_generation is None:
+        matched_receipt = same_state_receipts[-1]
         return operation_packet(
             ok=True,
             goal_id=goal_id,
@@ -622,18 +643,7 @@ def notify_lark_goal_channel_gate(
             execute=execute,
             status="already_sent",
             public_summary="the unchanged human gate generation was already sent",
-            readback_verified=True,
-            idempotency_key=key,
-        )
-    if legacy_receipts and reminder_generation is None:
-        return operation_packet(
-            ok=True,
-            goal_id=goal_id,
-            operation="notify_gate",
-            execute=execute,
-            status="already_sent",
-            public_summary="a legacy receipt already covers this human gate",
-            readback_verified=True,
+            readback_verified=matched_receipt.get("readback_verified") is not False,
             idempotency_key=key,
         )
     if not execute:
@@ -745,6 +755,7 @@ def notify_lark_goal_channel_gate(
     mutable_receipts[key] = {
         "kind": "gate_notification",
         "gate_identity": gate_identity,
+        "target_generation": target_generation,
         "state_generation": state_generation,
         "delivery_generation": delivery_generation,
         "message_id": message_id,

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -154,7 +154,7 @@ def _fake_runner(
             text = args[args.index("--text") + 1]
             message_id = (
                 GATE_MESSAGE_ID
-                if text.startswith("LoopX human gate")
+                if text.startswith("LoopX · Action required")
                 else CONTROL_MESSAGE_ID
             )
             sent_texts[message_id] = text
@@ -225,6 +225,30 @@ def _write_binding(binding_path: Path, kanban_path: Path) -> None:
         )
         + "\n",
         encoding="utf-8",
+    )
+
+
+def _gate_test_binding(tmp_path: Path) -> Path:
+    binding_path = tmp_path / ".loopx" / "goal-channel.json"
+    binding_path.parent.mkdir(parents=True)
+    _write_binding(binding_path, tmp_path / ".loopx" / "lark-kanban.json")
+    return binding_path
+
+
+def _notify_test_gate(
+    *,
+    tmp_path: Path,
+    binding_path: Path,
+    quota_packet: dict[str, Any],
+    runner: Any,
+) -> dict[str, Any]:
+    return notify_lark_goal_channel_gate(
+        registry=_registry(tmp_path),
+        goal_id=GOAL_ID,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        execute=True,
+        runner=runner,
     )
 
 
@@ -1006,16 +1030,7 @@ def test_notify_gate_is_idempotent_after_verified_send(tmp_path: Path) -> None:
 def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
     tmp_path: Path,
 ) -> None:
-    binding_path = tmp_path / ".loopx" / "goal-channel.json"
-    binding_path.parent.mkdir(parents=True)
-    kanban_path = tmp_path / ".loopx" / "lark-kanban.json"
-    save_lark_kanban_board_config(
-        kanban_path,
-        base_token="base_public_fixture",
-        table_id="tbl_public_fixture",
-        base_url="https://example.invalid/base/public-fixture",
-    )
-    _write_binding(binding_path, kanban_path)
+    binding_path = _gate_test_binding(tmp_path)
     calls: list[list[str]] = []
     runner = _fake_runner(calls)
 
@@ -1035,20 +1050,16 @@ def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
             },
         }
 
-    first = notify_lark_goal_channel_gate(
-        registry=_registry(tmp_path),
-        goal_id=GOAL_ID,
+    first = _notify_test_gate(
+        tmp_path=tmp_path,
         binding_path=binding_path,
         quota_packet=quota("todo_gate_one"),
-        execute=True,
         runner=runner,
     )
-    second = notify_lark_goal_channel_gate(
-        registry=_registry(tmp_path),
-        goal_id=GOAL_ID,
+    second = _notify_test_gate(
+        tmp_path=tmp_path,
         binding_path=binding_path,
         quota_packet=quota("todo_gate_two"),
-        execute=True,
         runner=runner,
     )
 
@@ -1056,6 +1067,224 @@ def test_notify_gate_distinguishes_different_gate_ids_with_same_question(
     assert second["status"] == "sent_verified"
     assert first["idempotency_key"] != second["idempotency_key"]
     assert sum("+messages-send" in args for args in calls) == 2
+
+
+def test_notify_gate_uses_material_state_generation_not_projection_copy(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    calls: list[list[str]] = []
+    runner = _fake_runner(calls)
+    item = {
+        "todo_id": "todo_gate_fixture",
+        "status": "open",
+        "task_class": "user_gate",
+        "updated_at": "2026-08-08T00:00:00Z",
+        "text": "Approve the bounded external write.",
+    }
+
+    def packet(*, prompt: str, recommended_action: str) -> dict[str, Any]:
+        return {
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": prompt,
+            "recommended_action": recommended_action,
+            "user_todo_summary": {"gate_open_items": [item]},
+            "interaction_contract": {
+                "user_channel": {
+                    "action_required": True,
+                    "notify": "NOTIFY",
+                    "actions": [item["text"]],
+                }
+            },
+        }
+
+    first = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=packet(
+            prompt="Approve the bounded external write.",
+            recommended_action="Wait for the owner decision.",
+        ),
+        runner=runner,
+    )
+    second = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=packet(
+            prompt="Current recommendation: approve the bounded external write.",
+            recommended_action="Keep waiting for the same owner decision.",
+        ),
+        runner=runner,
+    )
+
+    assert first["status"] == "sent_verified"
+    assert second["status"] == "already_sent"
+    assert first["idempotency_key"] == second["idempotency_key"]
+    assert sum("+messages-send" in args for args in calls) == 1
+
+
+def test_notify_gate_resends_for_material_transition_or_one_reminder_window(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    calls: list[list[str]] = []
+    runner = _fake_runner(calls)
+
+    def packet(
+        *,
+        updated_at: str,
+        text: str,
+        reminder: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        item = {
+            "todo_id": "todo_gate_fixture",
+            "status": "open",
+            "task_class": "user_gate",
+            "updated_at": updated_at,
+            "text": text,
+        }
+        result: dict[str, Any] = {
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": text,
+            "user_todo_summary": {"gate_open_items": [item]},
+            "interaction_contract": {
+                "user_channel": {
+                    "action_required": True,
+                    "notify": "NOTIFY",
+                    "actions": [text],
+                }
+            },
+        }
+        if reminder is not None:
+            result["user_gate_notification_cooldown"] = reminder
+        return result
+
+    initial = packet(
+        updated_at="2026-08-08T00:00:00Z",
+        text="Approve the bounded external write.",
+    )
+    changed = packet(
+        updated_at="2026-08-08T01:00:00Z",
+        text="Approve the bounded external write after reviewing the diff.",
+    )
+    reminder = {
+        "notification_due": True,
+        "notification_suppressed": False,
+        "policy": "failed_host_update_bounded_reminder_window",
+        "failed_at": "2026-08-08T00:00:00Z",
+        "next_reminder_at": "2026-08-08T03:00:00Z",
+        "cooldown_minutes": 60,
+        "reminder_window_minutes": 5,
+    }
+
+    first = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=initial,
+        runner=runner,
+    )
+    material = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=changed,
+        runner=runner,
+    )
+    reminded = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=packet(
+            updated_at="2026-08-08T01:00:00Z",
+            text="Approve the bounded external write after reviewing the diff.",
+            reminder=reminder,
+        ),
+        runner=runner,
+    )
+    reminder_replay = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=packet(
+            updated_at="2026-08-08T01:00:00Z",
+            text="Approve the bounded external write after reviewing the diff.",
+            reminder=reminder,
+        ),
+        runner=runner,
+    )
+
+    assert first["status"] == "sent_verified"
+    assert material["status"] == "sent_verified"
+    assert reminded["status"] == "sent_verified"
+    assert reminder_replay["status"] == "already_sent"
+    assert (
+        len(
+            {
+                first["idempotency_key"],
+                material["idempotency_key"],
+                reminded["idempotency_key"],
+            }
+        )
+        == 3
+    )
+    assert sum("+messages-send" in args for args in calls) == 3
+
+
+def test_notify_gate_honors_interaction_contract_and_renders_one_clear_action_list(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    calls: list[list[str]] = []
+    quota_packet = {
+        "state": "operator_gate",
+        "notify_user_on_gate": True,
+        "gate_prompt": "- Current recommendation: approve. - User todo: revoke key.",
+        "recommended_action": "Approve the same gate again.",
+        "interaction_contract": {
+            "user_channel": {
+                "action_required": False,
+                "notify": "DONT_NOTIFY",
+                "actions": [
+                    "- [ ] [P0] Approve the bounded change.",
+                    "12. Revoke the test key.",
+                ],
+            }
+        },
+    }
+
+    rejected = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        runner=_fake_runner(calls),
+    )
+    message, _question = goal_channel_contracts.gate_message(
+        goal_id=GOAL_ID,
+        objective="Deliver one bounded change.",
+        quota_packet={
+            **quota_packet,
+            "interaction_contract": {
+                "user_channel": {
+                    "action_required": True,
+                    "notify": "NOTIFY",
+                    "actions": [
+                        "- [ ] [P0] Approve the bounded change.",
+                        "12. Revoke the test key.",
+                    ],
+                }
+            },
+        },
+        kanban_url="https://example.invalid/kanban",
+    )
+
+    assert rejected["status"] == "rejected"
+    assert rejected["blocker"] == "state_transition_rejected"
+    assert calls == []
+    assert message.startswith("LoopX · Action required\n\nGoal:")
+    assert "\n1. Approve the bounded change." in message
+    assert "\n2. Revoke the test key." in message
+    assert "Current recommendation" not in message
+    assert "Next safe action" not in message
+    assert "\n- " not in message
 
 
 def test_notify_gate_reports_missing_shared_target_for_direct_caller(
@@ -1090,7 +1319,7 @@ def test_notify_gate_reports_missing_shared_target_for_direct_caller(
     _assert_public_packet(payload)
 
 
-def test_notify_gate_resends_when_existing_receipt_readback_is_stale(
+def test_notify_gate_does_not_resend_unchanged_generation_when_readback_is_stale(
     tmp_path: Path,
 ) -> None:
     binding_path = tmp_path / ".loopx" / "goal-channel.json"
@@ -1144,11 +1373,55 @@ def test_notify_gate_resends_when_existing_receipt_readback_is_stale(
     )
 
     assert first["status"] == "sent_verified"
-    assert second["status"] == "sent_verified"
+    assert second["status"] == "already_sent"
     assert second["readback_verified"] is True
-    assert sum("+messages-send" in args for args in calls) == first_send_count + 1
+    assert sum("+messages-send" in args for args in calls) == first_send_count
+    assert mget_count == 1
     _assert_public_packet(first)
     _assert_public_packet(second)
+
+
+def test_notify_gate_records_sent_unverified_generation_before_returning(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    calls: list[list[str]] = []
+    base_runner = _fake_runner(calls)
+
+    def runner(
+        args: list[str],
+        cwd: Path | None,
+        timeout: float | None,
+    ) -> dict[str, object]:
+        if "+messages-mget" in args:
+            calls.append(args)
+            return _result({"ok": True, "data": {"items": []}})
+        return base_runner(args, cwd, timeout)
+
+    quota_packet = {
+        "state": "operator_gate",
+        "notify_user_on_gate": True,
+        "gate_prompt": "Approve the bounded external write.",
+    }
+    first = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        runner=runner,
+    )
+    second = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        runner=runner,
+    )
+
+    assert first["status"] == "sent_unverified"
+    assert first["external_write_performed"] is True
+    assert second["status"] == "already_sent"
+    assert second["readback_verified"] is False
+    assert sum("+messages-send" in args for args in calls) == 1
+    assert sum("+messages-mget" in args for args in calls) == 1
 
 
 def test_notify_gate_respects_quota_cooldown_without_external_call(
@@ -1537,9 +1810,7 @@ def test_cli_rejects_custom_binding_path_for_auto_notify(
     assert result == 1
     assert captured["blocker"] == "noncanonical_binding_path"
     assert (
-        read_goal_channel_binding(custom_binding)["bindings"][GOAL_ID].get(
-            "automation"
-        )
+        read_goal_channel_binding(custom_binding)["bindings"][GOAL_ID].get("automation")
         is None
     )
 

--- a/tests/extensions/test_lark_goal_channel.py
+++ b/tests/extensions/test_lark_goal_channel.py
@@ -1083,7 +1083,12 @@ def test_notify_gate_uses_material_state_generation_not_projection_copy(
         "text": "Approve the bounded external write.",
     }
 
-    def packet(*, prompt: str, recommended_action: str) -> dict[str, Any]:
+    def packet(
+        *,
+        prompt: str,
+        recommended_action: str,
+        projected_action: str,
+    ) -> dict[str, Any]:
         return {
             "state": "operator_gate",
             "notify_user_on_gate": True,
@@ -1094,7 +1099,7 @@ def test_notify_gate_uses_material_state_generation_not_projection_copy(
                 "user_channel": {
                     "action_required": True,
                     "notify": "NOTIFY",
-                    "actions": [item["text"]],
+                    "actions": [projected_action],
                 }
             },
         }
@@ -1105,6 +1110,7 @@ def test_notify_gate_uses_material_state_generation_not_projection_copy(
         quota_packet=packet(
             prompt="Approve the bounded external write.",
             recommended_action="Wait for the owner decision.",
+            projected_action="- [ ] [P0] Approve the bounded external write.",
         ),
         runner=runner,
     )
@@ -1114,6 +1120,7 @@ def test_notify_gate_uses_material_state_generation_not_projection_copy(
         quota_packet=packet(
             prompt="Current recommendation: approve the bounded external write.",
             recommended_action="Keep waiting for the same owner decision.",
+            projected_action="1. Approve the bounded external write.",
         ),
         runner=runner,
     )
@@ -1122,6 +1129,139 @@ def test_notify_gate_uses_material_state_generation_not_projection_copy(
     assert second["status"] == "already_sent"
     assert first["idempotency_key"] == second["idempotency_key"]
     assert sum("+messages-send" in args for args in calls) == 1
+
+
+def test_notify_gate_does_not_apply_legacy_receipt_to_unknown_material_state(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["receipts"] = {
+        "sha256:legacy": {
+            "kind": "gate_notification",
+            "gate_identity": "todo_gate_fixture",
+            "message_id": GATE_MESSAGE_ID,
+            "verified_at": "2026-08-08T00:00:00+00:00",
+        }
+    }
+    write_goal_channel_binding(binding_path, binding)
+    calls: list[list[str]] = []
+    result = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet={
+            "state": "operator_gate",
+            "notify_user_on_gate": True,
+            "gate_prompt": "Approve the changed bounded external write.",
+            "user_todo_summary": {
+                "gate_open_items": [
+                    {
+                        "todo_id": "todo_gate_fixture",
+                        "status": "open",
+                        "task_class": "user_gate",
+                        "updated_at": "2026-08-08T01:00:00Z",
+                        "text": "Approve the changed bounded external write.",
+                    }
+                ]
+            },
+        },
+        runner=_fake_runner(calls),
+    )
+
+    assert result["status"] == "sent_verified"
+    assert sum("+messages-send" in args for args in calls) == 1
+
+
+def test_notify_gate_preserves_exact_legacy_delivery_for_same_target(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    quota_packet = {
+        "state": "operator_gate",
+        "notify_user_on_gate": True,
+        "gate_prompt": "Approve the bounded external write.",
+        "user_todo_summary": {
+            "gate_open_items": [
+                {
+                    "todo_id": "todo_gate_fixture",
+                    "task_class": "user_gate",
+                    "text": "Approve the bounded external write.",
+                }
+            ]
+        },
+    }
+    legacy_key = goal_channel_contracts.semantic_key(
+        GOAL_ID,
+        "lark",
+        "notify_gate",
+        "todo_gate_fixture",
+        "Approve the bounded external write.",
+        CHAT_ID,
+    )
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["receipts"] = {
+        legacy_key: {
+            "kind": "gate_notification",
+            "gate_identity": "todo_gate_fixture",
+            "message_id": GATE_MESSAGE_ID,
+            "verified_at": "2026-08-08T00:00:00+00:00",
+        }
+    }
+    write_goal_channel_binding(binding_path, binding)
+    calls: list[list[str]] = []
+    result = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        runner=_fake_runner(calls),
+    )
+
+    assert result["status"] == "already_sent"
+    assert sum("+messages-send" in args for args in calls) == 0
+
+
+def test_notify_gate_sends_same_generation_once_to_replacement_channel(
+    tmp_path: Path,
+) -> None:
+    binding_path = _gate_test_binding(tmp_path)
+    calls: list[list[str]] = []
+    runner = _fake_runner(calls)
+    quota_packet = {
+        "state": "operator_gate",
+        "notify_user_on_gate": True,
+        "gate_prompt": "Approve the bounded external write.",
+        "user_todo_summary": {
+            "gate_open_items": [
+                {
+                    "todo_id": "todo_gate_fixture",
+                    "status": "open",
+                    "task_class": "user_gate",
+                    "updated_at": "2026-08-08T00:00:00Z",
+                    "text": "Approve the bounded external write.",
+                }
+            ]
+        },
+    }
+    first = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        runner=runner,
+    )
+    binding = read_goal_channel_binding(binding_path)
+    binding["bindings"][GOAL_ID]["channel"]["chat_id"] = "oc_second_fixture"
+    write_goal_channel_binding(binding_path, binding)
+    second = _notify_test_gate(
+        tmp_path=tmp_path,
+        binding_path=binding_path,
+        quota_packet=quota_packet,
+        runner=runner,
+    )
+
+    assert first["status"] == "sent_verified"
+    assert second["status"] == "sent_verified"
+    assert first["idempotency_key"] != second["idempotency_key"]
+    assert sum("+messages-send" in args for args in calls) == 2
 
 
 def test_notify_gate_resends_for_material_transition_or_one_reminder_window(


### PR DESCRIPTION
## Motivation

The same open human gate could be sent repeatedly when scheduler cooldown made `action_required=false` but an open `user_action` re-promoted the interaction contract to `NOTIFY`. Goal Channel delivery also keyed receipts by presentation copy, so harmless copy changes and readback misses could create duplicate sends.

## What changed

- Give cooldown/scope suppression precedence in `interaction_contract.user_channel` and remove suppressed action projections.
- Deduplicate Goal Channel sends by gate identity, material state generation, and an explicit reminder-window generation.
- Persist a receipt after a provider send even when readback is temporarily unavailable.
- Render one clear action-required heading and one numbered action list, stripping inherited bullets, checkboxes, priorities, and numbering.
- Extend interaction-contract and Goal Channel smoke coverage, including a natural refresh → unchanged refresh → Todo material transition → refresh path.

## Self-review

- Findings: no remaining correctness, safety, or public/private-boundary findings.
- Solved: unchanged copies of one gate no longer notify; a different gate, material Todo transition, or new explicit reminder window can notify once.
- Operator impact: fewer duplicate Lark messages; message text is shorter and structurally consistent. Existing `--cooldown-seconds` callers remain accepted as a compatibility no-op while scheduler-projected reminder windows own repeat timing.
- Main risk: over-suppression. This is bounded by including gate identity and material state in the delivery generation and is covered by transition/reminder tests.
- Design judgment: delivery identity is semantic state, not rendered prose or provider readback availability.
- Merge decision: self-merge; LoopX premerge reports `merge_gate_passed=true` and `self_merge_allowed=true`.

## Validation

- `59 passed` across Goal Channel, scheduler interaction arbitration, and cooldown timing tests after rebase.
- Goal Channel human-gate natural-trigger smoke passed.
- Interaction-contract state-machine smoke passed.
- Standard `loopx canary premerge --from-git-diff --goal-id ark-4-0-goal` passed all 18 selected checks.
- Public/private boundary scan clean for all 9 changed files.
