### PR TITLE
feat(site): publish SWE-Marathon research brief

### DIFF
--- a/apps/presentation/site/src/App.tsx
+++ b/apps/presentation/site/src/App.tsx
@@ -1106,6 +1106,7 @@ export function App() {
         <p>{copy.footer}</p>
         <nav>
           <a href="https://github.com/huangruiteng/loopx">GitHub</a>
+          <a href={`${basePath}benchmarks/swe-marathon/${language === "zh" ? "?lang=zh" : ""}`}>Research</a>
           <a href={`${basePath}frontstage/`}>Frontstage</a>
           <a href={`${basePath}docs/`}>Docs</a>
         </nav>

--- a/apps/presentation/site/src/SweMarathonBrief.tsx
+++ b/apps/presentation/site/src/SweMarathonBrief.tsx
@@ -1,0 +1,342 @@
+import {
+  ArrowLeft,
+  ExternalLink,
+  FlaskConical,
+  GitCompareArrows,
+  ShieldCheck,
+  TimerReset,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { CSSProperties } from "react";
+import benchmarkData from "../../../../benchmark/swe-marathon/data.json";
+import caseInsights from "../../../../benchmark/swe-marathon/case_insights.json";
+import copy from "./swe-marathon-copy.json";
+
+type Language = "en" | "zh";
+type Arm = (typeof benchmarkData.arms)[number];
+
+const armOrder = ["plain", "goal", "ssh-goal", "codex-cli", "heartbeat"] as const;
+const publicAnalysisUrl =
+  "https://github.com/huangruiteng/loopx/pull/3887#issuecomment-5535839229";
+const repositoryStudyUrl =
+  "https://github.com/huangruiteng/loopx/tree/main/benchmark/swe-marathon";
+
+const studyObservation = caseInsights.study_observations[0];
+const behaviorMetrics = studyObservation.metrics;
+const zstdHeartbeat = caseInsights.records.find(
+  (record) => record.case_id === "zstd-decoder" && record.run_id.includes("heartbeat"),
+);
+
+const armLabels: Record<Language, Record<string, string>> = {
+  en: {
+    plain: "Plain Codex",
+    goal: "Native Goal",
+    "ssh-goal": "Codex App SSH Goal + LoopX",
+    "codex-cli": "Codex CLI Goal profile + LoopX*",
+    heartbeat: "LoopX Turn (external-scheduler automation)",
+  },
+  zh: {
+    plain: "裸 Codex",
+    goal: "原生 Goal",
+    "ssh-goal": "Codex App SSH Goal + LoopX",
+    "codex-cli": "Codex CLI Goal profile + LoopX*",
+    heartbeat: "LoopX Turn（外部调度 Automation）",
+  },
+};
+
+
+function updateLanguage(language: Language) {
+  const url = new URL(window.location.href);
+  if (language === "zh") url.searchParams.set("lang", "zh");
+  else url.searchParams.delete("lang");
+  window.history.replaceState({}, "", url);
+  document.documentElement.lang = language === "zh" ? "zh-CN" : "en";
+}
+
+function HorizonDiagram({ language }: Readonly<{ language: Language }>) {
+  const c = copy[language];
+  return (
+    <figure className="bm-horizon" aria-labelledby="benchmark-horizon-caption">
+      <div className="bm-horizon-track" aria-hidden="true">
+        {c.horizonLabels.map((label, index) => (
+          <div className="bm-horizon-stop" key={label}>
+            <i style={{ "--stop": index } as CSSProperties} />
+            <span>{label}</span>
+          </div>
+        ))}
+        <div className="bm-horizon-window">
+          <span>SWE-Marathon</span>
+          <b>{language === "zh" ? "多小时 / repo 级" : "multi-hour / repository scale"}</b>
+        </div>
+      </div>
+      <figcaption id="benchmark-horizon-caption">
+        {language === "zh"
+          ? "示意：任务 horizon 足以让可见完成与隐藏正确性分离。"
+          : "Conceptual view: the task horizon separates visible completion from hidden correctness."}
+      </figcaption>
+    </figure>
+  );
+}
+
+function BarChart({
+  title,
+  values,
+  format,
+}: Readonly<{
+  title: string;
+  values: Array<[string, number, boolean?]>;
+  format: (value: number) => string;
+}>) {
+  const max = Math.max(...values.map(([, value]) => value));
+  return (
+    <figure className="bm-bar-chart" aria-label={title}>
+      <figcaption>{title}</figcaption>
+      <div className="bm-bars">
+        {values.map(([label, value, accent]) => (
+          <div className="bm-bar-row" key={label}>
+            <span>{label}</span>
+            <div className="bm-bar-track">
+              <i
+                className={accent ? "is-accent" : undefined}
+                style={{ width: `${Math.max(2, (value / max) * 100)}%` }}
+              />
+            </div>
+            <b>{format(value)}</b>
+          </div>
+        ))}
+      </div>
+    </figure>
+  );
+}
+
+export function SweMarathonBrief() {
+  const [language, setLanguage] = useState<Language>(() =>
+    new URLSearchParams(window.location.search).get("lang") === "zh" ? "zh" : "en",
+  );
+  const c = copy[language];
+  const basePath = import.meta.env.BASE_URL;
+
+  useEffect(() => {
+    document.title = language === "zh"
+      ? "LoopX × SWE-Marathon：持续自我验证"
+      : "LoopX × SWE-Marathon: Continued self-verification";
+    document.documentElement.lang = language === "zh" ? "zh-CN" : "en";
+  }, [language]);
+
+  const summaries = useMemo(
+    () =>
+      armOrder.map((arm) => ({
+        arm,
+        ...benchmarkData.arm_summary[arm],
+      })),
+    [],
+  );
+
+  const setLocale = (next: Language) => {
+    setLanguage(next);
+    updateLanguage(next);
+  };
+
+  return (
+    <div className="bm-page" id="top">
+      <header className="bm-topbar">
+        <a href={`${basePath}${language === "zh" ? "?lang=zh" : ""}`} className="bm-home-link">
+          <ArrowLeft size={14} /> {c.back}
+        </a>
+        <span className="bm-edition">RESEARCH BRIEF / 01</span>
+        <div className="bm-top-actions">
+          <div className="bm-language" aria-label="Language">
+            <button className={language === "en" ? "is-active" : ""} onClick={() => setLocale("en")} type="button">EN</button>
+            <button className={language === "zh" ? "is-active" : ""} onClick={() => setLocale("zh")} type="button">中文</button>
+          </div>
+          <a href={repositoryStudyUrl} target="_blank" rel="noreferrer">
+            {c.source} <ExternalLink size={13} />
+          </a>
+        </div>
+      </header>
+
+      <main>
+        <section className="bm-hero bm-shell">
+          <div className="bm-hero-copy">
+            <p className="bm-eyebrow"><FlaskConical size={14} /> {c.meta}</p>
+            <h1>
+              {language === "zh" ? (
+                <>
+                  <span className="bm-title-desktop">LoopX 让 Agent 在说“完成”<br />之后继续验证。</span>
+                  <span className="bm-title-mobile">说“完成”后，<br />继续验证。</span>
+                </>
+              ) : c.title}
+            </h1>
+            <p className="bm-deck">{c.deck}</p>
+            <span className="bm-evidence-tag"><ShieldCheck size={14} /> {c.evidenceTag}</span>
+          </div>
+        </section>
+
+        <section className="bm-section bm-shell bm-summary" id="summary">
+          <div className="bm-section-lead bm-section-lead-wide">
+            <p className="bm-kicker">{c.executiveEyebrow}</p>
+            <h2>{c.executiveTitle}</h2>
+            <p>{c.executiveBody}</p>
+          </div>
+          <div className="bm-table-wrap bm-score-table bm-executive-table">
+            <table>
+              <thead><tr>{c.executiveColumns.map((column) => <th key={column}>{column}</th>)}</tr></thead>
+              <tbody>
+                {summaries.map((row) => {
+                  const owner = c.armRows.find(([arm]) => arm === row.arm)?.[1];
+                  let rowClassName: string | undefined;
+                  if (row.arm === "heartbeat") rowClassName = "is-highlight";
+                  else if (row.arm === "codex-cli") rowClassName = "is-caution";
+                  return (
+                    <tr key={row.arm} className={rowClassName}>
+                      <th scope="row"><code>{row.arm}</code><span>{armLabels[language][row.arm]}</span></th>
+                      <td>{owner}</td>
+                      <td>{row.reward.toFixed(3)}</td>
+                      <td><strong>{row.partial.toFixed(3)}</strong></td>
+                      <td>${Math.round(row.cost)}</td>
+                      <td>{row.cont_total}</td>
+                      <td>{c.executiveReads[row.arm]}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <p className="bm-runner-note"><strong>{language === "zh" ? "Runner 注释" : "Runner note"}</strong>{c.runnerNote}</p>
+        </section>
+
+        <section className="bm-section bm-shell" id="background">
+          <div className="bm-section-lead">
+            <p className="bm-kicker">{c.backgroundEyebrow}</p>
+            <h2>{c.backgroundTitle}</h2>
+            <p>{c.backgroundBody}</p>
+          </div>
+          <HorizonDiagram language={language} />
+          <div className="bm-fact-grid">
+            {c.benchmarkFacts.map(([value, label, note]) => (
+              <article key={label}>
+                <strong>{value}</strong>
+                <span>{label}</span>
+                <small>{note}</small>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="bm-section bm-shell" id="mechanism">
+          <div className="bm-section-lead bm-section-lead-wide">
+            <p className="bm-kicker">{c.mechanismEyebrow}</p>
+            <h2>{c.mechanismTitle}</h2>
+            <p>{c.mechanismBody}</p>
+          </div>
+          <div className="bm-chart-grid">
+            <BarChart
+              title={c.stepsChart}
+              values={[
+                [armLabels[language].goal, behaviorMetrics.agent_step_ratio_vs_plain_median.goal_native],
+                [armLabels[language]["codex-cli"], behaviorMetrics.agent_step_ratio_vs_plain_median["codex-cli"]],
+                [armLabels[language].heartbeat, behaviorMetrics.agent_step_ratio_vs_plain_median.heartbeat],
+                [armLabels[language]["ssh-goal"], behaviorMetrics.agent_step_ratio_vs_plain_median["ssh-goal"], true],
+              ]}
+              format={(value) => `${value.toFixed(2)}×`}
+            />
+            <BarChart
+              title={c.densityChart}
+              values={[
+                [armLabels[language].plain, behaviorMetrics.self_verification_density_per_step_median.plain],
+                [armLabels[language].goal, behaviorMetrics.self_verification_density_per_step_median.goal_native],
+                [armLabels[language].heartbeat, behaviorMetrics.self_verification_density_per_step_median.heartbeat],
+                [armLabels[language]["ssh-goal"], behaviorMetrics.self_verification_density_per_step_median["ssh-goal"], true],
+              ]}
+              format={(value) => value.toFixed(3)}
+            />
+          </div>
+          <div className="bm-chain" aria-label="Mechanism chain">
+            {c.mechanismChain.map(([number, title, body]) => (
+              <article key={number}><span>{number}</span><h3>{title}</h3><p>{body}</p></article>
+            ))}
+          </div>
+          <div className="bm-insight-grid bm-insight-grid-compact">
+            {c.insights.map(([title, body], index) => (
+              <article key={title}><span>0{index + 1}</span><h3>{title}</h3><p>{body}</p></article>
+            ))}
+          </div>
+          <blockquote>
+            <p>“{c.quote}”</p>
+            <cite><a href={publicAnalysisUrl} target="_blank" rel="noreferrer">{c.quoteBy} <ExternalLink size={12} /></a></cite>
+          </blockquote>
+        </section>
+
+        <section className="bm-section bm-shell" id="zstd">
+          <div className="bm-section-lead bm-section-lead-wide">
+            <p className="bm-kicker">{c.caseEyebrow}</p>
+            <h2>{c.caseTitle}</h2>
+            <p>{c.caseBody}</p>
+          </div>
+          <div className="bm-timeline">
+            {c.timeline.map(([step, title, action, outcome], index) => (
+              <article key={step} className={index > 0 ? "is-loopx" : undefined}>
+                <span>{step}</span><h3>{title}</h3><p>{action}</p><strong>{outcome}</strong>
+              </article>
+            ))}
+          </div>
+          <div className="bm-case-note"><TimerReset size={18} /><p>{c.trajectoryNote}</p></div>
+          {zstdHeartbeat ? <span className="bm-data-attestation">{language === "zh" ? "来源：" : "Source: "}{zstdHeartbeat.schema_version} · {zstdHeartbeat.confidence} confidence</span> : null}
+        </section>
+
+        <section className="bm-section bm-shell bm-official" id="official-comparison">
+          <div className="bm-section-lead bm-section-lead-wide">
+            <p className="bm-kicker">{c.officialEyebrow}</p>
+            <h2>{c.officialTitle}</h2>
+            <p>{c.officialBody}</p>
+          </div>
+          <div className="bm-table-wrap bm-official-table">
+            <table>
+              <thead><tr>{c.officialColumns.map((column) => <th key={column}>{column}</th>)}</tr></thead>
+              <tbody>
+                {c.officialRows.map(([dimension, study, official, interpretation]) => (
+                  <tr key={dimension}>
+                    <th scope="row">{dimension}</th>
+                    <td>{study}</td>
+                    <td>{official}</td>
+                    <td>{interpretation}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="bm-official-note"><strong>{language === "zh" ? "阅读方式" : "How to read it"}</strong>{c.officialNote}</p>
+        </section>
+
+        <section className="bm-section bm-shell bm-boundary" id="boundary">
+          <div>
+            <p className="bm-kicker">{c.limitsEyebrow}</p>
+            <h2>{c.limitsTitle}</h2>
+            <ul>{c.limits.map((item) => <li key={item}>{item}</li>)}</ul>
+          </div>
+          <aside>
+            <GitCompareArrows size={24} />
+            <h3>{c.nextTitle}</h3>
+            <p>{c.nextBody}</p>
+          </aside>
+        </section>
+
+        <section className="bm-section bm-shell" id="sources">
+          <div className="bm-section-lead bm-section-lead-wide">
+            <p className="bm-kicker">{c.sourcesEyebrow}</p>
+            <h2>{c.sourcesTitle}</h2>
+          </div>
+          <div className="bm-source-list">
+            {c.sourceItems.map(([title, body, href], index) => (
+              <a href={href} target="_blank" rel="noreferrer" key={title}>
+                <span>0{index + 1}</span><div><strong>{title}</strong><p>{body}</p></div><ExternalLink size={15} />
+              </a>
+            ))}
+          </div>
+        </section>
+      </main>
+
+      <footer className="bm-footer bm-shell"><span>LoopX / Research Brief 01</span><p>{c.footer}</p><a href="#top">{language === "zh" ? "回到顶部" : "Back to top"}</a></footer>
+    </div>
+  );
+}

--- a/apps/presentation/site/src/main.tsx
+++ b/apps/presentation/site/src/main.tsx
@@ -1,13 +1,16 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { SweMarathonBrief } from "./SweMarathonBrief";
 import "./styles.css";
+import "./swe-marathon-brief.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("LoopX homepage root is missing");
 
+const pathSegments = window.location.pathname.split("/").filter(Boolean);
+const isSweMarathonBrief = pathSegments.slice(-2).join("/") === "benchmarks/swe-marathon";
+
 createRoot(rootElement).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <StrictMode>{isSweMarathonBrief ? <SweMarathonBrief /> : <App />}</StrictMode>,
 );

--- a/apps/presentation/site/src/swe-marathon-brief.css
+++ b/apps/presentation/site/src/swe-marathon-brief.css
@@ -1,0 +1,1198 @@
+.bm-page {
+  --bm-ink: #171717;
+  --bm-body: #4d4d4d;
+  --bm-muted: #737373;
+  --bm-faint: #a1a1a1;
+  --bm-canvas: #fafafa;
+  --bm-surface: #ffffff;
+  --bm-soft: #f2f2f2;
+  --bm-border: #e5e5e5;
+  --bm-blue: #075fce;
+  --bm-blue-soft: #eaf3ff;
+  --bm-amber: #8b5c00;
+  --bm-amber-soft: #fff5d9;
+  min-height: 100vh;
+  color: var(--bm-ink);
+  background:
+    linear-gradient(90deg, rgb(23 23 23 / 0.035) 1px, transparent 1px) 0 0 / 64px 64px,
+    var(--bm-canvas);
+  font-family: Geist, "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.55;
+}
+
+.bm-page *,
+.bm-page *::before,
+.bm-page *::after {
+  box-sizing: border-box;
+}
+
+.bm-page a {
+  color: inherit;
+}
+
+.bm-page button,
+.bm-page a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.bm-page button:focus-visible,
+.bm-page a:focus-visible {
+  outline: 2px solid var(--bm-blue);
+  outline-offset: 3px;
+}
+
+.bm-shell {
+  width: min(1400px, calc(100% - 48px));
+  margin-inline: auto;
+}
+
+.bm-topbar {
+  position: sticky;
+  z-index: 20;
+  top: 0;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 52px;
+  padding: 0 24px;
+  border-bottom: 1px solid var(--bm-border);
+  background: rgb(250 250 250 / 0.94);
+  backdrop-filter: blur(16px);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bm-home-link,
+.bm-top-actions > a {
+  display: inline-flex;
+  gap: 7px;
+  align-items: center;
+  width: max-content;
+  text-decoration: none;
+}
+
+.bm-edition {
+  color: var(--bm-muted);
+}
+
+.bm-top-actions {
+  display: flex;
+  gap: 22px;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.bm-language {
+  display: flex;
+  padding: 2px;
+  border: 1px solid var(--bm-border);
+  border-radius: 999px;
+  background: var(--bm-surface);
+}
+
+.bm-language button {
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--bm-muted);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+
+.bm-title-mobile {
+  display: none;
+}
+
+.bm-language button.is-active {
+  color: #fff;
+  background: var(--bm-ink);
+}
+
+.bm-hero {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 20px;
+  padding-block: 48px 32px;
+}
+
+.bm-eyebrow,
+.bm-kicker {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin: 0 0 22px;
+  color: var(--bm-blue);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bm-hero h1 {
+  max-width: 1180px;
+  margin: 0;
+  font-size: clamp(46px, 5.4vw, 76px);
+  font-weight: 540;
+  letter-spacing: -0.065em;
+  line-height: 0.96;
+  text-wrap: balance;
+}
+
+.bm-deck {
+  max-width: 980px;
+  margin: 24px 0 20px;
+  color: var(--bm-body);
+  font-size: clamp(17px, 1.35vw, 21px);
+  line-height: 1.48;
+}
+
+.bm-evidence-tag {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 36px;
+  padding: 7px 12px;
+  border: 1px solid #bdd8fa;
+  border-radius: 999px;
+  color: #084b9a;
+  background: var(--bm-blue-soft);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.bm-hero-metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-self: end;
+  border-top: 1px solid var(--bm-ink);
+  border-left: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-hero-metrics article {
+  display: flex;
+  flex-direction: column;
+  min-height: 162px;
+  padding: 20px;
+  border-right: 1px solid var(--bm-border);
+  border-bottom: 1px solid var(--bm-border);
+}
+
+.bm-hero-metrics strong {
+  margin-bottom: auto;
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: clamp(32px, 3.2vw, 48px);
+  font-weight: 540;
+  letter-spacing: -0.055em;
+  line-height: 1;
+}
+
+.bm-hero-metrics span {
+  margin-top: 24px;
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.bm-hero-metrics small {
+  color: var(--bm-muted);
+  font-size: 11px;
+}
+
+.bm-thesis {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: 190px minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  padding: 20px 24px;
+  border: 1px solid var(--bm-ink);
+  background: var(--bm-ink);
+  color: #fff;
+}
+
+.bm-thesis > span {
+  color: #a3a3a3;
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bm-thesis p {
+  max-width: 840px;
+  margin: 0;
+  font-size: clamp(17px, 1.7vw, 23px);
+  font-weight: 500;
+  letter-spacing: -0.025em;
+  line-height: 1.3;
+}
+
+.bm-thesis a {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 44px;
+  color: #d4d4d4;
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.bm-reading-path {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--bm-ink);
+  border-left: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-reading-path a {
+  position: relative;
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  min-height: 64px;
+  padding: 12px 18px;
+  border-right: 1px solid var(--bm-border);
+  border-bottom: 1px solid var(--bm-border);
+  text-decoration: none;
+  transition: background 180ms ease;
+}
+
+.bm-reading-path a:hover {
+  background: var(--bm-blue-soft);
+}
+
+.bm-reading-path a:not(:last-child)::after {
+  position: absolute;
+  right: 12px;
+  color: var(--bm-faint);
+  content: "→";
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+}
+
+.bm-reading-path span {
+  color: var(--bm-blue);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.bm-reading-path b {
+  padding-right: 14px;
+  font-size: 12px;
+}
+
+.bm-section {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.72fr) minmax(0, 1.48fr);
+  gap: 36px 64px;
+  padding-block: 72px;
+  border-top: 1px solid var(--bm-border);
+}
+
+.bm-section-lead h2,
+.bm-boundary h2 {
+  max-width: 970px;
+  margin: 0;
+  font-size: clamp(36px, 3.7vw, 56px);
+  font-weight: 540;
+  letter-spacing: -0.055em;
+  line-height: 1.02;
+}
+
+.bm-section-lead > p:last-child {
+  max-width: 780px;
+  margin: 18px 0 0;
+  color: var(--bm-body);
+  font-size: 17px;
+}
+
+.bm-section-lead-wide {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.55fr);
+  gap: 28px 64px;
+}
+
+.bm-summary {
+  gap: 28px;
+  padding-block: 40px 56px;
+}
+
+.bm-section-lead-wide .bm-kicker {
+  grid-column: 1 / -1;
+  margin-bottom: -16px;
+}
+
+.bm-section-lead-wide > p:last-child {
+  align-self: end;
+  margin: 0;
+}
+
+.bm-horizon {
+  margin: 0;
+  padding: 30px;
+  border: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-horizon-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  min-height: 200px;
+  padding-top: 118px;
+}
+
+.bm-horizon-track::before {
+  position: absolute;
+  top: 124px;
+  right: 5%;
+  left: 5%;
+  height: 1px;
+  background: var(--bm-ink);
+  content: "";
+}
+
+.bm-horizon-stop {
+  position: relative;
+  display: grid;
+  justify-items: center;
+  color: var(--bm-muted);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.bm-horizon-stop i {
+  z-index: 2;
+  width: 9px;
+  height: 9px;
+  margin: 2px 0 17px;
+  border: 2px solid var(--bm-surface);
+  border-radius: 999px;
+  background: var(--bm-ink);
+  box-shadow: 0 0 0 1px var(--bm-ink);
+}
+
+.bm-horizon-window {
+  position: absolute;
+  top: 18px;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  width: 55%;
+  padding: 16px 18px;
+  border-left: 3px solid var(--bm-blue);
+  background: var(--bm-blue-soft);
+}
+
+.bm-horizon-window span {
+  color: var(--bm-blue);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.bm-horizon-window b {
+  margin-top: 4px;
+  font-size: 16px;
+}
+
+.bm-horizon figcaption {
+  margin-top: 14px;
+  color: var(--bm-muted);
+  font-size: 11px;
+}
+
+.bm-fact-grid {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--bm-border);
+  border-left: 1px solid var(--bm-border);
+}
+
+.bm-fact-grid article {
+  display: flex;
+  flex-direction: column;
+  min-height: 150px;
+  padding: 20px;
+  border-right: 1px solid var(--bm-border);
+  border-bottom: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-fact-grid strong {
+  color: var(--bm-blue);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 32px;
+  font-weight: 540;
+}
+
+.bm-fact-grid span {
+  margin-top: auto;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.bm-fact-grid small {
+  margin-top: 2px;
+  color: var(--bm-muted);
+  font-size: 11px;
+}
+
+.bm-table-wrap {
+  grid-column: 1 / -1;
+  overflow-x: auto;
+  border: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-table-wrap table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.bm-executive-table table {
+  min-width: 840px;
+  table-layout: fixed;
+}
+
+.bm-executive-table th:nth-child(1) { width: 22%; }
+.bm-executive-table th:nth-child(2) { width: 18%; }
+.bm-executive-table th:nth-child(3),
+.bm-executive-table th:nth-child(4),
+.bm-executive-table th:nth-child(5),
+.bm-executive-table th:nth-child(6) { width: 8%; }
+.bm-executive-table th:nth-child(7) { width: 28%; }
+
+.bm-executive-table th,
+.bm-executive-table td {
+  padding: 13px 14px;
+}
+
+.bm-executive-table td:last-child {
+  color: var(--bm-body);
+}
+
+.bm-official-table table {
+  min-width: 920px;
+  table-layout: fixed;
+}
+
+.bm-official-table th:nth-child(1) { width: 15%; }
+.bm-official-table th:nth-child(2) { width: 24%; }
+.bm-official-table th:nth-child(3) { width: 27%; }
+.bm-official-table th:nth-child(4) { width: 34%; }
+
+.bm-official-table th,
+.bm-official-table td {
+  padding: 13px 14px;
+  vertical-align: top;
+  line-height: 1.45;
+}
+
+.bm-official-table tbody th {
+  color: var(--bm-ink);
+  background: var(--bm-soft);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.01em;
+}
+
+.bm-official-note {
+  grid-column: 1 / -1;
+  margin: -8px 0 0;
+  padding: 16px 18px;
+  border-left: 3px solid var(--bm-blue);
+  color: var(--bm-body);
+  background: var(--bm-blue-soft);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.bm-official-note strong {
+  margin-right: 9px;
+  color: var(--bm-ink);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bm-table-wrap th,
+.bm-table-wrap td {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--bm-border);
+  vertical-align: middle;
+  font-size: 13px;
+}
+
+.bm-table-wrap thead th {
+  color: var(--bm-muted);
+  background: var(--bm-soft);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.bm-table-wrap tbody tr:last-child > * {
+  border-bottom: 0;
+}
+
+.bm-table-wrap tbody th {
+  white-space: nowrap;
+}
+
+.bm-table-wrap code {
+  display: block;
+  color: var(--bm-ink);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.bm-table-wrap tbody th span {
+  display: block;
+  margin-top: 2px;
+  color: var(--bm-muted);
+  font-size: 11px;
+  font-weight: 400;
+}
+
+.bm-pill {
+  display: inline-flex;
+  padding: 4px 8px;
+  border: 1px solid var(--bm-border);
+  border-radius: 999px;
+  color: var(--bm-muted);
+  background: var(--bm-soft);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.bm-pill.is-loopx {
+  border-color: #bdd8fa;
+  color: #084b9a;
+  background: var(--bm-blue-soft);
+}
+
+.bm-results-grid,
+.bm-chart-grid {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.bm-bar-chart {
+  margin: 0;
+  padding: 24px;
+  border: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-bar-chart figcaption {
+  margin-bottom: 24px;
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bm-bars {
+  display: grid;
+  gap: 14px;
+}
+
+.bm-bar-row {
+  display: grid;
+  grid-template-columns: 116px minmax(80px, 1fr) 54px;
+  gap: 12px;
+  align-items: center;
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+}
+
+.bm-bar-row > b {
+  text-align: right;
+}
+
+.bm-bar-track {
+  height: 12px;
+  background: var(--bm-soft);
+}
+
+.bm-bar-track i {
+  display: block;
+  height: 100%;
+  background: #8f8f8f;
+}
+
+.bm-bar-track i.is-accent {
+  background: var(--bm-blue);
+}
+
+.bm-finding-stack {
+  display: grid;
+  grid-template-rows: 1fr 1fr;
+  gap: 12px;
+}
+
+.bm-finding {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  align-items: start;
+  padding: 22px;
+  border: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-finding p {
+  margin: 0;
+  font-size: 14px;
+}
+
+.bm-finding.is-positive {
+  border-left: 3px solid var(--bm-blue);
+}
+
+.bm-finding.is-positive svg {
+  color: var(--bm-blue);
+}
+
+.bm-finding.is-caution {
+  border-left: 3px solid var(--bm-amber);
+  background: var(--bm-amber-soft);
+}
+
+.bm-finding.is-caution svg {
+  color: var(--bm-amber);
+}
+
+.bm-score-table h3 {
+  margin: 0;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--bm-border);
+  font-size: 14px;
+}
+
+.bm-score-table .is-highlight {
+  background: var(--bm-blue-soft);
+}
+
+.bm-score-table .is-caution {
+  background: var(--bm-amber-soft);
+}
+
+.bm-runner-note {
+  grid-column: 1 / -1;
+  margin: -8px 0 0;
+  color: var(--bm-muted);
+  font-size: 11px;
+}
+
+.bm-runner-note strong {
+  margin-right: 8px;
+  color: var(--bm-ink);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bm-finding-row {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.bm-chain {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border-top: 1px solid var(--bm-ink);
+  border-left: 1px solid var(--bm-border);
+}
+
+.bm-chain article {
+  position: relative;
+  min-height: 210px;
+  padding: 20px;
+  border-right: 1px solid var(--bm-border);
+  border-bottom: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-chain article:not(:last-child)::after {
+  position: absolute;
+  z-index: 2;
+  top: 28px;
+  right: -10px;
+  display: grid;
+  width: 20px;
+  height: 20px;
+  place-items: center;
+  border: 1px solid var(--bm-border);
+  border-radius: 999px;
+  background: var(--bm-surface);
+  color: var(--bm-blue);
+  content: "→";
+  font-size: 11px;
+}
+
+.bm-chain span,
+.bm-insight-grid span {
+  color: var(--bm-blue);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.bm-chain h3 {
+  margin: 64px 0 10px;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+
+.bm-chain p,
+.bm-insight-grid p {
+  margin: 0;
+  color: var(--bm-body);
+  font-size: 13px;
+}
+
+.bm-page blockquote {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 40px 48px;
+  border: 1px solid var(--bm-ink);
+  background: var(--bm-ink);
+  color: #fff;
+}
+
+.bm-page blockquote p {
+  max-width: 1120px;
+  margin: 0;
+  font-size: clamp(26px, 3.4vw, 46px);
+  font-weight: 500;
+  letter-spacing: -0.045em;
+  line-height: 1.16;
+}
+
+.bm-page blockquote cite {
+  display: block;
+  margin-top: 28px;
+  color: #a3a3a3;
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-style: normal;
+}
+
+.bm-page blockquote a {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  text-decoration: none;
+}
+
+.bm-timeline {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+}
+
+.bm-timeline article {
+  display: flex;
+  flex-direction: column;
+  min-height: 250px;
+  padding: 22px;
+  border: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-timeline article.is-loopx {
+  border-top: 3px solid var(--bm-blue);
+}
+
+.bm-timeline span {
+  color: var(--bm-muted);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.bm-timeline h3 {
+  margin: 36px 0 10px;
+  font-size: 19px;
+  letter-spacing: -0.025em;
+}
+
+.bm-timeline p {
+  margin: 0;
+  color: var(--bm-body);
+  font-size: 13px;
+}
+
+.bm-timeline strong {
+  margin-top: auto;
+  padding-top: 28px;
+  color: var(--bm-blue);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 12px;
+}
+
+.bm-case-note {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  align-items: start;
+  padding: 18px 22px;
+  border-left: 3px solid var(--bm-amber);
+  background: var(--bm-amber-soft);
+}
+
+.bm-case-note p {
+  margin: 0;
+  font-size: 13px;
+}
+
+.bm-case-note svg {
+  color: var(--bm-amber);
+}
+
+.bm-data-attestation {
+  grid-column: 1 / -1;
+  color: var(--bm-muted);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+}
+
+.bm-insight-grid {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--bm-ink);
+  border-left: 1px solid var(--bm-border);
+}
+
+.bm-insight-grid article {
+  min-height: 220px;
+  padding: 20px;
+  border-right: 1px solid var(--bm-border);
+  border-bottom: 1px solid var(--bm-border);
+  background: var(--bm-surface);
+}
+
+.bm-insight-grid h3 {
+  margin: 52px 0 10px;
+  font-size: 18px;
+  letter-spacing: -0.025em;
+}
+
+.bm-insight-grid-compact {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.bm-insight-grid-compact article {
+  min-height: 180px;
+}
+
+.bm-insight-grid-compact h3 {
+  margin-top: 36px;
+}
+
+.bm-boundary {
+  grid-template-columns: 1.15fr 0.85fr;
+}
+
+.bm-boundary ul {
+  display: grid;
+  gap: 10px;
+  margin: 28px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bm-boundary li {
+  position: relative;
+  padding-left: 18px;
+  color: var(--bm-body);
+  font-size: 14px;
+}
+
+.bm-boundary li::before {
+  position: absolute;
+  top: 0.62em;
+  left: 0;
+  width: 6px;
+  height: 6px;
+  border: 1px solid var(--bm-muted);
+  border-radius: 999px;
+  content: "";
+}
+
+.bm-boundary aside {
+  align-self: end;
+  padding: 28px;
+  border: 1px solid var(--bm-ink);
+  background: var(--bm-surface);
+}
+
+.bm-boundary aside svg {
+  color: var(--bm-blue);
+}
+
+.bm-boundary aside h3 {
+  margin: 52px 0 12px;
+  font-size: 23px;
+  letter-spacing: -0.035em;
+}
+
+.bm-boundary aside p {
+  margin: 0;
+  color: var(--bm-body);
+  font-size: 14px;
+}
+
+.bm-source-list {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--bm-ink);
+}
+
+.bm-source-list a {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  gap: 18px;
+  align-items: center;
+  min-height: 88px;
+  padding: 14px 8px;
+  border-bottom: 1px solid var(--bm-border);
+  text-decoration: none;
+  transition: background 180ms ease;
+}
+
+.bm-source-list a:hover {
+  background: var(--bm-surface);
+}
+
+.bm-source-list > a > span {
+  color: var(--bm-muted);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 11px;
+}
+
+.bm-source-list strong {
+  font-size: 15px;
+}
+
+.bm-source-list p {
+  margin: 3px 0 0;
+  color: var(--bm-muted);
+  font-size: 12px;
+}
+
+.bm-footer {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 32px;
+  align-items: center;
+  min-height: 108px;
+  border-top: 1px solid var(--bm-border);
+  font-family: "Geist Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+}
+
+.bm-footer p {
+  margin: 0;
+  color: var(--bm-muted);
+  text-align: center;
+}
+
+.bm-footer a {
+  min-height: 44px;
+  align-content: center;
+  text-decoration: none;
+}
+
+@media (max-width: 980px) {
+  .bm-hero,
+  .bm-section,
+  .bm-boundary {
+    grid-template-columns: 1fr;
+  }
+
+  .bm-hero-metrics {
+    align-self: auto;
+  }
+
+  .bm-section-lead-wide {
+    grid-template-columns: 1fr;
+  }
+
+  .bm-section-lead-wide .bm-kicker {
+    margin-bottom: -12px;
+  }
+
+  .bm-fact-grid,
+  .bm-chain,
+  .bm-insight-grid,
+  .bm-insight-grid-compact {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .bm-chain article:nth-child(2)::after {
+    display: none;
+  }
+}
+
+@media (max-width: 700px) {
+  .bm-shell {
+    width: min(100% - 28px, 1400px);
+  }
+
+  .bm-topbar {
+    grid-template-columns: 1fr auto;
+    padding-inline: 14px;
+  }
+
+  .bm-title-desktop {
+    display: none;
+  }
+
+  .bm-title-mobile {
+    display: inline;
+  }
+
+  .bm-edition,
+  .bm-top-actions > a {
+    display: none;
+  }
+
+  .bm-hero {
+    gap: 38px;
+    padding-block: 56px 32px;
+  }
+
+  .bm-hero h1 {
+    font-size: clamp(46px, 14vw, 66px);
+  }
+
+  .bm-hero-metrics,
+  .bm-fact-grid,
+  .bm-results-grid,
+  .bm-chart-grid,
+  .bm-finding-row,
+  .bm-chain,
+  .bm-timeline,
+  .bm-insight-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bm-reading-path {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .bm-reading-path a:nth-child(2)::after {
+    display: none;
+  }
+
+  .bm-hero-metrics article {
+    min-height: 130px;
+  }
+
+  .bm-thesis {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    padding: 22px;
+  }
+
+  .bm-thesis a {
+    margin-top: 8px;
+  }
+
+  .bm-section {
+    gap: 36px;
+    padding-block: 72px;
+  }
+
+  .bm-section-lead h2,
+  .bm-boundary h2 {
+    font-size: clamp(36px, 11vw, 50px);
+  }
+
+  .bm-horizon {
+    padding: 18px;
+  }
+
+  .bm-horizon-track {
+    min-height: 230px;
+    padding-top: 134px;
+  }
+
+  .bm-horizon-track::before {
+    top: 140px;
+  }
+
+  .bm-horizon-window {
+    width: 72%;
+  }
+
+  .bm-horizon-stop span {
+    max-width: 68px;
+  }
+
+  .bm-chain article:not(:last-child)::after {
+    display: none;
+  }
+
+  .bm-page blockquote {
+    padding: 28px 24px;
+  }
+
+  .bm-bar-row {
+    grid-template-columns: 94px minmax(70px, 1fr) 48px;
+  }
+
+  .bm-footer {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding-block: 28px;
+  }
+
+  .bm-footer p {
+    text-align: left;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bm-page *,
+  .bm-page *::before,
+  .bm-page *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 1ms !important;
+  }
+}

--- a/apps/presentation/site/src/swe-marathon-copy.json
+++ b/apps/presentation/site/src/swe-marathon-copy.json
@@ -1,0 +1,482 @@
+{
+  "en": {
+    "meta": "SWE-MARATHON / EXPLORATORY STUDY 01",
+    "back": "LoopX home",
+    "source": "Public evidence",
+    "title": "LoopX keeps agents verifying after they say ‘done.’",
+    "deck": "Across 15 matched SWE-Marathon tasks, LoopX-governed runners produced a large, consistent shift toward audit, falsification, and hardening after visible tests passed.",
+    "evidenceTag": "SWE-Marathon v1.1 · exploratory evidence · 15 matched tasks · 75 trials",
+    "executiveEyebrow": "00 / Core result",
+    "executiveTitle": "LoopX Turn (external-scheduler automation) led on outcome; Codex App SSH Goal + LoopX led on verification; the CLI Goal-profile arm was the counterexample.",
+    "executiveBody": "GPT-5.6 Sol · high reasoning · 15 matched tasks · 1 trial per task-arm · 30% timeout budget. The table combines treatment, outcome, cost, and the decision-relevant read.",
+    "executiveColumns": [
+      "Arm",
+      "Continuation owner",
+      "Reward",
+      "Partial",
+      "Cost",
+      "Continues",
+      "Decision read"
+    ],
+    "executiveReads": {
+      "plain": "Lowest-cost baseline; stops earlier",
+      "goal": "Goal alone improves partial, not binary reward",
+      "ssh-goal": "Highest verification density; stable build",
+      "codex-cli": "Regressed in this runner; transport/host mismatch present",
+      "heartbeat": "Highest reward and partial; highest cost"
+    },
+    "runnerNote": "Runner naming: ssh-goal is Codex App SSH Goal-driven LoopX; codex-cli is Codex CLI Goal-profile-driven LoopX, but this benchmark substitutes app-server transport for the live TUI; heartbeat is the LoopX Turn / automation arm, driven externally through generic_cli rather than a real Codex App automation host.",
+    "backgroundEyebrow": "01 / Why this benchmark",
+    "backgroundTitle": "Long enough to expose the work after ‘done.’",
+    "backgroundBody": "SWE-Marathon v1.1 contains 20 realistic, multi-hour software tasks. It combines visible and hidden tests, adversarial checks, and, for product clones, computer-use verification. This study used 15 non-GPU tasks so every arm shared one matched denominator.",
+    "benchmarkFacts": [
+      [
+        "20",
+        "multi-hour tasks",
+        "8 library/repro · 5 product · 5 ML · 2 optimization"
+      ],
+      [
+        "15",
+        "matched tasks here",
+        "five GPU tasks excluded · 4 H100 + 1 A100"
+      ],
+      [
+        "30%",
+        "time budget",
+        "agent timeout multiplier = 0.3"
+      ],
+      [
+        "binary",
+        "official reward",
+        "partial score retained to measure progress"
+      ]
+    ],
+    "horizonLabels": [
+      "issue-sized",
+      "repo-scale",
+      "multi-hour",
+      "hidden long tail"
+    ],
+    "armRows": [
+      [
+        "plain",
+        "Model session",
+        "Fixed “Finish the task” prompt",
+        "Baseline 1"
+      ],
+      [
+        "goal",
+        "Codex Goal",
+        "Clean native goal",
+        "Baseline 2"
+      ],
+      [
+        "ssh-goal",
+        "Codex visible Goal",
+        "LoopX body/skills + codex_app_ssh_goal",
+        "Treatment"
+      ],
+      [
+        "codex-cli",
+        "Codex visible Goal*",
+        "codex_cli body via app-server substitute",
+        "Treatment / mismatch probe"
+      ],
+      [
+        "heartbeat",
+        "External driver",
+        "generic_cli wake, replan, writeback",
+        "Treatment"
+      ]
+    ],
+    "mechanismEyebrow": "02 / Statistics & mechanism insight",
+    "mechanismTitle": "The control plane takes back the right to declare completion.",
+    "mechanismBody": "Wanli’s trajectory analysis in PR #3887 found stronger self-verification in at least one LoopX arm on 14/14 comparable tasks; the SSH Goal median was 0.107 events/step versus 0.024 for plain (~4.5×). The stronger result is quality per step, not raw step count.",
+    "stepsChart": "Median agent steps vs plain",
+    "densityChart": "Self-verification events per step",
+    "mechanismChain": [
+      [
+        "01",
+        "Reject premature exit",
+        "A model-level ‘done’ becomes evidence, not the final authority."
+      ],
+      [
+        "02",
+        "Re-anchor the next turn",
+        "The runner rereads current worktree state instead of trusting the prior narrative."
+      ],
+      [
+        "03",
+        "Activate falsification",
+        "Audit, sanitizer, fuzz, regression, and edge-case work become the next action."
+      ],
+      [
+        "04",
+        "Convert hidden tails",
+        "Where visible success masks defects, additional verification can become score."
+      ]
+    ],
+    "quote": "LoopX’s value is not that it makes the model smarter. It takes back the authority to decide when the work is complete.",
+    "quoteBy": "Wanli-Lee · public analysis in PR #3887",
+    "caseEyebrow": "03 / Case analysis",
+    "caseTitle": "zstd-decoder: the visible finish line was not the real one.",
+    "caseBody": "The same model and budget produced very different stopping behavior. The plain run stopped after visible success; governed continuations moved into protocol acceptance and memory-safety work.",
+    "timeline": [
+      [
+        "Plain · step 52",
+        "Declares RFC 8878 complete",
+        "6 visible fixtures pass",
+        "hidden 25/37 · partial 0.72"
+      ],
+      [
+        "Codex App SSH Goal + LoopX · step 135",
+        "Continues past self-declared completion",
+        "hardens dictionary, frame, malformed-input paths",
+        "hidden 37/37 · partial 1.00"
+      ],
+      [
+        "LoopX Turn (external-scheduler automation) · step 453",
+        "Builds a 156-check RFC acceptance suite",
+        "audits memory safety; fixes offset-table and Huffman underflow edges",
+        "hidden 37/37 · partial 1.00"
+      ]
+    ],
+    "trajectoryNote": "This is a mechanism-revealing case, not proof that more turns always win. Many tasks were already saturated; on those tasks the extra loop tied rather than improved the baseline.",
+    "insights": [
+      [
+        "Completion is a control-plane decision",
+        "Treat self-reported completion as a checkpoint requiring verification and settlement, not an unconditional stop signal."
+      ],
+      [
+        "Self-verification is a leading indicator",
+        "Track verification events per step alongside score and cost. It explains whether added horizon is buying quality."
+      ],
+      [
+        "Host-mode fit is part of capability",
+        "A TUI contract adapted to an unattended runner can underperform even with nearly identical goal text."
+      ],
+      [
+        "Stateful control, replaceable executors",
+        "A promising next test is durable LoopX state with ephemeral executor sessions, so each turn starts clean without losing project intent."
+      ]
+    ],
+    "officialEyebrow": "04 / Reading against official results",
+    "officialTitle": "Official Max is higher. The experiment is not directly comparable.",
+    "officialBody": "The gap mixes reasoning effort, task composition, runner reliability, time budget, and trial count. It is not evidence that LoopX—or the underlying model—regressed.",
+    "officialColumns": [
+      "Dimension",
+      "This study",
+      "Official reporting",
+      "Interpretation"
+    ],
+    "officialRows": [
+      [
+        "Model / reasoning",
+        "GPT-5.6 Sol · high",
+        "GPT-5.6 Sol High: 30.0% · Max: 42.5% pass@1",
+        "Max has a larger reasoning budget; only Max exceeds this study's 33.3% best arm."
+      ],
+      [
+        "Task set",
+        "v1.1 · 15/20; 4 H100 + 1 A100 task excluded",
+        "v1.1 · 20/20; all GPU tasks included",
+        "The denominator and task mix differ."
+      ],
+      [
+        "Runtime",
+        "Research harness; sandbox, sidecar, and build instability observed",
+        "Standardized official runner",
+        "Infrastructure failures can depress this study's result."
+      ],
+      [
+        "Budget / repeats",
+        "30% timeout; one trial per task-arm",
+        "Full task windows; eight trials per configuration",
+        "The official setup has a longer horizon and lower sampling variance."
+      ],
+      [
+        "Metric",
+        "Binary reward + descriptive partial",
+        "Official pass@1",
+        "Partial is uncalibrated within-task progress; do not compare it to pass@1."
+      ]
+    ],
+    "officialNote": "Bottom line: use this study to compare matched runner arms and inspect mechanism—not as a replacement leaderboard score. The official v1.1 leaderboard is the right external reference, but its published High/Max results follow a different protocol.",
+    "limitsEyebrow": "05 / Evidence boundary",
+    "limitsTitle": "Strong mechanism signal, incomplete causal identification.",
+    "limits": [
+      "One trial per task-arm cell; no confidence intervals or run-to-run variance estimate.",
+      "Several mechanism variables move together across arms: prompt body, host transport, turn boundary, and recovery policy.",
+      "The 15-task subset excludes five GPU-dependent tasks (four H100, one A100) and represents one benchmark family.",
+      "Step and keyword-density measures are public-safe projections, not raw trajectory publication.",
+      "Cost rose materially; the current data does not establish the best quality-per-dollar policy."
+    ],
+    "nextTitle": "The next decisive experiment",
+    "nextBody": "Repeat matched cells while isolating one variable at a time: continuation owner, session reuse vs ephemeral turns, replan policy, and a cost-matched stopping rule. Pre-register score, verification density, effective-turn rate, idle churn, and spend.",
+    "sourcesEyebrow": "06 / Sources",
+    "sourcesTitle": "Reproducible where public evidence allows.",
+    "sourceItems": [
+      [
+        "LoopX study",
+        "Pinned aggregate, scoring code, and public-safe case insights",
+        "https://github.com/huangruiteng/loopx/tree/main/benchmark/swe-marathon"
+      ],
+      [
+        "Wanli analysis",
+        "Trajectory-derived mechanism analysis and zstd case",
+        "https://github.com/huangruiteng/loopx/pull/3887#issuecomment-5535839229"
+      ],
+      [
+        "SWE-Marathon",
+        "Official benchmark site, tasks, leaderboard, and methodology",
+        "https://www.swe-marathon.org/"
+      ],
+      [
+        "Paper",
+        "SWE-Marathon: Can Agents Autonomously Complete Ultra-Long-Horizon Software Work?",
+        "https://arxiv.org/abs/2606.07682"
+      ]
+    ],
+    "footer": "An exploratory LoopX research brief. Public aggregates only; raw trial traces are not included."
+  },
+  "zh": {
+    "meta": "SWE-MARATHON / 探索性研究 01",
+    "back": "返回 LoopX",
+    "source": "公开证据",
+    "title": "LoopX 让 Agent 在说“完成”之后继续验证。",
+    "deck": "在 15 个 matched SWE-Marathon 任务上，LoopX 治理的 runner 稳定地把可见测试通过后的工作转向审计、证伪和加固。",
+    "evidenceTag": "SWE-Marathon v1.1 · 探索性证据 · 15 个 matched 任务 · 75 trial",
+    "executiveEyebrow": "00 / 核心结论",
+    "executiveTitle": "LoopX Turn（外部调度 Automation）得分最高；Codex App SSH Goal + LoopX 自验证最强；Codex CLI Goal-profile arm 是反例。",
+    "executiveBody": "GPT-5.6 Sol · high 思考深度 · 15 个 matched 任务 · 每个 task-arm 1 次 · 30% timeout。下表合并实验处理、结果、成本和决策含义。",
+    "executiveColumns": [
+      "Arm",
+      "续跑权",
+      "Reward",
+      "Partial",
+      "成本",
+      "续跑",
+      "决策含义"
+    ],
+    "executiveReads": {
+      "plain": "最低成本基线；更早停止",
+      "goal": "Goal 提升 partial，未提升二值 reward",
+      "ssh-goal": "自验证密度最高；构建稳定",
+      "codex-cli": "本 runner 中退化；存在传输/Host 错配",
+      "heartbeat": "Reward 与 partial 最高；成本也最高"
+    },
+    "runnerNote": "Runner 命名：ssh-goal 是 Codex App SSH Goal 驱动 LoopX；codex-cli 是 Codex CLI Goal profile 驱动 LoopX，但本 benchmark 以 app-server 代替真实 TUI 承载；heartbeat 才是 LoopX Turn / Automation arm，由 generic_cli 外部调度，并非真实 Codex App automation host。",
+    "backgroundEyebrow": "01 / 为什么选这个 Benchmark",
+    "backgroundTitle": "它足够长，能看见 Agent 在“完成”之后做什么。",
+    "backgroundBody": "SWE-Marathon v1.1 包含 20 个真实、多小时的软件工程任务，使用可见与隐藏测试、对抗性检查，并对产品克隆任务加入 Computer-Use 验证。本实验选取其中 15 个非 GPU 任务，使五个 arm 保持同一 matched 分母。",
+    "benchmarkFacts": [
+      [
+        "20",
+        "个多小时任务",
+        "8 库/复现 · 5 产品 · 5 ML · 2 优化"
+      ],
+      [
+        "15",
+        "个 matched 任务",
+        "排除 5 个 GPU 任务 · 4 个 H100 + 1 个 A100"
+      ],
+      [
+        "30%",
+        "时限预算",
+        "agent timeout multiplier = 0.3"
+      ],
+      [
+        "二值",
+        "官方 reward",
+        "保留 partial score 衡量进度"
+      ]
+    ],
+    "horizonLabels": [
+      "Issue 级",
+      "Repo 级",
+      "多小时",
+      "隐藏长尾"
+    ],
+    "armRows": [
+      [
+        "plain",
+        "模型会话",
+        "固定“Finish the task”提示",
+        "基线 1"
+      ],
+      [
+        "goal",
+        "Codex Goal",
+        "干净的原生 Goal",
+        "基线 2"
+      ],
+      [
+        "ssh-goal",
+        "Codex visible Goal",
+        "LoopX body/skills + codex_app_ssh_goal",
+        "Treatment"
+      ],
+      [
+        "codex-cli",
+        "Codex visible Goal*",
+        "codex_cli body，由 app-server 代承载",
+        "Treatment / 错配探针"
+      ],
+      [
+        "heartbeat",
+        "外部 driver",
+        "generic_cli 唤醒、replan、writeback",
+        "Treatment"
+      ]
+    ],
+    "mechanismEyebrow": "02 / 统计与机制 Insight",
+    "mechanismTitle": "控制面收回“何时算完成”的判定权。",
+    "mechanismBody": "Wanli 在 PR #3887 中发现：14/14 个可比任务里，至少一个 LoopX arm 的自验证更强；SSH Goal 中位数为 0.107 次/step，plain 为 0.024（约 4.5×）。更强的结论来自单位 step 的质量，而非 raw step 数。",
+    "stepsChart": "Agent step 中位数 / plain",
+    "densityChart": "每 step 自验证事件密度",
+    "mechanismChain": [
+      [
+        "01",
+        "驳回过早退出",
+        "模型说“完成”只是一条证据，不再自动成为终局。"
+      ],
+      [
+        "02",
+        "下一轮重新锚定",
+        "Runner 重读当前 worktree，而不是相信上一轮叙述。"
+      ],
+      [
+        "03",
+        "激活证伪行为",
+        "Audit、sanitizer、fuzz、regression、edge-case 成为下一步。"
+      ],
+      [
+        "04",
+        "兑现隐藏长尾",
+        "当可见成功掩盖缺陷，额外验证才可能转化为得分。"
+      ]
+    ],
+    "quote": "LoopX 的价值不在于让模型更聪明，而在于收回‘何时算完成’的判定权。",
+    "quoteBy": "Wanli-Lee · PR #3887 公开分析",
+    "caseEyebrow": "03 / Case 分析",
+    "caseTitle": "zstd-decoder：可见终点，不是真正终点。",
+    "caseBody": "相同模型和预算产生了完全不同的停止行为。Plain 在可见成功后收工；受治理的续跑则进入协议验收和内存安全阶段。",
+    "timeline": [
+      [
+        "Plain · step 52",
+        "宣布完整实现 RFC 8878",
+        "6 个可见 fixture 通过",
+        "hidden 25/37 · partial 0.72"
+      ],
+      [
+        "Codex App SSH Goal + LoopX · step 135",
+        "越过自宣完成点继续推进",
+        "加固 dictionary、frame、畸形输入路径",
+        "hidden 37/37 · partial 1.00"
+      ],
+      [
+        "LoopX Turn（外部调度 Automation）· step 453",
+        "自建 156 项 RFC 验收程序",
+        "转入内存安全审计，修复 offset-table 与 Huffman 下溢边界",
+        "hidden 37/37 · partial 1.00"
+      ]
+    ],
+    "trajectoryNote": "这是揭示机制的个案，不代表更多 Turn 总能赢。许多任务已接近饱和；在这些任务上，额外续跑只是打平基线。",
+    "insights": [
+      [
+        "完成是控制面决策",
+        "把模型自报完成视为需要验证与 settlement 的 checkpoint，而不是无条件 stop 信号。"
+      ],
+      [
+        "自验证是领先指标",
+        "除分数和成本外，持续跟踪每 step 自验证事件，解释新增 horizon 是否买来了质量。"
+      ],
+      [
+        "Host-mode fit 也是能力",
+        "几乎相同的 Goal 文本，经面向 TUI 的契约适配到无人 Runner 后也可能显著退化。"
+      ],
+      [
+        "持久控制，短命执行器",
+        "值得验证的新方向是：LoopX 保留持久状态，每个 executor turn 可 ephemeral 重启，既清理上下文又不丢项目意图。"
+      ]
+    ],
+    "officialEyebrow": "04 / 与官方指标的差异",
+    "officialTitle": "官方 Max 指标更高，但两组数字不可直接横比。",
+    "officialBody": "当前差值同时混合了思考档位、任务集合、runner 稳定性、时限与重复次数，不能解释为 LoopX 或底层模型本身退化。",
+    "officialColumns": [
+      "维度",
+      "本研究",
+      "官方口径",
+      "比较影响"
+    ],
+    "officialRows": [
+      [
+        "模型 / 思考",
+        "GPT-5.6 Sol · high",
+        "GPT-5.6 Sol High：30.0% · Max：42.5% pass@1",
+        "Max 推理预算更高；官方仅 Max 高于本研究最佳 arm 的 33.3%。"
+      ],
+      [
+        "任务覆盖",
+        "v1.1 · 15/20；排除 4 个 H100 + 1 个 A100 任务",
+        "v1.1 · 20/20；包含全部 GPU 任务",
+        "分母与任务组合不同。"
+      ],
+      [
+        "运行环境",
+        "研究 harness；观察到 sandbox、sidecar 与构建稳定性问题",
+        "官方标准化 runner",
+        "基建失败可能压低本研究结果。"
+      ],
+      [
+        "预算 / 重复",
+        "30% timeout；每个 task-arm 1 次",
+        "完整任务时限；每配置 8 次",
+        "官方 horizon 更长，抽样方差更低。"
+      ],
+      [
+        "指标",
+        "二值 reward + 描述性 partial",
+        "官方 pass@1",
+        "Partial 是未校准的任务内进度，不能和 pass@1 对比。"
+      ]
+    ],
+    "officialNote": "结论：本研究用于比较同一 matched 分母下的 runner arm，并解释行为机制，不应替代官方榜单分数。官方 v1.1 榜单是正确的外部参照，但其 High/Max 结果属于另一套实验协议。",
+    "limitsEyebrow": "05 / 证据边界",
+    "limitsTitle": "机制信号很强，因果识别仍未完成。",
+    "limits": [
+      "每个 task-arm 只有 1 次 trial，尚无置信区间与运行方差。",
+      "各 arm 同时改变多项机制：prompt body、Host transport、Turn 边界与恢复策略。",
+      "15 任务子集排除了 5 个 GPU 依赖任务（4 个 H100、1 个 A100），且仅覆盖一个 benchmark family。",
+      "step 与关键词密度来自 public-safe projection，不公开 raw trajectory。",
+      "成本显著上升；现有数据尚不能确定最优 quality-per-dollar 策略。"
+    ],
+    "nextTitle": "下一轮最有决策价值的实验",
+    "nextBody": "重复 matched cell，并一次只隔离一个变量：续跑 owner、复用 session 还是 ephemeral turn、replan 策略、cost-matched 停止规则。预注册 score、自验证密度、有效 Turn 率、idle churn 和 spend。",
+    "sourcesEyebrow": "06 / 来源",
+    "sourcesTitle": "在公开证据允许的范围内可复算。",
+    "sourceItems": [
+      [
+        "LoopX 实验",
+        "Pinned 聚合、评分代码与 public-safe case insight",
+        "https://github.com/huangruiteng/loopx/tree/main/benchmark/swe-marathon"
+      ],
+      [
+        "Wanli 分析",
+        "轨迹机制分析与 zstd 个案",
+        "https://github.com/huangruiteng/loopx/pull/3887#issuecomment-5535839229"
+      ],
+      [
+        "SWE-Marathon",
+        "官方站点、任务、榜单与方法",
+        "https://www.swe-marathon.org/"
+      ],
+      [
+        "论文",
+        "SWE-Marathon: Can Agents Autonomously Complete Ultra-Long-Horizon Software Work?",
+        "https://arxiv.org/abs/2606.07682"
+      ]
+    ],
+    "footer": "LoopX 探索性研究简报。仅含公开聚合，不包含原始 trial 轨迹。"
+  }
+}

--- a/benchmark/swe-marathon/README.md
+++ b/benchmark/swe-marathon/README.md
@@ -1,7 +1,9 @@
 # SWE-Marathon：codex × LoopX 评测
 
-裸 `codex`、codex 原生 `goal`、以及三种 LoopX 接入模式在 SWE-Marathon（Harbor）15 个任务上的对照。
-模型 `gpt-5.6`；agent 预算压至任务时限的 ~30%（`agent_timeout_multiplier=0.3`）；共 75 trial（15×5，每格 1）。
+> [打开双语可视化研究简报](https://huangruiteng.github.io/loopx/benchmarks/swe-marathon/)：以高信息密度方式呈现实验 setting、结果、轨迹机制、证据边界与下一轮实验建议。
+
+裸 `codex`、codex 原生 `goal`、以及三种 LoopX 接入模式在 SWE-Marathon v1.1（Harbor）15 个任务上的对照。
+模型 `GPT-5.6 Sol`，思考深度 `high`；agent 预算压至任务时限的 ~30%（`agent_timeout_multiplier=0.3`）；共 75 trial（15×5，每格 1）。
 目标是在长程领域产出可复算的一手对照，为"无人自动化默认姿势"提供评测证据。
 
 > **性质**：单次、每格 1 trial、多机制同变的**探索性观察**。数值为描述性统计，机制陈述为假设，需重复的匹配实验方能证实。
@@ -107,11 +109,11 @@ python3 scoring/_compare.py   <private_results_dir>
 
 | 组件 | 版本 |
 |---|---|
-| model | `gpt-5.6` |
+| model | `GPT-5.6 Sol`（reasoning effort: `high`） |
 | Codex | `0.151.0` |
 | LoopX | `0.5.3`（repo `bd52b28a`） |
 | harness (harbor) | `0.20.0` |
-| benchmark / verifier | SWE-Marathon（Harbor 任务集，`partial_score` 由任务 verifier 写入 `/logs/verifier/metrics.json`） |
+| benchmark / verifier | SWE-Marathon v1.1（Harbor 任务集；`partial_score` 由任务 verifier 写入 `/logs/verifier/metrics.json`） |
 | 预算 | `agent_timeout_multiplier=0.3`（~30%） |
 | 规模 | 75 trial（15 任务 × 5 模式，每格 1） |
 

--- a/examples/export-frontstage-share-bundle.mjs
+++ b/examples/export-frontstage-share-bundle.mjs
@@ -108,6 +108,15 @@ async function copyHomepage(siteDir, base) {
   await copyFile(resolve(repoRoot, installerScriptPath), resolve(siteDir, "install.sh"));
 }
 
+async function copyPublicSiteRoutes(siteDir) {
+  const homepage = resolve(siteDir, "index.html");
+  for (const route of ["benchmarks/swe-marathon"]) {
+    const routeDir = resolve(siteDir, route);
+    await mkdir(routeDir, { recursive: true });
+    await copyFile(homepage, resolve(routeDir, "index.html"));
+  }
+}
+
 function validateShowcaseHtmlPath(path) {
   if (typeof path !== "string") {
     throw new Error(`showcase page must be a string: ${JSON.stringify(path)}`);
@@ -213,6 +222,7 @@ async function writeShareReadme(outDir, base, interactivePages) {
   const siteDir = resolve(outDir, "site");
   const homepageUrl = base;
   const frontstageUrl = `${base}frontstage/`;
+  const sweMarathonBriefUrl = `${base}benchmarks/swe-marathon/`;
   const previewBlock = base === "/"
     ? `## Try It Locally
 
@@ -226,6 +236,7 @@ Then open the homepage or showcase:
 \`\`\`text
 http://127.0.0.1:8080${homepageUrl}
 http://127.0.0.1:8080${frontstageUrl}
+http://127.0.0.1:8080${sweMarathonBriefUrl}
 \`\`\`
 `
     : `## Try It Locally
@@ -239,6 +250,7 @@ Hosted entries:
 \`\`\`text
 ${homepageUrl}
 ${frontstageUrl}
+${sweMarathonBriefUrl}
 \`\`\`
 `;
   const readme = `# LoopX Public Website Bundle
@@ -261,6 +273,7 @@ ${previewBlock}
   \`${statusFileName}\`, direct \`/frontstage/\` static route support, and
   catalog-declared interactive case pages.
 - Homepage source: \`apps/presentation/site\`.
+- SWE-Marathon research brief: \`${sweMarathonBriefUrl}\`, built from the pinned public-safe aggregate and case-insight projection under \`benchmark/swe-marathon/\`.
 - Homepage evidence assets: ${homepageEvidenceAssets.map((path) => `\`${path}\``).join(", ")}.
 - Primary case source: \`${showcaseCatalogPath}\`.
 - Interactive case pages: ${interactivePages.length ? interactivePages.map((path) => `\`${path}\``).join(", ") : "none"}.
@@ -278,10 +291,12 @@ async function writeManifest(outDir, base, interactivePages) {
     site_dir: "site",
     status_fixture: `site/${statusFileName}`,
     homepage_entry: "site/index.html",
+    swe_marathon_brief_entry: "site/benchmarks/swe-marathon/index.html",
     installer_entry: "site/install.sh",
     frontstage_entry: "site/frontstage/index.html",
     content_sources: {
       public_homepage: "apps/presentation/site",
+      swe_marathon_brief: "benchmark/swe-marathon",
       installer_script: installerScriptPath,
       homepage_evidence_assets: homepageEvidenceAssets,
       primary_public_story: showcaseCatalogPath,
@@ -374,6 +389,7 @@ async function main() {
   await removeCopiedLiveStatusFiles(siteDir);
   await copyIndexForFrontstage(siteDir);
   await copyHomepage(siteDir, args.base);
+  await copyPublicSiteRoutes(siteDir);
   const interactivePages = await copyInteractiveCasePages(siteDir);
 
   const projectionOutput = run("python3", [resolve(repoRoot, "examples/goal-channel-frontstage-fixture.py"), "--format", "json"], {
@@ -392,6 +408,7 @@ async function main() {
     out_dir: outDir,
     site_dir: siteDir,
     homepage_url: args.base,
+    swe_marathon_brief_url: `${args.base}benchmarks/swe-marathon/`,
     frontstage_url: `${args.base}frontstage/`,
     status_fixture: `site/${statusFileName}`,
   }, null, 2));

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -101,6 +101,7 @@ run(process.execPath, [
 const siteDir = resolve(outDir, "site");
 assertExists(resolve(siteDir, "index.html"));
 assertExists(resolve(siteDir, "frontstage/index.html"));
+assertExists(resolve(siteDir, "benchmarks/swe-marathon/index.html"));
 assertExists(resolve(siteDir, "install.sh"));
 assertExists(resolve(siteDir, "status.frontstage-share.json"));
 assertExists(resolve(outDir, "README.md"));
@@ -142,6 +143,10 @@ if (publishedInstaller !== canonicalInstaller) {
 }
 const homepageSource = await readFile(resolve(repoRoot, "apps/presentation/site/src/App.tsx"), "utf8");
 const homepageStyles = await readFile(resolve(repoRoot, "apps/presentation/site/src/styles.css"), "utf8");
+const benchmarkHtml = await readFile(resolve(siteDir, "benchmarks/swe-marathon/index.html"), "utf8");
+if (benchmarkHtml !== homepageHtml) {
+  throw new Error("SWE-Marathon static route must reuse the compiled public-site entry");
+}
 for (const sourceContract of [
   "Your agents keep",
   'secondPrefix: "the "',
@@ -169,6 +174,7 @@ for (const sourceContract of [
   "跨越 200+ 小时，依然清晰可读。",
   "Prefer the shell? Install LoopX manually.",
   "Developer book",
+  "benchmarks/swe-marathon/",
   "Iowan Old Style",
   "Pi",
 ]) {
@@ -254,6 +260,7 @@ if (manifest.base !== "/loopx/") {
 }
 if (
   manifest.homepage_entry !== "site/index.html" ||
+  manifest.swe_marathon_brief_entry !== "site/benchmarks/swe-marathon/index.html" ||
   manifest.frontstage_entry !== "site/frontstage/index.html" ||
   manifest.installer_entry !== "site/install.sh"
 ) {
@@ -261,6 +268,9 @@ if (
 }
 if (manifest.content_sources?.public_homepage !== "apps/presentation/site") {
   throw new Error(`manifest homepage source mismatch: ${JSON.stringify(manifest.content_sources)}`);
+}
+if (manifest.content_sources?.swe_marathon_brief !== "benchmark/swe-marathon") {
+  throw new Error(`manifest benchmark brief source mismatch: ${JSON.stringify(manifest.content_sources)}`);
 }
 if (manifest.content_sources?.installer_script !== "scripts/install-from-github.sh") {
   throw new Error(`manifest installer source mismatch: ${JSON.stringify(manifest.content_sources)}`);
@@ -331,6 +341,9 @@ if (!readmeText.includes("docs/showcases/showcase-catalog.json")) {
 }
 if (!readmeText.includes("frontstage/")) {
   throw new Error("share bundle README must publish the frontstage showcase entry");
+}
+if (!readmeText.includes("benchmarks/swe-marathon/")) {
+  throw new Error("share bundle README must publish the SWE-Marathon research brief entry");
 }
 
 console.log("frontstage-share-bundle-smoke: ok");


### PR DESCRIPTION
## Summary

- publish a bilingual, single-page LoopX × SWE-Marathon research brief at `/benchmarks/swe-marathon/`
- lead with the five-arm result table, then progress through benchmark context, mechanism statistics, the `zstd-decoder` case, official-result comparison, and evidence boundaries
- distinguish Native Goal, Codex App SSH Goal-driven LoopX, Codex CLI Goal-profile-driven LoopX, and the externally scheduled LoopX Turn / automation arm
- wire the page into the existing React/Vite public site and static share-bundle export

## Evidence and comparison boundary

- study setting: SWE-Marathon v1.1, GPT-5.6 Sol with `high` reasoning, 15 matched non-GPU tasks, one trial per task-arm, and a 30% timeout multiplier
- version evidence: the contributed runner targets the v1.1 task contract (`tasks/dataset.toml` and three-state `network_mode`), rather than v1.0's `allow_internet` contract
- official v1.1 reference: GPT-5.6 Sol High 30.0% and Max 42.5% pass@1 across 20 tasks with eight trials per configuration
- the page explicitly prevents direct leaderboard comparison: this study excludes four H100 tasks and one A100 task, uses a shorter horizon, has one trial per cell, and observed sandbox/sidecar/build instability
- only pinned public-safe aggregates and the public-safe case-insight projection are rendered; no raw trajectories, verifier tails, private links, or local paths are published

## Validation

- `cd apps/presentation/site && npm run build`
- `uv run --python 3.12 node examples/frontstage-share-bundle-smoke.mjs`
- `loopx check` across all eight changed files: public boundary clean
- `git diff --check origin/main...HEAD`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 9/9 catalog canaries, 8/8 risk-profile smokes, and public-boundary validation passed; no failures
- change-quality receipt `cqr_4269cb95fc5298996c46`: valid for fingerprint `4269cb95fc5298996c46c69d284608173140e55f8acf4682c3754347c7e75e1e`

## Review hold

The premerge gate retains the expected `benchmark_sensitive` manual hold. This PR does not launch benchmark jobs or change task scoring/runner behavior; it publishes a public-safe analysis surface, but should still receive explicit maintainer review before merge.

Future-facing scope review: no new framework was added. The durable bundle smoke covers only route, manifest, export, and public-boundary contracts. A bounded quality pass moved bilingual content into a data module and simplified route/row selection, removing Sonar duplication and static-analysis findings without changing the page.
