### PR TITLE
fix(authority): keep event lookup inside control plane

### DIFF
--- a/loopx/control_plane/coordination/local_authority_shadow_adapter.py
+++ b/loopx/control_plane/coordination/local_authority_shadow_adapter.py
@@ -687,11 +687,16 @@ def _read_state_text(path: Path) -> str:
 
 def _event_present(sources: _GoalSources, event_id: str) -> bool:
     from ...event_sourced_state import AppendOnlyStateEventStore
-    from ...status import state_event_log_candidates
+    from ..goals.active_state_event_projection import state_event_log_candidates
+    from ..goals.path_resolution import resolve_goal_local_path
 
     if sources.goal is None:
         return False
-    for candidate in state_event_log_candidates(sources.goal, state_path=sources.state_path):
+    for candidate in state_event_log_candidates(
+        sources.goal,
+        state_path=sources.state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+    ):
         if not candidate.exists():
             continue
         for event in AppendOnlyStateEventStore(candidate).load():


### PR DESCRIPTION
## Summary

- fixes the post-merge Full Public Smokes regression introduced by #3870
- keeps event-log lookup inside the control-plane bounded context
- reuses the existing goal-owned event-log candidate resolver instead of importing the top-level `status` facade

## Motivation and design

The authority-shadow drain path needs to confirm whether a prepared event-log entry reached canonical storage. The implementation in #3870 obtained that read helper through `loopx.status`, which inverted the intended dependency direction: control-plane coordination depended on a top-level compatibility facade that itself depends on control-plane modules.

This patch calls the existing provider-neutral resolver in `control_plane.goals` directly. It changes no schema, state, transaction, or candidate-decision behavior.

## Validation

- `examples/control_plane/todo-readmodel-boundary-smoke.py`: passed
- focused authority-shadow pytest suite: 33 passed
- `mypy`: no issues in 21 configured files
- Ruff on the changed module: passed
- control-plane maintainability ratchet: passed, no new or stale debt
- LoopX premerge: 12/12 selected checks passed, 0 failures, 0 warnings, 0 manual holds
- change-quality receipt: `cqr_6e35a7e0855af76151aa`, exact committed diff verified
- DCO sign-off present

## Post-merge #3870 CI triage

The merge-commit Full Public Smokes run also reports three failures that reproduce on #3870's base commit: the Todo CLI module-size ratchet, the configure-goal feature-set assertion, and the concise-help line budget. They are pre-existing `main` failures and are intentionally excluded from this one-file regression fix.

Follow-up to #3870.
