### PR TITLE
test(hooks): separate deadline semantics from wall-clock timing

### DIFF
--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -9,6 +9,8 @@ import threading
 import time
 from collections.abc import Callable
 from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -1746,8 +1748,11 @@ def test_post_writeback_legacy_lock_timeout_isolates_other_hooks(
     assert len(receipts) == 1
 
 
+@pytest.mark.parametrize("controlled_clock", [False, True], ids=["real-clock", "budget"])
 def test_post_writeback_legacy_locks_share_one_batch_deadline(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    controlled_clock: bool,
 ) -> None:
     calls = {"free": 0}
     locked_hooks = [
@@ -1794,6 +1799,16 @@ def test_post_writeback_legacy_locks_share_one_batch_deadline(
     ]
     assert len(locked_receipts) == 3
 
+    if controlled_clock:
+        # A 50ms budget loses 20ms before the first guard, then overruns.
+        # Patch only this adapter's clock, not the real file-lock/runtime clock.
+        ticks = iter([100.0, 100.02, 100.075, 100.075, 100.075])
+        monkeypatch.setattr(
+            capability_hooks, "time", SimpleNamespace(monotonic=lambda: next(ticks))
+        )
+        lock_spy = Mock(wraps=exclusive_file_lock)
+        monkeypatch.setattr(capability_hooks, "exclusive_file_lock", lock_spy)
+
     with ExitStack() as held_locks:
         for receipt in locked_receipts:
             held_locks.enter_context(
@@ -1808,7 +1823,16 @@ def test_post_writeback_legacy_locks_share_one_batch_deadline(
         )
         elapsed = time.monotonic() - started
 
-    assert elapsed < 0.13
+    if controlled_clock:
+        # Neither restart a full timeout per lock nor pass a negative timeout;
+        # the free sibling must still get a nonblocking acquisition attempt.
+        assert [
+            call.kwargs["timeout_seconds"] for call in lock_spy.call_args_list
+        ] == pytest.approx([0.03, 0.0, 0.0, 0.0])
+    else:
+        # Coarse integration guard only: dispatch also includes runtime and I/O
+        # overhead. The controlled-clock case enforces the precise budget rule.
+        assert elapsed < 2.0
     assert calls == {"free": 1}
     assert dispatch["invoked_count"] == 1
     assert dispatch["intent_count"] == 1


### PR DESCRIPTION
## Summary

Make the legacy post-writeback lock deadline regression test insensitive to unrelated CI scheduling and coverage overhead, without weakening its shared-budget contract.

- Run the existing four-hook fixture in real-clock and controlled-clock modes, preserving real file locks and the real transaction runtime in both.
- Assert exact remaining lock budgets of 30ms, 0, 0, 0 after a 50ms batch budget loses 20ms and then overruns. This protects against per-lock timeout resets, negative timeouts, and starving the free sibling.
- Replace the 130ms whole-dispatch assertion with a coarse 2s real-clock guard. Precise deadline semantics no longer depend on end-to-end wall-clock latency.

Only one test file changes (+25/-1). Production lock policy, runtime behavior, configuration, activation, and authority are unchanged. This is independent of the protocol-binding refactor in #3950.

## Validation

- Entire post-writeback Python test module with coverage: **41 passed**.
- Mutation probes: resetting each lock's timeout and allowing negative remaining time both fail the new budget assertion, as intended. Production source was not modified by these probes.
- Ruff, Python compilation, and diff hygiene: passed.
- Public/private scan: clean for the changed file; no local state or raw probe artifacts included.
- Exact-scope change-quality receipt: `cqr_65552ae505c12d030b7f`, valid.
- Goal-aware standard premerge: passed (direct hygiene/compile checks; no additional catalog checks selected).

Full repository suites and native Windows execution were not run locally. Focused coverage is proportionate to this test-only cleanup: both modes execute real locking and transaction behavior, and independent mutations demonstrate regression sensitivity.

## Self-review and merge scope

No blocking finding in the final diff. Reuse the existing fixture instead of adding a duplicate test body or a production abstraction. Clock replacement is module-local, leaving the file-lock and runtime clocks real; pytest restores patches between cases. Existing timeout failure and free-sibling result assertions remain intact.

No typed-state, domain classification, default behavior, guidance/obligation, optional capability, or actor-authority changes. Future-facing pass: the related improvement is applied by separating semantic and integration timing oracles; no broader runtime refactor is warranted.

Owner requested self-merge of this narrow test cleanup after validation. This does not authorize merging #3950 or its dependency stack.
