### PR TITLE
feat(authority): promoted todo text/note edit through unified provider CAS

### DIFF
--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -110,6 +110,17 @@ slice; they must not be reported as migrated or globally free of prose rules.
    the existing TS authority owner. Deliver coherent vertical slices with the
    real CLI caller, replay/CAS/error tests, and removal of the replaced Python
    decisions. A schema or constants-only PR does not satisfy this exit.
+   A single-command slice (for example `todo update --text/--note` through a
+   shared compatibility editor) is a validation milestone for synthetic or
+   qualification goals, never a real-goal promotion: once a goal is promoted,
+   every other legacy writer is still fenced fail-closed. Promoting a live goal
+   therefore waits until the write-command family its agents actually use routes
+   through the same unified TS commit authority (per-command patch types on one
+   entry point, not parallel adapters) and until capture/projection outbox
+   delivery is flushed. The deletion payoff lands only when the in-place
+   Markdown editor is replaced by a pure projection renderer behind that one
+   entry point.
+
 2. **Qualification before activation.** Join that path with the shared-authority
    RFC's explicit v0 import, consumer parity, writer fencing, capture/projection
    outbox recovery, bounded retention, and fenced export. File qualification

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -87,6 +87,13 @@ lifecycle classification code 或其他 cadence policy，不能宣称全局已�
    complete-with-successor、archive 及相关 lease effect 经过现有 TS authority owner。
    每个内聚的纵向切片包含真实 CLI caller、replay/CAS/error 测试，并删除被替代的
    Python decision。仅统一 schema 或常量不满足退出条件。
+   单命令切片（例如通过同一兼容 editor 的 `todo update --text/--note`）只是
+   合成/资格化 goal 的验证里程碑，不是真实 goal 的 promote：一旦 promote，其余
+   legacy writer 仍被 fence 以 fail-closed 拦截。因此活跃 goal 的 promote 要等
+   到其 agent 实际使用的写命令族都经由同一个统一 TS 提交权威（同一入口的分命令
+   patch 类型，而不是平行 adapter），并且 capture/projection outbox 落盘接通之后。
+   删除的收益只在该入口背后的 in-place Markdown editor 被纯投影 renderer 替代时兑现。
+
 2. **先资格化，再启用。** 与 shared-authority RFC 的显式 v0 import、consumer
    parity、writer fencing、capture/projection outbox recovery、有界 retention、
    fenced export 汇合。file 资格化不等待 PostgreSQL service 就绪；不默认切换 authority。

--- a/loopx/control_plane/coordination/local_authority_runtime.ts
+++ b/loopx/control_plane/coordination/local_authority_runtime.ts
@@ -41,6 +41,7 @@ import {
   COORDINATION_TODO_CLAIM_RESULT_SCHEMA,
   executeCoordinationTodoClaim,
 } from "./todo_claim.ts";
+import { editCoordinationTodo, TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA } from "./todo_compatibility_edit.ts";
 
 export const LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_claim_request_v0";
@@ -574,6 +575,27 @@ export async function claimLocalCoordinationTodo(
       decision_read_from_provider: true,
       legacy_fallback_used: false,
     };
+  }
+}
+
+/** Embedded file adapter; no Markdown input or projection write is accepted. */
+export async function editLocalCoordinationTodo(
+  value: unknown,
+  dependencies: LocalAuthorityRuntimeDependencies = {},
+): Promise<JsonObject> {
+  try {
+    const input = requireJsonObject(value, "local compatibility edit");
+    const {runtime_root, ...request} = input;
+    const root = runtimeRoot(runtime_root);
+    const goalId = requireAuthorityStoreId(input.goal_id, "goal id");
+    const store = dependencies.createStore?.(authorityDirectory(root), goalId) ??
+      new FileAuthorityStore(authorityDirectory(root), goalId);
+    return {...await editCoordinationTodo(store, request),
+      source_authority: "file_v0", decision_read_from_provider: true, legacy_fallback_used: false};
+  } catch (error) {
+    return {schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA, status: "failed",
+      reason_code: "invalid_local_compatibility_edit", changed: false,
+      reason: error instanceof Error ? error.message : "invalid local compatibility edit"};
   }
 }
 

--- a/loopx/control_plane/coordination/todo_compatibility_edit.ts
+++ b/loopx/control_plane/coordination/todo_compatibility_edit.ts
@@ -1,0 +1,141 @@
+import type { JsonObject } from "../effect_program.ts";
+import type { AuthorityStore } from "./authority_store.ts";
+import { canonicalAuthorityBytes, canonicalAuthorityObject, canonicalAuthoritySha256, requireAuthorityStoreId } from "./authority_store_codec.ts";
+import { prepareCoordinationProjectionCommit, indexCoordinationProjection, validateCoordinationTodoReadModel } from "./coordination_projection.ts";
+
+export const TODO_COMPATIBILITY_EDIT_SCHEMA = "loopx_todo_compatibility_edit_request_v0";
+export const TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA = "loopx_todo_compatibility_edit_result_v0";
+
+/**
+ * A compatibility editor proposes only text/note changes against an exact
+ * provider revision. It cannot submit a snapshot, change ownership/lifecycle,
+ * clear unrepresented fields, or make Markdown the commit authority.
+ *
+ * This trusted embedded entrypoint does not grant remote service authority.
+ * Conflict requires rereading and rerunning the editor, never snapshot rebasing.
+ */
+export async function editCoordinationTodo(
+  store: AuthorityStore,
+  value: unknown,
+): Promise<JsonObject> {
+  const failure = (reason_code: string, reason: string): JsonObject => ({
+    schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA,
+    status: "failed", changed: false, reason_code, reason,
+  });
+  try {
+    const input = canonicalAuthorityObject(value, "Todo compatibility edit");
+    if (input.schema_version !== TODO_COMPATIBILITY_EDIT_SCHEMA) {
+      throw new Error("Todo compatibility edit schema mismatch");
+    }
+    const allowed = new Set(["schema_version", "goal_id", "todo_id", "operation_id",
+      "expected_provider_revision", "actor_agent_id", "registered_agents", "patch", "dry_run", "observed_at"]);
+    if (Object.keys(input).some((key) => !allowed.has(key))) {
+      throw new Error("Todo compatibility edit contains unsupported fields");
+    }
+    const goalId = requireAuthorityStoreId(input.goal_id, "goal id");
+    const todoId = requireAuthorityStoreId(input.todo_id, "todo id");
+    const operationId = requireAuthorityStoreId(input.operation_id, "operation id");
+    const revision = requireAuthorityStoreId(input.expected_provider_revision, "expected provider revision");
+    const actor = requireAuthorityStoreId(input.actor_agent_id, "actor agent id");
+    if (typeof input.observed_at !== "string" ||
+        !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u.test(input.observed_at) ||
+        Number.isNaN(Date.parse(input.observed_at))) {
+      throw new Error("observed_at must be an ISO timestamp");
+    }
+    const updatedAt = new Date(input.observed_at).toISOString();
+    if (!Array.isArray(input.registered_agents) ||
+        input.registered_agents.some((agent) => typeof agent !== "string") ||
+        new Set(input.registered_agents).size !== input.registered_agents.length) {
+      throw new Error("registered_agents must be a unique string array");
+    }
+    if (typeof input.dry_run !== "boolean") throw new Error("dry_run must be a boolean");
+    const patch = canonicalAuthorityObject(input.patch, "compatibility patch");
+    if (Object.keys(patch).length === 0 || Object.entries(patch).some(([key, item]) =>
+      !["text", "note"].includes(key) || typeof item !== "string" || !item.trim()
+    )) {
+      throw new Error("compatibility patch accepts only non-empty text and note strings");
+    }
+    const requestSha = canonicalAuthoritySha256({
+      goal_id: goalId, todo_id: todoId, actor_agent_id: actor,
+      expected_provider_revision: revision, patch,
+    });
+    const readReceipt = async (status: string): Promise<JsonObject | null> => {
+      const receipt = await store.readReceipt(operationId);
+      if (receipt.status === "missing") return null;
+      if (receipt.status !== "found") return {schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA, ...receipt, changed: false};
+      const original = receipt.receipts[0];
+      if (receipt.receipts.length !== 1 ||
+          original?.schema_version !== "loopx_todo_compatibility_edit_receipt_v0" ||
+          original.operation_id !== operationId || original.request_sha256 !== requestSha ||
+          typeof original.changed !== "boolean") {
+        return failure("coordination_operation_identity_mismatch", "operation id names a different compatibility edit");
+      }
+      return {
+        schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA,
+        status: status === "applied" && !original.changed ? "no_change" : status,
+        changed: status !== "replayed" && original.changed,
+        provider_revision: receipt.provider_revision, cursor: receipt.cursor,
+        projection_delivery: original.changed ? "pending" : "not_required",
+        projection_source: "committed_authority_journal",
+      };
+    };
+    // Preview evaluates current eligibility and never consumes/replays identity.
+    if (!input.dry_run) {
+      const replay = await readReceipt("replayed");
+      if (replay !== null) return replay;
+    }
+    if (!input.registered_agents.includes(actor)) {
+      return failure("actor_not_registered", "compatibility edit requires a registered actor");
+    }
+    const head = await store.loadAuthority();
+    if (head.status !== "loaded") return {schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA, ...head, changed: false};
+    validateCoordinationTodoReadModel(head.head, goalId);
+    const index = indexCoordinationProjection(head.head, goalId);
+    if (head.provider_revision !== revision) return {
+      schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA,
+      status: "conflict", changed: false, conflict_kind: "provider_revision_mismatch",
+      current_provider_revision: head.provider_revision, current_cursor: head.cursor,
+    };
+    const todo = index.todos.get(todoId);
+    if (todo === undefined) return failure("todo_not_found", "canonical Todo is missing");
+    if (todo.role !== "agent" || todo.status !== "open" || todo.archive_state !== "active") {
+      return failure("unsupported_compatibility_edit_target", "compatibility editing requires an active open agent Todo");
+    }
+    if (todo.claimed_by !== actor ||
+        (Array.isArray(todo.excluded_agents) && todo.excluded_agents.includes(actor)) ||
+        (typeof todo.removed_continuation_policy === "string" && todo.removed_continuation_policy)) {
+      return failure("compatibility_edit_owner_mismatch", "compatibility editing requires the current non-excluded claim owner");
+    }
+    // Lease-bearing edits need a separate execution-instance proof; do not
+    // infer that proof merely from actor identity or bypass the existing fence.
+    if (![undefined, "legacy", "soft_claim"].includes(head.head.handoff_mode as string | undefined) || index.leases.has(todoId)) {
+      return failure("compatibility_edit_lease_unsupported", "lease-bearing compatibility edits are not yet supported");
+    }
+    const next = {...todo, ...patch};
+    const changed = !canonicalAuthorityBytes(next).equals(canonicalAuthorityBytes(todo));
+    if (input.dry_run) return {
+      schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA, status: changed ? "planned" : "no_change",
+      changed, provider_revision: revision, cursor: head.cursor,
+    };
+    if (changed) next.updated_at = updatedAt;
+    const commit = changed ? prepareCoordinationProjectionCommit({
+      goal_id: goalId, operation_id: operationId,
+      expected_provider_revision: revision,
+      projection: head.head,
+      mutations: [{kind: "todo_upsert", todo: next}],
+    }) : {operation_id: operationId, expected_provider_revision: revision,
+      next_projection: head.head, events: [], receipts: []};
+    commit.receipts = [{schema_version: "loopx_todo_compatibility_edit_receipt_v0",
+      operation_id: operationId, request_sha256: requestSha, changed}];
+    const result = await store.commitAuthority(commit);
+    const readback = await readReceipt(result.status === "applied" ? "applied" : "recovered");
+    if (readback !== null) return readback;
+    if (result.status === "applied") return failure("compatibility_commit_readback_mismatch", "applied edit lacks its durable receipt");
+    return {
+      schema_version: TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA, ...result,
+      changed: false,
+    };
+  } catch (error) {
+    return failure("invalid_todo_compatibility_edit", error instanceof Error ? error.message : "invalid compatibility edit");
+  }
+}

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -114,6 +114,7 @@ import {
 } from "./coordination/runtime_shadow.ts";
 import {
   claimLocalCoordinationTodo,
+  editLocalCoordinationTodo,
   mutateLocalCoordinationAuthority,
   listLocalCoordinationTodos,
   promoteLocalCoordinationAuthority,
@@ -391,6 +392,7 @@ export function createEffectRuntimeHandlers(
     ["coordination.runtime_shadow.rollback", rollbackCoordinationRuntimeShadow],
     ["coordination.local_authority.promote", promoteLocalCoordinationAuthority],
     ["coordination.local_authority.todo_claim", claimLocalCoordinationTodo],
+    ["coordination.local_authority.todo_compatibility_edit", editLocalCoordinationTodo],
     ["coordination.local_authority.mutate", mutateLocalCoordinationAuthority],
     ["coordination.local_authority.todo_read", readLocalCoordinationTodo],
     ["coordination.local_authority.todo_list", listLocalCoordinationTodos],

--- a/loopx/control_plane/todos/provider_compatibility_edit.py
+++ b/loopx/control_plane/todos/provider_compatibility_edit.py
@@ -1,0 +1,79 @@
+"""In-memory Markdown editing adapter; the TS provider owns the commit.
+
+Only the explicitly requested text/note fields cross back. Unrepresented
+canonical fields, section/index provenance and lease records never round-trip
+through Markdown. The on-disk projection is not an input or a commit target.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from ...agent_registry import registered_agent_ids_from_registry
+from ...state_refresh import now_local
+from ..coordination.local_authority import (
+    LocalCoordinationAuthorityUnavailable,
+    read_canonical_todos_if_promoted,
+)
+from ..effect_runtime import effect_runtime_result
+from .active_state_editing import find_todo_block, set_todo_text
+from .contract import format_todo_metadata_line, metadata_line_for_todo_block
+from .line_update import upsert_todo_metadata
+
+
+def edit_canonical_todo_if_promoted(
+    *, registry_path: Path, runtime_root: Path, goal_id: str, todo_id: str,
+    actor_agent_id: str | None, role: str | None, text: str | None,
+    note: str | None, dry_run: bool,
+) -> dict[str, Any] | None:
+    canonical = read_canonical_todos_if_promoted(runtime_root=runtime_root, goal_id=goal_id)
+    if canonical is None:
+        return None
+    todo = next((item for item in canonical["todos"] if item["todo_id"] == todo_id), None)
+    if todo is None:
+        raise ValueError("Todo is missing from canonical authority")
+    if role is not None and role != todo["role"]:
+        raise ValueError("Todo does not have the requested role")
+    # Reuse the existing Markdown text/metadata editor as a codec, not an
+    # authorization engine. This buffer is synthetic and is never persisted.
+    lines = ["## Agent Todo", "", f"- [ ] {todo['text']}",
+             format_todo_metadata_line(todo_id=todo_id, note=todo.get("note"))]
+    found = find_todo_block(lines, todo_id=todo_id, role="agent")
+    if found is None:
+        raise ValueError("canonical Todo cannot be represented by the compatibility editor")
+    block = found[4]
+    if text is not None:
+        set_todo_text(lines, block, text, status="open")
+    if note is not None:
+        upsert_todo_metadata(lines, block, metadata_line_for_todo_block(block, {"note": note}))
+    edited = find_todo_block(lines, todo_id=todo_id, role="agent")
+    if edited is None:
+        raise ValueError("compatibility editor lost Todo identity")
+    patch = {field: edited[4].get(field) for field, requested in
+             (("text", text), ("note", note)) if requested is not None}
+    result = effect_runtime_result("coordination.local_authority.todo_compatibility_edit", {
+        "schema_version": "loopx_todo_compatibility_edit_request_v0",
+        "runtime_root": str(runtime_root.resolve()), "goal_id": goal_id,
+        "todo_id": todo_id, "actor_agent_id": actor_agent_id,
+        "registered_agents": registered_agent_ids_from_registry(registry_path, goal_id),
+        "operation_id": f"todo-edit:{uuid4().hex}",
+        "expected_provider_revision": canonical["provider_revision"],
+        "patch": patch, "dry_run": dry_run,
+        "observed_at": now_local(),
+    })
+    if not isinstance(result, dict) or result.get("status") not in {
+        "applied", "recovered", "replayed", "no_change", "planned",
+    } or result.get("source_authority") != "file_v0" or (
+        result.get("decision_read_from_provider") is not True
+        or result.get("legacy_fallback_used") is not False
+    ):
+        payload = result if isinstance(result, dict) else {}
+        raise LocalCoordinationAuthorityUnavailable(
+            str(payload.get("reason") or "canonical compatibility edit failed; reread before retry"),
+            code=str(payload.get("reason_code") or payload.get("conflict_kind")
+                     or "compatibility_edit_failed"), payload=payload,
+        )
+    return {"ok": True, "goal_id": goal_id, "todo_id": todo_id,
+            "role": todo["role"], "dry_run": dry_run, **result}

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -125,6 +125,7 @@ from .control_plane.coordination.local_authority import (
     local_authority_is_promoted,
     read_canonical_todos_if_promoted,
 )
+from .control_plane.todos.provider_compatibility_edit import edit_canonical_todo_if_promoted
 from .control_plane.todos.handoff_mode import (
     enter_added_todo_ownership_handoff_gate,
     enter_todo_ownership_handoff_gate,
@@ -1102,6 +1103,27 @@ def update_goal_todo(
         )
         if canonical_claim is not None:
             return canonical_claim
+    # A narrow compatibility editor is admitted through provider CAS. All
+    # other legacy writes still encounter the existing promotion fence.
+    if not claim_only and (text is not None or note is not None) and not any((
+        monitor_metadata,
+        goal_bound, clear_blocks_agent, clear_excluded_agents, global_gate,
+        clear_global_gate, clear_resume_when, clear_claim, authority_reason,
+    )) and all(value is None for value in (
+        status, evidence, reason, task_class, action_kind, task_domain,
+        task_repository, continuation_policy, required_write_scopes,
+        required_capabilities, target_capabilities, explore_result_node_refs,
+        decision_scope, required_decision_scopes, claimed_by, bound_agent,
+        blocks_agent, excluded_agents, unblocks_todo_id, successor_todo_ids,
+        resume_when, no_followup, authority_reason,
+    )):
+        canonical_edit = edit_canonical_todo_if_promoted(
+            registry_path=registry_path, runtime_root=shadow_runtime_root,
+            goal_id=goal_id, todo_id=normalize_todo_id(todo_id) or todo_id,
+            actor_agent_id=agent_id, role=role, text=text, note=note, dry_run=dry_run,
+        )
+        if canonical_edit is not None:
+            return canonical_edit
     resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import hashlib
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -432,3 +434,28 @@ def test_real_shadow_projection_promotes_complete_complex_todo_semantics(
     )
     assert claimed_item["claimed_by"] == "agent-a"
     assert claimed_item["note"] == claimable["note"]
+
+    # Real CLI, no Markdown file: provider data feeds an in-memory editor and
+    # only requested fields return through TS CAS. Complex sibling fields do
+    # not round-trip through the lossy Markdown representation.
+    command = [sys.executable, "-m", "loopx.cli", "--format", "json",
+               "--registry", str(registry_path), "todo", "update", "--goal-id", "goal-a",
+               "--todo-id", "todo_claimable", "--agent-id", "agent-a",
+               "--text", "Edit provider-owned work", "--note", "compatibility edit"]
+    preview = subprocess.run([*command, "--dry-run"], capture_output=True, text=True, check=True)
+    assert json.loads(preview.stdout)["status"] == "planned"
+    assert list_goal_todos(registry_path=registry_path, goal_id="goal-a")["todos"] == after_claim["todos"]
+    edited = subprocess.run(command, capture_output=True, text=True, check=True)
+    edit_result = json.loads(edited.stdout)
+    assert edit_result["status"] == "applied"
+    assert edit_result["projection_delivery"] == "pending"
+    assert not state_file.exists()
+    after_edit = list_goal_todos(registry_path=registry_path, goal_id="goal-a")
+    edited_by_id = {item["todo_id"]: item for item in after_edit["todos"]}
+    assert edited_by_id["todo_claimable"] == {
+        **claimed_item, "text": "Edit provider-owned work", "note": "compatibility edit",
+        "updated_at": edited_by_id["todo_claimable"]["updated_at"],
+    }
+    assert edited_by_id["todo_claimable"]["updated_at"] != claimed_item["updated_at"]
+    assert edited_by_id["todo_complex"] == by_id["todo_complex"]
+    assert edited_by_id["todo_successor"] == by_id["todo_successor"]

--- a/tests/control_plane_ts/authority_store_conformance.ts
+++ b/tests/control_plane_ts/authority_store_conformance.ts
@@ -16,6 +16,7 @@ import {
 } from "../../loopx/control_plane/coordination/coordination_state_contract.ts";
 import { prepareCoordinationProjectionCommit } from "../../loopx/control_plane/coordination/coordination_projection.ts";
 import { executeCoordinationTodoClaim } from "../../loopx/control_plane/coordination/todo_claim.ts";
+import { editCoordinationTodo, TODO_COMPATIBILITY_EDIT_SCHEMA } from "../../loopx/control_plane/coordination/todo_compatibility_edit.ts";
 
 export interface AuthorityStoreConformanceFixture {
   store: AuthorityStore;
@@ -221,6 +222,105 @@ export function registerAuthorityStoreConformance(
   });
 
   for (const native of [false, true]) {
+    test(`${providerName} conformance: compatibility edit cannot overwrite a concurrent claim (${native ? "native" : "v0"})`, async (t) => {
+      const {store, contender} = await factory(t);
+      const goalId = "goal-claim";
+      const projection = todoClaimProjection(goalId, native);
+      const initialized = await store.commitAuthority({
+        expected_provider_revision: null, operation_id: "init-compatibility",
+        events: [], receipts: [], next_projection: projection,
+      });
+      assert.equal(initialized.status, "applied");
+      if (initialized.status !== "applied") return;
+      const request = {
+        schema_version: TODO_COMPATIBILITY_EDIT_SCHEMA, goal_id: goalId,
+        todo_id: "todo-claim", operation_id: "edit-compatibility",
+        actor_agent_id: "agent-a", registered_agents: ["agent-a", "agent-b"],
+        expected_provider_revision: initialized.provider_revision,
+        patch: {text: "Edited through a compatibility buffer"}, dry_run: false,
+        observed_at: "2026-09-05T05:00:00Z",
+      };
+      assert.equal((await executeCoordinationTodoClaim(contender, {
+        goal_id: goalId, todo_id: "todo-claim", claimed_by: "agent-a",
+        actor_agent_id: "agent-a", expected_role: "agent", registered_agents: ["agent-a", "agent-b"],
+        operation_id: "claim-before-edit", dry_run: false, now: new Date("2026-09-05T04:30:00Z"),
+      })).status, "applied");
+      const current = await store.loadAuthority();
+      assert.equal(current.status, "loaded");
+      if (current.status !== "loaded") return;
+      assert.equal((await editCoordinationTodo(store, request)).status, "conflict");
+      assert.deepEqual(await store.loadAuthority(), current);
+      request.expected_provider_revision = current.provider_revision;
+      const preview = await editCoordinationTodo(store, {...request, dry_run: true});
+      assert.equal(preview.status, "planned");
+      assert.deepEqual(await store.loadAuthority(), current);
+      assert.equal((await store.readReceipt(request.operation_id)).status, "missing");
+      for (const extra of [{claimed_by: "agent-b"}, {archive_state: "archive"}, {source_section: "fake"}]) {
+        assert.equal((await editCoordinationTodo(store, {...request, patch: extra})).status, "failed");
+      }
+      assert.equal((await editCoordinationTodo(store, {...request, actor_agent_id: "agent-b"})).status, "failed");
+      assert.deepEqual(await store.loadAuthority(), current);
+      const applied = await editCoordinationTodo(store, request);
+      assert.equal(applied.status, "applied", JSON.stringify(applied));
+      const after = await store.loadAuthority();
+      assert.equal(after.status, "loaded");
+      if (after.status !== "loaded") return;
+      const old = (current.head.todos as Record<string, unknown>[])[0]!;
+      assert.deepEqual(after.head.todos, [{...old, text: request.patch.text, updated_at: "2026-09-05T05:00:00.000Z"}]);
+      assert.deepEqual(after.head.leases, current.head.leases);
+      assert.equal((await editCoordinationTodo(store, {...request, registered_agents: []})).status, "replayed");
+      assert.deepEqual(await store.loadAuthority(), after);
+      assert.equal((await editCoordinationTodo(store, {...request, patch: {note: "different intent"}})).status, "failed");
+      const noop = {...request, operation_id: "edit-noop", expected_provider_revision: after.provider_revision};
+      assert.equal((await editCoordinationTodo(store, noop)).status, "no_change");
+      const afterNoop = await store.loadAuthority();
+      assert.equal(afterNoop.status, "loaded");
+      if (afterNoop.status !== "loaded") return;
+      assert.deepEqual(afterNoop.head, after.head);
+      assert.equal((await editCoordinationTodo(store, noop)).status, "replayed");
+      assert.deepEqual(await store.loadAuthority(), afterNoop);
+      // Losing the response after commit is recovered by the exact receipt.
+      const ambiguousStore: AuthorityStore = {
+        storeIdentity: () => store.storeIdentity(), loadAuthority: () => store.loadAuthority(),
+        readReceipt: (id) => store.readReceipt(id), scanCommitted: (cursor, limit) => store.scanCommitted(cursor, limit),
+        commitAuthority: async (commit) => {
+          assert.equal((await store.commitAuthority(commit)).status, "applied");
+          return {status: "ambiguous", reason_code: "lost_response", reason: "synthetic lost response"};
+        },
+      };
+      const recover = {...request, operation_id: "edit-recover",
+        expected_provider_revision: afterNoop.provider_revision, patch: {note: "Recovered edit"}};
+      assert.equal((await editCoordinationTodo(ambiguousStore, recover)).status, "recovered");
+      assert.equal((await editCoordinationTodo(store, recover)).status, "replayed");
+      const recoveredHead = await store.loadAuthority();
+      assert.equal(recoveredHead.status, "loaded");
+      if (recoveredHead.status !== "loaded") return;
+      // A competing receipt-only commit after read still invalidates the CAS.
+      const racingStore: AuthorityStore = {...ambiguousStore,
+        commitAuthority: async (commit) => {
+          assert.equal((await contender.commitAuthority({
+            ...commit, operation_id: "concurrent-writer", next_projection: recoveredHead.head,
+            events: [], receipts: [],
+          })).status, "applied");
+          return store.commitAuthority(commit);
+        },
+      };
+      assert.equal((await editCoordinationTodo(racingStore, {...recover,
+        operation_id: "edit-race", expected_provider_revision: recoveredHead.provider_revision,
+        patch: {note: "Must not commit"},
+      })).status, "conflict");
+      const afterRace = await store.loadAuthority();
+      assert.equal(afterRace.status, "loaded");
+      if (afterRace.status !== "loaded") return;
+      assert.deepEqual(afterRace.head, recoveredHead.head);
+      assert.equal((await store.readReceipt("edit-race")).status, "missing");
+      for (const invalid of [{dry_run: "false"}, {patch: {}}, {patch: {text: ""}},
+        {registered_agents: ["agent-a", "agent-a"]}, {observed_at: "yesterday"},
+        {projection: recoveredHead.head}]) {
+        assert.equal((await editCoordinationTodo(store, {...request, ...invalid})).status, "failed");
+      }
+      assert.deepEqual(await store.loadAuthority(), afterRace);
+    });
     test(`${providerName} conformance: provider-neutral Todo claim transaction (${native ? "native" : "v0"})`, async (t) => {
       const { store } = await factory(t);
       const goalId = "goal-claim";


### PR DESCRIPTION
## What

First vertical slice of the unified TS commit authority for the Todo lifecycle: on a **promoted** goal, `todo update --text/--note` (and nothing else) now commits through the TS authority owner.

- New TS entry `coordination.local_authority.todo_compatibility_edit`: accepts only `text`/`note` patches, requires the exact provider revision, a registered current non-excluded claim owner, an active open agent Todo, and no lease. Commits via `prepareCoordinationProjectionCommit` with a request-sha receipt so exact replay works after head changes.
- Python adapter reuses the existing in-place Markdown editor **only as an in-memory codec** to compute the patch; Markdown is never a commit target or input, and the on-disk projection is not touched (`projection_delivery: pending`).
- Conflict = reread + rerun, never snapshot rebasing. Dry-run is zero-write.

## Not a goal promotion

Every other command combination (add, archive, completion, status/evidence/role updates, lease-bearing writes) keeps the existing legacy path and stays **fail-closed under the promotion fence** once a goal is promoted. This PR does not flip any real goal's authority, and it does not remove any legacy call path.

## Decision recorded in the RFC

Updated the TS control-plane migration RFC (EN + zh-CN mirror) to make the sequencing explicit:

- A single-command compatibility slice is a **validation milestone for synthetic/qualification goals**, never a real-goal promotion.
- Real-goal promotion waits until the write-command family its agents actually use routes through the **same** unified TS commit authority (per-command patch types on one entry point, not parallel adapters) **and** until capture/projection outbox delivery is flushed.
- The deletion payoff arrives only when the in-place Markdown editor is replaced by a pure projection renderer behind that entry point.

## Validation

- `npm run typecheck:control-plane` — pass
- `npm run test:control-plane` — 588 pass / 1 skip
- PostgreSQL 16 authority-store integration — 602 pass
- `python -m ruff check ...` — pass
- `python -m mypy` — pass
- `pytest tests/control_plane/test_local_coordination_authority.py` — 6 pass (incl. new real-CLI e2e)
- `loopx canary premerge --from-git-diff` — 0 failures / 0 warnings / 0 manual holds

Stacked on current `main` (492b4f2), rebased, DCO-signed.