### PR TITLE
Promote opt-in CPA operator with ABC Sol/Astra routing

### DIFF
--- a/packages/loopx-codex-provider-routing/OPERATOR.md
+++ b/packages/loopx-codex-provider-routing/OPERATOR.md
@@ -1,0 +1,157 @@
+# Local CPA operator
+
+The package now includes `loopx-cpa-operator`, a separately invoked local CLI.
+The managed extension protocol remains read-only and permission-free. Installing
+or running that protocol does not enable the operator, discover credentials,
+start CPA, change an App, or write a task store.
+
+## Routing preset
+
+The operator's `abc-sol-astra` preset uses the existing `compile_catalog` ring
+contract. Its credentials, App catalog, validation and observations share the
+same selector definitions.
+
+| Entry | Sol and Astra candidate order | Terminal fallback |
+| --- | --- | --- |
+| Auto / Prefer A | A → B → C | Ark, for eligible Standard text requests |
+| Prefer B | B → C → A | Ark, for eligible Standard text requests |
+| Prefer C | C → A → B | Ark, for eligible Standard text requests |
+| Fast variants | Same account order | None |
+| Luna | A → B → C | None |
+
+Both Sol and Astra expose Auto, Prefer A/B/C and four Fast siblings. Together
+with Luna and four existing Ark/compatibility rows, the App catalog has 21 rows.
+Bare Sol/Astra identifiers are compatibility aliases and are not picker rows.
+A preferred account is an entrypoint, not an exclusive pin. Ineligible, cooling
+or exhausted accounts can be skipped. Auto affinity is a hint that CPA must
+revalidate against account availability, input modality and service tier.
+
+Standard routes keep the existing heterogeneous fallback, so their model labels
+explicitly name Ark. Image history, effective priority tier and unsupported tool
+transport must not be silently sent to a text/function-only provider. Code Mode
+needs the CPA candidate's qualified `custom_tool_call` adaptation; the extension
+compiler alone cannot enforce a wire capability. Fast/Luna routes have no Ark
+alias at all. Transparent retry ends at the first visible output or tool call.
+
+The pinned CPA runtime remains the only online router. The operator emits
+configuration and metadata; it does not reimplement request retries. Existing
+retry settings remain 10 CPA retries, up to a 65-second advised wait, and one
+account-ring traversal per selection pass. Outer App retries are separate and
+can start another request: one ring pass is **not** a bound on total turn time.
+Account A no longer bypasses cooling. Fresh quota resets and recovery probes
+remain CPA's responsibility; a cached quota observation is not permission to
+permanently disable an account.
+
+Fast rows set a picker default and the checksum-pinned request plugin forces
+`service_tier=priority` before alias mapping. Verify the provider-bound request,
+not just the App's thread default: a custom-provider App may report `default`.
+The upstream response may also report `default`; a priority request is not a
+promise that the upstream supplied an accelerated tier.
+
+## Configuration and activation
+
+Install in a dedicated Python 3.11+ environment:
+
+```sh
+python3 -m pip install packages/loopx-codex-provider-routing
+loopx-cpa-operator --config /absolute/private/operator.json validate
+loopx-cpa-operator --config /absolute/private/operator.json --execute validate
+```
+
+The first command produces a credential-free plan and performs no writes or
+network/process operations. `--execute` authorizes only that invocation. Supply
+a mode-0600 JSON file with `schema_version: "loopx_cpa_local_operator_v1"` and:
+
+- `paths`: explicit absolute references for `runtime_root`, `temporary_root`,
+  `binary`, `plugin_directory`, `codex_binary`, `gpt_cache`, `astra_cache`,
+  `ark_catalog`, `ark_profile_catalog`, `ark_env_file`; optionally `login_source`;
+- `binary_sha256`, `plugin_sha256`, `source_commit`: exact reviewed artifact pins;
+- `port`: an unprivileged local TCP port; `launchd_label`: the owned service id;
+- `ark_base_url`: a credential-free HTTPS endpoint;
+- `ark_model`, `ark_pro_model`: upstream model identifiers.
+
+Keep that file outside Git. Supply references, never inline keys or tokens.
+Writable roots must be dedicated directories outside Git worktrees. Slot files
+are basenames under the configured auth directory; traversal, duplicates and
+symlink targets are rejected. Every receipt stays symbolic and credential-free.
+The API key is read only by the local operator and placed in a private temporary
+runtime config. Credentials, caches, binaries, plugin artifacts, logs, snapshots
+and service-manager files are never package resources or LoopX state.
+
+The App cache for each model is its metadata source; Astra does not inherit
+Sol's prompt, context window or model capabilities. Auto retains the existing
+low-through-max effort policy, while preferred routes preserve native levels.
+CPA must refresh its model definitions: an old `-local-model` catalog can omit a
+new model even when the App picker advertises it. The operator enables CPA's
+model-definition refresh while keeping the executable/plugin hashes pinned.
+Model-definition refresh and binary upgrade are separate operations.
+
+## Commands
+
+```sh
+# Import the explicitly configured current login into a vacant symbolic slot.
+loopx-cpa-operator --config /absolute/private/operator.json enroll --slot c
+loopx-cpa-operator --config /absolute/private/operator.json --execute enroll --slot c
+
+# Validate all three identities before updating any routing metadata.
+loopx-cpa-operator --config /absolute/private/operator.json --execute reconcile
+loopx-cpa-operator --config /absolute/private/operator.json --execute write-catalog
+
+# Process supervision: configure the owned service manager to invoke this.
+loopx-cpa-operator --config /absolute/private/operator.json --execute serve
+
+# Content-free live and isolated App Server readback.
+loopx-cpa-operator --config /absolute/private/operator.json --execute status
+loopx-cpa-operator --config /absolute/private/operator.json --execute validate
+loopx-cpa-operator --config /absolute/private/operator.json --execute probe
+loopx-cpa-operator --config /absolute/private/operator.json --execute route-status
+```
+
+Enrollment checks account identity, token expiry, vacant slots and duplicate
+accounts. It leaves the source login untouched. CPA owns subsequent refreshes.
+Use a separately authorized OAuth login if another client concurrently rotates
+that login and causes refresh conflicts. Never copy task databases or rollouts.
+
+`serve` replaces its process with the pinned CPA executable; the service manager
+owns restart supervision. `start`/`stop` are for an unmanaged process. `stop`
+refuses to signal a launchd-managed or unrelated process. For launchd, unload the
+specific configured service before changing its program, then load it again.
+The operator does not modify LaunchAgents, App bundles or App processes itself.
+Restart only the affected App after changing its model catalog, and verify the
+21-row readback. Model registration is not proof of account entitlement or a
+successful model call; perform a bounded live request separately.
+
+## Rollback and disable
+
+`reconcile`, `write-catalog` and `enroll` emit a `rollback_snapshot` identifier.
+Snapshots stay in the configured private state directory. To restore one:
+
+```sh
+loopx-cpa-operator --config /absolute/private/operator.json rollback --snapshot-id SNAPSHOT_ID
+loopx-cpa-operator --config /absolute/private/operator.json --execute rollback --snapshot-id SNAPSHOT_ID
+```
+
+Integrity and target checks precede writes. Restore routing metadata onto the
+latest credential instead of restoring stale OAuth refresh tokens. Credentials
+newly enrolled after the snapshot are retained but disabled during rollback.
+Restart the owned service/App when restoring process configuration or a catalog.
+The operator never deletes a credential or changes a task store.
+
+To disable, unload the operator-owned service or stop its unmanaged process.
+Restore the previous service program and private config from the installation
+backup, or uninstall the dedicated environment. Keep auth/state for recovery.
+Uninstalling the managed read-only extension does not stop an independently
+installed operator service.
+
+## Verification
+
+```sh
+python3 packages/loopx-codex-provider-routing/smoke/operator_smoke.py
+python3 packages/loopx-codex-provider-routing/smoke/codex_provider_routing_smoke.py
+```
+
+Offline tests use only synthetic credentials and temporary directories. They
+cover default-off isolation, slot/target boundaries, Sol/Astra parity, ring
+order, rollback integrity and token rotation, and legacy A/B qualification.
+`qualify_snapshot` accepts `routing_preset: "abc-sol-astra"`; omitting it keeps
+the original A/B/Sol contract for existing consumers.

--- a/packages/loopx-codex-provider-routing/README.md
+++ b/packages/loopx-codex-provider-routing/README.md
@@ -201,3 +201,12 @@ python3 packages/loopx-codex-provider-routing/smoke/recovery_contracts_smoke.py
 python3 -m pytest -q tests/extensions/test_colocated_extension_layout.py
 loopx check --scan-path packages/loopx-codex-provider-routing
 ```
+
+## Optional local operator
+
+Version 0.9 adds a separately invoked `loopx-cpa-operator` CLI for explicit local
+configuration, account enrollment, catalog generation, process supervision and
+readback. It ships the A/B/C Sol/Astra preset while preserving the managed
+extension's read-only protocol and the original A/B qualification default.
+See [Local CPA operator](OPERATOR.md) for activation, exact target boundaries,
+validation, rollback and disable commands.

--- a/packages/loopx-codex-provider-routing/REFERENCES.md
+++ b/packages/loopx-codex-provider-routing/REFERENCES.md
@@ -10,14 +10,14 @@ ports, accounts or private receipts.
 | --- | --- | --- |
 | Compile secret-free profiles, one-pass account rings and logical model routes | Migrated and strengthened | `contract.py::compile_catalog`; preferred entry points, terminal fallback tails, modality and Fast eligibility are explicit |
 | Generate explicit Fast sibling rows and inject the Fast request tier | Migrated as a public-safe compiler/normalizer contract | `contract.py::compile_catalog` plus `normalize_selector_request`; the live CPA adapter/plugin enforces the same decision before alias mapping |
-| Project host identity separately from actual A/B routing and quota | Migrated as a public-safe adapter boundary | `contract.py::project_runtime_status`; raw CPA management responses and logs remain operator-local |
-| Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Partially migrated | Catalog contract and content-free readback assertions are public; spawning the host-owned App Server remains an operator adapter |
+| Project host identity separately from actual account routing and quota | Migrated | `operator_observations.py` reduces local observations; `contract.py::project_runtime_status` retains the public boundary |
+| Generate a Codex catalog from cached model entries, start an isolated App Server, call `model/list` | Migrated | `operator_catalog.py` uses explicit cache/binary references; `selectors.py` shares the existing ring compiler |
 | Verify a patched desktop runtime across versioned anchors, ASAR member/header integrity, signature, launch and heartbeat readback | Migrated as a read-only qualification | `qualify_desktop_patch`; patching, signing and process lifecycle remain operator-owned effects |
 | Invalidate a provider cooldown after a newer successful quota reset | Migrated as a recovery ordering contract | `qualify_quota_recovery`; CPA owns the live invalidation and bounded reprobe |
 | Invalidate incident cooldown and revalidate degraded fallback affinity after a provider-wide outage ends | Migrated as a recovery ordering contract | `qualify_outage_recovery`; CPA owns the live invalidation, bounded probe and binding revalidation |
 | Preserve Code Mode tool item shape across heterogeneous fallback | Migrated as admission plus qualification | profile `tool_transports`, `normalize_selector_request` and `qualify_tool_transport`; adapters must prove custom-item preservation before declaring support |
 | Reconcile an ordered multi-PR candidate against exact heads and required seams | Migrated as a public-safe planning contract | `reconcile_integration_candidate` returns core `integration-branch` inputs; Git effects remain outside the extension |
-| Prepare/start/serve/stop CPA; reconcile A/B OAuth slots; load third-party API credentials | Private runtime boundary | Not copied. A future permissioned provider may wrap install/status/validate, but login and secret loading stay operator-owned |
+| Prepare/start/serve/stop CPA; reconcile OAuth slots; load referenced credentials | Migrated as an explicit local CLI | `operator.py`, `operator_runtime.py` and `operator_settings.py`; private configuration and credentials remain outside Git and the read-only extension protocol |
 | Snapshot App/selector configuration, validate hashes and roll back selected files | Planning contract migrated | `upgrade_plan` owns order, matrix and rollback trigger; filesystem effects need a future request-bound execution envelope |
 | Scan local config/auth files for secret patterns | Split | `reject_private_material` protects extension input/output; scanning owner-local files remains an operator preflight |
 | Emit failover evidence rows | Replaced | `upgrade_plan.required_checks` and `qualify_snapshot.checks` are the public evidence vocabulary; raw evidence directories are excluded |
@@ -63,17 +63,11 @@ provider round and a 65-second cooldown ceiling. They contain placeholders and
 omit all credential-bearing CPA sections. The extension never fills those
 placeholders or writes the templates into a Codex home.
 
-## Future Promotion Gate
+## Local operator promotion
 
-An effectful operator adapter can move into this extension only after it has:
-
-1. a request-bound execution envelope with explicit local-write scope;
-2. dry-run and readback receipts for every file/process change;
-3. exact target allowlists instead of broad home-directory access;
-4. secret references that are never returned or copied into LoopX state;
-5. idempotent install/upgrade/rollback tests in an isolated temporary home;
-6. a stop condition that never deletes a task store or rewrites rollout/SQLite
-   history.
-
-Until then, the public extension remains read-only and the private runtime
-adapter remains the owner of live effects.
+The effectful adapter is now the optional [local operator](OPERATOR.md), invoked
+separately with an explicit private configuration and per-command `--execute`.
+The managed extension remains read-only. Fixed target allowlists, dry-run
+receipts, snapshots, integrity checks and isolated regression tests accompany
+the promotion. Host credentials, artifact pins, service-manager files and
+private evidence remain operator-owned; no local prototype path is shipped.

--- a/packages/loopx-codex-provider-routing/RUNBOOK.md
+++ b/packages/loopx-codex-provider-routing/RUNBOOK.md
@@ -102,6 +102,14 @@ observation 与 last-sync receipt，并把 Git 合并输入交给 LoopX core `in
 base/source/head 漂移都只产生 `sync_required`；monitor 不自动合并或 push。显式同步后必须重新
 执行 build、changed-seam matrix、字段级配置 diff 与 App Server readback，才允许更新部署指针。
 
+## A/B/C 与 Astra 的可执行维护入口
+
+`abc-sol-astra` preset 与独立 `loopx-cpa-operator` CLI 已在本 package 中维护。
+它把本机进程控制、账号元数据、模型目录生成及脱敏观测收拢到同一实现；
+私有配置通过显式路径传入，managed extension 仍只读。完整的三账号路由、
+Fast/Ark 边界、重试范围、部署与回滚操作见 [Local CPA operator](OPERATOR.md)。
+旧 A/B qualification 默认值保留；新 readback 显式指定 `routing_preset: abc-sol-astra`。
+
 ## 锁定的 qualification baseline
 
 在升级前锁定 commit，不直接跟随上游 `main`：

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.8.0"
+version = "0.9.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,12 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.8.0"
+version = "0.9.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"
 
 [project.scripts]
+loopx-cpa-operator = "loopx_codex_provider_routing.operator:main"
 loopx-codex-provider-routing = "loopx_codex_provider_routing.cli:main"
 
 [tool.setuptools.packages.find]

--- a/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
@@ -1,0 +1,343 @@
+"""Offline regression tests for the opt-in local operator (no real credentials)."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from loopx_codex_provider_routing.operator import rollback, run, snapshot
+from loopx_codex_provider_routing.operator_catalog import AppCatalog
+from loopx_codex_provider_routing.operator_runtime import (
+    CPAOperator,
+    sha256,
+    write_private,
+)
+from loopx_codex_provider_routing.operator_settings import OperatorSettings
+from loopx_codex_provider_routing.selectors import (
+    ROUTES,
+    aliases_for_slot,
+    compiled_routes,
+)
+
+
+class OperatorTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="cpa-operator-test-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name).resolve()
+        runtime = self.root / "runtime"
+        paths = {key: str(self.root / key) for key in OperatorSettings.PATH_KEYS}
+        paths.update(
+            runtime_root=str(runtime), temporary_root=str(self.root / "temporary")
+        )
+        self.data = {
+            "schema_version": "loopx_cpa_local_operator_v1",
+            "paths": paths,
+            "binary_sha256": "0" * 64,
+            "plugin_sha256": "0" * 64,
+            "source_commit": "0" * 40,
+            "port": 19876,
+            "launchd_label": "org.example.cpa-test",
+            "ark_base_url": "https://api.example.invalid/v1",
+            "ark_model": "deepseek-v4-flash-ga-260731",
+            "ark_pro_model": "deepseek-v4-pro-ga-260813",
+        }
+        self.settings = OperatorSettings(self.data)
+        self.runtime = CPAOperator(self.settings)
+        self.config = self.root / "operator.json"
+        write_private(self.config, json.dumps(self.data))
+
+    def seed(self):
+        r = self.runtime
+        r.AUTH_DIR.mkdir(parents=True)
+        slots = {}
+        for slot in "abc":
+            name = f"{slot}.json"
+            write_private(
+                r.AUTH_DIR / name,
+                json.dumps(
+                    {
+                        "type": "codex",
+                        "account_id": f"fixture-{slot}",
+                        "access_token": "fixture-access",
+                        "refresh_token": "fixture-refresh",
+                    }
+                ),
+            )
+            r.patch_slot_auth(r.AUTH_DIR / name, slot)
+            slots[slot] = name
+        write_private(r.SLOTS_FILE, json.dumps(slots))
+        write_private(r.MODEL_CATALOG, json.dumps({"models": []}))
+
+    def test_default_is_plan_without_files_or_processes(self):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            self.assertEqual(run(["--config", str(self.config), "serve"]), 0)
+        self.assertFalse(self.runtime.RUNTIME_ROOT.exists())
+        receipt = json.loads(output.getvalue())
+        self.assertFalse(receipt["executed"])
+        self.assertNotIn(str(self.root), output.getvalue())
+
+    def test_private_configuration_and_exact_targets(self):
+        self.config.chmod(0o644)
+        with self.assertRaises(ValueError):
+            OperatorSettings.read(self.config)
+        self.data["paths"]["runtime_root"] = "/"
+        with self.assertRaises(ValueError):
+            OperatorSettings(self.data)
+
+    def test_reject_state_inside_git_worktree(self):
+        (self.root / ".git").mkdir()
+        with self.assertRaises(ValueError):
+            OperatorSettings(self.data)
+
+    def test_reject_symlink_state(self):
+        self.runtime.RUNTIME_ROOT.mkdir()
+        other = self.root / "other"
+        other.mkdir()
+        self.runtime.AUTH_DIR.symlink_to(other)
+        with self.assertRaises(ValueError):
+            self.runtime.check_target_boundaries()
+
+    def test_reject_slot_escape_and_duplicate_credentials(self):
+        for slots in (
+            {"a": "../outside.json"},
+            {"a": "a.json", "b": "a.json"},
+            {"d": "d.json"},
+        ):
+            write_private(self.runtime.SLOTS_FILE, json.dumps(slots))
+            with self.assertRaises(ValueError):
+                self.runtime.load_slots()
+
+    def test_three_account_ring_and_model_parity(self):
+        expected = {
+            "auto": list("abc"),
+            "codex-a": list("abc"),
+            "codex-b": list("bca"),
+            "codex-c": list("cab"),
+        }
+        for model in ("gpt-5.6-sol", "gpt-6-astra"):
+            for prefix, order in expected.items():
+                for fast in (False, True):
+                    slug = ("fast/" if fast else "") + prefix + "/" + model
+                    entries = {
+                        slot: next(
+                            e for e in aliases_for_slot(slot) if e["alias"] == slug
+                        )
+                        for slot in "abc"
+                    }
+                    actual = sorted(
+                        entries, key=lambda slot: -entries[slot]["routing-priority"]
+                    )
+                    self.assertEqual(actual, order)
+                    self.assertTrue(all(e["name"] == model for e in entries.values()))
+                    self.assertEqual(ROUTES[slug]["tail"], [] if fast else ["ark-text"])
+        self.assertEqual(ROUTES["gpt-5.6-luna"]["tail"], [])
+        compiled = compiled_routes()
+        for row in compiled["selector_rows"]:
+            if row["slug"].startswith("fast/"):
+                self.assertNotIn("ark-text", row["candidates"])
+
+    def test_reconcile_preserves_tokens_and_is_idempotent(self):
+        self.seed()
+        path = self.runtime.AUTH_DIR / "c.json"
+        before = path.read_bytes()
+        self.runtime.patch_slot_auth(path, "c")
+        self.assertEqual(before, path.read_bytes())
+        self.assertEqual(json.loads(before)["refresh_token"], "fixture-refresh")
+        self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+
+    def test_rollback_preserves_rotated_credentials(self):
+        self.seed()
+        backup = snapshot(self.runtime)
+        path = self.runtime.AUTH_DIR / "a.json"
+        data = json.loads(path.read_text())
+        data.update(
+            refresh_token="fixture-refreshed",
+            access_token="fixture-new-access",
+            priority=1,
+        )
+        write_private(path, json.dumps(data))
+        rollback(self.runtime, backup)
+        restored = json.loads(path.read_text())
+        self.assertEqual(restored["priority"], 400)
+        self.assertEqual(restored["refresh_token"], "fixture-refreshed")
+        self.assertEqual(restored["access_token"], "fixture-new-access")
+
+    def test_rollback_rejects_tampering_before_any_write(self):
+        self.seed()
+        backup = snapshot(self.runtime)
+        before = self.runtime.SLOTS_FILE.read_bytes()
+        directory = self.runtime.STATE_DIR / "operator-backups" / backup
+        (directory / "0.json").write_text("{}")
+        with self.assertRaises(ValueError):
+            rollback(self.runtime, backup)
+        self.assertEqual(before, self.runtime.SLOTS_FILE.read_bytes())
+        with self.assertRaises(ValueError):
+            rollback(self.runtime, "../outside")
+
+    def test_catalog_uses_native_model_metadata_and_fast_parity(self):
+        self.seed()
+        base = {
+            "input_modalities": ["text", "image"],
+            "supported_reasoning_levels": [
+                {"effort": e}
+                for e in ("low", "medium", "high", "xhigh", "max", "ultra")
+            ],
+            "additional_speed_tiers": ["fast"],
+            "service_tiers": [{"id": "priority"}],
+        }
+        for key, models in (
+            ("gpt_cache", ["gpt-5.6-sol", "gpt-5.6-luna"]),
+            ("astra_cache", ["gpt-6-astra"]),
+            ("ark_catalog", [self.data["ark_model"], self.data["ark_pro_model"]]),
+        ):
+            write_private(
+                self.settings.paths[key],
+                json.dumps(
+                    {
+                        "models": [
+                            {
+                                **base,
+                                "slug": model,
+                                "context_window": 100000
+                                if model == "gpt-6-astra"
+                                else 50000,
+                            }
+                            for model in models
+                        ]
+                    }
+                ),
+            )
+        catalog = AppCatalog(self.runtime)
+        rows = {m["slug"]: m for m in catalog.generate_catalog()["models"]}
+        self.assertEqual(len(rows), 21)
+        for slug, row in rows.items():
+            self.assertEqual(
+                row["default_service_tier"],
+                "fast" if slug.startswith("fast/") else None,
+            )
+            if "astra" in slug:
+                self.assertEqual(row["context_window"], 100000)
+        self.assertEqual(
+            rows["codex-c/gpt-6-astra"]["supported_reasoning_levels"][-1]["effort"],
+            "ultra",
+        )
+        self.assertNotIn(
+            "ultra",
+            [
+                r["effort"]
+                for r in rows["auto/gpt-6-astra"]["supported_reasoning_levels"]
+            ],
+        )
+        catalog.write_catalog()
+        first = sha256(self.runtime.MODEL_CATALOG)
+        catalog.write_catalog()
+        self.assertEqual(first, sha256(self.runtime.MODEL_CATALOG))
+
+    def test_new_preset_qualification_and_negative_fast_admission(self):
+        from copy import deepcopy
+
+        from loopx_codex_provider_routing.contract import qualify_snapshot
+
+        package = Path(__file__).resolve().parents[1]
+        baseline = json.loads(
+            (package / "examples" / "qualification-snapshot.json").read_text()
+        )["snapshot"]
+        observation = deepcopy(baseline)
+        observation["routing_preset"] = "abc-sol-astra"
+        native = set(ROUTES)
+        ark = {
+            "ark/deepseek-v4-flash",
+            "deepseek-v4-flash",
+            "deepseek-v4-flash-ga-260731",
+            "deepseek-v4-pro-ga-260813",
+        }
+        observation["visible_models"] = sorted(native | ark)
+        observation["hidden_models"] = ["gpt-5.6-sol", "gpt-6-astra"]
+        observation["fast_models"] = sorted(
+            slug for slug in native if slug.startswith("fast/")
+        )
+        observation["input_modalities"] = {
+            slug: ["text", "image"] if slug in native else ["text"]
+            for slug in native | ark
+        }
+        observation["selector_default_service_tiers"] = {
+            slug: "fast" if slug.startswith("fast/") else "default"
+            for slug in native | ark
+        }
+        observation["route_traversal"] = {}
+        for slug, route in ROUTES.items():
+            observation["route_traversal"][slug] = {
+                "entrypoint": "affinity_then_first"
+                if slug.removeprefix("fast/").startswith("auto/")
+                or slug == "gpt-5.6-luna"
+                else f"codex-{route['order'][0]}",
+                "ordered_candidates": [f"codex-{slot}" for slot in route["order"]]
+                + route["tail"],
+                "fallback_tail": route["tail"],
+                "max_cycles": 1,
+            }
+        self.assertTrue(qualify_snapshot(observation)["qualified"])
+        broken = deepcopy(observation)
+        broken["route_traversal"]["fast/codex-c/gpt-6-astra"][
+            "ordered_candidates"
+        ].append("ark-text")
+        self.assertFalse(qualify_snapshot(broken)["qualified"])
+        self.assertTrue(qualify_snapshot(baseline)["qualified"])
+
+    def test_failed_reconcile_does_not_patch_earlier_slots(self):
+        from unittest.mock import patch
+
+        self.seed()
+        path = self.runtime.AUTH_DIR / "a.json"
+        original = path.read_bytes()
+        (self.runtime.AUTH_DIR / "c.json").unlink()
+        with patch.object(self.runtime, "prepare"), self.assertRaises(ValueError):
+            self.runtime.reconcile()
+        self.assertEqual(path.read_bytes(), original)
+
+    def test_rollback_rejects_changed_identity_before_writes(self):
+        self.seed()
+        backup = snapshot(self.runtime)
+        write_private(self.runtime.MODEL_CATALOG, '{"new": true}')
+        path = self.runtime.AUTH_DIR / "c.json"
+        data = json.loads(path.read_text())
+        data["account_id"] = "fixture-replaced"
+        write_private(path, json.dumps(data))
+        with self.assertRaises(ValueError):
+            rollback(self.runtime, backup)
+        self.assertEqual(self.runtime.MODEL_CATALOG.read_text(), '{"new": true}')
+
+    def test_rollback_deactivates_new_enrollment_without_deleting_tokens(self):
+        self.seed()
+        write_private(
+            self.runtime.SLOTS_FILE, json.dumps({"a": "a.json", "b": "b.json"})
+        )
+        backup = snapshot(self.runtime)
+        write_private(
+            self.runtime.SLOTS_FILE,
+            json.dumps({"a": "a.json", "b": "b.json", "c": "c.json"}),
+        )
+        rollback(self.runtime, backup)
+        data = json.loads((self.runtime.AUTH_DIR / "c.json").read_text())
+        self.assertTrue(data["disabled"])
+        self.assertEqual(data["refresh_token"], "fixture-refresh")
+        self.assertNotIn("c", self.runtime.load_slots())
+
+    def test_config_has_all_normal_fallbacks_but_no_fast_or_luna(self):
+        config = self.runtime.runtime_config(
+            "fixture-only", management_secret="fixture-management"
+        )
+        self.assertIn('alias: "codex-c/gpt-6-astra"', config)
+        self.assertNotIn('alias: "fast/', config)
+        self.assertNotIn('alias: "gpt-5.6-luna"', config)
+        self.assertIn('host: "127.0.0.1"', config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -341,10 +341,7 @@ def qualify_outage_recovery(observation: Mapping[str, Any]) -> dict[str, Any]:
         {
             "id": "degraded_binding_not_used_for_native",
             "passed": not native_requested
-            or (
-                not fallback_attempted
-                and (not outage_ended or degraded_cleared)
-            ),
+            or (not fallback_attempted and (not outage_ended or degraded_cleared)),
             "failure_code": "degraded_fallback_binding_used_for_native_request",
         }
     )
@@ -1603,6 +1600,22 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "gpt-5.6-luna",
         "ark/deepseek-v4-flash",
     }
+    preset = snapshot.get("routing_preset", "legacy-ab-sol")
+    if preset not in {"legacy-ab-sol", "abc-sol-astra"}:
+        raise ValueError("unsupported snapshot routing preset")
+    expected_hidden = {"gpt-5.6-sol"}
+    if preset == "abc-sol-astra":
+        from .selectors import MODEL_FAMILIES, ROUTES
+
+        expected_visible = set(ROUTES) | {
+            "ark/deepseek-v4-flash",
+            "deepseek-v4-flash",
+            "deepseek-v4-flash-ga-260731",
+            "deepseek-v4-pro-ga-260813",
+        }
+        expected_hidden = set(MODEL_FAMILIES)
+    expected_fast = {slug for slug in expected_visible if slug.startswith("fast/")}
+    expected_native = {slug for slug in expected_visible if "gpt-" in slug}
     checks: list[dict[str, Any]] = []
 
     def check(check_id: str, passed: bool, detail: str) -> None:
@@ -1615,11 +1628,11 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     check(
         "visible_routes",
         visible == expected_visible,
-        "selector exposes Standard and Fast Sol rows plus Luna and Ark",
+        "selector exposes the selected routing preset",
     )
     check(
         "hidden_alias",
-        "gpt-5.6-sol" in hidden,
+        expected_hidden <= hidden,
         "bare compatibility alias remains hidden",
     )
     modalities = snapshot.get("input_modalities")
@@ -1629,17 +1642,9 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         "codex_image_admission",
         all(
             set(modalities.get(slug, [])) == {"text", "image"}
-            for slug in (
-                "auto/gpt-5.6-sol",
-                "fast/auto/gpt-5.6-sol",
-                "codex-a/gpt-5.6-sol",
-                "fast/codex-a/gpt-5.6-sol",
-                "codex-b/gpt-5.6-sol",
-                "fast/codex-b/gpt-5.6-sol",
-                "gpt-5.6-luna",
-            )
+            for slug in expected_native
         ),
-        "Standard/Fast Sol selectors and Luna declare text and image",
+        "subscription selectors declare text and image",
     )
     check(
         "ark_text_only",
@@ -1649,13 +1654,8 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     fast_models = set(_string_list(snapshot.get("fast_models"), "snapshot.fast_models"))
     check(
         "fast_projection",
-        fast_models
-        == {
-            "fast/auto/gpt-5.6-sol",
-            "fast/codex-a/gpt-5.6-sol",
-            "fast/codex-b/gpt-5.6-sol",
-        },
-        "Fast is exposed only as explicit Auto/Prefer A/Prefer B sibling rows",
+        fast_models == expected_fast,
+        "Fast is exposed as explicit sibling rows",
     )
     selector_tiers = snapshot.get("selector_default_service_tiers")
     if not isinstance(selector_tiers, Mapping):
@@ -1729,6 +1729,19 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             "fallback_tail": [],
         },
     }
+    if preset == "abc-sol-astra":
+        expected_traversal = {
+            slug: {
+                "entrypoint": "affinity_then_first"
+                if slug.removeprefix("fast/").startswith("auto/")
+                or slug == "gpt-5.6-luna"
+                else f"codex-{route['order'][0]}",
+                "ordered_candidates": [f"codex-{slot}" for slot in route["order"]]
+                + route["tail"],
+                "fallback_tail": route["tail"],
+            }
+            for slug, route in ROUTES.items()
+        }
     traversal_rows: dict[str, Mapping[str, Any]] = {}
     for slug in expected_traversal:
         raw_row = route_traversal.get(slug)
@@ -1751,7 +1764,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             == expected["ordered_candidates"]
             for slug, expected in expected_traversal.items()
         ),
-        "Standard/Fast Sol selectors and Luna use the expected ring entrypoint and order",
+        "subscription selectors use the expected ring entrypoint and order",
     )
     check(
         "terminal_fallback_tail",
@@ -1759,17 +1772,17 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
             traversal_rows[slug].get("fallback_tail") == expected["fallback_tail"]
             for slug, expected in expected_traversal.items()
         ),
-        "only Standard Sol routes append Ark; Fast and Luna have no heterogeneous tail",
+        "only eligible Standard routes append Ark; Fast and Luna have no heterogeneous tail",
     )
     check(
         "fast_capable_only",
         all(
             traversal_rows[slug].get("ordered_candidates")
-            in (["codex-a", "codex-b"], ["codex-b", "codex-a"])
+            == expected_traversal[slug]["ordered_candidates"]
             and traversal_rows[slug].get("fallback_tail") == []
             for slug in fast_models
         ),
-        "Fast rows remain inside the A/B Fast-capable ring",
+        "Fast rows remain inside the selected Fast-capable account ring",
     )
     check(
         "single_cycle_traversal",

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator.py
@@ -1,0 +1,300 @@
+"""Opt-in local operator; deliberately separate from the read-only extension API."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import datetime as dt
+import hashlib
+import io
+import json
+import secrets
+import sys
+from pathlib import Path
+
+from .operator_catalog import AppCatalog
+from .operator_runtime import CPAOperator, sha256, write_private
+from .operator_settings import OperatorSettings
+from .selectors import SLOTS
+
+COMMANDS = (
+    "prepare",
+    "reconcile",
+    "write-catalog",
+    "probe",
+    "validate",
+    "status",
+    "route-status",
+    "start",
+    "serve",
+    "stop",
+    "enroll",
+    "snapshot",
+    "rollback",
+)
+
+
+def snapshot(runtime: CPAOperator) -> str:
+    """Snapshot only the fixed catalog and registered credentials, never task stores."""
+    snapshot_id = dt.datetime.now(dt.timezone.utc).strftime(
+        "%Y%m%dT%H%M%SZ-"
+    ) + secrets.token_hex(4)
+    directory = runtime.STATE_DIR / "operator-backups" / snapshot_id
+    directory.mkdir(parents=True, mode=0o700)
+    targets = [runtime.SLOTS_FILE, runtime.MODEL_CATALOG]
+    targets += [runtime.AUTH_DIR / name for name in runtime.load_slots().values()]
+    entries = []
+    for index, target in enumerate(targets):
+        if not target.exists():
+            continue
+        relative = str(target.relative_to(runtime.RUNTIME_ROOT))
+        content = target.read_text(encoding="utf-8")
+        saved = directory / f"{index}.json"
+        write_private(saved, content)
+        entries.append(
+            {"target": relative, "backup": saved.name, "sha256": sha256(saved)}
+        )
+    write_private(directory / "manifest.json", json.dumps({"files": entries}))
+    return snapshot_id
+
+
+def rollback(runtime: CPAOperator, snapshot_id: str) -> None:
+    if (
+        not snapshot_id
+        or Path(snapshot_id).name != snapshot_id
+        or snapshot_id in {".", ".."}
+    ):
+        raise ValueError("rollback requires a snapshot identifier")
+    directory = runtime.STATE_DIR / "operator-backups" / snapshot_id
+    if directory.is_symlink() or (directory / "manifest.json").is_symlink():
+        raise ValueError("snapshot must not be a symbolic link")
+    entries = json.loads((directory / "manifest.json").read_text())["files"]
+    allowed = {"state/oauth-slots.json", "codex-model-catalog.json"}
+    prepared = []
+    for entry in entries:
+        relative, name = entry["target"], entry["backup"]
+        parts = Path(relative).parts
+        if relative not in allowed and not (
+            len(parts) == 2 and parts[0] == "auth" and parts[1].endswith(".json")
+        ):
+            raise ValueError("snapshot target is outside the operator allowlist")
+        if Path(name).name != name:
+            raise ValueError("invalid backup member")
+        source, target = directory / name, runtime.RUNTIME_ROOT / relative
+        if (
+            source.is_symlink()
+            or target.is_symlink()
+            or sha256(source) != entry["sha256"]
+        ):
+            raise ValueError("snapshot integrity check failed")
+        prepared.append((target, source.read_text()))
+    # OAuth refresh tokens rotate. Restore routing metadata onto the newest
+    # credential, never roll a live credential back to a stale refresh token.
+    restored = []
+    previous_slots = None
+    for target, content in prepared:
+        if target == runtime.SLOTS_FILE:
+            previous_slots = json.loads(content)
+        if target.parent == runtime.AUTH_DIR and target.exists():
+            current = json.loads(target.read_text())
+            old = json.loads(content)
+            if current.get("account_id") != old.get("account_id"):
+                raise ValueError("credential identity changed since snapshot")
+            for field in (
+                "priority",
+                "request_retry",
+                "disable_cooling",
+                "websockets",
+                "loopx_slot",
+                "model_aliases",
+            ):
+                if field in old:
+                    current[field] = old[field]
+                else:
+                    current.pop(field, None)
+            content = json.dumps(current, separators=(",", ":"))
+        restored.append((target, content))
+    # Enrollment rollback preserves the newly saved credential, but removes it
+    # from the live router so file discovery cannot bypass the restored slots.
+    if previous_slots is not None:
+        for slot, name in runtime.load_slots().items():
+            if name not in previous_slots.values():
+                path = runtime.AUTH_DIR / name
+                if path.is_file():
+                    data = json.loads(path.read_text())
+                    if data.get("loopx_slot") != slot:
+                        raise ValueError(
+                            "new credential no longer belongs to this slot"
+                        )
+                    data.update(disabled=True, model_aliases=[])
+                    restored.append((path, json.dumps(data, separators=(",", ":"))))
+    for target, content in restored:
+        write_private(target, content)
+
+
+def enroll(runtime: CPAOperator, slot: str) -> None:
+    source = runtime.settings.paths.get("login_source")
+    if source is None:
+        raise ValueError("enrollment requires an explicit login_source reference")
+    slots = runtime.load_slots()
+    if slot in slots:
+        raise ValueError("slot already enrolled; existing credentials were retained")
+    auth = json.loads(source.read_text())
+    tokens = auth.get("tokens", {})
+    if auth.get("auth_mode") != "chatgpt" or any(
+        not isinstance(tokens.get(k), str) or not tokens[k]
+        for k in ("access_token", "id_token", "refresh_token", "account_id")
+    ):
+        raise ValueError("source is not a complete ChatGPT login")
+
+    def claims(token):
+        part = token.split(".")[1]
+        return json.loads(base64.urlsafe_b64decode(part + "=" * (-len(part) % 4)))
+
+    identity, access = claims(tokens["id_token"]), claims(tokens["access_token"])
+    account = identity.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
+    if (
+        account != tokens["account_id"]
+        or access.get("exp", 0) <= dt.datetime.now(dt.timezone.utc).timestamp()
+    ):
+        raise ValueError(
+            "login identity mismatch or expired access token; refresh the source login"
+        )
+    for name in slots.values():
+        if (
+            json.loads((runtime.AUTH_DIR / name).read_text()).get("account_id")
+            == account
+        ):
+            raise ValueError("this account is already enrolled in another slot")
+    target = runtime.AUTH_DIR / (
+        "codex-" + hashlib.sha256(account.encode()).hexdigest()[:16] + ".json"
+    )
+    if target.exists():
+        raise ValueError("credential target already exists")
+    record = {
+        k: tokens[k]
+        for k in ("access_token", "id_token", "refresh_token", "account_id")
+    }
+    record.update(
+        type="codex",
+        email=identity.get("email", ""),
+        disabled=False,
+        expired=dt.datetime.fromtimestamp(access["exp"], dt.timezone.utc).isoformat(),
+        last_refresh=auth.get("last_refresh"),
+    )
+    write_private(target, json.dumps(record, separators=(",", ":")))
+    runtime.patch_slot_auth(target, slot)
+    slots[slot] = target.name
+    write_private(runtime.SLOTS_FILE, json.dumps(slots, separators=(",", ":")))
+
+
+def run(argv=None) -> int:
+    parser = argparse.ArgumentParser(prog="loopx-cpa-operator")
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="authorize this exact local command; otherwise only emit a plan",
+    )
+    parser.add_argument("command", choices=COMMANDS)
+    parser.add_argument("--slot", choices=SLOTS)
+    parser.add_argument("--snapshot-id")
+    parser.add_argument("--modality", choices=("text", "image"), default="text")
+    parser.add_argument("--fast", action="store_true")
+    args = parser.parse_args(argv)
+    settings = OperatorSettings.read(args.config)
+    if args.command == "enroll" and not args.slot:
+        raise ValueError("enroll requires --slot")
+    if args.command == "rollback" and not args.snapshot_id:
+        raise ValueError("rollback requires --snapshot-id")
+    receipt = {
+        "schema_version": "loopx_cpa_operator_receipt_v1",
+        "command": args.command,
+        "executed": args.execute,
+        "credential_free": True,
+    }
+    if not args.execute:
+        receipt.update(
+            effect_boundary="explicit_local_operator",
+            task_store_effects="none",
+            targets="configured_paths_only",
+        )
+        print(json.dumps(receipt, sort_keys=True))
+        return 0
+    runtime = CPAOperator(settings)
+    runtime.check_target_boundaries()
+    catalog = AppCatalog(runtime)
+    if args.command in {"reconcile", "write-catalog", "enroll"}:
+        receipt["rollback_snapshot"] = snapshot(runtime)
+    captured = io.StringIO()
+    # Diagnostics can contain local paths. Public receipts return only typed,
+    # symbolic results; raw management data and subprocess output stay local.
+    with contextlib.redirect_stdout(captured):
+        if args.command == "write-catalog":
+            catalog.write_catalog()
+            receipt["model_count"] = len(catalog.generate_catalog()["models"])
+        elif args.command == "probe":
+            result = catalog.probe()
+            receipt["passed"] = result["passed"]
+            receipt["model_count"] = len(result["projected_selectors"])
+            receipt["checks"] = {
+                k: result[k]
+                for k in (
+                    "missing",
+                    "hidden",
+                    "cpa_missing",
+                    "route_mismatches",
+                    "wrong_default_service_tiers",
+                )
+            }
+        elif args.command == "enroll":
+            runtime.prepare()
+            enroll(runtime, args.slot)
+            receipt["enrolled_slot"] = args.slot
+        elif args.command == "snapshot":
+            receipt["rollback_snapshot"] = snapshot(runtime)
+        elif args.command == "rollback":
+            rollback(runtime, args.snapshot_id)
+        elif args.command in {"start", "serve"}:
+            getattr(runtime, args.command)(settings.paths["ark_env_file"])
+        elif args.command == "route-status":
+            runtime.route_status(modality=args.modality, fast=args.fast)
+            receipt["observation"] = json.loads(captured.getvalue())
+        elif args.command == "status":
+            receipt["running"] = runtime.pid_alive(runtime.read_pid())
+            receipt["slots"] = runtime.active_slots()
+        else:
+            getattr(runtime, args.command)()
+    print(json.dumps(receipt, ensure_ascii=False, sort_keys=True))
+    return 1 if receipt.get("passed") is False else 0
+
+
+def main() -> int:
+    try:
+        return run()
+    except (
+        OSError,
+        RuntimeError,
+        ValueError,
+        KeyError,
+        IndexError,
+        TypeError,
+        TimeoutError,
+    ) as error:
+        # Never echo arbitrary provider payloads, tokens or private filenames.
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": type(error).__name__,
+                    "message": "Local operator validation failed; check the configured targets and run the focused operator tests.",
+                }
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_catalog.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_catalog.py
@@ -1,0 +1,408 @@
+"""Project owner-supplied model caches and verify isolated Codex App readback."""
+
+from __future__ import annotations
+
+import json
+import os
+import selectors
+import stat
+import subprocess
+import tempfile
+import time
+import urllib.request
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from .selectors import FAST_MODELS, MODEL_FAMILIES, ROUTES, SLOTS
+
+SELECTORS = {slug: route["display_name"] for (slug, route) in ROUTES.items()}
+SELECTORS.update(
+    {
+        "ark/deepseek-v4-flash": "Ark · DeepSeek V4 Flash",
+        "deepseek-v4-flash": "Ark · DeepSeek V4 Flash (legacy id)",
+        "deepseek-v4-flash-ga-260731": "Ark · DeepSeek V4 Flash (260731)",
+        "deepseek-v4-pro-ga-260813": "Ark · DeepSeek V4 Pro (260813)",
+    }
+)
+FAST_SELECTORS = set(FAST_MODELS)
+ROUTE_FALLBACK_TAILS = {slug: route["tail"] for (slug, route) in ROUTES.items()}
+EXPECTED_ROUTE_ORDERS = {
+    slug: [f"codex-{slot}" for slot in route["order"]] + route["tail"]
+    for (slug, route) in ROUTES.items()
+}
+AUTO_REASONING_EFFORTS = ("low", "medium", "high", "xhigh", "max")
+
+
+def private_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=448)
+    path.parent.chmod(448)
+    temp = path.with_name(path.name + f".tmp.{os.getpid()}")
+    fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 384)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+        path.chmod(384)
+    finally:
+        temp.unlink(missing_ok=True)
+
+
+def source_model(path: Path, slug: str) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    for model in payload.get("models", []):
+        if isinstance(model, dict) and model.get("slug") == slug:
+            return deepcopy(model)
+    raise RuntimeError(f"model {slug} is absent from {path}")
+
+
+def make_entry(
+    source: dict[str, Any], slug: str, display_name: str, priority: int
+) -> dict[str, Any]:
+    entry = deepcopy(source)
+    entry["slug"] = slug
+    entry["display_name"] = display_name
+    entry["description"] = display_name
+    entry["priority"] = priority
+    entry["visibility"] = "list"
+    entry["upgrade"] = None
+    return entry
+
+
+def make_fast_entry(
+    source: dict[str, Any], slug: str, display_name: str, priority: int
+) -> dict[str, Any]:
+    entry = make_entry(source, slug, display_name, priority)
+    entry["default_service_tier"] = "fast"
+    return entry
+
+
+def read_messages(
+    process: subprocess.Popen[str], wanted_id: int, timeout: float
+) -> dict[str, Any]:
+    selector = selectors.DefaultSelector()
+    assert process.stdout is not None
+    selector.register(process.stdout, selectors.EVENT_READ)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stderr = process.stderr.read() if process.stderr is not None else ""
+            raise RuntimeError(
+                f"app-server exited before response {wanted_id}: {stderr[:300]}"
+            )
+        events = selector.select(timeout=min(0.2, deadline - time.monotonic()))
+        if not events:
+            continue
+        line = process.stdout.readline()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(message, dict) and message.get("id") == wanted_id:
+            return message
+    raise TimeoutError(f"app-server response {wanted_id} timed out")
+
+
+class AppCatalog:
+    def __init__(self, runtime):
+        self.runtime = runtime
+        settings = runtime.settings
+        self.CODEX_BINARY = settings.paths["codex_binary"]
+        self.ASTRA_CACHE = settings.paths["astra_cache"]
+        self.GPT_CACHE = settings.paths["gpt_cache"]
+        self.ARK_CATALOG = settings.paths["ark_catalog"]
+        self.ARK_PROFILE_CATALOG = settings.paths["ark_profile_catalog"]
+        self.OUTPUT = runtime.MODEL_CATALOG
+        self.AUTH_DIR = runtime.AUTH_DIR
+        self.SLOTS_FILE = runtime.SLOTS_FILE
+        self.PORT = runtime.PORT
+
+    def ark_source(self, slug: str) -> dict[str, Any]:
+        for path in (self.ARK_CATALOG, self.ARK_PROFILE_CATALOG, self.OUTPUT):
+            try:
+                return source_model(path, slug)
+            except (FileNotFoundError, RuntimeError):
+                continue
+        raise RuntimeError(f"missing cached Ark model: {slug}")
+
+    def generate_catalog(self) -> dict[str, Any]:
+        sources = {
+            model: source_model(
+                self.ASTRA_CACHE if model == "gpt-6-astra" else self.GPT_CACHE, model
+            )
+            for model in (*MODEL_FAMILIES, "gpt-5.6-luna")
+        }
+        entries = []
+        for slug, label in SELECTORS.items():
+            route = ROUTES.get(slug)
+            if route:
+                source = deepcopy(sources[route["model"]])
+                if slug.removeprefix("fast/").startswith("auto/"):
+                    source["default_reasoning_level"] = "high"
+                    source["supported_reasoning_levels"] = [
+                        level
+                        for level in source["supported_reasoning_levels"]
+                        if level["effort"] in AUTO_REASONING_EFFORTS
+                    ]
+            else:
+                source = self.ark_source(
+                    slug if slug.endswith("260813") else "deepseek-v4-flash-ga-260731"
+                )
+            entry = make_entry(source, slug, label, len(entries) + 1)
+            entry["default_service_tier"] = "fast" if slug in FAST_SELECTORS else None
+            entries.append(entry)
+        return {"models": entries}
+
+    def cpa_models(self) -> set[str]:
+        request = urllib.request.Request(f"http://127.0.0.1:{self.PORT}/v1/models")
+        with urllib.request.urlopen(request, timeout=3) as response:
+            payload = json.load(response)
+        data = payload.get("data", []) if isinstance(payload, dict) else []
+        return {
+            str(item["id"])
+            for item in data
+            if isinstance(item, dict) and isinstance(item.get("id"), str)
+        }
+
+    def route_traversal_readback(self) -> dict[str, Any]:
+        slots = json.loads(self.SLOTS_FILE.read_text(encoding="utf-8"))
+        priorities: dict[str, dict[str, int]] = {}
+        for slot in SLOTS:
+            auth_name = slots.get(slot)
+            if not isinstance(auth_name, str):
+                raise TypeError(f"missing symbolic OAuth slot {slot.upper()}")
+            auth = json.loads((self.AUTH_DIR / auth_name).read_text(encoding="utf-8"))
+            aliases = {
+                item.get("alias"): item.get("routing-priority")
+                for item in auth.get("model_aliases", [])
+                if isinstance(item, dict)
+                and isinstance(item.get("alias"), str)
+                and isinstance(item.get("routing-priority"), int)
+            }
+            priorities[slot] = aliases
+        rows: dict[str, Any] = {}
+        for route, tail in ROUTE_FALLBACK_TAILS.items():
+            members = sorted(
+                ((f"codex-{slot}", priorities[slot].get(route)) for slot in SLOTS),
+                key=lambda item: (-1 if item[1] is None else -item[1], item[0]),
+            )
+            if any(priority is None for (_, priority) in members):
+                raise RuntimeError(f"missing route priority for {route}")
+            ordered = [member for (member, _) in members] + list(tail)
+            rows[route] = {
+                "entrypoint": "affinity_then_first"
+                if route
+                in {
+                    "auto/gpt-5.6-sol",
+                    "fast/auto/gpt-5.6-sol",
+                    "auto/gpt-6-astra",
+                    "fast/auto/gpt-6-astra",
+                    "gpt-5.6-luna",
+                }
+                else ordered[0],
+                "ordered_candidates": ordered,
+                "fallback_tail": list(tail),
+                "max_cycles": 1,
+            }
+        return rows
+
+    def write_catalog(self) -> None:
+        payload = self.generate_catalog()
+        private_write(
+            self.OUTPUT, json.dumps(payload, ensure_ascii=False, indent=2) + "\n"
+        )
+
+    def app_config(self, home: Path) -> str:
+        return "\n".join(
+            [
+                'model = "auto/gpt-5.6-sol"',
+                'model_provider = "cpa"',
+                'service_tier = "default"',
+                f'model_catalog_json = "{self.OUTPUT}"',
+                "",
+                "[model_providers.cpa]",
+                'name = "CPA · Codex A → B → C → Ark"',
+                f'base_url = "http://127.0.0.1:{self.PORT}/v1"',
+                'wire_api = "responses"',
+                "requires_openai_auth = false",
+                "supports_websockets = false",
+                "request_max_retries = 0",
+                "stream_max_retries = 0",
+                "",
+                "[features]",
+                "fast_mode = true",
+                "",
+                f'[projects."{home}"]',
+                'trust_level = "trusted"',
+                "",
+            ]
+        )
+
+    def probe(self) -> dict[str, Any]:
+        thread_responses: dict[str, dict[str, Any]] = {}
+        with tempfile.TemporaryDirectory(prefix="cpa-codex-app-model-probe-") as raw:
+            home = Path(raw)
+            home.chmod(stat.S_IRWXU)
+            private_write(home / "config.toml", self.app_config(home))
+            env = os.environ.copy()
+            env["CODEX_HOME"] = str(home)
+            process = subprocess.Popen(
+                [str(self.CODEX_BINARY), "app-server"],
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stdin is not None
+            try:
+                initialize = {
+                    "method": "initialize",
+                    "id": 1,
+                    "params": {
+                        "clientInfo": {
+                            "name": "cpa_model_probe",
+                            "title": "CPA model probe",
+                            "version": "0.1.0",
+                        }
+                    },
+                }
+                process.stdin.write(json.dumps(initialize) + "\n")
+                process.stdin.flush()
+                initialized = read_messages(process, 1, 10)
+                if "error" in initialized:
+                    raise RuntimeError("app-server initialize failed")
+                process.stdin.write(
+                    json.dumps({"method": "initialized", "params": {}}) + "\n"
+                )
+                process.stdin.write(
+                    json.dumps(
+                        {
+                            "method": "model/list",
+                            "id": 2,
+                            "params": {"limit": 50, "includeHidden": False},
+                        }
+                    )
+                    + "\n"
+                )
+                process.stdin.flush()
+                response = read_messages(process, 2, 15)
+                for request_id, model in (
+                    (3, "auto/gpt-5.6-sol"),
+                    (4, "fast/auto/gpt-5.6-sol"),
+                    (5, "auto/gpt-6-astra"),
+                    (6, "fast/codex-c/gpt-6-astra"),
+                ):
+                    process.stdin.write(
+                        json.dumps(
+                            {
+                                "method": "thread/start",
+                                "id": request_id,
+                                "params": {
+                                    "model": model,
+                                    "modelProvider": "cpa",
+                                    "cwd": str(home),
+                                    "ephemeral": True,
+                                },
+                            }
+                        )
+                        + "\n"
+                    )
+                    process.stdin.flush()
+                    thread_responses[model] = read_messages(process, request_id, 15)
+            finally:
+                process.terminate()
+                try:
+                    process.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=3)
+        if "error" in response:
+            raise RuntimeError("app-server model/list returned an error")
+        data = response.get("result", {}).get("data", [])
+        rows = {
+            str(row.get("id")): {
+                "displayName": row.get("displayName"),
+                "hidden": row.get("hidden"),
+                "inputModalities": row.get("inputModalities"),
+                "defaultServiceTier": row.get("defaultServiceTier"),
+                "additionalSpeedTiers": row.get("additionalSpeedTiers"),
+                "serviceTiers": row.get("serviceTiers"),
+                "supportedReasoningEfforts": [
+                    effort.get("reasoningEffort")
+                    for effort in row.get("supportedReasoningEfforts", [])
+                    if isinstance(effort, dict)
+                ],
+            }
+            for row in data
+            if isinstance(row, dict) and row.get("id") in SELECTORS
+        }
+        missing = sorted(set(SELECTORS) - set(rows))
+        hidden = sorted(key for (key, row) in rows.items() if row.get("hidden"))
+        wrong_display_names = sorted(
+            key
+            for (key, display_name) in SELECTORS.items()
+            if rows.get(key, {}).get("displayName") != display_name
+        )
+        wrong_default_service_tiers = sorted(
+            key
+            for (key, row) in rows.items()
+            if row.get("defaultServiceTier")
+            != ("fast" if key in FAST_SELECTORS else None)
+        )
+        auto_efforts = rows.get("auto/gpt-5.6-sol", {}).get(
+            "supportedReasoningEfforts", []
+        )
+        missing_auto_efforts = sorted(set(AUTO_REASONING_EFFORTS) - set(auto_efforts))
+        live_models = self.cpa_models()
+        cpa_missing = sorted(set(SELECTORS) - live_models)
+        route_traversal = self.route_traversal_readback()
+        route_mismatches = sorted(
+            route
+            for (route, expected) in EXPECTED_ROUTE_ORDERS.items()
+            if route_traversal.get(route, {}).get("ordered_candidates") != expected
+            or route_traversal.get(route, {}).get("max_cycles") != 1
+        )
+        thread_default_service_tiers = {
+            model: payload.get("result", {}).get("serviceTier")
+            if "error" not in payload
+            else {"error": payload.get("error")}
+            for (model, payload) in thread_responses.items()
+        }
+        fast_selector_plugin_active = self.runtime.fast_selector_plugin_ready(
+            port=self.PORT
+        )
+        return {
+            "schema_version": "cpa_codex_app_model_probe_v1",
+            "codex_binary": str(self.CODEX_BINARY),
+            "catalog_path": str(self.OUTPUT),
+            "expected_selectors": sorted(SELECTORS),
+            "projected_selectors": rows,
+            "route_traversal": route_traversal,
+            "missing": missing,
+            "hidden": hidden,
+            "wrong_display_names": wrong_display_names,
+            "wrong_default_service_tiers": wrong_default_service_tiers,
+            "missing_auto_efforts": missing_auto_efforts,
+            "cpa_missing": cpa_missing,
+            "route_mismatches": route_mismatches,
+            "thread_default_service_tiers": thread_default_service_tiers,
+            "fast_selector_plugin_active": fast_selector_plugin_active,
+            "passed": not any(
+                (
+                    missing,
+                    hidden,
+                    wrong_display_names,
+                    wrong_default_service_tiers,
+                    missing_auto_efforts,
+                    cpa_missing,
+                    route_mismatches,
+                    not fast_selector_plugin_active,
+                )
+            ),
+        }

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_observations.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_observations.py
@@ -1,0 +1,229 @@
+"""Reduce local CPA observations to credential-free symbolic account status."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import re
+from typing import Any
+
+from .selectors import MODEL_FAMILIES, SLOTS
+
+GPT_MODEL = "gpt-5.6-sol"
+LUNA_MODEL = "gpt-5.6-luna"
+
+
+def utc_timestamp(value: Any) -> str | None:
+    if value is None:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    try:
+        if re.fullmatch("\\d+(?:\\.\\d+)?", raw):
+            parsed = dt.datetime.fromtimestamp(float(raw), tz=dt.timezone.utc)
+        else:
+            parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=dt.timezone.utc)
+            parsed = parsed.astimezone(dt.timezone.utc)
+    except (OverflowError, ValueError):
+        return None
+    return parsed.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def quota_projection(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    observed_at = utc_timestamp(raw.get("observed_at"))
+    signals = raw.get("signals")
+    if observed_at is None or not isinstance(signals, dict):
+        return None
+    normalized = {
+        str(key).strip().lower(): str(value).strip()
+        for (key, value) in signals.items()
+        if str(key).strip() and str(value).strip()
+    }
+    prefixes = sorted(
+        {
+            key.removesuffix("-used-percent")
+            for key in normalized
+            if key.startswith("x-codex-") and key.endswith("-used-percent")
+        }
+    )
+    windows: list[dict[str, Any]] = []
+    for prefix in prefixes:
+        try:
+            used = float(normalized[prefix + "-used-percent"])
+            minutes = int(float(normalized[prefix + "-window-minutes"]))
+        except (KeyError, ValueError):
+            continue
+        if not 0 <= used <= 100 or minutes <= 0:
+            continue
+        window_id = re.sub("[^a-z0-9-]+", "-", prefix.removeprefix("x-codex-"))
+        window_id = window_id.strip("-")[:64]
+        if not window_id:
+            continue
+        window: dict[str, Any] = {
+            "id": window_id,
+            "used_percent": used,
+            "window_minutes": minutes,
+        }
+        reset_at = utc_timestamp(normalized.get(prefix + "-reset-at"))
+        if reset_at is None:
+            try:
+                seconds = float(normalized[prefix + "-reset-after-seconds"])
+                base = dt.datetime.fromisoformat(observed_at.replace("Z", "+00:00"))
+                reset_at = (
+                    (base + dt.timedelta(seconds=seconds))
+                    .isoformat(timespec="seconds")
+                    .replace("+00:00", "Z")
+                )
+            except (KeyError, ValueError):
+                pass
+        if reset_at is not None:
+            window["reset_at"] = reset_at
+        windows.append(window)
+    return {"observed_at": observed_at, "windows": windows}
+
+
+class ObservationMixin:
+    def account_observations(self) -> list[dict[str, Any]]:
+        slots = self.load_slots()
+        by_name = {
+            str(item.get("name")): item
+            for item in self.fetch_management_auth_files()
+            if isinstance(item.get("name"), str)
+        }
+        observations: list[dict[str, Any]] = []
+        for slot in SLOTS:
+            name = slots.get(slot)
+            entry = by_name.get(name, {}) if name else {}
+            if entry.get("disabled") or entry.get("unavailable"):
+                state = "unavailable"
+            elif str(entry.get("status", "")).lower() in {"active", "ready"}:
+                state = "ready"
+            elif entry:
+                state = "degraded"
+            else:
+                state = "unknown"
+            recent = entry.get("recent_requests")
+            buckets = recent if isinstance(recent, list) else []
+            success = sum(
+                int(item.get("success", 0))
+                for item in buckets
+                if isinstance(item, dict)
+                and isinstance(item.get("success", 0), (int, float))
+            )
+            failed = sum(
+                int(item.get("failed", 0))
+                for item in buckets
+                if isinstance(item, dict)
+                and isinstance(item.get("failed", 0), (int, float))
+            )
+            quota = quota_projection(entry.get("quota"))
+            if quota is None:
+                model_quotas = entry.get("model_quotas")
+                if isinstance(model_quotas, dict):
+                    candidates = [
+                        quota_projection(model_quotas.get(model))
+                        for model in (*MODEL_FAMILIES, LUNA_MODEL)
+                    ]
+                    candidates = [item for item in candidates if item is not None]
+                    if candidates:
+                        quota = max(candidates, key=lambda item: item["observed_at"])
+            observations.append(
+                {
+                    "profile_id": f"codex-{slot}",
+                    "state": state,
+                    "quota": quota,
+                    "recent_activity": {
+                        "success": success,
+                        "failed": failed,
+                        "window_minutes": max(len(buckets), 1) * 10,
+                    },
+                }
+            )
+        return observations
+
+    def _map_auth_to_profile(
+        self, auth_value: str, slots: dict[str, str]
+    ) -> str | None:
+        for slot, name in slots.items():
+            if auth_value == name or auth_value.endswith("auth_file=" + name):
+                return f"codex-{slot}"
+        if auth_value.startswith("openai-compatibility:"):
+            return "ark-text"
+        return None
+
+    def latest_execution_observation(
+        self, *, modality: str = "text", fast: bool = False
+    ) -> dict[str, Any]:
+        log_path = next((path for path in self.LOG_CANDIDATES if path.is_file()), None)
+        if log_path is None:
+            raise RuntimeError("CPA runtime log is unavailable")
+        with log_path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - 16 * 1024 * 1024))
+            text = handle.read().decode("utf-8", errors="replace")
+        line_re = re.compile(
+            "^\\[(?P<time>[^]]+)] \\[(?P<request>[0-9a-f]{8})] \\[[^]]+] \\[(?P<source>[^]]+)].*$"
+        )
+        selector_re = re.compile("\\bauth=(?P<auth>\\S+).*\\bmodel=(?P<model>\\S+)")
+        terminal_re = re.compile(
+            '\\]\\s+(?P<status>\\d{3})\\s+\\|.*POST\\s+\\"/v1/responses\\"'
+        )
+        slots = self.load_slots()
+        attempts: dict[str, list[str]] = {}
+        routes: dict[str, str] = {}
+        latest: dict[str, Any] | None = None
+        for line in text.splitlines():
+            match = line_re.match(line)
+            if match is None:
+                continue
+            request_id = match.group("request")
+            if "selector.go:" in match.group("source"):
+                selected = selector_re.search(line)
+                if selected is None:
+                    continue
+                profile = self._map_auth_to_profile(selected.group("auth"), slots)
+                if profile is None:
+                    continue
+                chain = attempts.setdefault(request_id, [])
+                if not chain or chain[-1] != profile:
+                    chain.append(profile)
+                routes[request_id] = selected.group("model")
+                continue
+            if "gin_logger.go:" not in match.group("source"):
+                continue
+            terminal = terminal_re.search(line)
+            if (
+                terminal is None
+                or request_id not in attempts
+                or request_id not in routes
+            ):
+                continue
+            status_code = int(terminal.group("status"))
+            observed = utc_timestamp(
+                dt.datetime.fromisoformat(match.group("time")).astimezone().isoformat()
+            )
+            if observed is None:
+                continue
+            chain = attempts[request_id]
+            outcome = "success" if 200 <= status_code < 300 else "failed"
+            route_slug = routes[request_id]
+            latest = {
+                "route_slug": route_slug,
+                "modality": modality,
+                "fast": route_slug.startswith("fast/"),
+                "observed_at": observed,
+                "attempted_profiles": chain,
+                "selected_profile": chain[-1] if outcome == "success" else None,
+                "outcome": outcome,
+            }
+        if latest is None:
+            raise RuntimeError("no completed CPA route observation was found")
+        if latest["selected_profile"] is None:
+            latest.pop("selected_profile")
+        return latest

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_runtime.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_runtime.py
@@ -1,0 +1,651 @@
+"""Explicit local CPA operator. Managed extension calls never import this module."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import secrets
+import signal
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from .operator_observations import ObservationMixin
+from .selectors import FAST_MODELS, MODEL_FAMILIES, ROUTES, SLOTS, aliases_for_slot
+
+GPT_MODEL = "gpt-5.6-sol"
+AUTO_MODEL = f"auto/{GPT_MODEL}"
+PREFER_A_MODEL = f"codex-a/{GPT_MODEL}"
+PREFER_B_MODEL = f"codex-b/{GPT_MODEL}"
+LUNA_MODEL = "gpt-5.6-luna"
+FAST_AUTO_MODEL = f"fast/{AUTO_MODEL}"
+FAST_PREFER_A_MODEL = f"fast/{PREFER_A_MODEL}"
+FAST_PREFER_B_MODEL = f"fast/{PREFER_B_MODEL}"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def yaml_quote(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def write_private(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=448)
+    temp = path.with_name(path.name + f".tmp.{os.getpid()}")
+    fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 384)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp, path)
+        path.chmod(384)
+    finally:
+        temp.unlink(missing_ok=True)
+
+
+class CPAOperator(ObservationMixin):
+    def __init__(self, settings):
+        self.settings = settings
+        for name, value in settings.runtime_attributes().items():
+            setattr(self, name, value)
+
+    def check_target_boundaries(self):
+        for directory in (
+            self.RUNTIME_ROOT,
+            self.AUTH_DIR,
+            self.STATE_DIR,
+            self.LOG_DIR,
+            self.RUNTIME_TMP_ROOT,
+        ):
+            if directory.is_symlink():
+                raise ValueError("operator directories must not be symbolic links")
+        targets = (
+            self.MODEL_CATALOG,
+            self.PID_FILE,
+            self.SLOTS_FILE,
+            self.MANAGEMENT_KEY_FILE,
+            self.STATUS_SNAPSHOT_FILE,
+            self.RUNTIME_CONFIG,
+        )
+        if any(path.is_symlink() for path in targets):
+            raise ValueError("operator targets must not be symbolic links")
+        for name in self.load_slots().values():
+            if (self.AUTH_DIR / name).is_symlink():
+                raise ValueError("credential target must not be a symbolic link")
+
+    def check_artifacts(self) -> None:
+        if not self.BINARY.is_file():
+            raise RuntimeError(f"missing pinned CPA binary: {self.BINARY}")
+        actual = sha256(self.BINARY)
+        if actual != self.BINARY_SHA256:
+            raise RuntimeError(f"pinned CPA checksum mismatch: {actual}")
+        if not self.FAST_SELECTOR_PLUGIN.is_file():
+            raise RuntimeError(
+                f"missing Fast selector plugin: {self.FAST_SELECTOR_PLUGIN}"
+            )
+        plugin_sha256 = sha256(self.FAST_SELECTOR_PLUGIN)
+        if plugin_sha256 != self.FAST_SELECTOR_PLUGIN_SHA256:
+            raise RuntimeError(
+                f"Fast selector plugin checksum mismatch: {plugin_sha256}"
+            )
+
+    def prepare(self) -> None:
+        self.check_artifacts()
+        for directory in (
+            self.RUNTIME_ROOT,
+            self.AUTH_DIR,
+            self.STATE_DIR,
+            self.LOG_DIR,
+            self.RUNTIME_TMP_ROOT,
+        ):
+            directory.mkdir(parents=True, exist_ok=True, mode=448)
+            directory.chmod(448)
+
+    def load_ark_key(self, env_file: Path | None) -> str:
+        value = os.environ.get("ARK_API_KEY", "").strip()
+        if value:
+            return value
+        if env_file is None:
+            raise RuntimeError("ARK_API_KEY is unavailable to this command process")
+        if not env_file.is_file():
+            raise RuntimeError(f"Ark env file does not exist: {env_file}")
+        for raw in env_file.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            (key, candidate) = line.split("=", 1)
+            normalized_key = key.strip()
+            if normalized_key.startswith("export "):
+                normalized_key = normalized_key.removeprefix("export ").strip()
+            if normalized_key != "ARK_API_KEY":
+                continue
+            candidate = candidate.strip()
+            if (
+                len(candidate) >= 2
+                and candidate[0] == candidate[-1]
+                and (candidate[0] in {'"', "'"})
+            ):
+                candidate = candidate[1:-1]
+            if candidate:
+                return candidate
+        raise RuntimeError("ARK_API_KEY is missing from the supplied env file")
+
+    def management_key(self) -> str:
+        if self.MANAGEMENT_KEY_FILE.is_file():
+            key = self.MANAGEMENT_KEY_FILE.read_text(encoding="utf-8").strip()
+            if len(key) < 32:
+                raise RuntimeError("private management key is unexpectedly short")
+            return key
+        key = secrets.token_urlsafe(48)
+        write_private(self.MANAGEMENT_KEY_FILE, key + "\n")
+        return key
+
+    def ark_fallback_models(self) -> list[str]:
+        aliases = [slug for (slug, route) in ROUTES.items() if route["tail"]] + list(
+            MODEL_FAMILIES
+        )
+        lines = []
+        for alias in aliases:
+            route = ROUTES.get(alias, ROUTES.get(f"auto/{alias}"))
+            lines.extend(
+                [
+                    f"      - name: {yaml_quote(self.ARK_MODEL)}",
+                    f"        alias: {yaml_quote(alias)}",
+                    f"        display-name: {yaml_quote(route['display_name'])}",
+                    "        force-mapping: true",
+                    "        is-compat: true",
+                    "        input-modalities: [text]",
+                    "        output-modalities: [text]",
+                    "        thinking:",
+                    '          levels: ["high", "medium", "low"]',
+                ]
+            )
+        return lines
+
+    def runtime_config(
+        self,
+        ark_key: str,
+        port: int | None = None,
+        management_secret: str | None = None,
+    ) -> str:
+        if port is None:
+            port = self.PORT
+        if management_secret is None:
+            management_secret = self.management_key()
+        return "\n".join(
+            [
+                'host: "127.0.0.1"',
+                f"port: {port}",
+                f"auth-dir: {yaml_quote(str(self.AUTH_DIR))}",
+                "debug: false",
+                "logging-to-file: false",
+                "usage-statistics-enabled: false",
+                "remote-management:",
+                "  allow-remote: false",
+                f"  secret-key: {yaml_quote(management_secret)}",
+                "  disable-control-panel: true",
+                "request-retry: 10",
+                "max-retry-credentials: 0",
+                "max-retry-interval: 65",
+                "force-model-prefix: false",
+                "routing:",
+                '  strategy: "fill-first"',
+                "  session-affinity: true",
+                '  session-affinity-ttl: "1h"',
+                "codex:",
+                "  stream-bootstrap-buffering: true",
+                "  optimize-multi-agent-v2: true",
+                "plugins:",
+                "  enabled: true",
+                f"  dir: {yaml_quote(str(self.PLUGIN_DIR))}",
+                "  configs:",
+                "    fast-selector-tier:",
+                "      enabled: true",
+                "      priority: 100",
+                "openai-compatibility:",
+                '  - name: "volcengine-ark-deepseek-v4-flash"',
+                "    priority: 100",
+                f"    base-url: {yaml_quote(self.ARK_BASE_URL)}",
+                "    disable-cooling: false",
+                "    request-retry: 1",
+                "    api-key-entries:",
+                f"      - api-key: {yaml_quote(ark_key)}",
+                "    models:",
+                *self.ark_fallback_models(),
+                f"      - name: {yaml_quote(self.ARK_MODEL)}",
+                '        alias: "ark/deepseek-v4-flash"',
+                '        display-name: "Ark · DeepSeek V4 Flash"',
+                "        force-mapping: true",
+                "        is-compat: true",
+                "        input-modalities: [text]",
+                "        output-modalities: [text]",
+                "        thinking:",
+                '          levels: ["high", "medium", "low"]',
+                f"      - name: {yaml_quote(self.ARK_MODEL)}",
+                '        alias: "deepseek-v4-flash"',
+                '        display-name: "Ark · DeepSeek V4 Flash (legacy id)"',
+                "        force-mapping: true",
+                "        is-compat: true",
+                "        input-modalities: [text]",
+                "        output-modalities: [text]",
+                "        thinking:",
+                '          levels: ["high", "medium", "low"]',
+                f"      - name: {yaml_quote(self.ARK_MODEL)}",
+                f"        alias: {yaml_quote(self.ARK_MODEL)}",
+                '        display-name: "Ark · DeepSeek V4 Flash (endpoint id)"',
+                "        force-mapping: true",
+                "        is-compat: true",
+                "        input-modalities: [text]",
+                "        output-modalities: [text]",
+                "        thinking:",
+                '          levels: ["high", "medium", "low"]',
+                f"      - name: {yaml_quote(self.ARK_PRO_MODEL)}",
+                f"        alias: {yaml_quote(self.ARK_PRO_MODEL)}",
+                '        display-name: "Ark · DeepSeek V4 Pro"',
+                "        force-mapping: true",
+                "        is-compat: true",
+                "        input-modalities: [text]",
+                "        output-modalities: [text]",
+                "        thinking:",
+                '          levels: ["high", "medium", "low"]',
+                "",
+            ]
+        )
+
+    def read_pid(self) -> int | None:
+        try:
+            return int(self.PID_FILE.read_text(encoding="utf-8").strip())
+        except (FileNotFoundError, ValueError):
+            return None
+
+    def pid_alive(self, pid: int | None) -> bool:
+        if pid is None or pid <= 1:
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def wait_port(
+        self, pid: int, port: int | None = None, timeout: float = 15.0
+    ) -> None:
+        if port is None:
+            port = self.PORT
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if not self.pid_alive(pid):
+                raise RuntimeError("CPA exited before binding its loopback port")
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                    return
+            except OSError:
+                time.sleep(0.05)
+        raise TimeoutError(f"CPA did not bind 127.0.0.1:{port}")
+
+    def start(self, env_file: Path | None) -> None:
+        self.prepare()
+        current = self.read_pid()
+        if self.pid_alive(current):
+            print(f"already-running pid={current} port={self.PORT}")
+            return
+        self.PID_FILE.unlink(missing_ok=True)
+        ark_key = self.load_ark_key(env_file)
+        config_path = self.RUNTIME_CONFIG
+        write_private(config_path, self.runtime_config(ark_key))
+        log_path = self.LOG_DIR / "cpa.log"
+        log_handle = log_path.open("ab", buffering=0)
+        try:
+            process = subprocess.Popen(
+                [str(self.BINARY), "-config", str(config_path)],
+                cwd=self.RUNTIME_ROOT,
+                stdin=subprocess.DEVNULL,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                close_fds=True,
+            )
+        finally:
+            log_handle.close()
+        try:
+            self.wait_port(process.pid)
+            time.sleep(0.75)
+            if not self.pid_alive(process.pid):
+                raise RuntimeError("CPA exited during post-bind stabilization")
+            write_private(self.PID_FILE, f"{process.pid}\n")
+        except Exception:
+            config_path.unlink(missing_ok=True)
+            raise
+        print(
+            f"started pid={process.pid} port={self.PORT} commit={self.SOURCE_COMMIT[:8]} auth_slots={','.join(self.active_slots()) or 'none'}"
+        )
+
+    def serve(self, env_file: Path | None) -> None:
+        """Run CPA in the foreground for launchd supervision."""
+        self.prepare()
+        ark_key = self.load_ark_key(env_file)
+        write_private(self.RUNTIME_CONFIG, self.runtime_config(ark_key))
+        write_private(self.PID_FILE, f"{os.getpid()}\n")
+        os.chdir(self.RUNTIME_ROOT)
+        os.execv(
+            str(self.BINARY), [str(self.BINARY), "-config", str(self.RUNTIME_CONFIG)]
+        )
+
+    def launchd_loaded(self) -> bool:
+        completed = subprocess.run(
+            ["launchctl", "print", f"gui/{os.getuid()}/{self.LAUNCHD_LABEL}"],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return completed.returncode == 0
+
+    def stop(self) -> None:
+        if self.launchd_loaded():
+            raise RuntimeError(
+                "runtime is launchd-managed; boot out the dedicated LaunchAgent before stopping"
+            )
+        pid = self.read_pid()
+        if not self.pid_alive(pid):
+            self.PID_FILE.unlink(missing_ok=True)
+            print("already-stopped")
+            return
+        assert pid is not None
+        command = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            check=False,
+            capture_output=True,
+            text=True,
+        ).stdout
+        if str(self.BINARY) not in command:
+            raise RuntimeError(f"refusing to signal unrelated pid {pid}")
+        os.kill(pid, signal.SIGTERM)
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and self.pid_alive(pid):
+            time.sleep(0.05)
+        if self.pid_alive(pid):
+            raise RuntimeError(f"CPA pid {pid} did not stop after SIGTERM")
+        self.PID_FILE.unlink(missing_ok=True)
+        self.RUNTIME_CONFIG.unlink(missing_ok=True)
+        print(f"stopped pid={pid}")
+
+    def load_slots(self) -> dict[str, str]:
+        if not self.SLOTS_FILE.is_file():
+            return {}
+        data = json.loads(self.SLOTS_FILE.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise TypeError("invalid OAuth slot state")
+        if any(
+            key not in SLOTS
+            or not isinstance(value, str)
+            or Path(value).name != value
+            or not value.endswith(".json")
+            for key, value in data.items()
+        ):
+            raise ValueError("invalid OAuth slot filename")
+        if len(set(data.values())) != len(data):
+            raise ValueError("OAuth slots must reference distinct credentials")
+        return data
+
+    def active_slots(self) -> list[str]:
+        return sorted(
+            slot
+            for (slot, name) in self.load_slots().items()
+            if (self.AUTH_DIR / name).is_file()
+        )
+
+    def patch_slot_auth(self, path: Path, slot: str) -> None:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or str(data.get("type", "")).lower() != "codex":
+            raise RuntimeError("OAuth result is not a Codex auth record")
+        data.update(
+            {
+                "priority": 400 - 100 * SLOTS.index(slot),
+                "request_retry": 10,
+                "disable_cooling": False,
+                "websockets": False,
+                "loopx_slot": slot,
+                "model_aliases": aliases_for_slot(slot),
+            }
+        )
+        write_private(path, json.dumps(data, ensure_ascii=False, separators=(",", ":")))
+
+    def reconcile(self) -> None:
+        """Validate the entire slot set before changing any routing metadata."""
+        self.prepare()
+        self.check_target_boundaries()
+        slots = self.load_slots()
+        missing = [
+            slot
+            for slot in SLOTS
+            if slot not in slots or not (self.AUTH_DIR / slots[slot]).is_file()
+        ]
+        if missing:
+            raise ValueError(
+                "cannot reconcile missing OAuth slots: " + ",".join(missing)
+            )
+        identities = set()
+        for slot in SLOTS:
+            data = json.loads((self.AUTH_DIR / slots[slot]).read_text())
+            if (
+                data.get("type") != "codex"
+                or not data.get("account_id")
+                or data["account_id"] in identities
+            ):
+                raise ValueError("slots require distinct Codex account identities")
+            identities.add(data["account_id"])
+        for slot in SLOTS:
+            self.patch_slot_auth(self.AUTH_DIR / slots[slot], slot)
+
+    def fetch_models(self, port: int | None = None) -> list[str]:
+        if port is None:
+            port = self.PORT
+        request = urllib.request.Request(f"http://127.0.0.1:{port}/v1/models")
+        try:
+            with urllib.request.urlopen(request, timeout=3) as response:
+                payload = json.load(response)
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise RuntimeError(
+                f"CPA model endpoint unavailable: {type(error).__name__}"
+            ) from error
+        data = payload.get("data", []) if isinstance(payload, dict) else []
+        return sorted(
+            str(item["id"])
+            for item in data
+            if isinstance(item, dict) and isinstance(item.get("id"), str)
+        )
+
+    def fetch_management_auth_files(
+        self, port: int | None = None
+    ) -> list[dict[str, Any]]:
+        if port is None:
+            port = self.PORT
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v0/management/auth-files",
+            headers={"Authorization": "Bearer " + self.management_key()},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=3) as response:
+                payload = json.load(response)
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise RuntimeError(
+                f"CPA management endpoint unavailable: {type(error).__name__}"
+            ) from error
+        files = payload.get("files") if isinstance(payload, dict) else None
+        if not isinstance(files, list):
+            raise TypeError(
+                "CPA management endpoint returned an invalid auth-file list"
+            )
+        return [item for item in files if isinstance(item, dict)]
+
+    def fetch_management_plugins(self, port: int | None = None) -> list[dict[str, Any]]:
+        if port is None:
+            port = self.PORT
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v0/management/plugins",
+            headers={"Authorization": "Bearer " + self.management_key()},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=3) as response:
+                payload = json.load(response)
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise RuntimeError(
+                f"CPA plugin endpoint unavailable: {type(error).__name__}"
+            ) from error
+        plugins = payload.get("plugins") if isinstance(payload, dict) else None
+        if not isinstance(plugins, list):
+            raise TypeError("CPA plugin endpoint returned an invalid plugin list")
+        return [item for item in plugins if isinstance(item, dict)]
+
+    def fast_selector_plugin_ready(self, port: int | None = None) -> bool:
+        if port is None:
+            port = self.PORT
+        return any(
+            item.get("id") == "fast-selector-tier"
+            and item.get("registered") is True
+            and (item.get("effective_enabled") is True)
+            for item in self.fetch_management_plugins(port=port)
+        )
+
+    def route_status(self, *, modality: str, fast: bool) -> None:
+        self.prepare()
+        if modality not in {"text", "image"}:
+            raise ValueError("route-status modality must be text or image")
+        payload = {
+            "schema_version": "cpa_route_status_v0",
+            "credential_free": True,
+            "host_identity": {
+                "state": "retained",
+                "projection": "not_projected",
+                "route_binding": "none",
+            },
+            "execution_observation": self.latest_execution_observation(
+                modality=modality, fast=fast
+            ),
+            "account_observations": self.account_observations(),
+        }
+        serialized = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        for private_value in self.load_slots().values():
+            if private_value and private_value in serialized:
+                raise RuntimeError("private auth filename reached route status")
+        write_private(self.STATUS_SNAPSHOT_FILE, serialized + "\n")
+        print(serialized)
+
+    def validate(self) -> None:
+        self.check_target_boundaries()
+        self.check_artifacts()
+        slots = self.load_slots()
+        errors: list[str] = []
+        if not self.MODEL_CATALOG.is_file():
+            errors.append("model-catalog-missing")
+        else:
+            catalog = json.loads(self.MODEL_CATALOG.read_text(encoding="utf-8"))
+            by_slug = {
+                item.get("slug"): item
+                for item in catalog.get("models", [])
+                if isinstance(item, dict) and isinstance(item.get("slug"), str)
+            }
+            expected_modalities = {
+                **{slug: {"text", "image"} for slug in ROUTES},
+                AUTO_MODEL: {"text", "image"},
+                PREFER_A_MODEL: {"text", "image"},
+                PREFER_B_MODEL: {"text", "image"},
+                LUNA_MODEL: {"text", "image"},
+                FAST_AUTO_MODEL: {"text", "image"},
+                FAST_PREFER_A_MODEL: {"text", "image"},
+                FAST_PREFER_B_MODEL: {"text", "image"},
+                "ark/deepseek-v4-flash": {"text"},
+                "deepseek-v4-flash": {"text"},
+                self.ARK_MODEL: {"text"},
+                self.ARK_PRO_MODEL: {"text"},
+            }
+            for model, expected in expected_modalities.items():
+                item = by_slug.get(model)
+                actual = set(item.get("input_modalities", [])) if item else set()
+                if actual != expected:
+                    errors.append(f"model-catalog-modalities:{model}")
+            for model in ROUTES:
+                item = by_slug.get(model) or {}
+                speed_tiers = set(item.get("additional_speed_tiers", []))
+                service_tiers = {
+                    tier.get("id")
+                    for tier in item.get("service_tiers", [])
+                    if isinstance(tier, dict)
+                }
+                if "fast" not in speed_tiers or "priority" not in service_tiers:
+                    errors.append(f"model-catalog-fast-tier:{model}")
+                expected_default = "fast" if model in FAST_MODELS else None
+                if item.get("default_service_tier") != expected_default:
+                    errors.append(f"model-catalog-fast-default:{model}")
+        for slot in SLOTS:
+            name = slots.get(slot)
+            if not name or not (self.AUTH_DIR / name).is_file():
+                errors.append(f"slot-{slot}-missing")
+                continue
+            data = json.loads((self.AUTH_DIR / name).read_text(encoding="utf-8"))
+            want_priority = 400 - 100 * SLOTS.index(slot)
+            alias_entries = {
+                item.get("alias"): item
+                for item in data.get("model_aliases", [])
+                if isinstance(item, dict) and isinstance(item.get("alias"), str)
+            }
+            if data.get("priority") != want_priority:
+                errors.append(f"slot-{slot}-priority")
+            expected_aliases = aliases_for_slot(slot)
+            if any(entry["alias"] not in alias_entries for entry in expected_aliases):
+                errors.append(f"slot-{slot}-aliases")
+            expected_route_priorities = {
+                entry["alias"]: entry["routing-priority"] for entry in expected_aliases
+            }
+            for entry in expected_aliases:
+                if alias_entries.get(entry["alias"], {}).get("name") != entry["name"]:
+                    errors.append(f"slot-{slot}-upstream-model:{entry['alias']}")
+            for alias, expected_priority in expected_route_priorities.items():
+                if (
+                    alias_entries.get(alias, {}).get("routing-priority")
+                    != expected_priority
+                ):
+                    errors.append(f"slot-{slot}-routing-priority:{alias}")
+            if data.get("websockets") is not False:
+                errors.append(f"slot-{slot}-websocket")
+        if errors:
+            raise RuntimeError("qualification incomplete: " + ",".join(errors))
+        if self.pid_alive(self.read_pid()):
+            if not self.fast_selector_plugin_ready():
+                raise RuntimeError("runtime Fast selector plugin is not active")
+            models = set(self.fetch_models())
+            required = {
+                *ROUTES,
+                *MODEL_FAMILIES,
+                AUTO_MODEL,
+                GPT_MODEL,
+                PREFER_A_MODEL,
+                PREFER_B_MODEL,
+                LUNA_MODEL,
+                *FAST_MODELS,
+                "ark/deepseek-v4-flash",
+                *self.ARK_LEGACY_MODELS,
+                self.ARK_PRO_MODEL,
+            }
+            missing = sorted(required - models)
+            if missing:
+                raise RuntimeError(
+                    "runtime model catalog missing: " + ",".join(missing)
+                )
+        print(
+            "validate-ok slots=A,B,C models=Sol,Astra auto=A-B-C-Ark prefer-b=B-C-A-Ark prefer-c=C-A-B-Ark luna=A-B-C fast-routes=A-B-C"
+        )

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_settings.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_settings.py
@@ -1,0 +1,141 @@
+"""Private, explicit local targets for the opt-in CPA operator CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import ClassVar
+from urllib.parse import urlsplit
+
+
+class OperatorSettings:
+    PATH_KEYS: ClassVar[set[str]] = {
+        "runtime_root",
+        "temporary_root",
+        "binary",
+        "plugin_directory",
+        "codex_binary",
+        "gpt_cache",
+        "astra_cache",
+        "ark_catalog",
+        "ark_profile_catalog",
+        "ark_env_file",
+    }
+    OPTIONAL_PATH_KEYS: ClassVar[set[str]] = {"login_source"}
+    VALUE_KEYS: ClassVar[set[str]] = {
+        "schema_version",
+        "paths",
+        "binary_sha256",
+        "plugin_sha256",
+        "source_commit",
+        "port",
+        "launchd_label",
+        "ark_base_url",
+        "ark_model",
+        "ark_pro_model",
+    }
+
+    def __init__(self, data: dict):
+        if (
+            set(data) != self.VALUE_KEYS
+            or data["schema_version"] != "loopx_cpa_local_operator_v1"
+        ):
+            raise ValueError("local configuration has missing or unsupported fields")
+        paths = data["paths"]
+        if (
+            not isinstance(paths, dict)
+            or not self.PATH_KEYS <= paths.keys()
+            or set(paths) - self.PATH_KEYS - self.OPTIONAL_PATH_KEYS
+        ):
+            raise ValueError("local configuration requires explicit path references")
+        self.paths = {}
+        for key, raw in paths.items():
+            if not isinstance(raw, str) or not Path(raw).is_absolute():
+                raise ValueError(f"{key} requires an absolute local path")
+            path = Path(raw)
+            if path.is_symlink():
+                raise ValueError(f"{key} must not be a symbolic link")
+            self.paths[key] = path.resolve()
+        for key in ("runtime_root", "temporary_root"):
+            target = self.paths[key]
+            if target == Path(target.anchor) or target == Path.home():
+                raise ValueError(f"{key} must be a dedicated directory")
+            if any((parent / ".git").exists() for parent in (target, *target.parents)):
+                raise ValueError(f"{key} must be outside Git worktrees")
+        if self.paths["runtime_root"] == self.paths["temporary_root"]:
+            raise ValueError("runtime and temporary roots must differ")
+        for key in ("binary_sha256", "plugin_sha256"):
+            if (
+                not isinstance(data[key], str)
+                or re.fullmatch(r"[0-9a-f]{64}", data[key]) is None
+            ):
+                raise ValueError(f"{key} must be an exact SHA-256")
+        if (
+            not isinstance(data["source_commit"], str)
+            or re.fullmatch(r"[0-9a-f]{40}", data["source_commit"]) is None
+        ):
+            raise ValueError("source_commit must be an exact Git commit")
+        if type(data["port"]) is not int or not 1024 <= data["port"] <= 65535:
+            raise ValueError("port must be an unprivileged TCP port")
+        if (
+            not isinstance(data["launchd_label"], str)
+            or re.fullmatch(r"[A-Za-z0-9._-]+", data["launchd_label"]) is None
+        ):
+            raise ValueError("launchd_label must be a service identifier")
+        url = urlsplit(data["ark_base_url"])
+        if (
+            url.scheme != "https"
+            or not url.hostname
+            or url.username
+            or url.password
+            or url.query
+            or url.fragment
+        ):
+            raise ValueError("fallback endpoint must be credential-free HTTPS")
+        for key in ("ark_model", "ark_pro_model"):
+            if (
+                not isinstance(data[key], str)
+                or re.fullmatch(r"[a-z0-9._-]+", data[key]) is None
+            ):
+                raise ValueError(f"{key} must be a model identifier")
+        self.data = data
+
+    @classmethod
+    def read(cls, path: Path):
+        if not path.is_absolute() or path.is_symlink() or path.stat().st_mode & 0o077:
+            raise ValueError(
+                "operator config requires a private regular file (mode 0600)"
+            )
+        return cls(json.loads(path.read_text(encoding="utf-8")))
+
+    def runtime_attributes(self):
+        p, d = self.paths, self.data
+        root, temporary = p["runtime_root"], p["temporary_root"]
+        state, logs = root / "state", root / "logs"
+        return {
+            "SOURCE_COMMIT": d["source_commit"],
+            "BINARY_SHA256": d["binary_sha256"],
+            "BINARY": p["binary"],
+            "PLUGIN_DIR": p["plugin_directory"],
+            "FAST_SELECTOR_PLUGIN": p["plugin_directory"] / "fast-selector-tier.dylib",
+            "FAST_SELECTOR_PLUGIN_SHA256": d["plugin_sha256"],
+            "RUNTIME_ROOT": root,
+            "AUTH_DIR": root / "auth",
+            "STATE_DIR": state,
+            "LOG_DIR": logs,
+            "MODEL_CATALOG": root / "codex-model-catalog.json",
+            "PID_FILE": state / "cpa.pid",
+            "SLOTS_FILE": state / "oauth-slots.json",
+            "MANAGEMENT_KEY_FILE": state / "management.key",
+            "STATUS_SNAPSHOT_FILE": state / "route-status.json",
+            "RUNTIME_TMP_ROOT": temporary,
+            "RUNTIME_CONFIG": temporary / "runtime-config.yaml",
+            "PORT": d["port"],
+            "LAUNCHD_LABEL": d["launchd_label"],
+            "ARK_BASE_URL": d["ark_base_url"],
+            "ARK_MODEL": d["ark_model"],
+            "ARK_PRO_MODEL": d["ark_pro_model"],
+            "ARK_LEGACY_MODELS": ("deepseek-v4-flash", d["ark_model"]),
+            "LOG_CANDIDATES": (logs / "launchd.log", logs / "cpa.log"),
+        }

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
@@ -1,0 +1,136 @@
+"""Credential-free selector definitions shared by CPA and the App catalog."""
+
+from .contract import compile_catalog
+
+SLOTS = ("a", "b", "c")
+MODEL_FAMILIES = {"gpt-5.6-sol": "Sol", "gpt-6-astra": "Astra"}
+ROUTES = {}
+for model, label in MODEL_FAMILIES.items():
+    for preferred in (None, *SLOTS):
+        order = (
+            list(SLOTS)
+            if preferred is None
+            else list(SLOTS[SLOTS.index(preferred) :] + SLOTS[: SLOTS.index(preferred)])
+        )
+        prefix = "auto" if preferred is None else f"codex-{preferred}"
+        title = "Auto" if preferred is None else f"Prefer {preferred.upper()}"
+        chain = " → ".join(s.upper() for s in order)
+        for fast in (False, True):
+            slug = ("fast/" if fast else "") + f"{prefix}/{model}"
+            ROUTES[slug] = {
+                "model": model,
+                "order": order,
+                "fast": fast,
+                "tail": [] if fast else ["ark-text"],
+                "display_name": f"{label} · {title} · "
+                + ("Fast · " if fast else "")
+                + f"Codex {chain}"
+                + ("" if fast else " → Ark"),
+            }
+ROUTES["gpt-5.6-luna"] = {
+    "model": "gpt-5.6-luna",
+    "order": list(SLOTS),
+    "fast": False,
+    "tail": [],
+    "display_name": "Luna · Codex A → B → C",
+}
+FAST_MODELS = tuple(slug for slug, route in ROUTES.items() if route["fast"])
+
+
+def aliases_for_slot(slot):
+    if slot not in SLOTS:
+        raise ValueError("unknown OAuth slot")
+    entries = []
+    for slug, route in ROUTES.items():
+        entries.append(
+            {
+                "name": route["model"],
+                "alias": slug,
+                "display-name": route["display_name"],
+                "force-mapping": True,
+                "routing-priority": 400 - 100 * route["order"].index(slot),
+            }
+        )
+    for model in MODEL_FAMILIES:
+        entry = dict(next(e for e in entries if e["alias"] == f"auto/{model}"))
+        entry["alias"] = model
+        entries.append(entry)
+    return entries
+
+
+def routing_source():
+    profiles = [
+        {
+            "id": f"codex-{s}",
+            "provider": "codex",
+            "priority": 400 - 100 * SLOTS.index(s),
+            "input_modalities": ["text", "image"],
+            "supports_fast": True,
+            "tool_transports": ["function_call", "custom_tool_call"],
+        }
+        for s in SLOTS
+    ]
+    profiles.append(
+        {
+            "id": "ark-text",
+            "provider": "openai_compatibility",
+            "priority": 100,
+            "input_modalities": ["text"],
+            "supports_fast": False,
+            "tool_transports": ["function_call"],
+        }
+    )
+    routes = []
+    for slug, spec in ROUTES.items():
+        if spec["fast"]:
+            continue
+        auto = slug.startswith("auto/") or slug == "gpt-5.6-luna"
+        route = {
+            "slug": slug,
+            "display_name": spec["display_name"],
+            "mode": "auto" if auto else "preferred",
+            "ring": "codex-accounts",
+            "entrypoint": "affinity_then_first"
+            if auto
+            else f"codex-{spec['order'][0]}",
+            "fallback_tail": spec["tail"],
+            "input_modalities": ["text", "image"],
+            "supports_fast": True,
+            "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
+        }
+        fast = ROUTES.get(f"fast/{slug}")
+        if fast:
+            route["fast_selector"] = {
+                "display_name": fast["display_name"],
+                "fallback_policy": "fast_capable_only",
+            }
+        routes.append(route)
+    return {
+        "profiles": profiles,
+        "rings": [
+            {
+                "id": "codex-accounts",
+                "members": [f"codex-{s}" for s in SLOTS],
+                "max_cycles": 1,
+            }
+        ],
+        "routes": routes,
+    }
+
+
+def compiled_routes():
+    return compile_catalog(routing_source())
+
+
+# The existing contract compiler owns ring traversal and Fast admission.
+# Both credential aliases and App rows consume its resolved candidates.
+for _row in compiled_routes()["selector_rows"]:
+    _spec = ROUTES[_row["slug"]]
+    _spec["order"] = [
+        profile.removeprefix("codex-")
+        for profile in _row["candidates"]
+        if profile.startswith("codex-")
+    ]
+    _spec["tail"] = [
+        profile for profile in _row["candidates"] if not profile.startswith("codex-")
+    ]


### PR DESCRIPTION
The routing package previously described the integration while local operators owned the executable maintenance scripts. Add a separately invoked `loopx-cpa-operator` CLI so account enrollment, routing metadata, App catalogs, process supervision and readback have one maintained implementation.

- Add an A/B/C Sol/Astra preset using the existing ring compiler: eight matching selectors per model, with Fast restricted to subscription accounts. Preserve legacy A/B qualification and the managed extension's read-only protocol.
- Require an explicit private configuration and per-command `--execute`. Keep credentials, artifact pins, service-manager configuration and state outside Git. Validate target boundaries and snapshot routing changes; rollback preserves rotated credentials.
- Refresh CPA model definitions while retaining executable/plugin hash checks, respect cooling for every account, and document App/upstream Fast-tier limitations and eligible Ark fallback.

Validation: existing extension smoke, 15 offline operator tests, Ruff, Python compilation and public/private boundary scan passed. Configured-runtime validation and isolated App Server readback passed with all 21 selectors. Provider-bound Fast requests were separately verified to carry `priority`; upstream acceleration is not guaranteed by that request. No live exhaustion was forced to qualify Ark fallback.

The local operator is opt-in and does not modify App bundles, service-manager files or task stores. See `OPERATOR.md` for installation, activation, rollback and disable commands.
