### PR TITLE
feat(authority): project canonical todos into Markdown

### DIFF
--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -151,6 +151,22 @@ The projection command has four safety properties:
 - it parses the rendered sections back and requires deterministic parity and
   idempotent second rendering before an `--execute` write.
 
+The writer imports the legacy LoopX-generated H2/list/metadata layout. It stops
+at the first non-generated line, rather than extending replacement to the next
+H2 or EOF; following H1, Setext, indented headings and ordinary narrative remain
+outside its ownership. Code fences and multiline comments are not Todo headers.
+The projection then emits paired `loopx:todo-region-v0` begin/end markers under
+each Todo heading. The renderer, active Todo reader and section editor share
+that boundary contract. Future projections use those explicit bounds; orphan,
+nested, mismatched or missing markers, and non-generated content inside a marked
+region, fail closed. No ordinary Goal is rewritten or opted in by installation.
+Legacy unmarked readers and bootstrap output remain unchanged.
+
+Narrative byte preservation and canonical Todo parse/render parity are separate
+checks: the former compares untouched source slices, while the latter reads only
+the generated regions. Neither marker is provider authority or a current-head
+freshness guarantee.
+
 Each section includes a compact `loopx:todo-section-projection-v0` marker with
 the canonical provider revision and a SHA-256 digest of the complete canonical
 records for that role. The marker is lineage evidence, not a write API.

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -154,6 +154,11 @@ The projection command has four safety properties:
 Each section includes a compact `loopx:todo-section-projection-v0` marker with
 the canonical provider revision and a SHA-256 digest of the complete canonical
 records for that role. The marker is lineage evidence, not a write API.
+The command proves that the rendered records came from the exact provider head
+observed at read time. It does not claim that the revision remains the current
+head after that read; a later canonical mutation makes the Markdown projection
+stale and requires another explicit projection. Consumers must always read the
+provider, never the Markdown marker, when they need current authority state.
 
 Rollback is intentionally asymmetric. Before promotion, the existing shadow
 rollback quarantines the candidate provider lineage and Markdown remains

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -168,6 +168,15 @@ Todo sections, but must not promote stale Markdown back to canonical truth.
 
 ## Migration Path
 
+The explicit projector currently accepts only complete legacy v0 records for
+the two active Todo sections. Native `TodoDomainRecord` manifests and archived
+records remain fail-closed inputs; this command must not invent missing
+Markdown provenance or claim native/archive export qualification. A later
+adapter slice must prove native domain parity, legacy ordering preservation,
+and archive ownership before expanding that boundary. It is a manual
+read-time projection, not the transaction-bound projection outbox needed for
+automatic synchronization.
+
 1. Emit this projection from active-state Markdown.
 2. Add parity smokes comparing it with existing status todo summaries.
 3. Move Markdown parsing into a dedicated active-state read-model module behind

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -138,8 +138,28 @@ The cutover is deliberately section-sized, not document-sized:
 
 The first write using this boundary is Todo claim. It exercises a complete
 provider-neutral TypeScript transaction while leaving the default local path
-unchanged. Deterministic Markdown regeneration is a later migration step, not
-an implicit side effect of promotion.
+unchanged. After promotion, `loopx todo project-markdown` can explicitly
+regenerate the two active Todo sections from the exact provider revision. It
+never runs before promotion and never turns Markdown back into authority.
+
+The projection command has four safety properties:
+
+- it replaces only the active user and agent Todo section spans;
+- it preserves every segment outside those spans byte-for-byte;
+- it fails closed when a canonical field cannot be represented by the current
+  Markdown metadata grammar, rather than dropping that field;
+- it parses the rendered sections back and requires deterministic parity and
+  idempotent second rendering before an `--execute` write.
+
+Each section includes a compact `loopx:todo-section-projection-v0` marker with
+the canonical provider revision and a SHA-256 digest of the complete canonical
+records for that role. The marker is lineage evidence, not a write API.
+
+Rollback is intentionally asymmetric. Before promotion, the existing shadow
+rollback quarantines the candidate provider lineage and Markdown remains
+canonical. After promotion, a provider outage or revision mismatch fails
+closed; operators may restore a reviewed provider snapshot and regenerate the
+Todo sections, but must not promote stale Markdown back to canonical truth.
 
 ## Migration Path
 
@@ -149,7 +169,7 @@ an implicit side effect of promotion.
    the same projection fields.
 4. Promote one complete provider-backed mutation at a time behind the durable
    writer fence; keep the default Markdown mode unchanged.
-5. Regenerate only machine-owned sections from canonical state, preserving
-   human narrative and validating parse/render parity.
+5. Regenerate only machine-owned sections from one exact canonical provider
+   revision, preserving human narrative and validating parse/render parity.
 6. Promote a provider projection only after rollback and idempotency checks are
    in place.

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -105,8 +105,8 @@ def _atomic_write_text(path: Path, text: str) -> None:
     )
     temporary_path = Path(temporary)
     try:
-        os.fchmod(descriptor, original_mode)
         with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            os.chmod(temporary_path, original_mode)
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+import tempfile
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -81,6 +83,24 @@ from .post_writeback import (
     PostWritebackProjectionBuilder,
     dispatch_committed_cli_post_writeback_hooks,
 )
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Replace a projection without exposing a partially written state file."""
+
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
 
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
@@ -824,7 +844,7 @@ def handle_todo_command(
                     provider_revision=args.provider_revision,
                 )
                 if args.execute and projection.changed:
-                    state_path.write_text(projection.markdown, encoding="utf-8")
+                    _atomic_write_text(state_path, projection.markdown)
                     if state_path.read_text(encoding="utf-8") != projection.markdown:
                         raise RuntimeError("Todo Markdown projection readback mismatch")
             payload = {

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import stat
 import tempfile
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -86,18 +87,26 @@ from .post_writeback import (
 
 
 def _atomic_write_text(path: Path, text: str) -> None:
-    """Replace a projection without exposing a partially written state file."""
+    """Durably replace a projection without changing the state-file mode."""
 
+    original_mode = stat.S_IMODE(path.stat().st_mode)
     descriptor, temporary = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
     )
     temporary_path = Path(temporary)
     try:
+        os.fchmod(descriptor, original_mode)
         with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary_path, path)
+        if os.name == "posix":
+            directory_descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
     finally:
         temporary_path.unlink(missing_ok=True)
 

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -86,6 +86,16 @@ from .post_writeback import (
 )
 
 
+def _fsync_parent_directory(path: Path) -> None:
+    if os.name != "posix":  # pragma: no cover - Windows has no directory fsync
+        return
+    descriptor = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
 def _atomic_write_text(path: Path, text: str) -> None:
     """Durably replace a projection without changing the state-file mode."""
 
@@ -101,12 +111,7 @@ def _atomic_write_text(path: Path, text: str) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.replace(temporary_path, path)
-        if os.name == "posix":
-            directory_descriptor = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(directory_descriptor)
-            finally:
-                os.close(directory_descriptor)
+        _fsync_parent_directory(path)
     finally:
         temporary_path.unlink(missing_ok=True)
 

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -102,6 +102,13 @@ def _atomic_write_text(path: Path, text: str) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def _read_text_exact(path: Path) -> str:
+    """Decode UTF-8 while preserving every source newline sequence."""
+
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
 PrintPayload = Callable[
     [dict[str, object], str, Callable[[dict[str, object]], str]],
     None,
@@ -837,7 +844,7 @@ def handle_todo_command(
                 state_path,
                 operation="project_canonical_todo_sections",
             ):
-                source = state_path.read_text(encoding="utf-8")
+                source = _read_text_exact(state_path)
                 projection = render_canonical_todo_sections(
                     source,
                     authority_read["todos"],
@@ -845,7 +852,7 @@ def handle_todo_command(
                 )
                 if args.execute and projection.changed:
                     _atomic_write_text(state_path, projection.markdown)
-                    if state_path.read_text(encoding="utf-8") != projection.markdown:
+                    if _read_text_exact(state_path) != projection.markdown:
                         raise RuntimeError("Todo Markdown projection readback mismatch")
             payload = {
                 "ok": True,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -18,12 +18,19 @@ from ..control_plane.coordination.runtime_shadow import (
     load_task_lease_runtime_shadow_records,
     resolve_coordination_runtime_shadow_config,
 )
+from ..control_plane.coordination.local_authority import (
+    read_canonical_todos_if_promoted,
+)
 from ..control_plane.quota.settlement import (
     QuotaSettlementReadback,
     read_heartbeat_settlement,
     settlement_result_payload,
 )
 from ..control_plane.todos.markdown import render_todo_markdown
+from ..control_plane.todos.machine_section_projection import (
+    render_canonical_todo_sections,
+)
+from ..file_lock import exclusive_file_lock
 from ..history import load_index, load_registry
 from ..paths import resolve_runtime_root
 from ..registry import find_registry_goal, registry_goals
@@ -44,6 +51,7 @@ from ..todos import (
     complete_goal_todo,
     list_goal_todos,
     resolve_todo_state,
+    resolve_todo_state_path,
     supersede_goal_todo,
     update_goal_todo,
 )
@@ -58,6 +66,7 @@ from .todo_argument_validation import (
     validate_todo_claim_options,
     validate_todo_complete_options,
     validate_todo_list_options,
+    validate_todo_project_markdown_options,
     validate_todo_suggest_options,
     validate_todo_supersede_options,
     validate_todo_update_options,
@@ -306,6 +315,7 @@ def register_todo_command(
             "archive-completed",
             "suggest",
             "capture-followups",
+            "project-markdown",
         ],
         default=None,
         help=(
@@ -721,7 +731,18 @@ def register_todo_command(
     todo_parser.add_argument("--project", help="Project root. Defaults to the registry goal repo.")
     todo_parser.add_argument("--state-file", help="Active goal state path. Defaults to the registry goal state_file.")
     todo_parser.add_argument("--dry-run", action="store_true", help="Preview the active-state edit without writing.")
-    todo_parser.add_argument("--execute", action="store_true", help="For archive-completed, write the active-state edit.")
+    todo_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="For archive-completed or project-markdown, write the active-state edit.",
+    )
+    todo_parser.add_argument(
+        "--provider-revision",
+        help=(
+            "For project-markdown, exact canonical authority revision rendered "
+            "into the Todo section markers."
+        ),
+    )
 
 
 def _todo_path_args(args: argparse.Namespace) -> dict[str, Path | None]:
@@ -770,6 +791,61 @@ def handle_todo_command(
                 **_todo_path_args(args),
                 runtime_root_arg=runtime_root_arg,
             )
+        elif args.todo_command == "project-markdown":
+            validate_todo_project_markdown_options(args)
+            registry = load_registry(registry_path)
+            authority_read = read_canonical_todos_if_promoted(
+                runtime_root=resolve_runtime_root(registry, runtime_root_arg),
+                goal_id=args.goal_id,
+            )
+            if not isinstance(authority_read, dict):
+                raise ValueError(
+                    "todo project-markdown requires promoted canonical authority; "
+                    "legacy Markdown mode is unchanged"
+                )
+            if authority_read.get("provider_revision") != args.provider_revision:
+                raise ValueError(
+                    "todo project-markdown provider revision does not match the "
+                    "canonical read head"
+                )
+            _resolved_project, state_path = resolve_todo_state_path(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                **_todo_path_args(args),
+            )
+            with exclusive_file_lock(
+                state_path,
+                operation="project_canonical_todo_sections",
+            ):
+                source = state_path.read_text(encoding="utf-8")
+                projection = render_canonical_todo_sections(
+                    source,
+                    authority_read["todos"],
+                    provider_revision=args.provider_revision,
+                )
+                if args.execute and projection.changed:
+                    state_path.write_text(projection.markdown, encoding="utf-8")
+                    if state_path.read_text(encoding="utf-8") != projection.markdown:
+                        raise RuntimeError("Todo Markdown projection readback mismatch")
+            payload = {
+                "ok": True,
+                "dry_run": not bool(args.execute),
+                "command": "project-markdown",
+                "goal_id": args.goal_id,
+                "state_file": str(state_path),
+                "source_authority": authority_read.get("source_authority"),
+                "provider_revision": projection.provider_revision,
+                "todo_count": projection.todo_count,
+                "changed": projection.changed,
+                "executed": bool(args.execute),
+                "source_sha256": projection.source_sha256,
+                "rendered_sha256": projection.rendered_sha256,
+                "narrative_sha256": projection.narrative_sha256,
+                "section_record_sha256": projection.section_record_sha256,
+                "parse_render_parity": True,
+                "narrative_preserved": True,
+                "legacy_fallback_used": False,
+            }
         elif args.todo_command == "add":
             validate_todo_add_options(args)
             replan_obligation_id = _validated_replan_successor_obligation(

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -77,6 +77,7 @@ TODO_OPTION_FIELDS = (
     ("--trigger", "suggestion_trigger"),
     ("--state-file", "state_file"),
     ("--execute", "execute"),
+    ("--provider-revision", "provider_revision"),
 )
 
 _TODO_UPDATE_MUTABLE_FIELDS = (
@@ -294,6 +295,18 @@ def validate_todo_list_options(args: argparse.Namespace) -> None:
         "--agent-id, --limit, --thin, --project, --state-file, --dry-run, and "
         "--format; "
         "unsupported: ",
+    )
+
+
+def validate_todo_project_markdown_options(args: argparse.Namespace) -> None:
+    if not getattr(args, "provider_revision", None):
+        raise ValueError("todo project-markdown requires --provider-revision")
+    _validate_todo_option_subset(
+        args,
+        {"state_file", "execute", "provider_revision"},
+        "todo project-markdown only accepts --goal-id, --provider-revision, "
+        "--project, --state-file, --execute, and "
+        "--format; unsupported: ",
     )
 
 

--- a/loopx/control_plane/todos/active_state_editing.py
+++ b/loopx/control_plane/todos/active_state_editing.py
@@ -17,6 +17,7 @@ from .contract import (
 )
 from .text import normalize_new_todo
 from .todo_summary import normalize_todo_text
+from .machine_region import TODO_REGION_PREFIX, find_todo_regions
 
 
 TODO_SECTION_HEADINGS = {
@@ -27,6 +28,9 @@ COMPLETED_WORK_ARCHIVE_HEADING = "Completed Work Archive"
 
 
 def section_bounds(lines: list[str], role: str) -> tuple[int, int, str] | None:
+    if any(TODO_REGION_PREFIX in line for line in lines):
+        region = next((r for r in find_todo_regions(lines) if r.role == role), None)
+        return (region.start, region.body_end, region.heading) if region else None
     for index, line in enumerate(lines):
         if not line.startswith("## "):
             continue

--- a/loopx/control_plane/todos/active_state_todo_parser.py
+++ b/loopx/control_plane/todos/active_state_todo_parser.py
@@ -59,7 +59,6 @@ def parse_active_state_todos(
         if index in region_ends:
             role = None
             current_todo = None
-            continue
         if line.startswith("## "):
             heading = line.lstrip("#").strip()
             normalized_heading = heading.strip().lower()

--- a/loopx/control_plane/todos/active_state_todo_parser.py
+++ b/loopx/control_plane/todos/active_state_todo_parser.py
@@ -17,6 +17,7 @@ from .contract import (
     todo_status_from_marker,
 )
 from .decision_scope import build_standing_decision_authority
+from .machine_region import TODO_REGION_PREFIX, find_todo_regions
 from .todo_summary import (
     MAX_STATUS_TODOS_PER_ROLE,
     compact_todo_group,
@@ -50,7 +51,15 @@ def parse_active_state_todos(
     archive_source_section: str | None = None
     current_todo: dict[str, Any] | None = None
 
-    for line in state_text.splitlines():
+    lines = state_text.splitlines()
+    regions = find_todo_regions(lines) if TODO_REGION_PREFIX in state_text else None
+    region_starts = {r.start for r in regions} if regions is not None else None
+    region_ends = {r.body_end for r in regions} if regions is not None else set()
+    for index, line in enumerate(lines):
+        if index in region_ends:
+            role = None
+            current_todo = None
+            continue
         if line.startswith("## "):
             heading = line.lstrip("#").strip()
             normalized_heading = heading.strip().lower()
@@ -59,6 +68,8 @@ def parse_active_state_todos(
             )
             archive_source_section = heading if archive_mode else None
             role = todo_role_for_heading(heading)
+            if role and region_starts is not None and index not in region_starts:
+                role = None
             current_todo = None
             if role and source_sections[role] is None:
                 source_sections[role] = heading

--- a/loopx/control_plane/todos/machine_region.py
+++ b/loopx/control_plane/todos/machine_region.py
@@ -1,0 +1,116 @@
+"""Versioned ownership of generated Todo regions, not a general Markdown parser.
+
+Legacy import accepts the actual LoopX-produced H2/list/metadata grammar.
+New projections have paired markers, shared by the writer and readers.
+Text outside that grammar is never silently adopted as machine-owned content.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from .contract import TODO_TASK_PATTERN, parse_todo_metadata_line
+
+
+TODO_REGION_PREFIX = "<!-- loopx:todo-region-v0 "
+_FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
+_ROLE_HEADINGS = {
+    "user todo": "user",
+    "user todo / owner review reading queue": "user",
+    "owner review reading queue": "user",
+    "owner reading queue": "user",
+    "agent todo": "agent",
+    "codex todo": "agent",
+    "project agent todo": "agent",
+}
+
+
+@dataclass(frozen=True)
+class TodoRegion:
+    role: str
+    start: int
+    end: int
+    body_end: int
+    heading: str
+    marked: bool
+
+
+def todo_region_marker(role: str, edge: str) -> str:
+    if role not in {"user", "agent"} or edge not in {"begin", "end"}:
+        raise ValueError("invalid Todo region marker")
+    return f"{TODO_REGION_PREFIX}role={role} {edge} -->"
+
+
+def find_todo_regions(lines: list[str]) -> list[TodoRegion]:
+    """Locate generated regions without consuming narrative or code examples.
+
+    Offsets are half-open line indexes. A marked region includes its heading
+    and both delimiters; body_end excludes the end marker for legacy editors.
+    The legacy import stops at the first non-generated line, not the next H2.
+    """
+    regions: list[TodoRegion] = []
+    fence: str | None = None
+    in_comment = False
+    index = 0
+    if lines and lines[0].strip() == "---":
+        end = next((i for i in range(1, len(lines)) if lines[i].strip() in {"---", "..."}), None)
+        if end is None:
+            raise ValueError("unterminated Goal frontmatter")
+        index = end + 1
+    while index < len(lines):
+        line = lines[index].rstrip("\r\n")
+        if fence is not None:
+            if re.fullmatch(r" {0,3}" + re.escape(fence[0]) + "{" + str(len(fence)) + r",}[ \t]*", line):
+                fence = None
+            index += 1
+            continue
+        if in_comment:
+            in_comment = "-->" not in line
+            index += 1
+            continue
+        opening = _FENCE.fullmatch(line)
+        if opening:
+            fence = opening.group(1)
+            index += 1
+            continue
+        if line.lstrip().startswith("<!--") and "-->" not in line:
+            in_comment = True
+            index += 1
+            continue
+        if TODO_REGION_PREFIX in line:
+            raise ValueError("orphan or malformed Todo region marker")
+        heading = line[3:].strip() if line.startswith("## ") else ""
+        role = _ROLE_HEADINGS.get(heading.lower())
+        if role is None:
+            index += 1
+            continue
+        start = index
+        index += 1
+        marked = index < len(lines) and lines[index].rstrip("\r\n") == todo_region_marker(role, "begin")
+        if marked:
+            index += 1
+        while index < len(lines):
+            content = lines[index].rstrip("\r\n")
+            if content == todo_region_marker(role, "end") and marked:
+                break
+            if TODO_REGION_PREFIX in content:
+                raise ValueError("nested, mismatched, or malformed Todo region marker")
+            generated = (
+                not content.strip()
+                or TODO_TASK_PATTERN.match(content) is not None
+                or parse_todo_metadata_line(content) is not None
+                or content.startswith("<!-- loopx:todo-section-projection-v0 ")
+            )
+            if not generated:
+                if marked:
+                    raise ValueError("non-generated content inside marked Todo region")
+                break
+            index += 1
+        if marked and index == len(lines):
+            raise ValueError("unterminated Todo region")
+        body_end = index
+        if marked:
+            index += 1
+        regions.append(TodoRegion(role, start, index, body_end, heading, marked))
+    return regions

--- a/loopx/control_plane/todos/machine_section_projection.py
+++ b/loopx/control_plane/todos/machine_section_projection.py
@@ -1,0 +1,320 @@
+"""Deterministic active-Todo Markdown projection.
+
+The user/agent Todo sections are machine-owned after authority promotion.
+Everything outside those sections remains opaque human-authored Markdown and
+is preserved byte-for-byte. Canonical provider records remain the truth; the
+readable Markdown syntax is regenerated and then parsed back for parity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ..coordination.coordination_state_contract import (
+    TODO_CANONICAL_READ_RECORD_FIELDS,
+    TODO_CANONICAL_REQUIRED_READ_FIELDS,
+    canonical_record_fields,
+)
+from ..goals.active_state_metadata import todo_role_for_heading
+from .active_state_editing import TODO_SECTION_HEADINGS
+from .active_state_todo_parser import parse_active_state_todos
+from .contract import (
+    TODO_METADATA_FIELDS,
+    TODO_STATUS_OPEN,
+    format_todo_metadata_line,
+    normalize_todo_status,
+    todo_marker_for_status,
+)
+from .todo_summary import canonical_todo_read_record
+
+
+TODO_SECTION_PROJECTION_SCHEMA_VERSION = "loopx_todo_section_projection_v0"
+_HEADING_PATTERN = re.compile(r"(?m)^##\s+(.+?)\s*(?:\r?\n|$)")
+_MARKER_PATTERN = re.compile(
+    r"(?m)^<!-- loopx:todo-section-projection-v0 "
+    r"role=(?P<role>user|agent) "
+    r"provider_revision=(?P<revision>[A-Za-z0-9_.:-]+) "
+    r"records_sha256=(?P<digest>[a-f0-9]{64}) -->$"
+)
+
+
+class TodoSectionProjectionError(ValueError):
+    """Canonical records or Markdown violate the projection contract."""
+
+
+@dataclass(frozen=True)
+class TodoSectionProjectionResult:
+    markdown: str
+    changed: bool
+    source_sha256: str
+    rendered_sha256: str
+    narrative_sha256: str
+    provider_revision: str
+    todo_count: int
+    section_record_sha256: dict[str, str]
+
+
+@dataclass(frozen=True)
+class _SectionSpan:
+    role: str
+    start: int
+    end: int
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _canonical_records(records: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    canonical: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for index, value in enumerate(records):
+        record = canonical_record_fields(
+            value,
+            fields=TODO_CANONICAL_READ_RECORD_FIELDS,
+            required_fields=TODO_CANONICAL_REQUIRED_READ_FIELDS,
+            label=f"canonical Todo projection record {index}",
+            reject_unknown=True,
+        )
+        todo_id = str(record.get("todo_id") or "")
+        if todo_id in seen:
+            raise TodoSectionProjectionError(f"duplicate canonical Todo id: {todo_id}")
+        seen.add(todo_id)
+        if record.get("role") not in TODO_SECTION_HEADINGS:
+            raise TodoSectionProjectionError(f"Todo {todo_id!r} has invalid role")
+        if record.get("archive_state") != "active":
+            raise TodoSectionProjectionError(
+                f"Todo {todo_id!r} is not part of an active Markdown Todo section"
+            )
+        canonical_todo_read_record(record, reject_unknown=True)
+        canonical.append(record)
+    return canonical
+
+
+def _record_sort_key(record: Mapping[str, object]) -> tuple[int, str]:
+    raw_index = record.get("index")
+    try:
+        index = int(raw_index) if isinstance(raw_index, (str, int)) else 2**31 - 1
+    except (TypeError, ValueError):
+        index = 2**31 - 1
+    return index, str(record.get("todo_id") or "")
+
+
+def _section_spans(markdown: str) -> dict[str, _SectionSpan]:
+    headings = list(_HEADING_PATTERN.finditer(markdown))
+    spans: dict[str, _SectionSpan] = {}
+    for index, heading in enumerate(headings):
+        role = todo_role_for_heading(heading.group(1))
+        if role is None:
+            continue
+        if role in spans:
+            raise TodoSectionProjectionError(
+                f"active Markdown contains multiple {role} Todo sections"
+            )
+        end = headings[index + 1].start() if index + 1 < len(headings) else len(markdown)
+        spans[role] = _SectionSpan(role=role, start=heading.start(), end=end)
+    return spans
+
+
+def _narrative_segments(markdown: str) -> list[str]:
+    spans = sorted(_section_spans(markdown).values(), key=lambda span: span.start)
+    cursor = 0
+    parts: list[str] = []
+    for span in spans:
+        parts.append(markdown[cursor : span.start])
+        cursor = span.end
+    parts.append(markdown[cursor:])
+    return parts
+
+
+def _render_record(record: Mapping[str, object]) -> list[str]:
+    status = normalize_todo_status(record.get("status")) or TODO_STATUS_OPEN
+    text = " ".join(str(record.get("text") or "").strip().split())
+    if not text:
+        raise TodoSectionProjectionError(
+            f"Todo {record.get('todo_id')!r} has empty projection text"
+        )
+    metadata_values = {
+        field: record[field]
+        for field in TODO_METADATA_FIELDS
+        if field in record and record[field] is not None
+    }
+    metadata = format_todo_metadata_line(**metadata_values)
+    return [
+        f"- [{todo_marker_for_status(status)}] {text}",
+        *([metadata] if metadata else []),
+    ]
+
+
+def _render_section(
+    *,
+    role: str,
+    records: list[dict[str, object]],
+    provider_revision: str,
+    newline: str,
+) -> tuple[str, str]:
+    digest = _sha256_text(_canonical_json(records))
+    lines = [
+        f"## {TODO_SECTION_HEADINGS[role]}",
+        f"<!-- loopx:todo-section-projection-v0 role={role} "
+        f"provider_revision={provider_revision} records_sha256={digest} -->",
+        "",
+    ]
+    for record in records:
+        lines.extend(_render_record(record))
+    lines.append("")
+    return newline.join(lines), digest
+
+
+def _replace_existing_sections(
+    markdown: str,
+    *,
+    rendered_sections: Mapping[str, str],
+) -> str:
+    result = markdown
+    for span in sorted(
+        _section_spans(markdown).values(), key=lambda value: value.start, reverse=True
+    ):
+        result = result[: span.start] + rendered_sections[span.role] + result[span.end :]
+    return result
+
+
+def _parsed_active_records(markdown: str) -> list[dict[str, Any]]:
+    fields = parse_active_state_todos(markdown, item_limit=None)
+    records: list[dict[str, Any]] = []
+    for role in TODO_SECTION_HEADINGS:
+        summary = fields.get(f"{role}_todos")
+        items = summary.get("items") if isinstance(summary, dict) else []
+        for item in items or []:
+            if isinstance(item, dict) and item.get("archive_state") == "active":
+                records.append(canonical_todo_read_record(item, reject_unknown=False))
+    return records
+
+
+_DERIVED_READ_MODEL_FIELDS = {
+    "created_by",
+    "last_actor_agent_id",
+    "resume_condition",
+    "resume_ready",
+    "completion_validation_required",
+    "handoff_note",
+}
+
+
+def _parity_records(records: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    return [
+        {
+            field: record[field]
+            for field in TODO_CANONICAL_READ_RECORD_FIELDS
+            if field in record and field not in _DERIVED_READ_MODEL_FIELDS
+        }
+        for record in records
+    ]
+
+
+def render_canonical_todo_sections(
+    markdown: str,
+    records: Sequence[Mapping[str, object]],
+    *,
+    provider_revision: str,
+) -> TodoSectionProjectionResult:
+    """Replace only Todo sections and verify deterministic parse/render parity."""
+
+    if not re.fullmatch(r"[A-Za-z0-9_.:-]+", provider_revision):
+        raise TodoSectionProjectionError("provider_revision must be a public-safe token")
+    canonical = _canonical_records(records)
+    source_spans = _section_spans(markdown)
+    missing_roles = sorted(set(TODO_SECTION_HEADINGS).difference(source_spans))
+    if missing_roles:
+        raise TodoSectionProjectionError(
+            "active Markdown omits required Todo sections: " + ", ".join(missing_roles)
+        )
+    lossy_fields = sorted(
+        {
+            field
+            for record in canonical
+            for field in _DERIVED_READ_MODEL_FIELDS
+            if field in record and record[field] not in (None, False, "", [], {})
+        }
+    )
+    if lossy_fields:
+        raise TodoSectionProjectionError(
+            "canonical Todo fields are not representable in Markdown: "
+            + ", ".join(lossy_fields)
+        )
+    by_role = {
+        role: sorted(
+            [record for record in canonical if record.get("role") == role],
+            key=_record_sort_key,
+        )
+        for role in TODO_SECTION_HEADINGS
+    }
+    newline = "\r\n" if "\r\n" in markdown else "\n"
+    rendered_sections: dict[str, str] = {}
+    section_digests: dict[str, str] = {}
+    for role in TODO_SECTION_HEADINGS:
+        rendered_sections[role], section_digests[role] = _render_section(
+            role=role,
+            records=by_role[role],
+            provider_revision=provider_revision,
+            newline=newline,
+        )
+
+    rendered = _replace_existing_sections(
+        markdown,
+        rendered_sections=rendered_sections,
+    )
+    before_narrative = _narrative_segments(markdown)
+    after_narrative = _narrative_segments(rendered)
+    if before_narrative != after_narrative:
+        raise TodoSectionProjectionError("render changed Markdown outside Todo sections")
+
+    expected = _parity_records(
+        [*by_role["user"], *by_role["agent"]]
+    )
+    actual = _parity_records(_parsed_active_records(rendered))
+    if _canonical_json(actual) != _canonical_json(expected):
+        raise TodoSectionProjectionError("Todo section parse/render parity mismatch")
+    second = _replace_existing_sections(rendered, rendered_sections=rendered_sections)
+    if second != rendered:
+        raise TodoSectionProjectionError("Todo section projection is not idempotent")
+
+    return TodoSectionProjectionResult(
+        markdown=rendered,
+        changed=rendered != markdown,
+        source_sha256=_sha256_text(markdown),
+        rendered_sha256=_sha256_text(rendered),
+        narrative_sha256=_sha256_text(_canonical_json(after_narrative)),
+        provider_revision=provider_revision,
+        todo_count=len(canonical),
+        section_record_sha256=section_digests,
+    )
+
+
+def inspect_todo_section_projection(markdown: str) -> dict[str, object]:
+    """Return compact marker diagnostics without treating Markdown as truth."""
+
+    markers = [match.groupdict() for match in _MARKER_PATTERN.finditer(markdown)]
+    return {
+        "schema_version": TODO_SECTION_PROJECTION_SCHEMA_VERSION,
+        "section_count": len(markers),
+        "sections": markers,
+    }
+
+
+__all__ = [
+    "TODO_SECTION_PROJECTION_SCHEMA_VERSION",
+    "TodoSectionProjectionError",
+    "TodoSectionProjectionResult",
+    "inspect_todo_section_projection",
+    "render_canonical_todo_sections",
+]

--- a/loopx/control_plane/todos/machine_section_projection.py
+++ b/loopx/control_plane/todos/machine_section_projection.py
@@ -20,8 +20,8 @@ from ..coordination.coordination_state_contract import (
     TODO_CANONICAL_REQUIRED_READ_FIELDS,
     canonical_record_fields,
 )
-from ..goals.active_state_metadata import todo_role_for_heading
 from .active_state_editing import TODO_SECTION_HEADINGS
+from .machine_region import find_todo_regions, todo_region_marker
 from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
     TODO_METADATA_FIELDS,
@@ -34,12 +34,11 @@ from .todo_summary import canonical_todo_read_record
 
 
 TODO_SECTION_PROJECTION_SCHEMA_VERSION = "loopx_todo_section_projection_v0"
-_HEADING_PATTERN = re.compile(r"(?m)^##\s+(.+?)\s*(?:\r?\n|$)")
 _MARKER_PATTERN = re.compile(
     r"(?m)^<!-- loopx:todo-section-projection-v0 "
     r"role=(?P<role>user|agent) "
     r"provider_revision=(?P<revision>[A-Za-z0-9_.:-]+) "
-    r"records_sha256=(?P<digest>[a-f0-9]{64}) -->$"
+    r"records_sha256=(?P<digest>[a-f0-9]{64}) -->\r?$"
 )
 
 
@@ -110,18 +109,17 @@ def _record_sort_key(record: Mapping[str, object]) -> tuple[int, str]:
 
 
 def _section_spans(markdown: str) -> dict[str, _SectionSpan]:
-    headings = list(_HEADING_PATTERN.finditer(markdown))
+    lines = markdown.splitlines(keepends=True)
+    offsets = [0]
+    for line in lines:
+        offsets.append(offsets[-1] + len(line))
     spans: dict[str, _SectionSpan] = {}
-    for index, heading in enumerate(headings):
-        role = todo_role_for_heading(heading.group(1))
-        if role is None:
-            continue
-        if role in spans:
+    for region in find_todo_regions(lines):
+        if region.role in spans:
             raise TodoSectionProjectionError(
-                f"active Markdown contains multiple {role} Todo sections"
+                f"active Markdown contains multiple {region.role} Todo sections"
             )
-        end = headings[index + 1].start() if index + 1 < len(headings) else len(markdown)
-        spans[role] = _SectionSpan(role=role, start=heading.start(), end=end)
+        spans[region.role] = _SectionSpan(region.role, offsets[region.start], offsets[region.end])
     return spans
 
 
@@ -165,12 +163,14 @@ def _render_section(
     digest = _sha256_text(_canonical_json(records))
     lines = [
         f"## {TODO_SECTION_HEADINGS[role]}",
+        todo_region_marker(role, "begin"),
         f"<!-- loopx:todo-section-projection-v0 role={role} "
         f"provider_revision={provider_revision} records_sha256={digest} -->",
         "",
     ]
     for record in records:
         lines.extend(_render_record(record))
+    lines.append(todo_region_marker(role, "end"))
     lines.append("")
     return newline.join(lines), digest
 
@@ -281,7 +281,8 @@ def render_canonical_todo_sections(
     expected = _parity_records(
         [*by_role["user"], *by_role["agent"]]
     )
-    actual = _parity_records(_parsed_active_records(rendered))
+    # Validate the generated payload, independently of unrelated document text.
+    actual = _parity_records(_parsed_active_records("\n".join(rendered_sections.values())))
     if _canonical_json(actual) != _canonical_json(expected):
         raise TodoSectionProjectionError("Todo section parse/render parity mismatch")
     second = _replace_existing_sections(rendered, rendered_sections=rendered_sections)

--- a/loopx/control_plane/todos/markdown.py
+++ b/loopx/control_plane/todos/markdown.py
@@ -6,6 +6,24 @@ from .contract import TODO_STATUS_OPEN, todo_marker_for_status
 
 
 def render_todo_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("command") == "project-markdown":
+        return "\n".join(
+            [
+                "# LoopX Todo Markdown Projection",
+                "",
+                f"- ok: `{payload.get('ok')}`",
+                f"- goal_id: `{payload.get('goal_id')}`",
+                f"- dry_run: `{payload.get('dry_run')}`",
+                f"- executed: `{payload.get('executed')}`",
+                f"- changed: `{payload.get('changed')}`",
+                f"- source_authority: `{payload.get('source_authority')}`",
+                f"- provider_revision: `{payload.get('provider_revision')}`",
+                f"- todo_count: `{payload.get('todo_count')}`",
+                f"- parse_render_parity: `{payload.get('parse_render_parity')}`",
+                f"- narrative_preserved: `{payload.get('narrative_preserved')}`",
+                f"- error: `{payload.get('error')}`" if payload.get("error") else "",
+            ]
+        ).rstrip()
     if payload.get("command") == "list":
         if payload.get("thin"):
             field_projection = payload.get("todo_list_field_projection")

--- a/tests/control_plane/test_todo_machine_region.py
+++ b/tests/control_plane/test_todo_machine_region.py
@@ -83,3 +83,14 @@ def test_section_editor_and_reader_share_generated_bounds() -> None:
     assert [item["text"] for item in parsed["agent_todos"]["items"]] == ["A generated Todo."]
     assert lines[end + 1:] == tail.splitlines()
     assert len(find_todo_regions(lines)) == 2
+
+
+def test_mixed_legacy_boundary_does_not_skip_next_heading() -> None:
+    source = "\n".join([
+        "## User Todo", "- [ ] User task.", "## Agent Todo",
+        todo_region_marker("agent", "begin"), "- [ ] Agent task.",
+        todo_region_marker("agent", "end"),
+    ])
+    parsed = parse_active_state_todos(source, item_limit=None)
+    assert [item["text"] for item in parsed["user_todos"]["items"]] == ["User task."]
+    assert [item["text"] for item in parsed["agent_todos"]["items"]] == ["Agent task."]

--- a/tests/control_plane/test_todo_machine_region.py
+++ b/tests/control_plane/test_todo_machine_region.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.control_plane.todos.active_state_editing import (
+    insert_into_existing_section,
+    section_bounds,
+    todo_blocks,
+)
+from loopx.control_plane.todos.active_state_todo_parser import parse_active_state_todos
+from loopx.control_plane.todos.machine_region import find_todo_regions, todo_region_marker
+from loopx.control_plane.todos.machine_section_projection import render_canonical_todo_sections
+
+
+def _source() -> str:
+    return "## User Todo / Owner Review Reading Queue\n\n## Agent Todo\n\n"
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+@pytest.mark.parametrize("tail", [
+    "# Next Action\n\n- [ ] Narrative checkbox, not a Todo.\n",
+    "Next Action\n===========\n\n- [ ] Narrative checkbox, not a Todo.\n",
+    "  ## Next Action\n\n- [ ] Narrative checkbox, not a Todo.\n",
+    "This paragraph is not generated Todo data.\n\n- [ ] Narrative checkbox.\n",
+])
+def test_legacy_adoption_preserves_non_generated_suffix(tail: str, newline: str) -> None:
+    source = (_source() + tail).replace("\n", newline)
+    projected = render_canonical_todo_sections(source, [], provider_revision="rev-1")
+    suffix = tail.replace("\n", newline)
+    assert projected.markdown.endswith(suffix)
+    assert todo_region_marker("agent", "end") in projected.markdown
+    parsed = parse_active_state_todos(projected.markdown, item_limit=None)
+    assert parsed["agent_todos"]["items"] == []
+    assert render_canonical_todo_sections(
+        projected.markdown, [], provider_revision="rev-1"
+    ).markdown == projected.markdown
+
+
+@pytest.mark.parametrize("example", [
+    "```markdown\n## Agent Todo\n- [ ] Example only.\n```\n",
+    "~~~~markdown\n## Agent Todo\n- [ ] Example only.\n~~~~\n",
+    "<!-- example\n## Agent Todo\n- [ ] Example only.\n-->\n",
+])
+def test_code_and_comment_examples_are_not_adopted(example: str) -> None:
+    source = example + "\n" + _source()
+    projected = render_canonical_todo_sections(source, [], provider_revision="rev-1")
+    assert projected.markdown.startswith(example + "\n")
+    parsed = parse_active_state_todos(projected.markdown, item_limit=None)
+    assert parsed["agent_todos"]["items"] == []
+
+
+def test_unclosed_code_example_cannot_supply_todo_regions() -> None:
+    with pytest.raises(ValueError, match="required Todo sections"):
+        render_canonical_todo_sections("```markdown\n" + _source(), [], provider_revision="rev-1")
+
+
+@pytest.mark.parametrize("replacement", [
+    "",
+    "<!-- loopx:todo-region-v0 role=user end -->",
+    "<!-- loopx:todo-region-v0 role=agent begin -->",
+    "<!-- loopx:todo-region-v0 role=agent finish -->",
+    "Human narrative unexpectedly placed inside.\n<!-- loopx:todo-region-v0 role=agent end -->",
+])
+def test_malformed_region_is_never_reinterpreted_as_legacy(replacement: str) -> None:
+    projected = render_canonical_todo_sections(_source(), [], provider_revision="rev-1")
+    malformed = projected.markdown.replace(todo_region_marker("agent", "end"), replacement)
+    with pytest.raises(ValueError, match="Todo region"):
+        render_canonical_todo_sections(malformed, [], provider_revision="rev-1")
+
+
+def test_section_editor_and_reader_share_generated_bounds() -> None:
+    projected = render_canonical_todo_sections(_source(), [], provider_revision="rev-1")
+    tail = "Narrative outside the paired marker.\n- [ ] Not an active Todo.\n"
+    lines = (projected.markdown + tail).splitlines()
+    start, end, heading = section_bounds(lines, "agent")
+    assert heading == "Agent Todo"
+    assert lines[end] == todo_region_marker("agent", "end")
+    insert_into_existing_section(lines, start, end, "- [ ] A generated Todo.")
+    start, end, heading = section_bounds(lines, "agent")
+    blocks = todo_blocks(lines, start, end, role="agent", source_section=heading)
+    assert [block["text"] for block in blocks] == ["A generated Todo."]
+    parsed = parse_active_state_todos("\n".join(lines), item_limit=None)
+    assert [item["text"] for item in parsed["agent_todos"]["items"]] == ["A generated Todo."]
+    assert lines[end + 1:] == tail.splitlines()
+    assert len(find_todo_regions(lines)) == 2

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -300,6 +300,7 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
     state_path.write_text(SOURCE, encoding="utf-8")
     state_path.chmod(0o640)
+    original_mode = stat.S_IMODE(state_path.stat().st_mode)
     parent_syncs: list[object] = []
     monkeypatch.setattr(
         todo_command,
@@ -358,8 +359,32 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     assert target == state_path
     assert temporary != target
     assert "todo_agent" in state_path.read_text(encoding="utf-8")
-    assert stat.S_IMODE(state_path.stat().st_mode) == 0o640
+    assert stat.S_IMODE(state_path.stat().st_mode) == original_mode
     assert parent_syncs == [state_path]
+
+
+@pytest.mark.parametrize("operation", ["chmod", "fsync", "replace"])
+def test_atomic_projection_failure_preserves_original(monkeypatch, tmp_path, operation):
+    state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_path.write_bytes(b"original\r\n")
+    opened = []
+    real_fdopen = todo_command.os.fdopen
+
+    def capture_handle(*args, **kwargs):
+        handle = real_fdopen(*args, **kwargs)
+        opened.append(handle)
+        return handle
+
+    def fail(*_args, **_kwargs):
+        raise OSError("injected pre-publication failure")
+
+    monkeypatch.setattr(todo_command.os, "fdopen", capture_handle)
+    monkeypatch.setattr(todo_command.os, operation, fail)
+    with pytest.raises(OSError, match="injected pre-publication failure"):
+        todo_command._atomic_write_text(state_path, "replacement\n")
+    assert state_path.read_bytes() == b"original\r\n"
+    assert opened and all(handle.closed for handle in opened)
+    assert list(tmp_path.iterdir()) == [state_path]
 
 
 @pytest.mark.parametrize(

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -280,6 +280,12 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
     state_path.write_text(SOURCE, encoding="utf-8")
     state_path.chmod(0o640)
+    parent_syncs: list[object] = []
+    monkeypatch.setattr(
+        todo_command,
+        "_fsync_parent_directory",
+        lambda path: parent_syncs.append(path),
+    )
     monkeypatch.setattr(
         todo_command,
         "load_registry",
@@ -333,6 +339,7 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     assert temporary != target
     assert "todo_agent" in state_path.read_text(encoding="utf-8")
     assert stat.S_IMODE(state_path.stat().st_mode) == 0o640
+    assert parent_syncs == [state_path]
 
 
 def test_project_markdown_cli_preserves_crlf_narrative_bytes(

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -122,6 +122,17 @@ def test_projection_rejects_missing_role_section() -> None:
         )
 
 
+def test_projection_does_not_invent_native_markdown_provenance() -> None:
+    records = _records()
+    for record in records:
+        record["schema_version"] = "todo_domain_record_v0"
+        del record["source_section"]
+        del record["index"]
+    with pytest.raises(ValueError, match="omits required fields: source_section"):
+        render_canonical_todo_sections(SOURCE, records, provider_revision="rev-native")
+    assert all("source_section" not in record and "index" not in record for record in records)
+
+
 def test_projection_rejects_unknown_or_derived_field_loss() -> None:
     unknown = deepcopy(_records())
     unknown[0]["future_field"] = "must-not-disappear"

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -330,3 +330,57 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     assert target == state_path
     assert temporary != target
     assert "todo_agent" in state_path.read_text(encoding="utf-8")
+
+
+def test_project_markdown_cli_preserves_crlf_narrative_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
+    source_bytes = SOURCE.replace("\n", "\r\n").encode("utf-8")
+    state_path.write_bytes(source_bytes)
+    monkeypatch.setattr(
+        todo_command,
+        "load_registry",
+        lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "read_canonical_todos_if_promoted",
+        lambda **_kwargs: {
+            "todos": _records(),
+            "source_authority": "file_v0",
+            "provider_revision": "rev-1",
+        },
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "resolve_todo_state_path",
+        lambda **_kwargs: (tmp_path, state_path),
+    )
+
+    result = todo_command.handle_todo_command(
+        build_parser().parse_args(
+            [
+                "todo",
+                "project-markdown",
+                "--goal-id",
+                "goal-a",
+                "--provider-revision",
+                "rev-1",
+                "--execute",
+            ]
+        ),
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        print_payload=lambda *_args: None,
+        append_cli_rollout_event=lambda *_args, **_kwargs: None,
+    )
+
+    assert result == 0
+    projected = state_path.read_bytes()
+    assert b"\r\n" in projected
+    assert b"Human rationale stays here.\r\n" in projected
+    assert b"Do not rewrite this paragraph.\r\n" in projected
+    assert b"Continue the approved migration.\r\n" in projected
+    assert b"\n" not in projected.replace(b"\r\n", b"")

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 import stat
+import hashlib
+import json
+import subprocess
+import sys
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
@@ -12,6 +17,9 @@ from loopx.control_plane.todos.machine_section_projection import (
 )
 from loopx.cli import build_parser
 from loopx.cli_commands import todo as todo_command
+from loopx.control_plane.coordination.local_authority import read_canonical_todos_if_promoted
+from loopx.control_plane.coordination.runtime_shadow import build_todo_runtime_shadow_projection
+from loopx.control_plane.effect_runtime import effect_runtime_result
 
 
 SOURCE = """---
@@ -84,9 +92,10 @@ def _records() -> list[dict[str, object]]:
     ]
 
 
-def test_projection_replaces_only_machine_sections_and_is_idempotent() -> None:
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_projection_replaces_only_machine_sections_and_is_idempotent(newline: str) -> None:
     projected = render_canonical_todo_sections(
-        SOURCE,
+        SOURCE.replace("\n", newline),
         _records(),
         provider_revision="sha256:abc123",
     )
@@ -353,12 +362,20 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     assert parent_syncs == [state_path]
 
 
-def test_project_markdown_cli_preserves_crlf_narrative_bytes(
+@pytest.mark.parametrize(
+    "heading",
+    ["## Next Action", "# Next Action", "Next Action\n===========",
+     "Next Action\n-----------", "   # Next Action", "  ## Next Action"],
+)
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_project_markdown_cli_preserves_narrative_boundaries(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
+    heading: str,
+    newline: str,
 ) -> None:
     state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
-    source_bytes = SOURCE.replace("\n", "\r\n").encode("utf-8")
+    source_bytes = SOURCE.replace("## Next Action", heading).replace("\n", newline).encode("utf-8")
     state_path.write_bytes(source_bytes)
     monkeypatch.setattr(
         todo_command,
@@ -380,6 +397,7 @@ def test_project_markdown_cli_preserves_crlf_narrative_bytes(
         lambda **_kwargs: (tmp_path, state_path),
     )
 
+    captured: dict[str, object] = {}
     result = todo_command.handle_todo_command(
         build_parser().parse_args(
             [
@@ -394,14 +412,108 @@ def test_project_markdown_cli_preserves_crlf_narrative_bytes(
         ),
         registry_path=tmp_path / "registry.json",
         runtime_root_arg=None,
-        print_payload=lambda *_args: None,
+        print_payload=lambda value, *_args: captured.update(value),
         append_cli_rollout_event=lambda *_args, **_kwargs: None,
     )
 
-    assert result == 0
     projected = state_path.read_bytes()
-    assert b"\r\n" in projected
-    assert b"Human rationale stays here.\r\n" in projected
-    assert b"Do not rewrite this paragraph.\r\n" in projected
-    assert b"Continue the approved migration.\r\n" in projected
-    assert b"\n" not in projected.replace(b"\r\n", b"")
+    assert result == 0
+    assert captured["narrative_preserved"] is True
+    assert "Human rationale stays here.".encode() in projected
+    assert "Do not rewrite this paragraph.".encode() in projected
+    assert (heading.replace("\n", newline) + newline + newline + "- Continue the approved migration." + newline).encode() in projected
+    if newline == "\r\n":
+        assert b"\n" not in projected.replace(b"\r\n", b"")
+
+
+def test_real_promoted_provider_to_cli_projection(tmp_path: Path) -> None:
+    """Real file authority, TS bridge, CLI process and publication; no live Goal."""
+    runtime = tmp_path / "runtime"
+    state = tmp_path / "ACTIVE_GOAL_STATE.md"
+    source = SOURCE.replace("\n", "\r\n").encode()
+    state.write_bytes(source)
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({
+        "schema_version": 1,
+        "common_runtime_root": str(runtime),
+        "goals": [{"id": "goal-a", "status": "active", "repo": str(tmp_path),
+                   "state_file": state.name}],
+    }))
+
+    def run(revision: str, *extra: str) -> tuple[int, dict]:
+        process = subprocess.run(
+            [sys.executable, "-m", "loopx.cli", "--registry", str(registry),
+             "--runtime-root", str(runtime), "--format", "json", "todo",
+             "project-markdown", "--goal-id", "goal-a", "--provider-revision",
+             revision, *extra],
+            cwd=Path(__file__).resolve().parents[2],
+            capture_output=True, text=True, timeout=60, check=False,
+        )
+        return process.returncode, json.loads(process.stdout)
+
+    code, result = run("unpromoted", "--execute")
+    assert code == 1
+    assert "requires promoted canonical authority" in result["error"]
+    assert state.read_bytes() == source
+
+    projection = build_todo_runtime_shadow_projection(goal_id="goal-a", todos=_records())
+    digest = hashlib.sha256(json.dumps(
+        projection, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode()).hexdigest()
+    common = {"runtime_root": str(runtime), "goal_id": "goal-a"}
+    for action in ("bootstrap", "commit"):
+        applied = effect_runtime_result(f"coordination.runtime_shadow.{action}", {
+            **common,
+            "schema_version": f"loopx_coordination_runtime_shadow_{action}_v0",
+            "operation_id": f"projection-{action}", "source_version": f"source-{action}",
+            "projection": projection,
+            **({"event_kind": "todo_update"} if action == "commit" else {}),
+        })
+        assert applied["status"] == "applied"
+    revision = applied["provider_revision"]
+    fence = {
+        "schema_version": "loopx_legacy_coordination_writer_fence_v0",
+        "state": "engaged", "goal_id": "goal-a", "fence_id": "projection-fence",
+        "source_version": "source-commit", "source_projection_sha256": digest,
+        "expected_shadow_provider_revision": revision,
+    }
+    engaged = effect_runtime_result("coordination.local_authority.legacy_writer_fence.engage", {
+        **common, "schema_version": "loopx_legacy_coordination_writer_fence_engage_request_v0",
+        "fence": fence,
+    })
+    assert engaged["status"] == "applied"
+    promoted = effect_runtime_result("coordination.local_authority.promote", {
+        **common, "schema_version": "loopx_local_coordination_promotion_request_v0",
+        "operation_id": "projection-promote", "expected_shadow_provider_revision": revision,
+        "expected_shadow_projection_sha256": digest, "minimum_operations": 1,
+        "required_event_kinds": ["todo_update"], "writer_fence": fence,
+    })
+    assert promoted["status"] == "applied"
+    before = read_canonical_todos_if_promoted(runtime_root=runtime, goal_id="goal-a")
+    revision = before["provider_revision"]
+    code, preview = run(revision)
+    assert code == 0 and preview["dry_run"] is True
+    assert state.read_bytes() == source
+    code, mismatch = run("stale-revision", "--execute")
+    assert code == 1 and "does not match" in mismatch["error"]
+    assert state.read_bytes() == source
+
+    for heading in ("# Next Action", "Next Action\n===========", "Next Action\n-----------"):
+        variant = SOURCE.replace("## Next Action", heading).replace("\n", "\r\n").encode()
+        state.write_bytes(variant)
+        code, preserved = run(revision, "--execute")
+        assert code == 0 and preserved["narrative_preserved"] is True
+        suffix = (heading + "\n\n- Continue the approved migration.\n").replace("\n", "\r\n").encode()
+        assert state.read_bytes().endswith(suffix)
+
+    state.write_bytes(source)
+    code, written = run(revision, "--execute")
+    assert code == 0 and written["changed"] is True
+    published = state.read_bytes()
+    assert b"todo_agent" in published and b"todo_user" in published
+    assert published.endswith(b"## Next Action\r\n\r\n- Continue the approved migration.\r\n")
+    assert b"\n" not in published.replace(b"\r\n", b"")
+    code, replay = run(revision, "--execute")
+    assert code == 0 and replay["changed"] is False
+    assert state.read_bytes() == published
+    assert read_canonical_todos_if_promoted(runtime_root=runtime, goal_id="goal-a") == before

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import stat
 from copy import deepcopy
 
 import pytest
@@ -278,6 +279,7 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
 ) -> None:
     state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
     state_path.write_text(SOURCE, encoding="utf-8")
+    state_path.chmod(0o640)
     monkeypatch.setattr(
         todo_command,
         "load_registry",
@@ -330,6 +332,7 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     assert target == state_path
     assert temporary != target
     assert "todo_agent" in state_path.read_text(encoding="utf-8")
+    assert stat.S_IMODE(state_path.stat().st_mode) == 0o640
 
 
 def test_project_markdown_cli_preserves_crlf_narrative_bytes(

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -270,3 +270,63 @@ def test_project_markdown_cli_uses_raw_provider_records(
 
     assert result == 0
     assert captured["todo_count"] == len(raw_records)
+
+
+def test_project_markdown_cli_publishes_with_atomic_replace(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_path.write_text(SOURCE, encoding="utf-8")
+    monkeypatch.setattr(
+        todo_command,
+        "load_registry",
+        lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "read_canonical_todos_if_promoted",
+        lambda **_kwargs: {
+            "todos": _records(),
+            "source_authority": "file_v0",
+            "provider_revision": "rev-1",
+        },
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "resolve_todo_state_path",
+        lambda **_kwargs: (tmp_path, state_path),
+    )
+    replacements: list[tuple[object, object]] = []
+    real_replace = todo_command.os.replace
+
+    def record_replace(source, target) -> None:
+        replacements.append((source, target))
+        real_replace(source, target)
+
+    monkeypatch.setattr(todo_command.os, "replace", record_replace)
+
+    result = todo_command.handle_todo_command(
+        build_parser().parse_args(
+            [
+                "todo",
+                "project-markdown",
+                "--goal-id",
+                "goal-a",
+                "--provider-revision",
+                "rev-1",
+                "--execute",
+            ]
+        ),
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        print_payload=lambda *_args: None,
+        append_cli_rollout_event=lambda *_args, **_kwargs: None,
+    )
+
+    assert result == 0
+    assert len(replacements) == 1
+    temporary, target = replacements[0]
+    assert target == state_path
+    assert temporary != target
+    assert "todo_agent" in state_path.read_text(encoding="utf-8")

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from loopx.control_plane.todos.machine_section_projection import (
+    TodoSectionProjectionError,
+    inspect_todo_section_projection,
+    render_canonical_todo_sections,
+)
+from loopx.cli import build_parser
+from loopx.cli_commands import todo as todo_command
+
+
+SOURCE = """---
+status: active
+---
+
+# Goal
+
+Human rationale stays here.
+
+## User Todo / Owner Review Reading Queue
+
+- [ ] stale user text
+  <!-- loopx:todo todo_id=todo_stale status=open -->
+
+## Notes
+
+Do not rewrite this paragraph.
+
+## Agent Todo
+
+- [ ] stale agent text
+  <!-- loopx:todo todo_id=todo_old status=open -->
+
+## Next Action
+
+- Continue the approved migration.
+"""
+
+
+def _records() -> list[dict[str, object]]:
+    return [
+        {
+            "schema_version": "todo_item_v0",
+            "todo_id": "todo_agent",
+            "role": "agent",
+            "status": "open",
+            "done": False,
+            "text": "[P0] Move one complete transaction.",
+            "archive_state": "active",
+            "source_section": "Agent Todo",
+            "index": 1,
+            "priority": "P0",
+            "title": "Move one complete transaction.",
+            "task_class": "advancement_task",
+            "action_kind": "migrate_transaction",
+            "required_capabilities": ["filesystem_write"],
+            "claimed_by": "codex-worker",
+            "updated_at": "2026-09-05T00:00:00Z",
+        },
+        {
+            "schema_version": "todo_item_v0",
+            "todo_id": "todo_user",
+            "role": "user",
+            "status": "blocked",
+            "done": False,
+            "text": "Approve the bounded cutover.",
+            "archive_state": "active",
+            "source_section": "User Todo / Owner Review Reading Queue",
+            "index": 1,
+            "task_class": "user_gate",
+            "decision_scope": {
+                "schema_version": "decision_scope_v0",
+                "kind": "direction",
+                "granularity": "action",
+                "scope_key": "authority_cutover",
+            },
+            "global_gate": True,
+        },
+    ]
+
+
+def test_projection_replaces_only_machine_sections_and_is_idempotent() -> None:
+    projected = render_canonical_todo_sections(
+        SOURCE,
+        _records(),
+        provider_revision="sha256:abc123",
+    )
+
+    assert projected.changed is True
+    assert "Human rationale stays here." in projected.markdown
+    assert "Do not rewrite this paragraph." in projected.markdown
+    assert "Continue the approved migration." in projected.markdown
+    assert "stale user text" not in projected.markdown
+    assert "todo_agent" in projected.markdown
+    assert "todo_user" in projected.markdown
+    markers = inspect_todo_section_projection(projected.markdown)
+    assert markers["section_count"] == 2
+    assert {item["revision"] for item in markers["sections"]} == {"sha256:abc123"}
+
+    replay = render_canonical_todo_sections(
+        projected.markdown,
+        _records(),
+        provider_revision="sha256:abc123",
+    )
+    assert replay.changed is False
+    assert replay.markdown == projected.markdown
+    assert replay.rendered_sha256 == projected.rendered_sha256
+
+
+def test_projection_rejects_missing_role_section() -> None:
+    source = "# Goal\n\nHuman introduction.\n\n## Agent Todo\n\n- [ ] old\n\n## Next Action\n\n- Continue.\n"
+    with pytest.raises(TodoSectionProjectionError, match="required Todo sections: user"):
+        render_canonical_todo_sections(
+            source,
+            [_records()[0]],
+            provider_revision="rev-9",
+        )
+
+
+def test_projection_rejects_unknown_or_derived_field_loss() -> None:
+    unknown = deepcopy(_records())
+    unknown[0]["future_field"] = "must-not-disappear"
+    with pytest.raises(ValueError, match="unversioned fields: future_field"):
+        render_canonical_todo_sections(SOURCE, unknown, provider_revision="rev-1")
+
+    derived = deepcopy(_records())
+    derived[0]["resume_ready"] = True
+    with pytest.raises(TodoSectionProjectionError, match="resume_ready"):
+        render_canonical_todo_sections(SOURCE, derived, provider_revision="rev-1")
+
+
+def test_projection_rejects_duplicate_sections_and_unsafe_revision() -> None:
+    duplicate = SOURCE + "\n## Agent Todo\n\n- [ ] duplicate\n"
+    with pytest.raises(TodoSectionProjectionError, match="multiple agent"):
+        render_canonical_todo_sections(duplicate, _records(), provider_revision="rev-1")
+    with pytest.raises(TodoSectionProjectionError, match="public-safe token"):
+        render_canonical_todo_sections(SOURCE, _records(), provider_revision="rev 1")
+
+
+def test_project_markdown_cli_requires_promoted_exact_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_path.write_text(SOURCE, encoding="utf-8")
+    parser = build_parser()
+
+    def run(
+        extra: list[str], payload: dict[str, object] | None
+    ) -> tuple[int, dict[str, object]]:
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            todo_command,
+            "load_registry",
+            lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
+        )
+        monkeypatch.setattr(
+            todo_command,
+            "read_canonical_todos_if_promoted",
+            lambda **_kwargs: payload,
+        )
+        monkeypatch.setattr(
+            todo_command,
+            "resolve_todo_state_path",
+            lambda **_kwargs: (tmp_path, state_path),
+        )
+        result = todo_command.handle_todo_command(
+            parser.parse_args(
+                [
+                    "todo",
+                    "project-markdown",
+                    "--goal-id",
+                    "goal-a",
+                    "--provider-revision",
+                    "rev-1",
+                    *extra,
+                ]
+            ),
+            registry_path=tmp_path / "registry.json",
+            runtime_root_arg=None,
+            print_payload=lambda value, *_args: captured.update(value),
+            append_cli_rollout_event=lambda *_args, **_kwargs: None,
+        )
+        return result, captured
+
+    failed, failure = run([], None)
+    assert failed == 1
+    assert "requires promoted canonical authority" in str(failure["error"])
+    assert state_path.read_text(encoding="utf-8") == SOURCE
+
+    canonical_payload = {
+        "todos": _records(),
+        "source_authority": "file_v0",
+        "provider_revision": "rev-1",
+        "cursor": "7",
+    }
+    preview_result, preview = run([], canonical_payload)
+    assert preview_result == 0
+    assert preview["dry_run"] is True
+    assert preview["parse_render_parity"] is True
+    assert state_path.read_text(encoding="utf-8") == SOURCE
+
+    mismatch_result, mismatch = run(
+        [], {**canonical_payload, "provider_revision": "rev-2"}
+    )
+    assert mismatch_result == 1
+    assert "does not match" in str(mismatch["error"])
+    assert state_path.read_text(encoding="utf-8") == SOURCE
+
+    write_result, written = run(["--execute"], canonical_payload)
+    assert write_result == 0
+    assert written["executed"] is True
+    assert written["narrative_preserved"] is True
+    assert "todo_agent" in state_path.read_text(encoding="utf-8")
+
+
+def test_project_markdown_cli_uses_raw_provider_records(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state_path.write_text(SOURCE, encoding="utf-8")
+    raw_records = _records()
+    monkeypatch.setattr(
+        todo_command,
+        "load_registry",
+        lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "read_canonical_todos_if_promoted",
+        lambda **_kwargs: {
+            "todos": raw_records,
+            "source_authority": "file_v0",
+            "provider_revision": "rev-1",
+        },
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "list_goal_todos",
+        lambda **_kwargs: pytest.fail("projection must not consume the enriched list view"),
+    )
+    monkeypatch.setattr(
+        todo_command,
+        "resolve_todo_state_path",
+        lambda **_kwargs: (tmp_path, state_path),
+    )
+    captured: dict[str, object] = {}
+
+    result = todo_command.handle_todo_command(
+        build_parser().parse_args(
+            [
+                "todo",
+                "project-markdown",
+                "--goal-id",
+                "goal-a",
+                "--provider-revision",
+                "rev-1",
+            ]
+        ),
+        registry_path=tmp_path / "registry.json",
+        runtime_root_arg=None,
+        print_payload=lambda value, *_args: captured.update(value),
+        append_cli_rollout_event=lambda *_args, **_kwargs: None,
+    )
+
+    assert result == 0
+    assert captured["todo_count"] == len(raw_records)


### PR DESCRIPTION
## Summary

Add an explicit, promoted-goal-only `todo project-markdown` command. It renders complete legacy v0 active Todo records from a requested provider revision into the two Markdown Todo regions, preserving everything outside those regions.

The producer, active Todo reader and section editor share paired `loopx:todo-region-v0` ownership markers. Initial legacy adoption accepts LoopX's generated H2/list/metadata grammar and stops at non-generated text; following H1, Setext, indented headings and narrative are preserved. No general Markdown parser dependency or default Goal-format change is introduced.

## Stack and review fixes

Rebased onto `main` at `54f2c07b1a6df3530b32bfbbe5524ffec2f58ceb`, which already contains #3945 and #3947. This PR no longer depends on an unmerged stacked base.

Current head: `27febd78081dcb8b6b4a02a8163898657876bac0`.

- Fix the reviewed H2-only destructive span bug with shared generated-region ownership and independent narrative byte assertions.
- Accept CRLF in lineage-marker diagnostics.
- Keep publication atomic, preserve actual file mode, and close temporary handles on chmod/fsync/replace failure; use portable chmod rather than Unix-only fchmod.
- Preserve the following heading when reading mixed legacy/marked regions.

## Validation

- 129 focused Python tests passed, including real file-authority bootstrap, shadow commit, fence, promotion, production CLI subprocess, atomic publish and readback in a disposable runtime.
- 589 TypeScript tests passed, zero failures/skips, against isolated real PostgreSQL 16.15. This validates the store/TS seam, not a CLI-to-PostgreSQL service cutover.
- TypeScript typecheck, configured mypy (21 files), repository fast-path Ruff, diff checks and changed-doc/test public-boundary scan passed.
- Exact-scope quality receipt: `cqr_bb1c6e2ebe02aa578e2c` (10 files). Remote CI and premerge canaries are checked separately before merge.

## Explicit limits

Only complete legacy v0 active records are exportable here. Native domain records and archived records fail closed; native/archive export and automatic outbox synchronization remain separate work. Provider revision markers prove read-time lineage, not ongoing freshness or write authority. Ordinary unpromoted Goals and bootstrap output remain unchanged. No live Goal is promoted or rewritten for testing. Native Windows projection and power-loss recovery have not been independently qualified.
