### PR TITLE
fix(chat): reject reserved session path segments

### DIFF
--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -148,7 +148,10 @@ class ChatSessionStore:
         self.compact_completed_events()
 
     def _session_dir(self, session_id: str) -> Path:
-        return self.sessions_root / _opaque_id(session_id, field="session_id")
+        token = _opaque_id(session_id, field="session_id")
+        if token in {".", ".."}:
+            raise ValueError("session_id must be a compact opaque id")
+        return self.sessions_root / token
 
     def _session_path(self, session_id: str) -> Path:
         return self._session_dir(session_id) / "session.json"

--- a/tests/test_chat_store_input_validation.py
+++ b/tests/test_chat_store_input_validation.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.chat_store import CHAT_SESSION_SCHEMA_VERSION, ChatSessionStore
+
+
+def test_session_id_cannot_escape_sessions_directory(tmp_path: Path) -> None:
+    store = ChatSessionStore(tmp_path)
+    (store.root / "session.json").write_text(
+        json.dumps(
+            {
+                "schema_version": CHAT_SESSION_SCHEMA_VERSION,
+                "session_id": "outside-sessions",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="session_id"):
+        store.load_session("..")


### PR DESCRIPTION
## Summary
- reject reserved dot path segments before building Chat session paths
- prevent a session_id value of two dots from escaping the sessions directory
- add a focused regression through the public store API

## Root cause
The compact opaque-ID character allowlist accepted the reserved path segments dot and dot-dot. Because session_id is used as a directory segment, dot-dot resolved to the parent chat directory and could read a valid session.json outside sessions/.

## Validation
- 61 Chat tests passed
- focused regression passed
- Ruff passed
- loopx canary premerge passed (1/1 selected, no warnings or manual holds)

## Scope
The guard is centralized in the existing session path boundary. No new abstraction or dependency was added.