### PR TITLE
docs: refresh DevBook for v0.5.4

### DIFF
--- a/docs/book/chapters/00-reading-guide.md
+++ b/docs/book/chapters/00-reading-guide.md
@@ -131,8 +131,9 @@ node --version
 
 `v0.5.4` 不是“已经把 LoopX 全部重写成 TypeScript”。当前发布基线是：
 
-- TypeScript 已拥有 Effect Program、Turn settlement、Todo completion、quota delivery routing、
-  workspace causality、scheduler transition/state 等迁移切片的 canonical semantics；
+- TypeScript 已拥有 Effect Program、Turn/Host Todo settlement、Todo completion、quota
+  delivery/spend/void/monitor-poll、本地 task-lease lifecycle、Vision refresh、governed capability
+  validation，以及 scheduler heartbeat/state 等迁移切片的 canonical semantics；
 - Python CLI 仍负责迁移期 transport、legacy response projection、明确的外部 Provider 调用和部分
   Markdown/event 写回；
 - 同一条迁移后的规则只能有一个 semantic owner。Python facade 适配 TypeScript transaction，
@@ -142,7 +143,8 @@ node --version
 
 发布态以 `v0.5.4` tag 和 release notes 为准；迁移阶段、下一批 cutover 与最终 CLI/App 收敛以
 [TypeScript Control-Plane Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/)
-的当前状态为准。RFC 中的 Stage 3/4 仍是后续方向，不应写成已经发布。
+的当前状态为准。`v0.5.4` 只交付了 Stage 3 的第一个 receipt-bound scheduler follow-up 切片；更广的
+CLI/App convergence 与 Stage 4 distribution cleanup 仍是后续方向。
 
 ### 从 `v0.4.4` 阅读基线升级到 `v0.5.4`
 
@@ -150,10 +152,11 @@ node --version
 
 | 主题 | `v0.5.4` 已发布事实 | 深入入口 |
 | --- | --- | --- |
-| Control Plane | 多个高风险 decision/effect 已迁入 typed TypeScript transaction owner；Python facade 仍承担迁移期边界 | [迁移 RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/) |
+| Control Plane | Turn/Host Todo settlement、quota commit、task-lease lifecycle、Vision refresh 与 scheduler heartbeat 等完整事务已迁入 typed TypeScript owner；Python facade 仍承担迁移期边界 | [迁移 RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/) |
 | Operator surface | Personal Workspace 已提供 Goal、Task、Chat 和 read-only status source 入口；界面不是新的事实源 | [Dashboard README](https://github.com/huangruiteng/loopx/blob/v0.5.4/apps/presentation/dashboard/README.md) |
 | Host runtime | Codex、Claude Code、OpenCode、Pi、KunlunCode、DeepSeek Harness 与 custom runner 具有不同 activation/stop contract | [Runtime Connector Catalog](/loopx/docs/integrations/runtime-connector-catalog/) |
 | Capability / Provider | Capability 由 package-owned catalog entry、真实 command 和 durable validation 共同定义；Provider/Extension 不继承 Kernel authority | [Capability Catalog](/loopx/docs/capabilities/) |
+| Shared authority | file、NoKV 与 PostgreSQL provider 仍是 staged candidate；安装 Provider 不会改变默认本地 authority | [Shared Authority RFC](/loopx/docs/architecture/rfcs/shared-goal-authority-state-provider-v0/) |
 
 这张表是阅读导航，不是 release notes 的副本。某个 surface 是否可用，仍应从当前安装版本的
 `doctor`、`capability show`、对应 Host readback 和 versioned 文档判断。

--- a/docs/book/chapters/03-one-turn.md
+++ b/docs/book/chapters/03-one-turn.md
@@ -330,13 +330,14 @@ Codex App heartbeat、Codex CLI visible Goal 或其他 Host 不必都用同一�
 
 !!! info "当前成熟度"
     TurnEnvelope 目前是显式启用的 bounded projection，不是默认 quota 输出；LoopX Turn 是
-    experimental protocol，但 `v0.5.2` 已有可执行的 `turn plan` / `turn run-once` 路径和
+    experimental protocol，但 `v0.5.4` 仍提供可执行的 `turn plan` / `turn run-once` 路径和
     Host adapter。它们适合贡献者理解边界和做显式 opt-in 集成，不应被描述成所有 Host 都默认采用的
     recurring runtime。
 
 ### TypeScript Effect Program 在这一轮中的位置
 
-`v0.5.2` 已把 Effect Program 与若干高风险事务的 canonical semantics 迁到 TypeScript：
+`v0.5.4` 在 Effect Program 基础上，进一步把完整 transaction 的 canonical semantics 迁到
+TypeScript：
 
 ```text
 Python CLI / Host adapter
@@ -346,9 +347,12 @@ Python CLI / Host adapter
   -> Python compatibility projection / explicit external Provider
 ```
 
-其中 Turn settlement、Todo completion、quota delivery routing、workspace causality 与 scheduler
-state 已有 TypeScript owner。Python 仍是当前 CLI、外部 Provider adapter 和部分持久化写回的
-重要组成，不应把迁移理解成“Python 已被移除”，也不能在 Python facade 中重新实现同一条规则。
+已发布的 typed owner 包括 Turn settlement、Todo completion 与 Host Todo settlement，quota
+delivery routing、spend/void/monitor-poll commit，本地 task-lease 完整生命周期，Vision refresh、
+governed capability-lifecycle validation，以及 scheduler heartbeat/state 与 receipt-bound scheduler
+follow-up。Python 仍负责当前 CLI transport、明确的外部 Provider/Host effect、legacy projection 和
+尚未迁移的 Markdown/event 写回；不应把迁移理解成“Python 已被移除”，也不能在 Python facade 中
+重新实现同一条规则。
 
 当前 `main` 的
 [TypeScript Control-Plane Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/)

--- a/docs/book/chapters/appendix-reference.md
+++ b/docs/book/chapters/appendix-reference.md
@@ -61,11 +61,16 @@ loopx doctor
 loopx registry
 loopx status
 loopx todo list --goal-id <goal-id>
+loopx todo list --goal-id <goal-id> --thin --format json
 loopx history --goal-id <goal-id>
 loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin --limit 30
 loopx quota should-run --goal-id <goal-id> --agent-id <agent-id>
 loopx extension list --format json
 ```
+
+`v0.5.4` 新增的 `todo list --thin` 是显式启用的有界投影；它压缩字段和每个 lane 的返回条数，
+但不改变默认 list 的选择、排序、quota 或 lifecycle 语义。需要完整详情时，继续使用不带
+`--thin` 的命令或按 `todo_id` 精确读取。
 
 ## 项目接入入口
 

--- a/docs/book/chapters/source-protocol-map.md
+++ b/docs/book/chapters/source-protocol-map.md
@@ -250,10 +250,11 @@ proof。
 | `handoff` | 跨 runtime handoff、review packet 与 owner route |
 | `work_items` | attention、selection 与 operator-facing work read model |
 
-在 `v0.5.2` 的迁移基线上，bounded context 和实现语言是两个维度。部分
-`goals`、`todos`、`quota`、`scheduler`、`work_items` 与 `turn_driver` 规则已经由同目录下的
-TypeScript module 拥有语义，Python facade/module 可能只是 CLI transport、legacy projection
-或外部 Provider adapter。定位 owner 时应先读
+在 `v0.5.4` 的迁移基线上，bounded context 和实现语言是两个维度。`goals`、`todos`、`quota`、
+`scheduler`、`work_items` 与 `turn_driver` 已有完整 transaction 由 TypeScript module 拥有语义；
+典型例子包括 Vision refresh、本地 task-lease lifecycle、quota spend/void/monitor-poll commit 和
+receipt-bound scheduler follow-up。旁边的 Python facade/module 可能只负责 CLI transport、legacy
+projection、明确的外部 Provider/Host effect 或尚未迁移的写回。定位 owner 时应先读
 [TypeScript Control-Plane Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/)
 的 shipped baseline，再沿真实 request handler 和 caller 判断；不要因为入口仍是 Python，就默认
 Python 仍拥有该 decision。

--- a/docs/book/chapters/state-substrate.md
+++ b/docs/book/chapters/state-substrate.md
@@ -236,9 +236,16 @@ authority 回答的是“哪次状态转换合法”。
 
 ### 当前已发布与仍在设计中的边界
 
-当前公开架构把 CLI 作为 compatibility baseline，并把 local server/daemon 描述为 roadmap。
-多 Host 协作、离线队列和 shared control plane 的详细方案存在于状态为 **Draft** 的 RFC 中，不能
-写成当前安装后即可用的云端功能。
+`v0.5.4` 的 shared-authority 工作已经不只是纸面方案：仓库包含 provider-neutral TypeScript
+`AuthorityStore` contract，以及 file、NoKV 和 PostgreSQL 的 staged candidate 与 conformance evidence。
+但这仍不等于已启用 shared control plane。发布版没有把这些 candidate 接到默认运行时，也没有
+提供可直接启用的远端 authority service；安装 Provider 更不会自动改变某个 Goal 的事实源。
+
+`v0.5.4` 之后的 `main` 可能继续出现 default-off shadow、parity、fencing 或 provider-first cutover
+切片。它们证明迁移机制，不应倒推成 `v0.5.4` 已交付云端协作。稳定版行为以对应 tag 和 release
+notes 为准，实验状态以
+[Shared Control-Plane Authority RFC](/loopx/docs/architecture/rfcs/shared-goal-authority-state-provider-v0/)
+的当前 stage 为准。
 
 当前可以依赖：
 
@@ -246,6 +253,8 @@ authority 回答的是“哪次状态转换合法”。
 - Todo lifecycle writer 的 active-state file lock、preview/readback 和当前已实现的幂等行为；
 - registered peer、soft claim、可选 task lease 与独立 worktree guard；
 - 不同 Host 通过同一 registry/Goal 读取并受控写回。
+- 用于开发和 qualification 的 staged file/NoKV/PostgreSQL candidate；它们不自动获得 runtime
+  authority。
 
 当前不应承诺：
 
@@ -255,8 +264,9 @@ authority 回答的是“哪次状态转换合法”。
 - NoKV、数据库或 IM 自动替代 LoopX lifecycle owner。
 
 如果要实现跨设备控制面，应保留一个 canonical LoopX authority，要求 revision-bound、幂等的受控
-命令与 receipt，并把消息传递、上下文记忆和状态 authority 分开。直到该 Draft 经过发布验证，
-Dev Book 只教授这些协议边界，不提供“云端模式已可用”的操作步骤。
+命令与 receipt，并把消息传递、上下文记忆和状态 authority 分开。直到 shared mode 经过独立
+promotion、运行时接线和发布验证，Dev Book 只教授这些协议边界，不提供“云端模式已可用”的操作
+步骤。
 
 ## 历史产物的三层完整性
 

--- a/docs/book/en/chapters/00-reading-guide.md
+++ b/docs/book/en/chapters/00-reading-guide.md
@@ -145,8 +145,9 @@ different version identifiers imply.
 
 `v0.5.4` does not mean that all of LoopX has been rewritten in TypeScript. The current release baseline is:
 
-- TypeScript owns the canonical semantics for migrated slices of the Effect Program, Turn settlement,
-  Todo completion, quota delivery routing, workspace causality, and scheduler transition/state;
+- TypeScript owns the canonical semantics for migrated slices of the Effect Program, Turn and Host Todo
+  settlement, Todo completion, quota delivery/spend/void/monitor-poll, the local task-lease lifecycle,
+  Vision refresh, governed capability validation, and scheduler heartbeat/state;
 - during the migration, the Python CLI still owns transport, legacy response projection, explicit
   external Provider calls, and some Markdown/event writeback;
 - each migrated rule has one semantic owner. A Python facade adapts a TypeScript transaction; it must not
@@ -156,8 +157,9 @@ different version identifiers imply.
 
 Treat the `v0.5.4` tag and release notes as the shipped baseline. Use the current status of the
 [TypeScript Control-Plane Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/)
-for later cutovers and final CLI/App convergence. RFC Stages 3 and 4 remain future direction, not shipped
-behavior.
+for later cutovers and final CLI/App convergence. `v0.5.4` ships only the first receipt-bound scheduler
+follow-up slice of Stage 3; broader CLI/App convergence and Stage 4 distribution cleanup remain future
+work.
 
 ### Updating your mental model from `v0.4.4` to `v0.5.4`
 
@@ -165,10 +167,11 @@ If you read an earlier edition of the Dev Book, recalibrate these four areas fir
 
 | Area | Shipped in `v0.5.4` | Continue with |
 | --- | --- | --- |
-| Control Plane | Several high-risk decisions and effects have typed TypeScript transaction owners; Python facades still carry migration-time boundaries | [Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/) |
+| Control Plane | Complete Turn/Host Todo settlement, quota commit, task-lease lifecycle, Vision refresh, and scheduler-heartbeat transactions have typed TypeScript owners; Python facades still carry migration-time boundaries | [Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/) |
 | Operator surface | Personal Workspace exposes Goal, Task, Chat, and read-only status-source entrypoints; the UI is not a new source of truth | [Dashboard README](https://github.com/huangruiteng/loopx/blob/v0.5.4/apps/presentation/dashboard/README.md) |
 | Host runtime | Codex, Claude Code, OpenCode, Pi, KunlunCode, DeepSeek Harness, and custom runners have distinct activation and stop contracts | [Runtime Connector Catalog](/loopx/docs/integrations/runtime-connector-catalog/) |
 | Capability and Provider | A Capability is defined by a package-owned catalog entry, a real command, and durable validation; a Provider or Extension does not inherit Kernel authority | [Capability Catalog](/loopx/docs/capabilities/) |
+| Shared authority | File, NoKV, and PostgreSQL providers remain staged candidates; installing a Provider does not change the default local authority | [Shared Authority RFC](/loopx/docs/architecture/rfcs/shared-goal-authority-state-provider-v0/) |
 
 This table is a reading map, not a copy of the release notes. Confirm whether a surface is usable through
 the installed release's `doctor`, `capability show`, Host readback, and versioned documentation.

--- a/docs/book/en/chapters/03-one-turn.md
+++ b/docs/book/en/chapters/03-one-turn.md
@@ -353,15 +353,15 @@ does not directly trust a Host completion claim.
 
 !!! info "Current maturity"
     TurnEnvelope is currently an explicitly enabled bounded projection, not the default quota output.
-    LoopX Turn remains an experimental protocol, but `v0.5.2` ships executable `turn plan` /
+    LoopX Turn remains an experimental protocol, but `v0.5.4` still ships executable `turn plan` /
     `turn run-once` paths and Host adapters. They are suitable for understanding boundaries and building
     explicit opt-in integrations, but should not be described as a recurring runtime enabled by default
     across every Host.
 
 ### Where the TypeScript Effect Program sits in one turn
 
-`v0.5.2` moves the canonical semantics for the Effect Program and several high-risk transactions into
-TypeScript:
+`v0.5.4` extends the Effect Program foundation by moving the canonical semantics for complete
+transactions into TypeScript:
 
 ```text
 Python CLI / Host adapter
@@ -371,10 +371,12 @@ Python CLI / Host adapter
   -> Python compatibility projection / explicit external Provider
 ```
 
-Turn settlement, Todo completion, quota delivery routing, workspace causality, and scheduler state now
-have TypeScript owners. Python remains important as the current CLI, the adapter for explicit external
-Providers, and part of durable writeback. Do not read the migration as “Python has been removed,” and do
-not reimplement the same rule inside a Python facade.
+Shipped typed owners include Turn settlement, Todo completion and Host Todo settlement, quota delivery
+routing plus spend/void/monitor-poll commit, the full local task-lease lifecycle, Vision refresh, governed
+capability-lifecycle validation, and scheduler heartbeat/state plus receipt-bound scheduler follow-up.
+Python still owns current CLI transport, explicit external Provider or Host effects, legacy projections,
+and Markdown/event writeback that has not migrated. Do not read the migration as “Python has been
+removed,” and do not reimplement the same rule inside a Python facade.
 
 The current
 [TypeScript Control-Plane Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/)

--- a/docs/book/en/chapters/appendix-reference.md
+++ b/docs/book/en/chapters/appendix-reference.md
@@ -61,11 +61,16 @@ loopx doctor
 loopx registry
 loopx status
 loopx todo list --goal-id <goal-id>
+loopx todo list --goal-id <goal-id> --thin --format json
 loopx history --goal-id <goal-id>
 loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin --limit 30
 loopx quota should-run --goal-id <goal-id> --agent-id <agent-id>
 loopx extension list --format json
 ```
+
+The `todo list --thin` option added in `v0.5.4` is an explicit bounded projection. It compacts fields and
+the number of returned items per lane without changing default selection, ordering, quota, or lifecycle
+semantics. Use the command without `--thin`, or an exact `todo_id`, when you need full detail.
 
 ## Project onboarding entrypoints
 

--- a/docs/book/en/chapters/source-protocol-map.md
+++ b/docs/book/en/chapters/source-protocol-map.md
@@ -262,10 +262,12 @@ Protocols define cross-module contracts. Bounded contexts identify which change 
 | `handoff` | Cross-runtime handoff, review packets, and owner routes |
 | `work_items` | Attention, selection, and operator-facing work read models |
 
-On the `v0.5.2` migration baseline, bounded context and implementation language are separate dimensions.
-Some rules under `goals`, `todos`, `quota`, `scheduler`, `work_items`, and `turn_driver` already have
-TypeScript semantic owners beside Python facade modules that may serve only as CLI transport, legacy
-projection, or an explicit external-Provider adapter. Read the shipped baseline in the
+On the `v0.5.4` migration baseline, bounded context and implementation language are separate dimensions.
+Complete transactions under `goals`, `todos`, `quota`, `scheduler`, `work_items`, and `turn_driver` now
+have TypeScript semantic owners. Examples include Vision refresh, the local task-lease lifecycle, quota
+spend/void/monitor-poll commit, and receipt-bound scheduler follow-up. Adjacent Python facade modules may
+serve only as CLI transport, legacy projection, an explicit external Provider or Host effect, or
+writeback that has not migrated. Read the shipped baseline in the
 [TypeScript Control-Plane Migration RFC](/loopx/docs/architecture/rfcs/typescript-control-plane-migration-v0/)
 and trace the active request handler and caller before assigning ownership. A Python entrypoint does not
 prove that Python still owns the decision.

--- a/docs/book/en/chapters/state-substrate.md
+++ b/docs/book/en/chapters/state-substrate.md
@@ -252,9 +252,17 @@ authority answer "which transition is legal?"
 
 ### Shipped Boundary Versus Design Boundary
 
-The current public architecture keeps the CLI as the compatibility baseline and describes a local
-server/daemon as a roadmap. Detailed multi-Host authority, offline queue, and shared-control-plane designs
-live in an RFC whose status is **Draft**. They are not installed cloud features.
+Shared-authority work in `v0.5.4` is more than a paper design: the repository contains a
+provider-neutral TypeScript `AuthorityStore` contract plus staged file, NoKV, and PostgreSQL candidates
+with conformance evidence. That is still not an enabled shared control plane. The release does not wire
+these candidates into the default runtime or ship a ready-to-enable remote authority service. Installing
+a Provider does not change a Goal's source of truth.
+
+Post-`v0.5.4` `main` may contain further default-off shadow, parity, fencing, or provider-first cutover
+slices. They prove migration mechanics; they are not evidence that `v0.5.4` shipped cloud collaboration.
+Use the matching tag and release notes for stable behavior and the current stage in the
+[Shared Control-Plane Authority RFC](/loopx/docs/architecture/rfcs/shared-goal-authority-state-provider-v0/)
+for experimental status.
 
 You can currently rely on:
 
@@ -263,6 +271,8 @@ You can currently rely on:
   idempotency behavior;
 - registered peers, soft claims, optional task leases, and independent-worktree guards;
 - several Hosts reading one registry and Goal through controlled writeback.
+- staged file, NoKV, and PostgreSQL candidates for development and qualification; they do not acquire
+  runtime authority automatically.
 
 Do not currently promise:
 
@@ -273,8 +283,8 @@ Do not currently promise:
 
 A future cross-device control plane should retain one canonical LoopX authority, revision-bound idempotent
 commands and receipts, and separate message delivery, context memory, and state authority. Until the Draft
-is promoted and validated, this book teaches those boundaries rather than a fictional cloud-mode
-quickstart.
+has an independently reviewed promotion, runtime wiring, and release validation, this book teaches those
+boundaries rather than a fictional cloud-mode quickstart.
 
 ## Three layers of integrity for historical artifacts
 

--- a/examples/dev-book-publication-smoke.py
+++ b/examples/dev-book-publication-smoke.py
@@ -390,7 +390,9 @@ def main() -> int:
             ("Python CLI 仍负责", "Python CLI still owns"),
             ("不能再实现第二套独立 decision", "must not become a second independent decision implementation"),
             ("transaction-payoff phase", "transaction-payoff phase"),
-            ("RFC 中的 Stage 3/4 仍是后续方向", "RFC Stages 3 and 4 remain future direction"),
+            ("Stage 3 的第一个 receipt-bound scheduler follow-up 切片", "first receipt-bound scheduler follow-up slice of Stage 3"),
+            ("Stage 4 distribution cleanup 仍是后续方向", "Stage 4 distribution cleanup remain future work"),
+            ("安装 Provider 不会改变默认本地 authority", "installing a Provider does not change the default local authority"),
         ),
     )
     assert_bilingual_concepts(
@@ -408,14 +410,27 @@ def main() -> int:
         "chapters/03-one-turn.md",
         "en/chapters/03-one-turn.md",
         (
+            (f"`{release_tag}` 仍提供", f"`{release_tag}` still ships"),
             ("显式 opt-in 集成", "explicit opt-in integrations"),
             ("Turn settlement", "Turn settlement"),
             ("Todo completion", "Todo completion"),
-            ("quota delivery routing", "quota delivery routing"),
-            ("workspace causality", "workspace causality"),
-            ("scheduler state", "scheduler state"),
+            ("Host Todo settlement", "Host Todo settlement"),
+            ("spend/void/monitor-poll commit", "spend/void/monitor-poll commit"),
+            ("本地 task-lease 完整生命周期", "full local task-lease lifecycle"),
+            ("Vision refresh", "Vision refresh"),
+            ("receipt-bound scheduler follow-up", "receipt-bound scheduler follow-up"),
             ("Python 已被移除", "Python has been removed"),
             ("TypeScript Control-Plane Migration RFC", "TypeScript Control-Plane Migration RFC"),
+        ),
+    )
+    assert_bilingual_concepts(
+        "chapters/state-substrate.md",
+        "en/chapters/state-substrate.md",
+        (
+            (f"`{release_tag}` 的 shared-authority 工作", f"Shared-authority work in `{release_tag}`"),
+            ("provider-neutral TypeScript `AuthorityStore` contract", "provider-neutral TypeScript `AuthorityStore` contract"),
+            ("不自动获得 runtime authority", "do not acquire runtime authority automatically"),
+            ("不应倒推成", "are not evidence that"),
         ),
     )
     assert_bilingual_concepts(
@@ -433,7 +448,10 @@ def main() -> int:
         "chapters/source-protocol-map.md",
         "en/chapters/source-protocol-map.md",
         (
+            (f"在 `{release_tag}` 的迁移基线上", f"On the `{release_tag}` migration baseline"),
             ("bounded context 和实现语言是两个维度", "bounded context and implementation language are separate dimensions"),
+            ("本地 task-lease lifecycle", "local task-lease lifecycle"),
+            ("receipt-bound scheduler follow-up", "receipt-bound scheduler follow-up"),
             ("Python facade", "Python facade"),
             ("loopx capability list --format json", "loopx capability list --format json"),
             ("仅有 目录或 README 不证明能力已经发布", "A directory or README alone does not prove that a capability is shipped"),
@@ -447,6 +465,15 @@ def main() -> int:
             ("loopx capability list --format json", "loopx capability list --format json"),
             ("TypeScript migration RFC", "TypeScript migration RFC"),
             ("facade exit condition", "facade exit conditions"),
+        ),
+    )
+    assert_bilingual_concepts(
+        "chapters/appendix-reference.md",
+        "en/chapters/appendix-reference.md",
+        (
+            ("loopx todo list --goal-id <goal-id> --thin --format json", "loopx todo list --goal-id <goal-id> --thin --format json"),
+            (f"`{release_tag}` 新增的 `todo list --thin`", f"The `todo list --thin` option added in `{release_tag}`"),
+            ("不改变默认 list 的选择、排序、quota 或 lifecycle 语义", "without changing default selection, ordering, quota, or lifecycle semantics"),
         ),
     )
 


### PR DESCRIPTION
## Summary

- refresh the bilingual DevBook baseline from stale v0.5.2 references to the v0.5.4 release
- document the shipped TypeScript transaction owners and the first receipt-bound Stage 3 scheduler-followup slice
- clarify that file, NoKV, and PostgreSQL AuthorityStore providers remain staged/default-off candidates rather than an enabled shared control plane
- add the v0.5.4 `todo list --thin` entry and strengthen bilingual publication checks for these boundaries

## Issue Or Task

- Contributor task ID: DevBook v0.5.4 freshness audit

## Validation

- [x] `/Users/bytedance/.local/bin/python3.12 examples/dev-book-publication-smoke.py`
- [x] `/Users/bytedance/.local/bin/python3.12 examples/dev-book-welcome-wagon-smoke.py`
- [x] strict MkDocs builds for the main docs, Chinese DevBook, and English DevBook
- [x] rendered-site publication and welcome-wagon smokes
- [x] `loopx check` on all 11 changed paths (public boundary clean; only unrelated existing state-projection warnings)
- [x] `loopx canary premerge --from-git-diff` (standard tier, 10/10 selected checks passed, no manual holds)
- [x] `git diff --check`

## Type of Change

- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Public docs or presentation surface (README, protocols, dashboard)

## Technical Direction

- [x] Core control-plane hardening
- [x] Shared Goal Authority and cross-host coordination

- Target base branch: `main`
- Direction tracker or promotion unit: TypeScript Control-Plane Migration RFC and Shared Goal Authority RFC

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

## Scope and future-facing pass

The related future-facing pass was applied in a bounded form: the publication smoke now derives the active release tag dynamically and guards the semantic ownership, shared-authority default-off boundary, and thin-projection contract. No new runtime abstraction or speculative documentation surface was added.