### PR TITLE
refactor(authority): generate local protocol schemas

### DIFF
--- a/loopx/control_plane/coordination/coordination_state_contract.generated.ts
+++ b/loopx/control_plane/coordination/coordination_state_contract.generated.ts
@@ -115,9 +115,29 @@ export const COORDINATION_STATE_CONTRACT = deepFreeze({
       "source_section"
     ]
   },
+  "local_authority_protocol": {
+    "mutation_request_schema": "loopx_local_coordination_mutation_request_v0",
+    "mutation_result_schema": "loopx_local_coordination_mutation_result_v0",
+    "todo_read_request_schema": "loopx_local_coordination_todo_read_request_v0",
+    "todo_read_result_schema": "loopx_local_coordination_todo_read_result_v0",
+    "todo_list_request_schema": "loopx_local_coordination_todo_list_request_v0",
+    "todo_list_result_schema": "loopx_local_coordination_todo_list_result_v0",
+    "promotion_request_schema": "loopx_local_coordination_promotion_request_v0",
+    "promotion_result_schema": "loopx_local_coordination_promotion_result_v0",
+    "promotion_receipt_schema": "loopx_local_coordination_promotion_receipt_v0"
+  },
   "compatibility": {
     "unknown_field_policy": "reject",
     "field_removal_policy": "maintainer_approval_required",
     "markdown_role": "human_workbench_and_compatibility_projection"
   }
 } as const);
+export const LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.mutation_request_schema;
+export const LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.mutation_result_schema;
+export const LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.todo_read_request_schema;
+export const LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.todo_read_result_schema;
+export const LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.todo_list_request_schema;
+export const LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.todo_list_result_schema;
+export const LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.promotion_request_schema;
+export const LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.promotion_result_schema;
+export const LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA = COORDINATION_STATE_CONTRACT.local_authority_protocol.promotion_receipt_schema;

--- a/loopx/control_plane/coordination/coordination_state_contract_generated.py
+++ b/loopx/control_plane/coordination/coordination_state_contract_generated.py
@@ -113,12 +113,12 @@ COORDINATION_STATE_CONTRACT: Final = _freeze({'schema_version': 'loopx_coordinat
  'compatibility': {'unknown_field_policy': 'reject',
                    'field_removal_policy': 'maintainer_approval_required',
                    'markdown_role': 'human_workbench_and_compatibility_projection'}})
-LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['mutation_request_schema']
-LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['mutation_result_schema']
-LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_read_request_schema']
-LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_read_result_schema']
-LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_list_request_schema']
-LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_list_result_schema']
-LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['promotion_request_schema']
-LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['promotion_result_schema']
-LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['promotion_receipt_schema']
+LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA: Final[str] = 'loopx_local_coordination_mutation_request_v0'
+LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA: Final[str] = 'loopx_local_coordination_mutation_result_v0'
+LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA: Final[str] = 'loopx_local_coordination_todo_read_request_v0'
+LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA: Final[str] = 'loopx_local_coordination_todo_read_result_v0'
+LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA: Final[str] = 'loopx_local_coordination_todo_list_request_v0'
+LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA: Final[str] = 'loopx_local_coordination_todo_list_result_v0'
+LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA: Final[str] = 'loopx_local_coordination_promotion_request_v0'
+LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA: Final[str] = 'loopx_local_coordination_promotion_result_v0'
+LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA: Final[str] = 'loopx_local_coordination_promotion_receipt_v0'

--- a/loopx/control_plane/coordination/coordination_state_contract_generated.py
+++ b/loopx/control_plane/coordination/coordination_state_contract_generated.py
@@ -101,6 +101,24 @@ COORDINATION_STATE_CONTRACT: Final = _freeze({'schema_version': 'loopx_coordinat
                                             'archive_state']},
  'todo_projection_metadata': {'fields': ['source_section', 'index'],
                               'required_fields': ['source_section']},
+ 'local_authority_protocol': {'mutation_request_schema': 'loopx_local_coordination_mutation_request_v0',
+                              'mutation_result_schema': 'loopx_local_coordination_mutation_result_v0',
+                              'todo_read_request_schema': 'loopx_local_coordination_todo_read_request_v0',
+                              'todo_read_result_schema': 'loopx_local_coordination_todo_read_result_v0',
+                              'todo_list_request_schema': 'loopx_local_coordination_todo_list_request_v0',
+                              'todo_list_result_schema': 'loopx_local_coordination_todo_list_result_v0',
+                              'promotion_request_schema': 'loopx_local_coordination_promotion_request_v0',
+                              'promotion_result_schema': 'loopx_local_coordination_promotion_result_v0',
+                              'promotion_receipt_schema': 'loopx_local_coordination_promotion_receipt_v0'},
  'compatibility': {'unknown_field_policy': 'reject',
                    'field_removal_policy': 'maintainer_approval_required',
                    'markdown_role': 'human_workbench_and_compatibility_projection'}})
+LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['mutation_request_schema']
+LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['mutation_result_schema']
+LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_read_request_schema']
+LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_read_result_schema']
+LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_list_request_schema']
+LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['todo_list_result_schema']
+LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['promotion_request_schema']
+LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['promotion_result_schema']
+LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA: Final = COORDINATION_STATE_CONTRACT['local_authority_protocol']['promotion_receipt_schema']

--- a/loopx/control_plane/coordination/coordination_state_contract_v0.json
+++ b/loopx/control_plane/coordination/coordination_state_contract_v0.json
@@ -94,6 +94,17 @@
     "fields": ["source_section", "index"],
     "required_fields": ["source_section"]
   },
+  "local_authority_protocol": {
+    "mutation_request_schema": "loopx_local_coordination_mutation_request_v0",
+    "mutation_result_schema": "loopx_local_coordination_mutation_result_v0",
+    "todo_read_request_schema": "loopx_local_coordination_todo_read_request_v0",
+    "todo_read_result_schema": "loopx_local_coordination_todo_read_result_v0",
+    "todo_list_request_schema": "loopx_local_coordination_todo_list_request_v0",
+    "todo_list_result_schema": "loopx_local_coordination_todo_list_result_v0",
+    "promotion_request_schema": "loopx_local_coordination_promotion_request_v0",
+    "promotion_result_schema": "loopx_local_coordination_promotion_result_v0",
+    "promotion_receipt_schema": "loopx_local_coordination_promotion_receipt_v0"
+  },
   "compatibility": {
     "unknown_field_policy": "reject",
     "field_removal_policy": "maintainer_approval_required",

--- a/loopx/control_plane/coordination/local_authority.py
+++ b/loopx/control_plane/coordination/local_authority.py
@@ -21,12 +21,12 @@ from .coordination_state_contract import (
     TODO_DOMAIN_ITEM_SCHEMA_VERSION,
     TODO_ITEM_SCHEMA_VERSION,
 )
+from .coordination_state_contract_generated import (
+    LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+)
 from .legacy_writer_fence import legacy_coordination_writer_fence_path
 
 
-LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA = (
-    "loopx_local_coordination_todo_list_request_v0"
-)
 LOCAL_COORDINATION_TODO_LIST_METHOD = "coordination.local_authority.todo_list"
 LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA = (
     "loopx_local_coordination_todo_claim_request_v0"

--- a/loopx/control_plane/coordination/local_authority_runtime.ts
+++ b/loopx/control_plane/coordination/local_authority_runtime.ts
@@ -3,6 +3,17 @@ import { isAbsolute, join } from "node:path";
 import type { JsonObject } from "../effect_program.ts";
 import { requireJsonObject } from "../runtime_decode.ts";
 import {
+  LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA,
+  LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA,
+  LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA,
+  LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA,
+  LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA,
+} from "./coordination_state_contract.generated.ts";
+import {
   commitCoordinationProjectionMutation,
   indexCoordinationProjection,
   indexCoordinationProjectionTodos,
@@ -31,26 +42,19 @@ import {
   executeCoordinationTodoClaim,
 } from "./todo_claim.ts";
 
-export const LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA =
-  "loopx_local_coordination_mutation_request_v0";
-export const LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA =
-  "loopx_local_coordination_mutation_result_v0";
-export const LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA =
-  "loopx_local_coordination_todo_read_request_v0";
-export const LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA =
-  "loopx_local_coordination_todo_read_result_v0";
-export const LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA =
-  "loopx_local_coordination_todo_list_request_v0";
-export const LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA =
-  "loopx_local_coordination_todo_list_result_v0";
 export const LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_claim_request_v0";
-export const LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA =
-  "loopx_local_coordination_promotion_request_v0";
-export const LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA =
-  "loopx_local_coordination_promotion_result_v0";
-export const LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA =
-  "loopx_local_coordination_promotion_receipt_v0";
+export {
+  LOCAL_COORDINATION_MUTATION_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_MUTATION_RESULT_SCHEMA,
+  LOCAL_COORDINATION_PROMOTION_RECEIPT_SCHEMA,
+  LOCAL_COORDINATION_PROMOTION_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_PROMOTION_RESULT_SCHEMA,
+  LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_TODO_LIST_RESULT_SCHEMA,
+  LOCAL_COORDINATION_TODO_READ_REQUEST_SCHEMA,
+  LOCAL_COORDINATION_TODO_READ_RESULT_SCHEMA,
+} from "./coordination_state_contract.generated.ts";
 export { LEGACY_COORDINATION_WRITER_FENCE_SCHEMA } from "./legacy_writer_fence.ts";
 
 interface LocalAuthorityRuntimeDependencies {

--- a/scripts/generate_coordination_state_contract.py
+++ b/scripts/generate_coordination_state_contract.py
@@ -122,9 +122,9 @@ def load_contract() -> dict[str, Any]:
 
 def render_python(contract: dict[str, Any]) -> str:
     literal = pformat(contract, width=88, sort_dicts=False)
+    protocol = contract["local_authority_protocol"]
     constants = "\n".join(
-        f"LOCAL_COORDINATION_{key.upper()}: Final = "
-        f"COORDINATION_STATE_CONTRACT['local_authority_protocol']['{key}']"
+        f"LOCAL_COORDINATION_{key.upper()}: Final[str] = {protocol[key]!r}"
         for key in LOCAL_AUTHORITY_PROTOCOL_KEYS
     )
     return (

--- a/scripts/generate_coordination_state_contract.py
+++ b/scripts/generate_coordination_state_contract.py
@@ -25,6 +25,7 @@ TYPESCRIPT_PATH = CONTRACT_PATH.with_name("coordination_state_contract.generated
 EXPECTED_TOP_LEVEL_KEYS = {
     "schema_version", "todo_read_record", "todo_domain_record",
     "todo_projection_metadata", "compatibility",
+    "local_authority_protocol",
 }
 EXPECTED_TODO_KEYS = {
     "schema_version",
@@ -37,6 +38,17 @@ EXPECTED_COMPATIBILITY = {
     "field_removal_policy": "maintainer_approval_required",
     "markdown_role": "human_workbench_and_compatibility_projection",
 }
+LOCAL_AUTHORITY_PROTOCOL_KEYS = (
+    "mutation_request_schema",
+    "mutation_result_schema",
+    "todo_read_request_schema",
+    "todo_read_result_schema",
+    "todo_list_request_schema",
+    "todo_list_result_schema",
+    "promotion_request_schema",
+    "promotion_result_schema",
+    "promotion_receipt_schema",
+)
 
 
 def _string_list(value: object, *, label: str) -> list[str]:
@@ -73,6 +85,16 @@ def load_contract() -> dict[str, Any]:
             "todo_read_record.required_fields are absent from fields: "
             + ", ".join(missing)
         )
+    protocol = raw.get("local_authority_protocol")
+    if not isinstance(protocol, dict) or tuple(protocol) != LOCAL_AUTHORITY_PROTOCOL_KEYS:
+        raise ValueError("local authority protocol has unexpected fields or order")
+    if any(
+        not isinstance(protocol.get(key), str) or not protocol[key]
+        for key in LOCAL_AUTHORITY_PROTOCOL_KEYS
+    ):
+        raise ValueError("local authority protocol schemas must be non-empty strings")
+    if len(set(protocol.values())) != len(protocol):
+        raise ValueError("local authority protocol schemas must be unique")
     if raw.get("compatibility") != EXPECTED_COMPATIBILITY:
         raise ValueError("coordination contract compatibility policy mismatch")
     projection = raw["todo_projection_metadata"]
@@ -100,6 +122,11 @@ def load_contract() -> dict[str, Any]:
 
 def render_python(contract: dict[str, Any]) -> str:
     literal = pformat(contract, width=88, sort_dicts=False)
+    constants = "\n".join(
+        f"LOCAL_COORDINATION_{key.upper()}: Final = "
+        f"COORDINATION_STATE_CONTRACT['local_authority_protocol']['{key}']"
+        for key in LOCAL_AUTHORITY_PROTOCOL_KEYS
+    )
     return (
         '"""Generated from coordination_state_contract_v0.json; do not edit."""\n\n'
         "from __future__ import annotations\n\n"
@@ -112,11 +139,17 @@ def render_python(contract: dict[str, Any]) -> str:
         "        return tuple(_freeze(item) for item in value)\n"
         "    return value\n\n"
         f"COORDINATION_STATE_CONTRACT: Final = _freeze({literal})\n"
+        f"{constants}\n"
     )
 
 
 def render_typescript(contract: dict[str, Any]) -> str:
     literal = json.dumps(contract, indent=2, ensure_ascii=False)
+    constants = "\n".join(
+        f"export const LOCAL_COORDINATION_{key.upper()} = "
+        f"COORDINATION_STATE_CONTRACT.local_authority_protocol.{key};"
+        for key in LOCAL_AUTHORITY_PROTOCOL_KEYS
+    )
     return (
         "// Generated from coordination_state_contract_v0.json; do not edit.\n\n"
         "function deepFreeze<T>(value: T): T {\n"
@@ -127,6 +160,7 @@ def render_typescript(contract: dict[str, Any]) -> str:
         "  return value;\n"
         "}\n\n"
         f"export const COORDINATION_STATE_CONTRACT = deepFreeze({literal} as const);\n"
+        f"{constants}\n"
     )
 
 

--- a/tests/control_plane/test_coordination_state_contract.py
+++ b/tests/control_plane/test_coordination_state_contract.py
@@ -15,6 +15,12 @@ from loopx.control_plane.coordination.coordination_state_contract import (
     TODO_DOMAIN_ITEM_SCHEMA_VERSION,
     TODO_PROJECTION_METADATA_FIELDS,
 )
+from loopx.control_plane.coordination.coordination_state_contract_generated import (
+    LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA,
+)
+from loopx.control_plane.coordination.local_authority import (
+    LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA as BRIDGE_LIST_REQUEST_SCHEMA,
+)
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -89,6 +95,10 @@ def test_domain_projection_split_keeps_archival_as_a_task_fact() -> None:
     with_archive = canonical_todo_summary_fields([todo, archived])
     assert with_archive["agent_todos"]["done_count"] == summary["agent_todos"]["done_count"]
     assert with_archive["agent_todos"]["archived_advancement_done_count"] == 1
+
+
+def test_python_bridge_uses_generated_local_authority_protocol_schemas() -> None:
+    assert BRIDGE_LIST_REQUEST_SCHEMA == LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA
 
 
 def test_record_validation_rejects_required_fields_outside_declared_fields() -> None:

--- a/tests/control_plane_ts/coordination_state_contract.test.ts
+++ b/tests/control_plane_ts/coordination_state_contract.test.ts
@@ -13,6 +13,12 @@ import {
   TODO_DOMAIN_ITEM_SCHEMA,
   TODO_DOMAIN_RECORD_CONTRACT,
 } from "../../loopx/control_plane/coordination/coordination_state_contract.ts";
+import {
+  LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA as GENERATED_LIST_REQUEST_SCHEMA,
+} from "../../loopx/control_plane/coordination/coordination_state_contract.generated.ts";
+import {
+  LOCAL_COORDINATION_TODO_LIST_REQUEST_SCHEMA as RUNTIME_LIST_REQUEST_SCHEMA,
+} from "../../loopx/control_plane/coordination/local_authority_runtime.ts";
 
 const TODO = {
   schema_version: "todo_item_v0",
@@ -69,6 +75,10 @@ test("generated coordination bindings are current", async () => {
     child.on("error", reject);
     child.on("close", (code) => code === 0 ? resolve() : reject(new Error(stderr)));
   });
+});
+
+test("TypeScript runtime re-exports generated local-authority protocol schemas", () => {
+  assert.equal(RUNTIME_LIST_REQUEST_SCHEMA, GENERATED_LIST_REQUEST_SCHEMA);
 });
 
 test("provider-bound Todo records preserve every declared field", () => {


### PR DESCRIPTION
## Summary

Generate the nine existing local-authority protocol identifiers from the existing immutable JSON contract source. Preserve wire values and runtime exports; remove duplicate declarations without changing provider activation, authority, or Todo lifecycle behavior.

## Integration and review

Current head: `8e0456c5cb85cb99b975a6064a4ccefbb7828257`.
Rebased onto `main` at `d0d729a0a89dda9de3d3d4e3c2407b2a8b8c6434`, including merged #3945, #3946 and #3947.

The latest peer review approved the previous increment but held merge for a conflict with main's new claim declarations. The resolved version preserves `LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA` and the claim handler, while replacing only the nine older declarations with generated imports/re-exports. Neither side was selected wholesale.

Downstream maintenance order remains #3948 → #3949 → #3950. Old integration-candidate results do not qualify these rebased heads.

## Validation

- 590 TypeScript tests passed, zero failures/skips, with an isolated real PostgreSQL 16.15 server and fsync enabled.
- 111 Python tests passed, including authority/shadow/claim tests and the real file-provider → promotion → production CLI projection path in a disposable runtime.
- Independent base comparison: all nine JSON/generated/runtime wire identities equal main's original literals; all pre-existing JSON contract sections are identical; the claim request identity is preserved.
- Generator freshness, TypeScript typecheck, configured mypy (21 files), repository fast-path Ruff and diff checks passed.
- Exact quality receipt `cqr_38eff00a4cf261dadda6` is valid for the eight-file diff. New-head remote CI and premerge checks must finish before merge; prior CI is historical evidence only.

## Boundaries

This is contract-maintenance work, not a provider-first lifecycle cutover. No new provider, gate, permission, production deployment, canonical migration or automatic Markdown synchronization is introduced. Real backend tests use synthetic isolated state, never an active goal. PostgreSQL verification covers the TS/store seam; the current production CLI integration uses the file provider, not a claimed CLI-to-PG service cutover.
