### PR TITLE
fix(quota): distinguish blocked work from monitor-only

### DIFF
--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -442,6 +442,22 @@ def _monitor_lane_rule(
                     ),
                 }
             )
+        non_runnable_non_monitor_count = max(
+            0,
+            int(lane.get("non_runnable_non_monitor_count") or 0),
+        )
+        if non_runnable_non_monitor_count:
+            reason = (
+                "no executable advancement todo is runnable; "
+                f"{non_runnable_non_monitor_count} non-monitor todo(s) are "
+                "blocked or otherwise non-executable, and the remaining "
+                "schedulable work is non-due monitor-class"
+            )
+        else:
+            reason = (
+                "all visible open agent todos are monitor-class work with no "
+                "material transition to record"
+            )
         return _recommendation(
             {
                 "recommended_mode": "monitor_quiet_until_material_transition",
@@ -449,10 +465,7 @@ def _monitor_lane_rule(
                     "do not append quota spend until a material monitor transition, "
                     "regression, or concrete blocker is validated and written back"
                 ),
-                "reason": (
-                    "all visible open agent todos are monitor-class work with no "
-                    "material transition to record"
-                ),
+                "reason": reason,
             }
         )
     if must_attempt_work is not True or facts.has_user_todos:

--- a/loopx/control_plane/quota/turn_envelope.ts
+++ b/loopx/control_plane/quota/turn_envelope.ts
@@ -38,7 +38,8 @@ const CONTRACT_CAPSULE_FIELDS: Readonly<Record<string, readonly string[]>> = {
   work_lane_contract: [
     "schema_version", "lane", "monitor_kind", "next_lane", "obligation",
     "must_attempt_work", "reason_codes", "monitor_policy", "selected_todo_id",
-    "selected_next_due_at", "material_transition", "action",
+    "selected_next_due_at", "non_runnable_non_monitor_count",
+    "material_transition", "action",
   ],
   execution_profile: ["cadence", "minimum_scale", "spend_rule", "must_include"],
   execution_obligation: [

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -702,13 +702,10 @@ def build_work_lane_contract(
                 "must_attempt_work": False,
                 "reason_codes": [
                     *(
-                        [
-                            "monitor_only_schedule",
-                            "non_runnable_non_monitor_todos_present",
-                        ]
+                        ["non_runnable_non_monitor_todos_present"]
                         if non_runnable_non_monitor_count
                         else ["monitor_todo_only"]
-                    )
+                    ),
                 ],
                 "non_runnable_non_monitor_count": non_runnable_non_monitor_count,
                 "monitor_policy": "write_once_per_material_transition_else_no_spend",

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -505,7 +505,10 @@ def build_work_lane_contract(
     has_agent_todos = open_count > 0
     has_advancement_todos = advancement_count > 0
     has_monitor_todos = monitor_count > 0
-    monitor_only_todos = has_agent_todos and has_monitor_todos and not has_advancement_todos
+    monitor_only_schedule = (
+        has_agent_todos and has_monitor_todos and not has_advancement_todos
+    )
+    non_runnable_non_monitor_count = max(0, open_count - monitor_count)
     first_due_monitor = due_monitor_items[0] if due_monitor_items else None
     blocked_by_monitor_items = resume_blocked_by_monitor_items or []
     schedule_gap_items = monitor_schedule_gap_items or []
@@ -621,8 +624,8 @@ def build_work_lane_contract(
         if resume_blocked_by_monitor_count > 0 and not first_due_monitor:
             selected = blocked_by_monitor_items[0] if blocked_by_monitor_items else {}
             reason_codes = ["resume_blocked_by_open_monitor"]
-            if monitor_only_todos:
-                reason_codes.insert(0, "monitor_todo_only")
+            if monitor_only_schedule:
+                reason_codes.insert(0, "monitor_only_schedule")
             return {
                 "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
                 "lane": "advancement_task",
@@ -644,10 +647,10 @@ def build_work_lane_contract(
                     "non-blocking monitor contract"
                 ),
             }
-        if monitor_only_todos:
+        if monitor_only_schedule:
             if first_due_monitor:
                 return due_monitor_contract(
-                    reason_codes=["monitor_todo_only", "monitor_due"]
+                    reason_codes=["monitor_only_schedule", "monitor_due"]
                 )
             if next_action_requires_advancement:
                 return {
@@ -656,7 +659,10 @@ def build_work_lane_contract(
                     "next_lane": "advancement_task",
                     "obligation": "materialize_advancement_todo_or_blocker",
                     "must_attempt_work": True,
-                    "reason_codes": ["monitor_todo_only", "next_action_requires_advancement"],
+                    "reason_codes": [
+                        "monitor_only_schedule",
+                        "next_action_requires_advancement",
+                    ],
                     "monitor_policy": "material_transition_only",
                     "action": (
                         "materialize the planning/self-repair advancement todo or write a concrete blocker"
@@ -671,7 +677,7 @@ def build_work_lane_contract(
                     "obligation": "repair_monitor_schedule_metadata",
                     "must_attempt_work": True,
                     "reason_codes": [
-                        "monitor_todo_only",
+                        "monitor_only_schedule",
                         "monitor_schedule_metadata_gap",
                     ],
                     "monitor_policy": "repair_schedule_metadata_before_quiet_wait",
@@ -694,7 +700,15 @@ def build_work_lane_contract(
                 "next_lane": "continuous_monitor",
                 "obligation": "quiet_until_material_monitor_transition",
                 "must_attempt_work": False,
-                "reason_codes": ["monitor_todo_only"],
+                "reason_codes": [
+                    "monitor_only_schedule",
+                    *(
+                        ["non_runnable_non_monitor_todos_present"]
+                        if non_runnable_non_monitor_count
+                        else []
+                    ),
+                ],
+                "non_runnable_non_monitor_count": non_runnable_non_monitor_count,
                 "monitor_policy": "write_once_per_material_transition_else_no_spend",
                 "material_transition": (
                     "a monitor todo may write back only material state transitions, regressions, or concrete blockers"
@@ -708,8 +722,8 @@ def build_work_lane_contract(
         reason_codes.append("open_agent_todo")
         if effective_due_monitor_preemption:
             reason_codes.append("due_monitor_priority_preempts_advancement")
-    elif monitor_only_todos:
-        reason_codes.append("monitor_todo_only")
+    elif monitor_only_schedule:
+        reason_codes.append("monitor_only_schedule")
         if first_due_monitor:
             reason_codes.append("monitor_due")
     else:

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -625,7 +625,7 @@ def build_work_lane_contract(
             selected = blocked_by_monitor_items[0] if blocked_by_monitor_items else {}
             reason_codes = ["resume_blocked_by_open_monitor"]
             if monitor_only_schedule:
-                reason_codes.insert(0, "monitor_only_schedule")
+                reason_codes.insert(0, "monitor_todo_only")
             return {
                 "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
                 "lane": "advancement_task",
@@ -650,7 +650,7 @@ def build_work_lane_contract(
         if monitor_only_schedule:
             if first_due_monitor:
                 return due_monitor_contract(
-                    reason_codes=["monitor_only_schedule", "monitor_due"]
+                    reason_codes=["monitor_todo_only", "monitor_due"]
                 )
             if next_action_requires_advancement:
                 return {
@@ -660,7 +660,7 @@ def build_work_lane_contract(
                     "obligation": "materialize_advancement_todo_or_blocker",
                     "must_attempt_work": True,
                     "reason_codes": [
-                        "monitor_only_schedule",
+                        "monitor_todo_only",
                         "next_action_requires_advancement",
                     ],
                     "monitor_policy": "material_transition_only",
@@ -677,7 +677,7 @@ def build_work_lane_contract(
                     "obligation": "repair_monitor_schedule_metadata",
                     "must_attempt_work": True,
                     "reason_codes": [
-                        "monitor_only_schedule",
+                        "monitor_todo_only",
                         "monitor_schedule_metadata_gap",
                     ],
                     "monitor_policy": "repair_schedule_metadata_before_quiet_wait",
@@ -701,12 +701,14 @@ def build_work_lane_contract(
                 "obligation": "quiet_until_material_monitor_transition",
                 "must_attempt_work": False,
                 "reason_codes": [
-                    "monitor_only_schedule",
                     *(
-                        ["non_runnable_non_monitor_todos_present"]
+                        [
+                            "monitor_only_schedule",
+                            "non_runnable_non_monitor_todos_present",
+                        ]
                         if non_runnable_non_monitor_count
-                        else []
-                    ),
+                        else ["monitor_todo_only"]
+                    )
                 ],
                 "non_runnable_non_monitor_count": non_runnable_non_monitor_count,
                 "monitor_policy": "write_once_per_material_transition_else_no_spend",
@@ -723,7 +725,7 @@ def build_work_lane_contract(
         if effective_due_monitor_preemption:
             reason_codes.append("due_monitor_priority_preempts_advancement")
     elif monitor_only_schedule:
-        reason_codes.append("monitor_only_schedule")
+        reason_codes.append("monitor_todo_only")
         if first_due_monitor:
             reason_codes.append("monitor_due")
     else:

--- a/tests/control_plane/test_heartbeat_recommendation_rules.py
+++ b/tests/control_plane/test_heartbeat_recommendation_rules.py
@@ -180,6 +180,16 @@ def test_quiet_monitor_keeps_user_todo_non_blocking() -> None:
     assert "open user todo" in recommendation["spend_policy"]
 
 
+def test_true_monitor_only_lane_keeps_monitor_only_reason() -> None:
+    recommendation = _recommend(
+        lane="continuous_monitor",
+        must_attempt_work=False,
+        agent_open=1,
+    )
+
+    assert "all visible open agent todos are monitor-class" in recommendation["reason"]
+
+
 def test_due_monitor_lane_preempts_first_read_only_map() -> None:
     recommendation = _recommend(
         {

--- a/tests/control_plane/test_work_lane_contract_core.py
+++ b/tests/control_plane/test_work_lane_contract_core.py
@@ -127,9 +127,34 @@ def test_quiet_monitor_explains_blocked_non_monitor_todos() -> None:
 
     assert guard["effective_action"] == "monitor_quiet_skip"
     assert lane["non_runnable_non_monitor_count"] == 2
-    assert "non_runnable_non_monitor_todos_present" in lane["reason_codes"]
+    assert lane["reason_codes"] == ["non_runnable_non_monitor_todos_present"]
     assert "no executable advancement todo is runnable" in guard["reason"]
     assert "all visible open agent todos are monitor-class" not in guard["reason"]
+
+
+def test_true_monitor_only_lane_keeps_existing_reason_code() -> None:
+    payload = _status(
+        agent_todo_items=[
+            {
+                "index": 1,
+                "text": "[P3] Check the dependency next week.",
+                "role": "agent",
+                "status": "open",
+                "priority": "P3",
+                "task_class": "continuous_monitor",
+                "action_kind": "monitor",
+                "next_due_at": "2999-01-01T00:00:00+00:00",
+            },
+        ],
+        next_action="Wait for a material dependency transition.",
+    )
+
+    guard = build_quota_should_run(payload, goal_id=GOAL_ID)
+    lane = guard["work_lane_contract"]
+
+    assert guard["effective_action"] == "monitor_quiet_skip"
+    assert lane["non_runnable_non_monitor_count"] == 0
+    assert lane["reason_codes"] == ["monitor_todo_only"]
 
 
 def test_work_lane_context_progress_scope_sources() -> None:

--- a/tests/control_plane/test_work_lane_contract_core.py
+++ b/tests/control_plane/test_work_lane_contract_core.py
@@ -89,6 +89,49 @@ def test_due_monitor_preempts_lower_priority_advancement() -> None:
     assert guard["recommended_action"] == "[P0] Monitor one overdue dependency."
 
 
+def test_quiet_monitor_explains_blocked_non_monitor_todos() -> None:
+    payload = _status(
+        agent_todo_items=[
+            {
+                "index": 1,
+                "text": "[P0] Wait for the blocked product dependency.",
+                "role": "agent",
+                "status": "blocked",
+                "priority": "P0",
+                "task_class": "advancement_task",
+            },
+            {
+                "index": 2,
+                "text": "[P1] Preserve the explicit blocker.",
+                "role": "agent",
+                "status": "blocked",
+                "priority": "P1",
+                "task_class": "blocker",
+            },
+            {
+                "index": 3,
+                "text": "[P3] Check the dependency next week.",
+                "role": "agent",
+                "status": "open",
+                "priority": "P3",
+                "task_class": "continuous_monitor",
+                "action_kind": "monitor",
+                "next_due_at": "2999-01-01T00:00:00+00:00",
+            },
+        ],
+        next_action="Wait for a material dependency transition.",
+    )
+
+    guard = build_quota_should_run(payload, goal_id=GOAL_ID)
+    lane = guard["work_lane_contract"]
+
+    assert guard["effective_action"] == "monitor_quiet_skip"
+    assert lane["non_runnable_non_monitor_count"] == 2
+    assert "non_runnable_non_monitor_todos_present" in lane["reason_codes"]
+    assert "no executable advancement todo is runnable" in guard["reason"]
+    assert "all visible open agent todos are monitor-class" not in guard["reason"]
+
+
 def test_work_lane_context_progress_scope_sources() -> None:
     payload = _status(
         agent_todo_items=_monitor_and_advancement(),

--- a/tests/control_plane_ts/turn_envelope.test.ts
+++ b/tests/control_plane_ts/turn_envelope.test.ts
@@ -114,6 +114,54 @@ test("Turn envelope transaction owns compaction and signature construction", () 
   );
 });
 
+test("monitor-only capsule preserves the non-runnable non-monitor count", () => {
+  const source = payload();
+  source.should_run = false;
+  source.effective_action = "monitor_quiet_skip";
+  source.protocol_action_packet = {};
+  source.interaction_contract = {
+    schema_version: "loopx_interaction_contract_v0",
+    mode: "monitor_quiet_until_material_transition",
+    user_channel: { action_required: false, notify: "DONT_NOTIFY" },
+    agent_channel: {
+      must_attempt: false,
+      delivery_allowed: false,
+      quiet_noop_allowed: true,
+    },
+    cli_channel: {
+      next_cli_actions: [],
+      spend_allowed_now: false,
+      spend_after_validation: false,
+    },
+  };
+  source.work_lane_contract = {
+    schema_version: "work_lane_contract_v0",
+    lane: "continuous_monitor",
+    obligation: "quiet_until_material_monitor_transition",
+    must_attempt_work: false,
+    reason_codes: ["non_runnable_non_monitor_todos_present"],
+    non_runnable_non_monitor_count: 2,
+  };
+
+  const envelope = buildTurnEnvelope({
+    payload: source,
+    protocol_action_fields: {
+      actor: "agent",
+      user_action_required: false,
+      agent_action_required: false,
+      quiet_noop_allowed: true,
+      lane: "continuous_monitor",
+      llm: "no_api",
+      agent_action:
+        "quiet until a material monitor transition, regression, or concrete blocker appears",
+    },
+    scheduler_execution_args: "",
+  });
+  const capsule = envelope.contract_capsule as Record<string, unknown>;
+
+  assert.deepEqual(capsule.work_lane_contract, source.work_lane_contract);
+});
+
 test("planning detail stays cold while its action dimension remains signed", () => {
   const source = payload();
   source.planning_horizon = {


### PR DESCRIPTION
## Summary

- distinguish a true monitor-only open frontier from a schedule where blocked or otherwise non-executable non-monitor Todos coexist with a future monitor
- preserve the existing quiet/no-spend decision while projecting one precise `non_runnable_non_monitor_todos_present` reason and count
- carry that typed count through the TypeScript TurnEnvelope contract capsule so compact host turns do not lose the explanation

## Design

- `build_work_lane_contract` remains the single owner of monitor-versus-advancement routing
- true monitor-only queues retain `monitor_todo_only`
- mixed blocked/non-executable queues use only the specific new reason; the redundant broader `monitor_only_schedule` code was removed during review
- TypeScript performs transport/compaction only and does not recreate Todo classification

No authority, scheduling, quota-spend, or external-effect behavior changes. The effective action remains `monitor_quiet_skip`, with `must_attempt_work=false` and no spend until a material transition.

## Validation

- focused Python tests: 28 passed
- TypeScript control-plane tests: 519 passed, 1 environment-gated PostgreSQL integration test skipped
- TypeScript control-plane typecheck: passed
- Ruff on changed Python files: passed
- targeted mypy base/head comparison: 144 pre-existing transitive diagnostics on both sides, no new diagnostics
- `git diff --check`: passed
- LoopX premerge: 17/17 selected canaries passed, zero manual holds
- exact-diff change-quality receipt: `cqr_3e5a02141e0dd83fd3c4`
