### PR TITLE
fix(replan): rotate periodic review identity with its run window

### DIFF
--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -217,6 +217,12 @@ def ensure_replan_novelty_policy(
                 "monitor_target_id",
                 "progress_fingerprint",
                 "agent_id",
+                *(
+                    ("latest_generated_at", "oldest_counted_generated_at")
+                    if trigger.get("kind")
+                    in {"periodic_review", "periodic_review_due"}
+                    else ()
+                ),
             )
             if trigger.get(key) is not None
         }

--- a/tests/control_plane/test_autonomous_replan_periodic_lookback.py
+++ b/tests/control_plane/test_autonomous_replan_periodic_lookback.py
@@ -4,11 +4,28 @@ from loopx.cli_commands.status import (
     _status_collection_limit_for_agent_lane,
     _trim_run_history_for_status_display,
 )
+from loopx.control_plane.goals.goal_frontier.ack_policy import (
+    autonomous_replan_ack_satisfies_obligation,
+)
 from loopx.status import (
     AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK,
     AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD,
     autonomous_replan_periodic_review_from_runs,
 )
+
+
+def _periodic_runs(*, minute_offset: int = 0) -> list[dict[str, object]]:
+    return [
+        {
+            "classification": f"bounded_delivery_{index:02d}",
+            "generated_at": (
+                f"2026-08-27T{minute_offset // 60:02d}:"
+                f"{minute_offset % 60:02d}:{59 - index:02d}Z"
+            ),
+            "agent_id": "codex-fixture",
+        }
+        for index in range(AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD)
+    ]
 
 
 def test_periodic_replan_lookback_survives_interleaved_neutral_runs() -> None:
@@ -40,6 +57,39 @@ def test_periodic_replan_lookback_survives_interleaved_neutral_runs() -> None:
     trigger = obligation["triggers"][0]
     assert trigger["kind"] == "periodic_review_due"
     assert trigger["run_count"] == AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD
+
+
+def test_periodic_replan_obligation_rotates_with_the_review_window() -> None:
+    first = autonomous_replan_periodic_review_from_runs(
+        _periodic_runs(minute_offset=0),
+        agent_todos=None,
+    )
+    replay = autonomous_replan_periodic_review_from_runs(
+        _periodic_runs(minute_offset=0),
+        agent_todos=None,
+    )
+    later = autonomous_replan_periodic_review_from_runs(
+        _periodic_runs(minute_offset=60),
+        agent_todos=None,
+    )
+
+    assert first is not None
+    assert replay is not None
+    assert later is not None
+    assert replay["obligation_id"] == first["obligation_id"]
+    assert later["obligation_id"] != first["obligation_id"]
+    assert not autonomous_replan_ack_satisfies_obligation(
+        {
+            "recorded": True,
+            "semantic_delta": {
+                "accepted": True,
+                "obligation_id": first["obligation_id"],
+                "outcomes": ["new_runnable_successor"],
+            },
+        },
+        replan_obligation=later,
+        acceptance_gaps=[],
+    )
 
 
 def test_agent_lane_keeps_periodic_control_history_off_the_display_path() -> None:

--- a/tests/control_plane/test_replan_novelty_policy.py
+++ b/tests/control_plane/test_replan_novelty_policy.py
@@ -261,6 +261,30 @@ def test_semantic_ack_is_bound_to_the_exact_rotated_obligation() -> None:
     ) is True
 
 
+def test_nonperiodic_obligation_identity_ignores_incidental_run_timestamps() -> None:
+    first = _obligation(
+        [
+            {
+                "kind": "typed_progress_repeat",
+                "progress_fingerprint": "fingerprint-repeat",
+                "latest_generated_at": "2026-08-27T00:00:00Z",
+                "oldest_counted_generated_at": "2026-08-26T23:59:00Z",
+            }
+        ]
+    )
+    replay = _obligation(
+        [
+            {
+                **first["triggers"][0],
+                "latest_generated_at": "2026-08-27T01:00:00Z",
+                "oldest_counted_generated_at": "2026-08-27T00:59:00Z",
+            }
+        ]
+    )
+
+    assert replay["obligation_id"] == first["obligation_id"]
+
+
 def test_semantic_terminal_ack_cannot_close_an_open_todo_succession_gap() -> None:
     obligation = _obligation(
         [{"kind": "completed_advancement_without_successor", "todo_id": "todo-1"}]


### PR DESCRIPTION
## Summary

Fixes #3918.

Periodic autonomous review now rotates its obligation identity when the durable-run review window advances. The same window remains replay-stable, while a receipt from an earlier window cannot close a later review.

## Why this is deliberately small

- Reuses the periodic trigger's existing `latest_generated_at` and `oldest_counted_generated_at` checkpoints.
- Adds no schema fields, retry counters, or new lifecycle state.
- Limits timestamp-sensitive identity to periodic review triggers; other replan identities keep their existing stability.
- Preserves all current exits, including typed runnable successors, concrete blockers, coverage-backed terminal outcomes, and accepted vision path dispositions.

## Validation

- Focused Python tests: 53 passed.
- Ruff on all changed paths: passed.
- Repository mypy configuration: passed.
- TypeScript control-plane typecheck: passed.
- TypeScript control-plane tests: 518 passed, 1 skipped (optional database integration).
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 12/12 risk-selected checks passed; no manual holds.
- Public/private boundary scan: clean.
- Change-quality receipt: `cqr_5461a77ce0ffd29df6c2`, exact scope verified valid.

No related refactor was needed: the existing trigger identity reducer is the owning boundary and the change remains one reversible rule.

