### PR TITLE
fix(desktop): show boot recovery and preserve one service owner

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -24,11 +24,13 @@ to approve the first launch in System Settings > Privacy & Security.
 
 The shell:
 
-1. verifies or starts `loopx serve-status` on `127.0.0.1:8766`;
-2. verifies or starts `loopx chat` on `127.0.0.1:8767`;
-3. loads the versioned LoopX Chat workspace from the local Chat service;
-4. opens the existing personal workspace in one native window;
-5. terminates only the service process groups it started when the window exits.
+1. immediately renders an embedded startup surface instead of a blank WebView;
+2. verifies or starts `loopx serve-status` on `127.0.0.1:8766`;
+3. verifies or starts `loopx chat` on `127.0.0.1:8767`;
+4. loads the versioned LoopX Chat workspace only after its lightweight
+   capabilities endpoint is readable, retrying transient service replacement;
+5. opens the existing personal workspace in one native window;
+6. terminates only the service process groups it started when the window exits.
 
 An unknown process on either LoopX port is a hard startup error. Existing
 services are reused only after a successful response exposes both the exact
@@ -47,6 +49,11 @@ their internal Python entry module. The shell also recognizes the historical
 fixed-CLI and lightweight-entrypoint launcher shapes, so upgrading LoopX can
 replace an already-running older service without asking the operator to find
 and stop it manually.
+
+On macOS, when the standard `com.loopx.status` or `com.loopx.chat` LaunchAgent
+is loaded, Desktop keeps launchd as the single service owner. After replacing a
+stale listener it requests a launchd wake and waits through the throttle
+interval instead of racing a second Desktop-owned process onto the same port.
 
 The WebView is pinned to the loopback Chat origin served by the installed
 LoopX release. Dashboard requests to the status and Chat services remain

--- a/apps/desktop/loopx-control-plane/src-tauri/Cargo.lock
+++ b/apps/desktop/loopx-control-plane/src-tauri/Cargo.lock
@@ -48,28 +48,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
-name = "ashpd"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,17 +86,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,17 +112,6 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -831,15 +787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,12 +823,6 @@ dependencies = [
  "selectors",
  "tendril",
 ]
-
-[[package]]
-name = "downcast-rs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -2062,7 +2003,6 @@ name = "loopx-control-plane"
 version = "0.1.0"
 dependencies = [
  "command-group",
- "rfd",
  "serde_json",
  "tauri",
  "tauri-build",
@@ -2658,12 +2598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
-
-[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2939,30 +2873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfd"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
-dependencies = [
- "ashpd",
- "block2",
- "dispatch2",
- "js-sys",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-foundation",
- "pollster",
- "raw-window-handle",
- "urlencoding",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3055,12 +2965,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.119",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4267,12 +4171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4434,66 +4332,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wayland-backend"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
-dependencies = [
- "cc",
- "downcast-rs",
- "rustix",
- "scoped-tls",
- "smallvec",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-client"
-version = "0.31.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
-dependencies = [
- "bitflags 2.13.1",
- "rustix",
- "wayland-backend",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
-version = "0.32.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
-dependencies = [
- "bitflags 2.13.1",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-scanner"
-version = "0.31.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
-dependencies = [
- "proc-macro2",
- "quick-xml",
- "quote",
-]
-
-[[package]]
-name = "wayland-sys"
-version = "0.31.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
-dependencies = [
- "dlib",
- "log",
- "pkg-config",
 ]
 
 [[package]]
@@ -5316,7 +5154,6 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "url",
  "winnow 1.0.4",
  "zcheapstr",
  "zvariant_derive",

--- a/apps/desktop/loopx-control-plane/src-tauri/Cargo.toml
+++ b/apps/desktop/loopx-control-plane/src-tauri/Cargo.toml
@@ -23,4 +23,3 @@ serde_json = "1.0"
 tauri = { version = "2.11.1", features = [] }
 tauri-plugin-single-instance = "2.4.3"
 tauri-plugin-notification = "2"
-rfd = "0.15"

--- a/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
@@ -1,7 +1,10 @@
 mod services;
 
 use services::ServiceSet;
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
 use tauri::{
     ipc::CapabilityBuilder, AppHandle, Manager, RunEvent, Url, WebviewUrl, WebviewWindowBuilder,
 };
@@ -27,6 +30,8 @@ pub fn run() {
     let services = Arc::new(Mutex::new(None::<ServiceSet>));
     let services_for_setup = Arc::clone(&services);
     let navigation_origin: Url = web_origin.parse().expect("valid desktop origin");
+    let shutting_down = Arc::new(AtomicBool::new(false));
+    let shutting_down_for_setup = Arc::clone(&shutting_down);
 
     let builder = tauri::Builder::default()
         .plugin(
@@ -37,36 +42,6 @@ pub fn run() {
         )
         .plugin(tauri_plugin_notification::init())
         .setup(move |app| {
-            let started = match ServiceSet::start() {
-                Ok(services) => services,
-                Err(error) => {
-                    // Soft gate: surface a service/runtime mismatch as a clear
-                    // owner-facing reminder instead of panicking the shell.
-                    let message = format!(
-                        "LoopX 检测到正在运行的服务来自不同的安装版本，已停止本次启动。\n\n详情：{error}\n\n请先退出旧的 loopx dashboard 或 LoopX App，再重新打开 LoopX。"
-                    );
-                    let _ = rfd::MessageDialog::new()
-                        .set_title("LoopX")
-                        .set_description(&message)
-                        .set_level(rfd::MessageLevel::Warning)
-                        .show();
-                    eprintln!("LoopX service error: {error}");
-                    app.handle().exit(1);
-                    return Ok(());
-                }
-            };
-            let healed = started.healed;
-            *services_for_setup.lock().expect("service state lock") = Some(started);
-
-            if healed {
-                let _ = app
-                    .notification()
-                    .builder()
-                    .title("LoopX")
-                    .body("已自动升级到当前 LoopX 版本，服务已重启。")
-                    .show();
-            }
-
             let origin: Url = web_origin.parse()?;
             app.add_capability(
                 CapabilityBuilder::new("desktop-loopx-chat")
@@ -74,12 +49,62 @@ pub fn run() {
                     .window("main"),
             )?;
 
-            WebviewWindowBuilder::new(app, "main", WebviewUrl::External(origin))
+            WebviewWindowBuilder::new(app, "main", WebviewUrl::App("index.html".into()))
                 .title("LoopX")
                 .inner_size(1280.0, 820.0)
                 .min_inner_size(960.0, 640.0)
-                .on_navigation(move |url| url.origin() == navigation_origin.origin())
+                .on_navigation(move |url| {
+                    url.scheme() == "tauri" || url.origin() == navigation_origin.origin()
+                })
                 .build()?;
+
+            let handle = app.handle().clone();
+            std::thread::spawn(move || {
+                while !shutting_down_for_setup.load(Ordering::Acquire) {
+                    match ServiceSet::start() {
+                        Ok(mut started) => {
+                            if shutting_down_for_setup.load(Ordering::Acquire) {
+                                started.stop();
+                                return;
+                            }
+                            let healed = started.healed;
+                            *services_for_setup.lock().expect("service state lock") = Some(started);
+                            if healed {
+                                let _ = handle
+                                    .notification()
+                                    .builder()
+                                    .title("LoopX")
+                                    .body("已自动升级到当前 LoopX 版本，服务已重启。")
+                                    .show();
+                            }
+                            if let Some(window) = handle.get_webview_window("main") {
+                                let _ = window.navigate(origin);
+                            }
+                            return;
+                        }
+                        Err(error) => {
+                            let message =
+                                format!("LoopX 本地服务暂时无法启动：{error}。正在自动重试…");
+                            eprintln!("LoopX service error: {error}");
+                            if let Some(window) = handle.get_webview_window("main") {
+                                if let Ok(encoded) = serde_json::to_string(&message) {
+                                    let _ =
+                                        window.eval(format!("window.loopxBootFailed({encoded})"));
+                                }
+                            }
+                            for _ in 0..10 {
+                                if shutting_down_for_setup.load(Ordering::Acquire) {
+                                    return;
+                                }
+                                std::thread::sleep(std::time::Duration::from_millis(200));
+                            }
+                            if let Some(window) = handle.get_webview_window("main") {
+                                let _ = window.eval("window.loopxBootRetrying()");
+                            }
+                        }
+                    }
+                }
+            });
             Ok(())
         });
 
@@ -88,6 +113,7 @@ pub fn run() {
         .expect("failed to build LoopX desktop shell");
     app.run(move |_app, event| {
         if matches!(event, RunEvent::Exit | RunEvent::ExitRequested { .. }) {
+            shutting_down.store(true, Ordering::Release);
             if let Ok(mut guard) = services.lock() {
                 if let Some(current) = guard.as_mut() {
                     current.stop();
@@ -96,4 +122,19 @@ pub fn run() {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn startup_surface_is_visible_and_names_automatic_recovery() {
+        let html = include_str!("../../static/index.html");
+        let script = include_str!("../../static/boot.js");
+
+        assert!(html.contains("正在启动本地控制面"));
+        assert!(html.contains("aria-busy=\"true\""));
+        assert!(html.contains("aria-live=\"polite\""));
+        assert!(script.contains("正在自动重试"));
+        assert!(script.contains("window.loopxBootRetrying"));
+    }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -167,6 +167,34 @@ impl ServiceSet {
             }
         }
 
+        if request_platform_managed_start(kind) {
+            let deadline = Instant::now() + STARTUP_TIMEOUT;
+            while Instant::now() < deadline {
+                match probe(kind, expected_runtime_identity.as_ref()) {
+                    Probe::Matching => return Ok(()),
+                    Probe::Foreign => {
+                        return Err(ServiceError(format!(
+                            "LoopX {} startup reached an unexpected service on port {}",
+                            kind.label(),
+                            kind.port()
+                        )));
+                    }
+                    Probe::Stale => {
+                        terminate_stale_listener(kind, &executable, kind.port())?;
+                        self.healed = true;
+                        request_platform_managed_start(kind);
+                    }
+                    Probe::Unavailable => {}
+                }
+                thread::sleep(Duration::from_millis(100));
+            }
+            return Err(ServiceError(format!(
+                "system-managed LoopX {} did not become ready on port {}",
+                kind.label(),
+                kind.port()
+            )));
+        }
+
         let mut command = Command::new(&executable);
         command
             .args(kind.command_args())
@@ -213,6 +241,51 @@ impl ServiceSet {
         }
         self.owned.clear();
     }
+}
+
+#[cfg(target_os = "macos")]
+fn request_platform_managed_start(kind: ServiceKind) -> bool {
+    let label = platform_managed_service_label(kind);
+    let uid = match Command::new("id").arg("-u").output() {
+        Ok(output) if output.status.success() => {
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
+        }
+        _ => return false,
+    };
+    if uid.is_empty() {
+        return false;
+    }
+    let target = format!("gui/{uid}/{label}");
+    let loaded = Command::new("launchctl")
+        .args(["print", target.as_str()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success());
+    if !loaded {
+        return false;
+    }
+    // Keep one service owner. A loaded KeepAlive LaunchAgent may be inside its
+    // throttle interval after stale-runtime replacement; ask launchd to wake
+    // it and wait instead of racing it with a Desktop-owned child process.
+    let _ = Command::new("launchctl")
+        .args(["kickstart", target.as_str()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    true
+}
+
+fn platform_managed_service_label(kind: ServiceKind) -> &'static str {
+    match kind {
+        ServiceKind::Status => "com.loopx.status",
+        ServiceKind::Chat => "com.loopx.chat",
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn request_platform_managed_start(_kind: ServiceKind) -> bool {
+    false
 }
 
 impl Drop for ServiceSet {

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
@@ -160,6 +160,18 @@ fn release_launchers_publish_the_stable_process_fingerprint() {
 }
 
 #[test]
+fn platform_managed_services_have_stable_launchd_labels() {
+    assert_eq!(
+        platform_managed_service_label(ServiceKind::Status),
+        "com.loopx.status"
+    );
+    assert_eq!(
+        platform_managed_service_label(ServiceKind::Chat),
+        "com.loopx.chat"
+    );
+}
+
+#[test]
 fn stale_listener_verification_rejects_the_entire_pid_set_on_mismatch() {
     let executable = "/fixture/bin/loopx";
     let confirmed = ListenerProcess {

--- a/apps/desktop/loopx-control-plane/static/boot.css
+++ b/apps/desktop/loopx-control-plane/static/boot.css
@@ -1,0 +1,20 @@
+:root { color-scheme: light dark; font-family: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+* { box-sizing: border-box; }
+body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #fafafa; color: #171717; }
+main { width: min(440px, calc(100vw - 48px)); padding: 32px; border: 1px solid #ebebeb; border-radius: 12px; background: #fff; }
+header { display: flex; align-items: center; gap: 12px; }
+.mark { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 8px; background: #171717; color: white; font-weight: 650; }
+h1 { margin: 0; font-size: 20px; letter-spacing: -.02em; }
+p { margin: 16px 0 0; color: #4d4d4d; font-size: 14px; line-height: 1.55; }
+.progress { height: 2px; margin-top: 24px; overflow: hidden; background: #ebebeb; }
+.progress::after { content: ""; display: block; width: 45%; height: 100%; background: #171717; animation: travel 1.1s ease-in-out infinite alternate; }
+main[data-state="error"] .progress::after { background: #f5a623; }
+@keyframes travel { from { transform: translateX(-10%); } to { transform: translateX(132%); } }
+@media (prefers-reduced-motion: reduce) { .progress::after { width: 100%; animation: none; } }
+@media (prefers-color-scheme: dark) {
+  body { background: #09090b; color: #fafafa; }
+  main { border-color: #27272a; background: #09090b; }
+  .mark, .progress::after { background: #fafafa; color: #171717; }
+  p { color: #a1a1aa; }
+  .progress { background: #27272a; }
+}

--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -1,0 +1,12 @@
+const panel = document.querySelector("main");
+const status = document.querySelector("#status");
+
+window.loopxBootFailed = (message) => {
+  panel.dataset.state = "error";
+  status.textContent = `${message} 正在自动重试…`;
+};
+
+window.loopxBootRetrying = () => {
+  panel.dataset.state = "loading";
+  status.textContent = "正在重新连接本地控制面…";
+};

--- a/apps/desktop/loopx-control-plane/static/index.html
+++ b/apps/desktop/loopx-control-plane/static/index.html
@@ -2,9 +2,16 @@
 <html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
-    <title>LoopX Desktop</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LoopX</title>
+    <link rel="stylesheet" href="boot.css" />
   </head>
   <body>
-    <p>LoopX desktop shell loads the local Chat workspace at /chat/.</p>
+    <main aria-busy="true" aria-live="polite" data-state="loading" role="status">
+      <header><span aria-hidden="true" class="mark">L</span><h1>LoopX</h1></header>
+      <p id="status">正在启动本地控制面…</p>
+      <div aria-hidden="true" class="progress"></div>
+    </main>
+    <script src="boot.js"></script>
   </body>
 </html>

--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -24,6 +24,7 @@ from .chat_actions import ChatActionService, ProtectedActionGate
 from .chat_action_store import ACTION_KINDS, ActionConflictError, ChatActionStore
 from . import chat_configuration_api as config_api
 from .chat_runtime import ChatRuntimeController, TERMINAL_TURN_STATES
+from .chat_status_api import ChatStatusRequestMixin
 from .chat_ssh_source_api import SSH_SOURCE_ENSURE_PATH, SshSourceRequestMixin
 from .chat_store import ChatSessionStore
 from .control_plane.status.ssh_host_catalog import (
@@ -64,7 +65,6 @@ from .paths import resolve_runtime_root
 from .release_manifest import release_runtime_identity
 from .registry import registry_goals, resolve_state_file
 from .state_projection import build_active_state_structured_projection
-from .status import collect_status
 from .status_server import (
     cors_response_headers,
     is_loopback_host,
@@ -432,6 +432,7 @@ class ChatRequestHandler(
     SshSourceRequestMixin,
     LarkChatRequestMixin,
     config_api.ChatConfigurationRequestMixin,
+    ChatStatusRequestMixin,
     BaseHTTPRequestHandler,
 ):
     server: ChatHTTPServer
@@ -535,31 +536,6 @@ class ChatRequestHandler(
         self.send_header("X-Content-Type-Options", "nosniff")
         self.end_headers()
         self.wfile.write(body)
-
-    def _status(self) -> None:
-        try:
-            projection = collect_status(
-                registry_path=self.server.registry_path,
-                runtime_root_override=self.server.runtime_root_override,
-                scan_roots=self.server.scan_roots,
-                limit=self.server.limit,
-                goal_id=self.server.selected_goal_id,
-                include_public_boundary_scan=False,
-            )
-            protected_paths = [
-                self.server.registry_path,
-                *self.server.scan_roots,
-            ]
-            projection = json.loads(
-                redact_local_paths(
-                    json.dumps(projection, ensure_ascii=False),
-                    protected_paths=protected_paths,
-                )
-            )
-        except Exception:
-            self._send_error("LoopX status could not be projected for the workspace.", status=500)
-            return
-        self._send_json(projection)
 
     def _create_session(self) -> None:
         try:

--- a/loopx/chat_status_api.py
+++ b/loopx/chat_status_api.py
@@ -1,0 +1,49 @@
+"""Loopback status route owned by the Chat HTTP surface."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+from .chat import redact_local_paths
+from .status import collect_status
+from .status_server import parse_goal_activation_filter
+
+
+class ChatStatusRequestMixin:
+    """Serve the full dashboard status contract through the Chat origin."""
+
+    def _status(self) -> None:
+        query = parse_qs(urlparse(self.path).query, keep_blank_values=True)
+        try:
+            activation_state_filter = parse_goal_activation_filter(query)
+        except ValueError as exc:
+            self._send_error(
+                str(exc),
+                status=400,
+                error_code="invalid_goal_activation",
+            )
+            return
+        try:
+            projection = collect_status(
+                registry_path=self.server.registry_path,
+                runtime_root_override=self.server.runtime_root_override,
+                scan_roots=self.server.scan_roots,
+                limit=self.server.limit,
+                goal_id=self.server.selected_goal_id,
+                include_public_boundary_scan=False,
+                activation_state_filter=activation_state_filter,
+            )
+            projection = json.loads(
+                redact_local_paths(
+                    json.dumps(projection, ensure_ascii=False),
+                    protected_paths=[self.server.registry_path, *self.server.scan_roots],
+                )
+            )
+        except Exception:
+            self._send_error(
+                "LoopX status could not be projected for the workspace.",
+                status=500,
+            )
+            return
+        self._send_json(projection)

--- a/loopx/chat_status_api.py
+++ b/loopx/chat_status_api.py
@@ -40,7 +40,7 @@ class ChatStatusRequestMixin:
                     protected_paths=[self.server.registry_path, *self.server.scan_roots],
                 )
             )
-        except Exception:
+        except Exception:  # noqa: BLE001 - do not expose local projection failures.
             self._send_error(
                 "LoopX status could not be projected for the workspace.",
                 status=500,

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -102,6 +102,15 @@ CONFIGURE_GOAL_REQUEST_FIELDS = {
 CONFIGURE_GOAL_APPLY_FIELDS = CONFIGURE_GOAL_REQUEST_FIELDS | {"preview_id"}
 
 
+def parse_goal_activation_filter(query: dict[str, list[str]]) -> str | None:
+    """Parse the shared scoped-status query without accepting ambiguous input."""
+
+    values = query.get("goal_activation", [])
+    if len(values) > 1 or (values and values[0] not in {"active", "stopped"}):
+        raise ValueError("goal_activation must be active or stopped")
+    return values[0] if values else None
+
+
 def is_loopback_host(host: str) -> bool:
     hostname = host.strip().lower()
     return hostname in {"127.0.0.1", "localhost", "::1", "[::1]"}
@@ -943,19 +952,17 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             )
             return
 
-        activation_values = query.get("goal_activation", [])
-        if len(activation_values) > 1 or (
-            activation_values and activation_values[0] not in {"active", "stopped"}
-        ):
+        try:
+            activation_state_filter = parse_goal_activation_filter(query)
+        except ValueError as exc:
             self._send_json(
                 {
                     "ok": False,
-                    "error": "goal_activation must be active or stopped",
+                    "error": str(exc),
                 },
                 status=400,
             )
             return
-        activation_state_filter = activation_values[0] if activation_values else None
 
         try:
             payload = collect_status(

--- a/tests/test_chat_server_cors.py
+++ b/tests/test_chat_server_cors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import http.client
 import json
 import threading
+from pathlib import Path
 
 from loopx.chat_server import ChatHTTPServer, ChatRequestHandler
 from loopx.extensions.lark.cli_resolution import LarkCliResolution
@@ -12,6 +13,10 @@ def _start_server() -> tuple[ChatHTTPServer, threading.Thread]:
     server = ChatHTTPServer(("127.0.0.1", 0), ChatRequestHandler)
     server.verbose = False
     server.selected_goal_id = None
+    server.registry_path = Path("/tmp/loopx-test-registry.json")
+    server.runtime_root_override = None
+    server.scan_roots = []
+    server.limit = 20
     server.runtime_controller = _RuntimeController()
     server.lark_cli_resolution = LarkCliResolution(
         command=None,
@@ -38,10 +43,11 @@ def _request(
     *,
     method: str,
     origin: str | None,
+    path: str = "/api/chat/capabilities",
 ) -> http.client.HTTPResponse:
     connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
     headers = {"Origin": origin} if origin else {}
-    connection.request(method, "/api/chat/capabilities", headers=headers)
+    connection.request(method, path, headers=headers)
     return connection.getresponse()
 
 
@@ -124,6 +130,56 @@ def test_chat_options_exposes_loopback_preflight_only() -> None:
         assert response.getheader("Access-Control-Allow-Methods") == (
             "GET, POST, DELETE, OPTIONS"
         )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_chat_status_forwards_valid_goal_activation_scope(monkeypatch) -> None:
+    calls: list[str | None] = []
+
+    def fake_collect_status(**kwargs):
+        calls.append(kwargs.get("activation_state_filter"))
+        return {"ok": True, "scope": kwargs.get("activation_state_filter")}
+
+    monkeypatch.setattr("loopx.chat_status_api.collect_status", fake_collect_status)
+    server, thread = _start_server()
+    try:
+        response = _request(
+            server.server_address[1],
+            method="GET",
+            origin=None,
+            path="/status.json?goal_activation=active",
+        )
+        payload = json.loads(response.read().decode("utf-8"))
+
+        assert response.status == 200
+        assert payload == {"ok": True, "scope": "active"}
+        assert calls == ["active"]
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def test_chat_status_rejects_invalid_goal_activation_scope(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "loopx.chat_status_api.collect_status",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("must fail before collection")),
+    )
+    server, thread = _start_server()
+    try:
+        response = _request(
+            server.server_address[1],
+            method="GET",
+            origin=None,
+            path="/status.json?goal_activation=active&goal_activation=stopped",
+        )
+        payload = json.loads(response.read().decode("utf-8"))
+
+        assert response.status == 400
+        assert payload["error_code"] == "invalid_goal_activation"
     finally:
         server.shutdown()
         thread.join(timeout=5)


### PR DESCRIPTION
## Summary

- render an embedded, accessible `正在启动本地控制面…` surface immediately instead of leaving the native WebView blank while local services start;
- move status/Chat startup off the Tauri setup thread, keep retrying bounded service recovery, and navigate to the packaged Chat workspace only after readiness;
- when the standard macOS LaunchAgents are loaded, preserve `launchd` as the single service owner and request a managed wake instead of racing a Desktop-owned child onto the same ports;
- serve the existing status projection through the Chat origin so the packaged workspace does not depend on a second cross-origin request during first render;
- remove the obsolete modal-only `rfd` startup path and document the resulting lifecycle model.

## Product and architecture judgment

The blank/frozen launch was not only a loading-state problem: Tauri setup synchronously waited on two service probes and recoveries before creating a window, while a loaded KeepAlive LaunchAgent and Desktop could both attempt to own the same service lifetime. This change gives the user an immediate, honest boot surface and makes the existing OS supervisor the sole durable lifecycle owner when installed. Desktop remains the presentation and recovery orchestrator; Goal/Todo/control-plane authority is unchanged.

This is intentionally narrower than the proposed unified `loopxd` architecture in #3930. It preserves the current status and Chat services while removing the immediate double-owner race.

## Relationship to #3921 and latest main

Rebased onto main after #3921. That PR fixes Python Dashboard startup when an unused Windows loopback port reports `TimeoutError`. The Rust Desktop probe already treats connect-stage failures as unavailable and lets subsequent process startup/bind decide ownership. Once a connection succeeds, malformed or non-responsive listeners remain foreign and are never taken over. The two fixes are complementary and have no overlapping files.

The final rebases also include #3926 and #3932, whose presentation-site and SWE-Marathon paths do not overlap this Desktop/chat/status scope.

## Validation

- owner-reviewed first-screen preview: accepted;
- `cargo fmt --check`, `cargo check`, `cargo test`: 13 passed;
- focused Chat/status pytest suite: 27 passed;
- focused Ruff for the changed Python modules and regression test: passed;
- `npm run typecheck:control-plane`: passed;
- `npm run test:control-plane`: 519 passed, 1 optional PostgreSQL integration skipped;
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 selected checks passed, zero failures, zero manual holds;
- public/private boundary scan: passed;
- exact change-quality receipt: `cqr_3a2ea1ff81e42b17ab0d`, valid for scope `3a2ea1ff81e42b17ab0d4057f5c2dade30c57ef7dd39509792c4c8237cefcb94`;
- `git diff --check origin/main...HEAD`: passed;
- all three commits carry DCO sign-off.

## Boundary

Desktop boot presentation, local service lifecycle reuse, and an existing read-only status projection route only. No Goal, Todo, gate, quota, provider permission, external write, benchmark, or public-evidence semantics change.
