### PR TITLE
docs(architecture): replace stale fact inventories with executable sources

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,24 +95,28 @@ Operator-facing docs and heartbeat prompts often summarize a turn as deliver,
 wait, ask, replan, repair, or stay quiet. That shorthand describes interaction
 intent; it is not the typed packet vocabulary carried by the Turn contracts.
 
-Typed Turn decisions use two enums in `loopx/control_plane/turn_driver/`:
+The executable vocabulary lives with its owning contracts:
 
-| Contract | When | Members |
+| Contract | When | Authoritative definition |
 | --- | --- | --- |
-| `LoopXTurnRoute` | Before host execution | `ready_for_host`, `repair_required`, `replan_required`, `user_action_required`, `wait`, `blocked`, `contract_error` |
-| `LoopXTurnResultKind` | After host execution | `validated_progress`, `validated_completion`, `repair_required`, `replan_required`, `user_action_required`, `wait`, `host_failure`, `validation_failed`, `writeback_failed`, `quota_spend_failed` |
+| `LoopXTurnRoute` | Before host execution | [`driver.py`](../loopx/control_plane/turn_driver/driver.py), enum `LoopXTurnRoute` |
+| `TurnResultKind` | After host execution | [`settlement.ts`](../loopx/control_plane/turn_driver/settlement.ts), `TURN_RESULT_KINDS`; Python adapter: [`transaction.py`](../loopx/control_plane/turn_driver/transaction.py), enum `LoopXTurnResultKind` |
 
-Important distinctions the shorthand erases:
+Read the complete member lists in those definitions; this page explains their
+meaning without maintaining another exhaustive enumeration.
 
-- prose "deliver" splits into `validated_progress` versus `validated_completion`;
-- failure kinds (`host_failure`, `validation_failed`, `writeback_failed`,
-  `quota_spend_failed`) are first-class post-execution results;
-- "stay quiet" is a notification / monitor behavior (for example
+- Prose "deliver" splits into `validated_progress` versus `validated_completion`.
+- Execution failures are first-class typed results. In particular,
+  `terminal_closeout_failed` means terminal closeout failed after durable
+  writeback and quota spend. Recovery retries the same Turn's closeout without
+  repeating those committed effects; it must not treat the failure as unspent.
+  The [Turn executor recovery tests](../tests/test_loopx_turn_executor.py)
+  exercise this boundary.
+- "Stay quiet" is notification / monitor behavior (for example
   `monitor_quiet_skip` or heartbeat `DONT_NOTIFY`), not a member of either enum.
 
 Quota `interaction_contract` and heartbeat guidance may still use the operator
-shorthand. When implementing or reviewing Turn adapters, prefer the enums above
-over the six-verb prose list.
+shorthand. Turn adapters use the executable definitions linked above.
 
 ## Runtime Responsibility Model
 
@@ -168,26 +172,27 @@ claim, gate, monitor, quota, writeback, recovery, and terminal closure. See the
 
 ## Current Dependency Budget
 
-Dependency direction is enforced incrementally while large compatibility
-facades are split. `loopx.control_plane` may not gain dependencies on
-presentation, CLI, capability, or benchmark-adapter layers; the architecture
-test keeps one explicit quota-Markdown migration edge as debt.
+The executable boundary policy lives in
+[`test_control_plane_import_boundaries.py`](../tests/architecture/test_control_plane_import_boundaries.py):
 
-The legacy `loopx.status` facade currently has one additional outward edge, the
-SkillsBench verifier-bootstrap attribution helper. This is migration debt, not
-an extension point. The architecture test records its exact module target so a
-new outward edge fails, and removing the edge requires deleting its stale
-allowlist entry in the same change.
+- `test_control_plane_does_not_gain_outward_dependencies` rejects control-plane
+  imports of presentation, CLI, capability, or benchmark-adapter layers.
+- `test_status_has_no_forbidden_outward_dependencies` rejects status imports of
+  benchmark-adapter or presentation layers.
+- `test_quota_markdown_is_owned_by_the_presentation_layer` protects the renderer
+  ownership and CLI composition boundary.
 
-Each edge should move only after characterization parity exists. Adapter-specific
-enrichment belongs behind application/plugin composition rather than in the
-status core. Status Markdown callers now use the presentation renderer directly;
-the former `loopx.status.render_status_markdown` wrapper was retired after parity
-fixtures and repository callers migrated. The formerly SkillsBench-named solution
-quality helper moved inward after characterization showed that it projects only
-generic compact benchmark fields; its shipped schema remains compatible. Hiding
-an adapter dependency inside a function or dynamic import does not count as
-architectural separation.
+These are zero-exception checks. The former quota-Markdown and status
+verifier-bootstrap edges have been removed; there is no remaining debt
+allowlist for these checks. Run the linked architecture test file to inspect
+current violations rather than maintaining an edge inventory in prose.
+
+Adapter-specific enrichment belongs behind application/plugin composition
+rather than in the status core. Move an edge only after characterization
+parity exists. Hiding an adapter dependency inside a function or dynamic import
+does not count as architectural separation; the current AST checks inspect
+static imports, including function-local imports, but do not prove the absence
+of dynamic imports.
 
 ### Status And Quota Facades
 

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -666,19 +666,21 @@ python3 -m pytest tests/test_smoke_suite.py \
   --junitxml smoke-suite.xml
 ```
 
-The required Python test workflow keeps `tests/**`, `canary/**`,
-`control_plane/**`, `domain_packs/**`, and `presentation/**` Ruff-clean. It also
-enforces an initial 19.6% package coverage floor.
-The floor is intentionally a regression guard, not a claim that 19.6% is
-sufficient; raise it as durable behavior moves from subprocess smokes into
-focused tests. An architecture test also prevents new control-plane dependencies
-on presentation, CLI, capability, or benchmark-adapter layers while preserving
-one explicit quota-Markdown migration debt edge. Existing source-wide lint debt
-is characterized separately. Strict mypy checking covers twelve characterized
-kernel and runtime contracts and should expand only as each next boundary
-becomes clean;
-expand the protected namespace list only after a bounded cleanup, rather than
-mass-fixing unrelated code merely to make a broad gate green.
+The required [Python test workflow](../../.github/workflows/python-tests.yml)
+owns the Ruff namespace selection and package coverage floor. The floor is a
+regression guard, not a claim of sufficient coverage; raise it as durable
+behavior moves from subprocess smokes into focused tests.
+
+[Architecture tests](../../tests/architecture/test_control_plane_import_boundaries.py)
+reject outward control-plane dependencies and forbidden status dependencies
+without migration exceptions, and protect presentation ownership of quota
+Markdown. See the [dependency policy](../architecture.md#current-dependency-budget)
+for the boundary rationale. Existing source-wide lint debt is characterized
+separately. Strict mypy scope is the `[tool.mypy].files` list in
+[`pyproject.toml`](../../pyproject.toml); use `python -m mypy` to check that exact
+scope. Expand each protected namespace only after a bounded cleanup rather
+than duplicating changing file counts or mass-fixing unrelated code to make a
+broad gate green.
 
 If the source checkout has optional frontend dependencies installed, dashboard
 readiness can be included in the same canary. If a release snapshot omits the

--- a/tests/architecture/test_control_plane_import_boundaries.py
+++ b/tests/architecture/test_control_plane_import_boundaries.py
@@ -51,7 +51,6 @@ STATUS_FORBIDDEN_DEPENDENCY_PREFIXES = (
     "loopx.benchmark_adapters",
     "loopx.presentation",
 )
-STATUS_OUTWARD_DEPENDENCY_DEBT: set[tuple[str, str]] = set()
 
 
 def _module_name(path: Path) -> str:
@@ -319,7 +318,7 @@ def test_public_facade_compatibility_entries_have_contract_evidence() -> None:
     )
 
 
-def test_status_outward_dependency_debt_only_shrinks() -> None:
+def test_status_has_no_forbidden_outward_dependencies() -> None:
     outward_dependencies = {
         (_module_name(STATUS_MODULE), dependency)
         for dependency in _resolved_imports(STATUS_MODULE)
@@ -329,15 +328,9 @@ def test_status_outward_dependency_debt_only_shrinks() -> None:
         )
     }
 
-    unexpected = outward_dependencies - STATUS_OUTWARD_DEPENDENCY_DEBT
-    stale_debt = STATUS_OUTWARD_DEPENDENCY_DEBT - outward_dependencies
-    assert not unexpected, (
-        "loopx.status must not gain new benchmark-adapter or presentation dependencies; "
-        f"unexpected edges: {sorted(unexpected)}"
-    )
-    assert not stale_debt, (
-        "remove resolved loopx.status edges from STATUS_OUTWARD_DEPENDENCY_DEBT; "
-        f"stale entries: {sorted(stale_debt)}"
+    assert not outward_dependencies, (
+        "loopx.status must not depend on benchmark-adapter or presentation layers; "
+        f"unexpected edges: {sorted(outward_dependencies)}"
     )
 
 


### PR DESCRIPTION
The architecture page omits `terminal_closeout_failed` and still describes dependency exceptions that the current tests no longer allow. Release readiness also repeats a stale mypy file count and the retired quota-Markdown exception.

This change links Turn vocabulary directly to its TypeScript definition and Python adapter, documents post-spend terminal-closeout recovery, and replaces the duplicated dependency inventory with links to executable boundary checks. Release readiness now points to CI and pyproject configuration for changing lint, coverage, and typing scope.

The bounded companion cleanup removes the empty status dependency-debt allowlist and its stale-entry bookkeeping: the test directly rejects all forbidden outward imports, preserving the same zero-exception behavior. This stays within documentation and the existing architecture-test owner; no runtime/API change or new capability, generator, or service.

Validation:
- Architecture import-boundary suite: 14 passed.
- Existing terminal-closeout order/recovery tests: 2 passed (51 unrelated tests deselected).
- Negative probes reject presentation and benchmark-adapter imports while accepting an inward control-plane import.
- Ruff, diff whitespace, relative documentation targets, and added-line private/credential scan passed.
- Premerge risk selection: 18 checks passed, zero failures or manual holds.

Full runtime, TypeScript, and PostgreSQL suites were not run for this documentation and behavior-preserving test simplification. No local/private artifacts are included.
