### PR TITLE
Strengthen PR review default-off isolation

### DIFF
--- a/loopx/capabilities/pr_review_queue/README.md
+++ b/loopx/capabilities/pr_review_queue/README.md
@@ -194,9 +194,16 @@ typed evidence groups before a verdict:
   maintenance surface. Correctness, green CI, and resolution of earlier
   findings do not override a `disproportionate` or `not_yet_proven` blocker;
 - default-off isolation: for an opt-in change, trace every shared schema,
-  prompt, accepted-input, projection, scheduling, and effect surface, then run
-  a paired counterfactual proving that disabled behavior still matches the
-  pre-change contract;
+  prompt, accepted-input, projection, scheduling, and effect surface. Include
+  installed or automatically loaded skills, agent instructions, prompt
+  templates, help, schemas, install bundles, and provider setup guidance:
+  runtime `default=false` is insufficient when one of those baseline surfaces
+  already changes model or user behavior. Separate availability signals such
+  as installation, discovery, provider readiness, accepted input, and resolver
+  success from activation authority. For scoped capabilities, prove that the
+  intended scope and every required subject are enabled before projecting
+  capability-specific guidance or effects, then run a paired counterfactual
+  proving that disabled behavior still matches the pre-change contract;
 - authority semantics: make public protocol ids and symbols match the real
   actor lifecycle and authority, distinguishing ephemeral sub-agents from
   registered peers and durable multi-agent coordination.

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -20,7 +20,9 @@ CODE_AREAS = {
 
 EXAMPLE_OR_SMOKE_AREAS = {"test_or_example"}
 
-NEGATIVE_PATH_AREAS = CODE_AREAS | {"public_entry_or_policy"}
+BEHAVIORAL_POLICY_AREAS = {"public_entry_or_policy", "agent_instruction_surface"}
+
+NEGATIVE_PATH_AREAS = CODE_AREAS | BEHAVIORAL_POLICY_AREAS
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:
@@ -150,7 +152,7 @@ def build_review_execution_contract() -> dict[str, Any]:
             },
             {
                 "evidence_id": "scope_fit",
-                "required_when": "code_change",
+                "required_when": "behavior_bearing_change",
                 "fields": [
                     "shipped_behavior",
                     "active_call_sites",
@@ -293,7 +295,7 @@ def build_review_execution_contract() -> dict[str, Any]:
             },
             {
                 "evidence_id": "default_off_isolation",
-                "required_when": "code_change",
+                "required_when": "behavior_bearing_change",
                 "verdict_values": [
                     "isolated",
                     "not_isolated",
@@ -303,15 +305,20 @@ def build_review_execution_contract() -> dict[str, Any]:
                 "fields": [
                     "opt_in_or_default_off_claim",
                     "authoritative_gate",
+                    "declared_activation_scope",
+                    "enabled_subjects",
                     "default_state",
+                    "availability_signals_that_do_not_activate",
                     "disabled_entry_path",
                     "enabled_entry_path",
                     "shared_changed_surfaces",
+                    "installed_or_auto_loaded_instruction_surfaces",
                     "disabled_schema_or_required_fields",
                     "disabled_prompt_or_guidance",
                     "disabled_accepted_inputs",
                     "disabled_state_or_projection",
                     "disabled_scheduling_quota_or_side_effects",
+                    "disabled_user_experience_parity",
                     "paired_counterfactual_validation",
                     "verdict",
                 ],
@@ -322,7 +329,19 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "preserve the previous observable contract: schema and required "
                     "fields, prompts and guidance, accepted host inputs, persisted "
                     "or journal projections, scheduling and quota decisions, and "
-                    "external effects. The absence of a topology, operation list, "
+                    "external effects. Treat installed or automatically loaded "
+                    "skills, system or agent instructions, prompt templates, help "
+                    "text, schemas, and provider setup guidance as production "
+                    "surfaces when they can change model or user behavior. A runtime "
+                    "default of false does not isolate guidance that is already "
+                    "present on one of those baseline surfaces. Distinguish "
+                    "availability from activation: installation, discovery, provider "
+                    "readiness, accepted input, locator resolution, or CLI presence "
+                    "does not enable a capability. For goal-, project-, tenant-, "
+                    "user-, or agent-scoped activation, prove that the authoritative "
+                    "gate binds the intended scope and every required subject before "
+                    "any capability-specific instruction, action, state mutation, or "
+                    "user-facing concept is projected. The absence of a topology, operation list, "
                     "or feature object proves only that one enabled path did not run; "
                     "it does not prove isolation of shared builders or serializers. "
                     "Run a paired counterfactual using otherwise identical inputs "
@@ -533,6 +552,8 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
         str(area) for area, count in _as_mapping(item.get("areas")).items() if count
     }
     code_change = bool(areas & CODE_AREAS)
+    behavioral_policy_change = bool(areas & BEHAVIORAL_POLICY_AREAS)
+    behavior_bearing_change = code_change or behavioral_policy_change
     docs_only = bool(areas) and areas <= {"public_docs", "public_entry_or_policy"}
     smoke_or_example_only = bool(areas & EXAMPLE_OR_SMOKE_AREAS) and not code_change
     required_evidence = [
@@ -548,11 +569,14 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
         required_evidence.insert(3, "symbol_map")
         required_evidence.append("scope_fit")
         required_evidence.append("change_proportionality")
-        required_evidence.append("default_off_isolation")
         required_evidence.append("authority_semantics")
         required_evidence.append("typed_state_rule")
+    if behavior_bearing_change:
+        if "scope_fit" not in required_evidence:
+            required_evidence.append("scope_fit")
+        required_evidence.append("default_off_isolation")
         required_evidence.append("behavior_change_disclosure")
-    if areas & {"product_runtime", "public_entry_or_policy"}:
+    if areas & {"product_runtime", "public_entry_or_policy", "agent_instruction_surface"}:
         required_evidence.append("domain_neutrality")
         required_evidence.append("guidance_vs_obligation")
     if smoke_or_example_only:
@@ -572,20 +596,24 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
         "applicability": {
             "areas": sorted(areas),
             "code_change": code_change,
+            "behavioral_policy_change": behavioral_policy_change,
+            "behavior_bearing_change": behavior_bearing_change,
             "docs_only": docs_only,
             "symbol_map_required": code_change,
-            "scope_fit_required": code_change,
+            "scope_fit_required": behavior_bearing_change,
             "change_proportionality_required": code_change,
-            "default_off_isolation_required": code_change,
+            "default_off_isolation_required": behavior_bearing_change,
             "authority_semantics_required": code_change,
             "negative_walkthrough_required": bool(areas & NEGATIVE_PATH_AREAS),
             "typed_state_rule_required": code_change,
-            "behavior_change_disclosure_required": code_change,
+            "behavior_change_disclosure_required": behavior_bearing_change,
             "domain_neutrality_required": bool(
-                areas & {"product_runtime", "public_entry_or_policy"}
+                areas
+                & {"product_runtime", "public_entry_or_policy", "agent_instruction_surface"}
             ),
             "guidance_vs_obligation_required": bool(
-                areas & {"product_runtime", "public_entry_or_policy"}
+                areas
+                & {"product_runtime", "public_entry_or_policy", "agent_instruction_surface"}
             ),
             "smoke_or_example_only": smoke_or_example_only,
             "durable_smoke_value_required": smoke_or_example_only,

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -560,7 +560,9 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
     behavioral_policy_change = bool(areas & BEHAVIORAL_POLICY_AREAS)
     behavior_bearing_change = code_change or behavioral_policy_change
     docs_only = bool(areas) and areas <= {"public_docs", "public_entry_or_policy"}
-    smoke_or_example_only = bool(areas & EXAMPLE_OR_SMOKE_AREAS) and not code_change
+    smoke_or_example_only = bool(areas & EXAMPLE_OR_SMOKE_AREAS) and not (
+        code_change or behavioral_policy_change
+    )
     required_evidence = [
         "problem_context",
         "architecture_flow",

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -156,17 +156,21 @@ def build_review_execution_contract() -> dict[str, Any]:
                 "fields": [
                     "shipped_behavior",
                     "active_call_sites",
+                    "instruction_install_or_load_path",
+                    "target_audience_and_scope",
                     "caller_path_or_none",
                     "coverage_only_declared",
                     "scope_fit_verdict",
                 ],
                 "rule": (
                     "For every added or moved production module, adapter, CLI "
-                    "command, or control-plane contract, verify a shipped "
-                    "behavior and at least one active production call site in "
-                    "the reviewed branch. Test-only coverage of an unused "
-                    "module is not a shipped behavior; name the gap and treat "
-                    "it as blocking unless an explicit, owner-accepted "
+                    "command, control-plane contract, or agent instruction surface, "
+                    "verify a shipped behavior and at least one active production "
+                    "call site or automatic installation/loading path in the reviewed "
+                    "branch. For instructions, verify the audience and activation "
+                    "scope reached by that path. Test-only coverage of an unused "
+                    "module or uninstalled instruction is not a shipped behavior; "
+                    "name the gap and treat it as blocking unless an explicit, owner-accepted "
                     "coverage-only boundary is recorded."
                 ),
             },
@@ -419,7 +423,7 @@ def build_review_execution_contract() -> dict[str, Any]:
             },
             {
                 "evidence_id": "behavior_change_disclosure",
-                "required_when": "runtime_behavior_change",
+                "required_when": "behavior_bearing_change",
                 "fields": [
                     "previous_default",
                     "new_default",
@@ -427,10 +431,11 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "disclosure_surface",
                 ],
                 "rule": (
-                    "Default behavior changes must be disclosed through renamed "
-                    "smokes, docs, or release notes. Flag silent behavior changes "
-                    "that alter existing automation without naming the old and new "
-                    "default."
+                    "Default behavior changes in runtime or automatically loaded "
+                    "instruction surfaces must be disclosed through renamed smokes, "
+                    "docs, or release notes. Flag silent changes that alter existing "
+                    "automation or ordinary agent behavior without naming the old and "
+                    "new default."
                 ),
             },
             {

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -430,6 +430,12 @@ def _commit_headlines(pr: dict[str, Any], *, limit: int = 5) -> list[str]:
 def _file_area(path: str) -> str:
     name = path.rsplit("/", 1)[-1]
     lowered = path.lower()
+    if (
+        path.startswith(("skills/", ".codex/", ".agents/"))
+        or name in {"AGENTS.md", "SKILL.md", "CLAUDE.md"}
+        or lowered.endswith((".prompt.md", ".instructions.md"))
+    ):
+        return "agent_instruction_surface"
     if path in {
         "README.md",
         "README.zh-CN.md",

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -508,6 +508,7 @@ def _area_counts(files: list[dict[str, Any]]) -> dict[str, int]:
 
 AREA_LABELS = {
     "public_entry_or_policy": "README/政策入口",
+    "agent_instruction_surface": "Agent 指令/Skill",
     "public_docs": "公开文档",
     "test_or_example": "smoke/示例",
     "app_or_ui_surface": "前端/展示面",
@@ -564,7 +565,14 @@ def _metadata_risk_hint(pr: dict[str, Any], files: list[dict[str, Any]], checks:
     additions = int(pr.get("additions") or 0)
     deletions = int(pr.get("deletions") or 0)
     has_runtime = any(
-        str(item.get("area")) in {"product_runtime", "app_or_ui_surface", "ci_or_release", "build_or_config"}
+        str(item.get("area"))
+        in {
+            "product_runtime",
+            "app_or_ui_surface",
+            "ci_or_release",
+            "build_or_config",
+            "agent_instruction_surface",
+        }
         for item in files
     )
     if checks.get("failures") or changed >= 12 or additions + deletions >= 800:
@@ -623,6 +631,16 @@ def _main_regression_analysis(pr: dict[str, Any], files: list[dict[str, Any]]) -
         )
         bug_risks.append("A prominent docs change can authorize behavior that the runtime or repository policy does not actually support.")
         verification_focus.append("Compare the public entry text with current CLI help, AGENTS policy, and any first-screen review gate.")
+    if "agent_instruction_surface" in area_names:
+        potential_regressions.append(
+            "Automatically loaded agent instructions can change ordinary-user behavior before any runtime feature gate is evaluated."
+        )
+        bug_risks.append(
+            "A skill or prompt can make an opt-in capability effectively default-on for agents even when runtime configuration remains false."
+        )
+        verification_focus.append(
+            "Trace installation and automatic-loading paths, then compare pre-change, disabled, and enabled instruction surfaces for user-experience parity."
+        )
     if areas and area_names <= {"public_docs", "test_or_example"}:
         potential_regressions.append(
             "Runtime regression risk is low, but public guidance or smoke expectations can drift from shipped behavior."
@@ -646,7 +664,16 @@ def _main_regression_analysis(pr: dict[str, Any], files: list[dict[str, Any]]) -
         bug_risks.append("No status-check rollup was available, so validation coverage must be inferred from local evidence.")
         verification_focus.append("Run at least one focused local validation command before approving.")
 
-    has_sensitive_area = bool(area_names & {"product_runtime", "app_or_ui_surface", "ci_or_release", "build_or_config"})
+    has_sensitive_area = bool(
+        area_names
+        & {
+            "product_runtime",
+            "app_or_ui_surface",
+            "ci_or_release",
+            "build_or_config",
+            "agent_instruction_surface",
+        }
+    )
     if checks.get("failures") or changed >= 12 or churn >= 800 or (state == "MERGED" and has_sensitive_area):
         level = "high"
     elif has_sensitive_area or checks.get("pending") or not checks.get("total"):
@@ -749,6 +776,8 @@ def _review_depth(files: list[dict[str, Any]]) -> str:
     areas = {str(item.get("area") or "") for item in files}
     if "product_runtime" in areas:
         return "runtime_behavior_review"
+    if "agent_instruction_surface" in areas:
+        return "agent_behavior_review"
     if "app_or_ui_surface" in areas or "public_entry_or_policy" in areas:
         return "presentation_or_policy_review"
     if areas <= {"public_docs", "test_or_example"}:

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -59,8 +59,16 @@ selected PR:
    repository-native validation when applicable.
 2. Fill `review_plan.result_template` from the shared execution contract;
    preserve missing evidence as `unverified`. For `default_off_isolation`, run
-   its paired counterfactual across all shared surfaces; for `authority_semantics`,
-   match names to actor authority. Never infer `verified` from metadata or CI.
+   its paired counterfactual across every shared and automatically loaded
+   surface, including skills, agent instructions, prompt templates, help,
+   schemas, install bundles, and provider guidance. Treat installation,
+   discovery, provider readiness, accepted input, and resolver success as
+   availability rather than activation; a runtime default-off flag cannot
+   compensate for capability behavior already projected through a baseline
+   instruction surface. For scoped activation, verify the intended scope and
+   every required subject before capability-specific guidance or effects. For
+   `authority_semantics`, match names to actor authority. Never infer
+   `verified` from metadata or CI.
 3. Apply `completion_gate` literally. If an applicable requirement is missing,
    do not manufacture a detailed verdict; name the evidence gap.
 4. Render the verified result through `review_template`. The five sections are

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -64,9 +64,14 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
     assert "negative_fields" in requirements["walkthroughs"]
     assert "regression_test" in requirements["failure_analysis"]["fields"]
     assert requirements["scope_fit"]["required_when"] == "behavior_bearing_change"
+    assert "instruction_install_or_load_path" in requirements["scope_fit"]["fields"]
+    assert "target_audience_and_scope" in requirements["scope_fit"]["fields"]
     assert requirements["typed_state_rule"]["required_when"] == "code_change"
     assert "substring denylists" in requirements["typed_state_rule"]["rule"]
     assert "domain-neutral" in requirements["domain_neutrality"]["rule"]
+    assert requirements["behavior_change_disclosure"]["required_when"] == (
+        "behavior_bearing_change"
+    )
     assert (
         "silent behavior changes" in requirements["behavior_change_disclosure"]["rule"]
     )

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -213,6 +213,8 @@ def test_agent_instruction_plan_requires_default_off_user_experience_evidence() 
     assert plan["applicability"]["code_change"] is False
     assert plan["applicability"]["behavioral_policy_change"] is True
     assert plan["applicability"]["behavior_bearing_change"] is True
+    assert plan["applicability"]["smoke_or_example_only"] is False
+    assert plan["applicability"]["durable_smoke_value_required"] is False
     assert plan["applicability"]["scope_fit_required"] is True
     assert plan["applicability"]["default_off_isolation_required"] is True
     assert plan["applicability"]["negative_walkthrough_required"] is True

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -63,6 +63,7 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
     assert "caller_evidence" in requirements["symbol_map"]["item_fields"]
     assert "negative_fields" in requirements["walkthroughs"]
     assert "regression_test" in requirements["failure_analysis"]["fields"]
+    assert requirements["scope_fit"]["required_when"] == "behavior_bearing_change"
     assert requirements["typed_state_rule"]["required_when"] == "code_change"
     assert "substring denylists" in requirements["typed_state_rule"]["rule"]
     assert "domain-neutral" in requirements["domain_neutrality"]["rule"]
@@ -82,7 +83,7 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
     assert "green CI" in proportionality["rule"]
     assert "original problem" in proportionality["rule"]
     isolation = requirements["default_off_isolation"]
-    assert isolation["required_when"] == "code_change"
+    assert isolation["required_when"] == "behavior_bearing_change"
     assert isolation["verdict_values"] == [
         "isolated",
         "not_isolated",
@@ -90,8 +91,15 @@ def test_execution_contract_owns_deep_review_requirements() -> None:
         "not_yet_proven",
     ]
     assert "disabled_prompt_or_guidance" in isolation["fields"]
+    assert "declared_activation_scope" in isolation["fields"]
+    assert "availability_signals_that_do_not_activate" in isolation["fields"]
+    assert "installed_or_auto_loaded_instruction_surfaces" in isolation["fields"]
+    assert "disabled_user_experience_parity" in isolation["fields"]
     assert "paired_counterfactual_validation" in isolation["fields"]
     assert "absence of a topology" in isolation["rule"]
+    assert "automatically loaded" in isolation["rule"]
+    assert "availability from activation" in isolation["rule"]
+    assert "runtime default of false" in isolation["rule"]
     authority = requirements["authority_semantics"]
     assert authority["verdict_values"] == [
         "aligned",
@@ -187,6 +195,29 @@ def test_docs_plan_does_not_invent_code_symbols() -> None:
     )
     assert "### 关键内容讲解" in concrete["agent_instruction"]
     assert template["review_order"] == ["docs/design.md"]
+
+
+def test_agent_instruction_plan_requires_default_off_user_experience_evidence() -> None:
+    item = _item(areas={"agent_instruction_surface": 1})
+    item["key_files"] = [
+        {"path": "skills/project/SKILL.md", "additions": 20, "deletions": 2}
+    ]
+
+    plan = build_review_plan(item)
+
+    assert plan["applicability"]["code_change"] is False
+    assert plan["applicability"]["behavioral_policy_change"] is True
+    assert plan["applicability"]["behavior_bearing_change"] is True
+    assert plan["applicability"]["scope_fit_required"] is True
+    assert plan["applicability"]["default_off_isolation_required"] is True
+    assert plan["applicability"]["negative_walkthrough_required"] is True
+    assert plan["applicability"]["behavior_change_disclosure_required"] is True
+    assert plan["applicability"]["guidance_vs_obligation_required"] is True
+    assert "scope_fit" in plan["required_evidence_ids"]
+    assert "default_off_isolation" in plan["required_evidence_ids"]
+    assert "behavior_change_disclosure" in plan["required_evidence_ids"]
+    assert "guidance_vs_obligation" in plan["required_evidence_ids"]
+    assert "symbol_map" not in plan["required_evidence_ids"]
 
 
 def test_smoke_only_plan_requires_durable_value_evidence() -> None:

--- a/tests/test_pr_review_github_scan.py
+++ b/tests/test_pr_review_github_scan.py
@@ -126,6 +126,16 @@ def test_security_policy_keeps_public_entry_classification_after_move() -> None:
     )
 
 
+def test_agent_instruction_files_are_behavior_bearing_surfaces() -> None:
+    assert pr_review_module._file_area("skills/loopx-project/SKILL.md") == (
+        "agent_instruction_surface"
+    )
+    assert pr_review_module._file_area(".github/copilot.instructions.md") == (
+        "agent_instruction_surface"
+    )
+    assert pr_review_module._file_area("AGENTS.md") == "agent_instruction_surface"
+
+
 def _queue_pr(
     number: int,
     *,

--- a/tests/test_pr_review_github_scan.py
+++ b/tests/test_pr_review_github_scan.py
@@ -136,6 +136,32 @@ def test_agent_instruction_files_are_behavior_bearing_surfaces() -> None:
     assert pr_review_module._file_area("AGENTS.md") == "agent_instruction_surface"
 
 
+def test_agent_instruction_surface_gets_behavior_risk_and_review_depth() -> None:
+    files = [
+        {
+            "path": "skills/loopx-project/SKILL.md",
+            "area": "agent_instruction_surface",
+            "additions": 20,
+            "deletions": 2,
+        }
+    ]
+
+    hint = pr_review_module._metadata_risk_hint({}, files, {"total": 1})
+    analysis = pr_review_module._main_regression_analysis({}, files)
+
+    assert hint["level"] == "medium"
+    assert pr_review_module._review_depth(files) == "agent_behavior_review"
+    assert analysis["risk_level"] == "medium"
+    assert any(
+        "Automatically loaded agent instructions" in item
+        for item in analysis["potential_regressions"]
+    )
+    assert any(
+        "pre-change, disabled, and enabled instruction surfaces" in item
+        for item in analysis["verification_focus"]
+    )
+
+
 def _queue_pr(
     number: int,
     *,


### PR DESCRIPTION
## Summary

- classify installed and automatically loaded agent instructions as behavior-bearing PR surfaces
- strengthen `default_off_isolation` to separate capability availability from scoped activation
- require disabled user-experience parity for skill-, prompt-, and policy-only changes
- document the invariant in the capability-owned review contract and thin host skill

## Why

A review of PR #3922 verified the runtime's `default_enabled = false` path but initially missed that new instructions in the globally installed `loopx-project` skill had already changed ordinary-user behavior. The old review packet mentioned prompts generically, yet the scanner classified `SKILL.md` as ordinary documentation and did not require behavior-level evidence for a skill-only change.

This change makes that failure mode explicit and machine-visible without encoding PR-specific wording.

## Validation

- `pytest -q tests/capabilities/test_pr_review_contract.py tests/test_pr_review_github_scan.py` — 14 passed
- `python -m py_compile loopx/pr_review.py loopx/capabilities/pr_review_queue/review_contract.py`
- skill creator `quick_validate.py skills/loopx-pr-review` — valid
- `git diff --check`

## Boundaries

- no merge requested
- no runtime capability activation or provider behavior changed
- no local/private state, credentials, raw logs, or generated artifacts included
