### PR TITLE
fix(benchmark): mount standalone Codex companions in isolated runtime

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -130,6 +130,16 @@ and PID namespaces, `pivot_root`, and `tini`. It runs `tini` as the isolated PID
 so long-lived workers reap orphaned command subprocesses, and fails closed when
 its roots overlap or the init resolves from a mutable task/profile/work root.
 
+Standalone Codex distributions also need their runtime companions after startup.
+The envelope now exposes existing `codex-resources/bwrap` files beside the resolved
+executable or at its distribution root, plus adjacent `codex-code-mode-host`, as
+individual read-only mounts. It does not expose the containing directories or
+unrelated neighboring files. Companions must be regular, non-symlinked files
+outside the private controller and task workspace roots; invalid candidates fail
+closed. Codex's own companion verification remains unchanged. Runners must stage
+the executable and companions outside private roots before constructing the
+envelope; executable-only custom launchers remain supported.
+
 ```python
 from loopx.capabilities.benchmark_toolkit.native_codex_isolation import (
     build_native_codex_isolation_envelope,

--- a/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_isolation.py
@@ -52,6 +52,8 @@ executable=$5
 setpriv_bin=$6
 init_bin=$7
 shift 7
+runtime_file_count=$1
+shift
 
 mount --make-rprivate /
 sandbox_root="$work_dir/.sandbox-root"
@@ -149,6 +151,11 @@ bind_runtime_file() {
 }
 bind_runtime_file "$executable"
 bind_runtime_file "$init_bin"
+while [ "$runtime_file_count" -gt 0 ]; do
+    bind_runtime_file "$1"
+    shift
+    runtime_file_count=$((runtime_file_count - 1))
+done
 
 mkdir -p "$sandbox_root/.old-root"
 cd "$sandbox_root"
@@ -482,6 +489,30 @@ def build_native_codex_isolation_envelope(
         )
     if init == resolved_private_root or resolved_private_root in init.parents:
         raise NativeCodexIsolationError("native_codex_init_inside_private_root")
+    # Standalone Codex invokes these companions after app-server startup.
+    # Bind exact files, never their containing distribution directory.
+    runtime_files: list[Path] = []
+    for candidate in (
+        resolved_executable.parent / "codex-resources" / "bwrap",
+        resolved_executable.parent.parent / "codex-resources" / "bwrap",
+        resolved_executable.with_name("codex-code-mode-host"),
+    ):
+        if not candidate.exists() and not candidate.is_symlink():
+            continue
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise NativeCodexIsolationError("native_codex_companion_invalid") from exc
+        if resolved != candidate or not resolved.is_file():
+            raise NativeCodexIsolationError("native_codex_companion_invalid")
+        if any(
+            root is not None and (resolved == root or root in resolved.parents)
+            for root in (resolved_private_root, resolved_workspace)
+        ):
+            raise NativeCodexIsolationError(
+                "native_codex_companion_inside_restricted_root"
+            )
+        runtime_files.append(resolved)
     mutable_roots = [resolved_work_dir]
     if resolved_workspace is not None:
         mutable_roots.append(resolved_workspace)
@@ -511,6 +542,8 @@ def build_native_codex_isolation_envelope(
         str(resolved_executable),
         str(setpriv),
         str(init),
+        str(len(runtime_files)),
+        *(str(path) for path in runtime_files),
         *(str(value) for value in process_args),
     )
     return NativeCodexIsolationEnvelope(

--- a/tests/capabilities/test_native_codex_isolation.py
+++ b/tests/capabilities/test_native_codex_isolation.py
@@ -44,6 +44,77 @@ def _native_codex_isolation_supported() -> bool:
     return _namespace_mounts_supported() and shutil.which("tini") is not None
 
 
+@pytest.mark.skipif(
+    not _native_codex_isolation_supported(), reason="Linux namespace mounts required"
+)
+@pytest.mark.parametrize("resource_parent", ["bin", "distribution"])
+def test_standalone_companions_visible_but_distribution_neighbors_hidden(
+    tmp_path, resource_parent
+):
+    private = tmp_path / "private"
+    work = tmp_path / "work"
+    binary_dir = tmp_path / "distribution" / "bin"
+    for directory in (private, work, binary_dir / "codex-resources"):
+        directory.mkdir(parents=True)
+    binary = binary_dir / "codex"
+    companion_root = binary_dir if resource_parent == "bin" else binary_dir.parent
+    (companion_root / "codex-resources").mkdir(exist_ok=True)
+    companion = companion_root / "codex-resources" / "bwrap"
+    code_host = binary_dir / "codex-code-mode-host"
+    neighbor = binary_dir / "unrelated-data"
+    neighbor.write_text("must remain hidden")
+    companion.write_text("#!/bin/sh\nexit 0\n")
+    code_host.write_text("#!/bin/sh\nexit 0\n")
+    binary.write_text(
+        '#!/bin/sh\nset -eu\n"$1"\n"$2"\n'
+        '[ ! -e "$3" ]\n[ "$4" = "argument with spaces" ]\n'
+    )
+    for path in (binary, companion, code_host):
+        path.chmod(0o755)
+    envelope = build_native_codex_isolation_envelope(
+        executable=str(binary),
+        process_args=[
+            str(companion),
+            str(code_host),
+            str(neighbor),
+            "argument with spaces",
+        ],
+        work_dir=work,
+        private_root=private,
+    )
+    result = subprocess.run(
+        envelope.process_command, capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("tini") is None, reason="tini required")
+@pytest.mark.parametrize("target_kind", ["private_file", "directory", "missing"])
+def test_standalone_companion_rejects_symlink_or_non_file(tmp_path, target_kind):
+    private = tmp_path / "private"
+    work = tmp_path / "work"
+    binary_dir = tmp_path / "distribution" / "bin"
+    for directory in (private, work, binary_dir / "codex-resources"):
+        directory.mkdir(parents=True)
+    binary = binary_dir / "codex"
+    binary.write_text("#!/bin/sh\nexit 0\n")
+    binary.chmod(0o755)
+    companion = binary_dir / "codex-resources" / "bwrap"
+    if target_kind == "directory":
+        companion.mkdir()
+    else:
+        target = private / "runtime"
+        if target_kind == "private_file":
+            target.write_text("restricted")
+        companion.symlink_to(target)
+    with pytest.raises(
+        NativeCodexIsolationError, match="native_codex_companion_invalid"
+    ):
+        build_native_codex_isolation_envelope(
+            executable=str(binary), process_args=[], work_dir=work, private_root=private
+        )
+
+
 def test_native_codex_isolation_rejects_overlapping_authority_roots(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
Standalone Codex can start its app-server inside the native isolation envelope while later tool execution fails because only the executable was mounted. Mount the known sandbox/code-mode companion files individually, preserving the private-root and task boundaries. No parent directory mount, sandbox bypass, scoring change, or benchmark launch is introduced.

## Behavior and validation
Existing regular companions are now included automatically; symlinked, non-file, or restricted-root candidates fail closed. Executable-only custom launchers remain supported. Documentation names this behavior change.

- 20 isolation/provider-gateway tests passed, including real Linux namespace mounts, both resource layouts, argument preservation, adjacent-file exclusion, and invalid companion rejection.
- Actual standalone Codex sandbox command succeeded inside the envelope without model/network use.
- Ruff, compile, and diff checks passed.
- Premerge: 18 selected checks passed, zero failures; benchmark-sensitive manual-review hold remains. No self-merge.

## 中文
修复独立发行版 Codex 能启动但后续工具执行缺少沙箱伴随文件的问题。仅挂载明确的伴随文件，不开放整个发行目录；保留私有根目录隔离及 Codex 自身校验。需维护者 review 后合并。