### PR TITLE
test: satisfy completed todo lint

### DIFF
--- a/tests/test_chat_completed_todos.py
+++ b/tests/test_chat_completed_todos.py
@@ -28,7 +28,10 @@ def test_snapshot_pagination_is_bounded_and_stable():
 
 def test_cursor_scope_expiry_and_capacity():
     pages = CompletedTodoPages()
-    load = lambda: [{}] * 41
+
+    def load():
+        return [{}] * 41
+
     cursor = pages.page(scope="a", cursor="", load=load)["next_cursor"]
     with pytest.raises(ValueError, match="expired"):
         pages.page(scope="b", cursor=cursor, load=load)


### PR DESCRIPTION
## Summary

- replace the test-only lambda introduced by #3970 with a named local function
- satisfy the repository Ruff E731 rule without changing production behavior

## Validation

- `ruff check tests loopx/canary loopx/control_plane loopx/domain_packs loopx/presentation`
- `pytest -q tests/test_chat_completed_todos.py` (5 passed)
- `loopx canary premerge --from-git-diff` (passed; 3/3 selected canaries, no holds)

Follow-up to #3970 after its hosted Python job exposed the lint failure.
