### PR TITLE
refactor(todo): unify claim decision in TypeScript

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2387,6 +2387,13 @@ export and cleanup. Each slice must prove an end-to-end transaction, not merely
 another schema identifier consolidation. Native contract acceptance alone is
 not permission to bypass any promotion hold.
 
+The first replacement-first `claim` slice routes both the default Markdown
+writer and the promoted provider transaction through one TypeScript decision.
+Python's default path retains only locked commit and existing projection-
+compatibility duties. This closes duplicate claim policy; it neither promotes
+Markdown to authority nor replaces the remaining unified
+create/update/complete/archive transactions and projection outbox.
+
 Use file-v0 for bounded conformance and import rehearsal only. Start the
 Section 7.2 embedded-store slice alongside the provider-first Todo caller; both
 converge before long-goal local qualification and promotion. PostgreSQL

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -1893,6 +1893,11 @@ kernel 的近期顺序是：（1）真实 provider-first Todo lifecycle caller�
 transaction，不能只做另一轮 schema identifier 统一。接受 native contract 不等于
 可以绕过任何 promotion hold。
 
+`claim` 的第一个 replacement-first 切片把默认 Markdown writer 与 promotion 后的
+provider transaction 接到同一个 TS decision；Python 默认路径只保留持锁提交和既有
+投影兼容职责。它关闭 claim policy 的双实现，但不把 Markdown 提升为 authority，
+也不替代剩余 create/update/complete/archive 的统一 transaction 与 projection outbox。
+
 file-v0 只用于有界 conformance 与 import 演练。第 7.2 节嵌入式存储切片与 provider-first
 Todo caller 同时推进，在长程本地资格化与晋升前汇合。PostgreSQL service/deployment
 继续并行，不成为本地晋升的依赖；NoKV 独立通过自己的 lineage/recovery 资格门禁。

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -31,7 +31,11 @@ native creation, archival, receipt replay, and store reopen are tested without
 Markdown metadata. Python only adapts the typed read result to the compatibility
 summary. This is a contract checkpoint, not a completed CLI lifecycle cutover.
 
-After explicit promotion, `todo claim` now crosses once into a TS-owned
+The default Markdown and explicitly promoted `todo claim` paths now share one
+TypeScript claim decision for actor, registration, role, status, archive,
+exclusion, and existing-owner checks; the Python legacy writer only commits
+that decision while holding its lock. After explicit promotion, claim crosses
+once into the same TS-owned
 transaction for both native and v0 records. New claims require active, open
 Todos and the current actor/lease checks. Exact operation retries recover the
 original claim receipt before current-state eligibility; observation time and

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -28,7 +28,10 @@ coordination 路径使用同一份语言中立的 `coordination_state_contract_v
 仅将 typed read result 适配为兼容 summary。这是 contract 检查点，不是已经完成的
 CLI lifecycle cutover。
 
-显式 promotion 后，`todo claim` 现在只跨一次 runtime 边界，由 TS 事务同时处理原生
+默认 Markdown 与显式 promotion 两条 `todo claim` 路径现在都由同一个 TS claim
+decision 处理 actor、registration、role、status、archive、exclusion 与现有 owner
+检查；Python legacy writer 只在持锁后提交该 decision。显式 promotion 后，claim
+只跨一次 runtime 边界，由同一 TS 事务同时处理原生
 和 v0 记录。新 claim 要求 active、open Todo，并检查当前 actor/lease；同一 operation
 的重试先恢复原 claim receipt，再考虑当前资格。观测时间和当前注册信息不属于请求
 身份。回放 receipt 不续租，也不表示当前仍持有任务。非 preview 的成功 `no_change`

--- a/loopx/control_plane/coordination/todo_claim.ts
+++ b/loopx/control_plane/coordination/todo_claim.ts
@@ -16,6 +16,8 @@ export const COORDINATION_TODO_CLAIM_RESULT_SCHEMA =
   "loopx_coordination_todo_claim_result_v0";
 export const COORDINATION_TODO_CLAIM_RECEIPT_SCHEMA =
   "loopx_coordination_todo_claim_receipt_v0";
+export const COORDINATION_TODO_CLAIM_DECISION_SCHEMA =
+  "loopx_coordination_todo_claim_decision_v0";
 
 export interface CoordinationTodoClaimInput {
   readonly goal_id: string;
@@ -32,6 +34,28 @@ export interface CoordinationTodoClaimInput {
 export type CoordinationTodoClaimResult = JsonObject & {
   readonly schema_version: typeof COORDINATION_TODO_CLAIM_RESULT_SCHEMA;
 };
+
+export interface CoordinationTodoClaimAcceptedDecision extends JsonObject {
+  readonly schema_version: typeof COORDINATION_TODO_CLAIM_DECISION_SCHEMA;
+  readonly status: "accepted";
+  readonly owner: string;
+  readonly actor: string | null;
+  readonly mode: "single_agent_compatibility" | "registered_peer_actor";
+  readonly mutation_authority: JsonObject;
+}
+
+export interface CoordinationTodoClaimRejectedDecision extends JsonObject {
+  readonly schema_version: typeof COORDINATION_TODO_CLAIM_DECISION_SCHEMA;
+  readonly status: "rejected";
+  readonly reason_code: string;
+  readonly reason: string;
+}
+
+export type CoordinationTodoClaimDecision =
+  | CoordinationTodoClaimAcceptedDecision
+  | CoordinationTodoClaimRejectedDecision;
+
+type ClaimRejection = CoordinationTodoClaimRejectedDecision | null;
 
 function normalizeAgent(value: unknown, label: string): string {
   if (typeof value !== "string") {
@@ -59,85 +83,155 @@ function normalizeRegisteredAgents(value: readonly string[]): string[] {
   return normalized;
 }
 
+function normalizeExcludedAgents(value: unknown): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new AuthorityStoreProtocolError("todo.excluded_agents must be an array");
+  }
+  const normalized = value.map((agent, index) =>
+    normalizeAgent(agent, `todo.excluded_agents[${index}]`)
+  );
+  if (new Set(normalized).size !== normalized.length) {
+    throw new AuthorityStoreProtocolError(
+      "todo.excluded_agents must contain unique public-safe agent ids",
+    );
+  }
+  return normalized;
+}
+
 function failure(code: string, reason: string, detail: JsonObject = {}): CoordinationTodoClaimResult {
   return {
+    ...detail,
     schema_version: COORDINATION_TODO_CLAIM_RESULT_SCHEMA,
     status: "failed",
     reason_code: code,
     reason,
-    ...detail,
   };
 }
 
-function claimAuthority(
-  todo: JsonObject,
+function decisionFailure(
+  code: string,
+  reason: string,
+  detail: JsonObject = {},
+): CoordinationTodoClaimRejectedDecision {
+  return {
+    ...detail,
+    schema_version: COORDINATION_TODO_CLAIM_DECISION_SCHEMA,
+    status: "rejected",
+    reason_code: code,
+    reason,
+  };
+}
+
+function rejectInvalidClaimActor(
   input: CoordinationTodoClaimInput,
-): { owner: string; actor: string | null; mode: string } | CoordinationTodoClaimResult {
-  const registered = input.registered_agents;
-  const owner = input.claimed_by;
-  const actor = input.actor_agent_id;
+): ClaimRejection {
+  const { registered_agents: registered, claimed_by: owner, actor_agent_id: actor } = input;
   if (!registered.includes(owner)) {
-    return failure("actor_not_registered", "claimed_by is not registered for this goal", {
-      claimed_by: owner,
-    });
+    return decisionFailure(
+      "actor_not_registered",
+      "claimed_by is not registered for this goal",
+      { claimed_by: owner },
+    );
   }
   if (actor !== null && !registered.includes(actor)) {
-    return failure("actor_not_registered", "actor_agent_id is not registered for this goal", {
-      actor_agent_id: actor,
-    });
+    return decisionFailure(
+      "actor_not_registered",
+      "actor_agent_id is not registered for this goal",
+      { actor_agent_id: actor },
+    );
   }
   if (registered.length > 1 && actor === null) {
-    return failure("actor_required", "multi-agent Todo claim requires actor_agent_id");
+    return decisionFailure(
+      "actor_required",
+      "multi-agent Todo claim requires actor_agent_id",
+    );
   }
-  if (actor !== null && actor !== owner) {
-    return failure(
+  return actor !== null && actor !== owner
+    ? decisionFailure(
       "claim_actor_mismatch",
       "Todo claim requires claimed_by to match actor_agent_id",
       { actor_agent_id: actor, claimed_by: owner },
-    );
-  }
+    )
+    : null;
+}
+
+function rejectIneligibleTodo(
+  todo: JsonObject,
+  input: CoordinationTodoClaimInput,
+): ClaimRejection {
   if (todo.role !== "agent") {
-    return failure("todo_not_agent", "claimed_by is only valid for agent Todos");
+    return decisionFailure("todo_not_agent", "claimed_by is only valid for agent Todos");
   }
   if (input.expected_role !== null && input.expected_role !== todo.role) {
-    return failure("todo_role_mismatch", "Todo does not have the requested role", {
-      requested_role: input.expected_role,
-      todo_role: todo.role,
-    });
-  }
-  if (todo.status !== "open") {
-    return failure("todo_not_open", "Todo claim requires status=open", {
-      todo_status: todo.status,
-    });
-  }
-  if (todo.archive_state !== "active") {
-    return failure("todo_archived", "Todo claim requires an active Todo");
-  }
-  if (typeof todo.removed_continuation_policy === "string" &&
-      todo.removed_continuation_policy.length > 0) {
-    return failure(
-      "removed_continuation_policy",
-      "Todo uses a removed continuation policy and must be repaired before claiming",
+    return decisionFailure(
+      "todo_role_mismatch",
+      "Todo does not have the requested role",
+      { requested_role: input.expected_role, todo_role: todo.role },
     );
   }
-  const excluded = Array.isArray(todo.excluded_agents) ? todo.excluded_agents : [];
+  if (todo.status !== "open") {
+    return decisionFailure(
+      "todo_not_open",
+      "Todo claim requires status=open",
+      { todo_status: todo.status },
+    );
+  }
+  if (todo.archive_state !== "active") {
+    return decisionFailure("todo_archived", "Todo claim requires an active Todo");
+  }
+  return typeof todo.removed_continuation_policy === "string" &&
+      todo.removed_continuation_policy.length > 0
+    ? decisionFailure(
+      "removed_continuation_policy",
+      "Todo uses a removed continuation policy and must be repaired before claiming",
+    )
+    : null;
+}
+
+export function evaluateCoordinationTodoClaimDecision(
+  todo: JsonObject,
+  input: CoordinationTodoClaimInput,
+): CoordinationTodoClaimDecision {
+  const registered = input.registered_agents;
+  const owner = input.claimed_by;
+  const actor = input.actor_agent_id;
+  const rejection = rejectInvalidClaimActor(input) ?? rejectIneligibleTodo(todo, input);
+  if (rejection !== null) return rejection;
+  const excluded = normalizeExcludedAgents(todo.excluded_agents);
   if (excluded.includes(owner)) {
-    return failure("actor_excluded", "claiming agent is excluded from this Todo", {
-      actor_agent_id: owner,
-    });
+    return decisionFailure(
+      "actor_excluded",
+      "claiming agent is excluded from this Todo",
+      { actor_agent_id: owner },
+    );
   }
   const existing = typeof todo.claimed_by === "string" && todo.claimed_by.length > 0
     ? normalizeAgent(todo.claimed_by, "todo.claimed_by")
     : null;
   if (existing !== null && existing !== owner) {
-    return failure("claim_owner_mismatch", "Todo is already claimed by another agent", {
-      claim_owner: existing,
-    });
+    return decisionFailure(
+      "claim_owner_mismatch",
+      "Todo is already claimed by another agent",
+      { claim_owner: existing },
+    );
   }
+  const mode = registered.length <= 1 ? "single_agent_compatibility" : "registered_peer_actor";
   return {
+    schema_version: COORDINATION_TODO_CLAIM_DECISION_SCHEMA,
+    status: "accepted",
     owner,
     actor,
-    mode: registered.length <= 1 ? "single_agent_compatibility" : "registered_peer_actor",
+    mode,
+    mutation_authority: {
+      schema_version: "todo_mutation_authority_v0",
+      command: "claim",
+      mode,
+      actor_agent_id: actor,
+      todo_id: todo.todo_id,
+      registered_agent_count: registered.length,
+      ...(mode === "registered_peer_actor" ? { claim_owner: existing } : {}),
+    },
   };
 }
 
@@ -269,16 +363,22 @@ export async function executeCoordinationTodoClaim(
     });
   }
 
-  let authority: ReturnType<typeof claimAuthority>;
+  let authority: ReturnType<typeof evaluateCoordinationTodoClaimDecision>;
   try {
-    authority = claimAuthority(todo, input);
+    authority = evaluateCoordinationTodoClaimDecision(todo, input);
   } catch (error) {
     return failure(
       "invalid_coordination_todo_claim",
       error instanceof Error ? error.message : "invalid Todo claim",
     );
   }
-  if (typeof authority.owner !== "string") return authority as CoordinationTodoClaimResult;
+  if (authority.status !== "accepted" || typeof authority.owner !== "string") {
+    return failure(
+      typeof authority.reason_code === "string" ? authority.reason_code : "invalid_coordination_todo_claim",
+      typeof authority.reason === "string" ? authority.reason : "Todo claim was rejected",
+      authority,
+    );
+  }
 
   const handoffMode = typeof head.head.handoff_mode === "string"
     ? head.head.handoff_mode
@@ -295,17 +395,10 @@ export async function executeCoordinationTodoClaim(
     );
   }
 
-  const mutationAuthority = {
-    schema_version: "todo_mutation_authority_v0",
-    command: "claim",
-    mode: authority.mode,
-    actor_agent_id: authority.actor,
-    todo_id: input.todo_id,
-    registered_agent_count: input.registered_agents.length,
-    ...(authority.mode === "registered_peer_actor"
-      ? { claim_owner: typeof todo.claimed_by === "string" ? todo.claimed_by : null }
-      : {}),
-  };
+  const mutationAuthority = canonicalAuthorityObject(
+    authority.mutation_authority,
+    "Todo claim mutation authority",
+  );
   const updatedAt = input.now.toISOString().replace(/\.\d{3}Z$/u, "Z");
   const changed = todo.claimed_by !== authority.owner;
   const result = {

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -120,6 +120,7 @@ import {
   promoteLocalCoordinationAuthority,
   readLocalCoordinationTodo,
 } from "./coordination/local_authority_runtime.ts";
+import { evaluateCoordinationTodoClaimDecision } from "./coordination/todo_claim.ts";
 import {
   checkLegacyCoordinationWriteAllowed,
   engageLegacyCoordinationWriterFence,
@@ -350,6 +351,25 @@ export function createEffectRuntimeHandlers(
     ["todo.completion_state.require_metadata", requireTodoCompletionMetadataValue],
     ["todo.completion_state.continuation_for_write", selectTodoCompletionContinuation],
     ["todo.completion_state.metadata_updates", buildTodoCompletionMetadataUpdates],
+    [
+      "todo.claim.decide",
+      (params) => evaluateCoordinationTodoClaimDecision(
+        requiredObject(params.todo, "todo"),
+        {
+          goal_id: requiredString(params.goal_id, "goal_id"),
+          todo_id: requiredString(params.todo_id, "todo_id"),
+          claimed_by: requiredString(params.claimed_by, "claimed_by"),
+          actor_agent_id: params.actor_agent_id === null
+            ? null : requiredString(params.actor_agent_id, "actor_agent_id"),
+          expected_role: params.expected_role === null
+            ? null : requiredString(params.expected_role, "expected_role"),
+          registered_agents: stringArray(params.registered_agents, "registered_agents"),
+          operation_id: "decision-only",
+          dry_run: true,
+          now: new Date(0),
+        },
+      ),
+    ],
     ["todo.completion.reduce", reduceTodoCompletionTransaction],
     ["todo.next_action.transition", transitionTodoNextAction],
     ["todo.resume_condition.normalize", normalizeTodoResumeWhen],

--- a/loopx/control_plane/todos/mutation_authority.py
+++ b/loopx/control_plane/todos/mutation_authority.py
@@ -17,6 +17,7 @@ from ..coordination.authority_core import (
     decide,
 )
 from ..coordination.local_snapshot import todo_snapshot_from_mapping
+from ..effect_runtime import effect_runtime_result
 from .contract import (
     normalize_todo_claimed_by,
     normalize_todo_decision_outcome,
@@ -180,6 +181,65 @@ def _raise_core_authority_rejection(
     )
 
 
+def _authorize_typescript_claim(
+    *,
+    goal_id: str,
+    todo: Mapping[str, Any],
+    core_todo: TodoSnapshot,
+    registered_agents: list[str],
+    actor: str | None,
+    requested_owner: str | None,
+) -> dict[str, Any]:
+    payload = effect_runtime_result(
+        "todo.claim.decide",
+        {
+            "goal_id": goal_id,
+            "todo_id": core_todo.todo_id,
+            "todo": {
+                "todo_id": core_todo.todo_id,
+                "role": core_todo.role,
+                "status": core_todo.status,
+                "archive_state": str(todo.get("archive_state") or "active"),
+                "claimed_by": core_todo.claimed_by,
+                "excluded_agents": sorted(core_todo.excluded_agents),
+                "removed_continuation_policy": todo.get(
+                    "removed_continuation_policy"
+                ),
+            },
+            "claimed_by": requested_owner,
+            "actor_agent_id": actor,
+            "expected_role": core_todo.role,
+            "registered_agents": registered_agents,
+        },
+    )
+    if not isinstance(payload, Mapping):
+        raise RuntimeError("TypeScript Todo claim decision shape mismatch")
+    if payload.get("status") != "accepted":
+        code = str(payload.get("reason_code") or "claim_rejected")
+        if code in {
+            "actor_not_registered",
+            "actor_required",
+            "actor_excluded",
+            "claim_owner_mismatch",
+            "claim_actor_mismatch",
+        }:
+            _raise_core_authority_rejection(
+                code=code,
+                goal_id=goal_id,
+                registered_agents=registered_agents,
+                command="claim",
+                actor=actor,
+                requested_owner=requested_owner,
+                todo=core_todo,
+                action="claim",
+            )
+        raise ValueError(str(payload.get("reason") or "Todo claim was rejected"))
+    mutation_authority = payload.get("mutation_authority")
+    if not isinstance(mutation_authority, Mapping):
+        raise RuntimeError("TypeScript Todo claim authority shape mismatch")
+    return dict(mutation_authority)
+
+
 def authorize_todo_lifecycle_mutation(
     *,
     registry_path: Path,
@@ -206,6 +266,15 @@ def authorize_todo_lifecycle_mutation(
     )
     requested_owner = normalize_todo_claimed_by(requested_claimed_by)
     effective_action = str(authority_action or command).strip().lower()
+    if command == "claim":
+        return _authorize_typescript_claim(
+            goal_id=goal_id,
+            todo=todo,
+            core_todo=core_todo,
+            registered_agents=registered_agents,
+            actor=normalized_actor,
+            requested_owner=requested_owner,
+        )
     try:
         core_action = TodoAction(command)
     except ValueError as exc:

--- a/tests/control_plane_ts/local_authority_runtime.test.ts
+++ b/tests/control_plane_ts/local_authority_runtime.test.ts
@@ -30,6 +30,10 @@ import {
   readLocalCoordinationTodo,
 } from "../../loopx/control_plane/coordination/local_authority_runtime.ts";
 import {
+  COORDINATION_TODO_CLAIM_RESULT_SCHEMA,
+  evaluateCoordinationTodoClaimDecision,
+} from "../../loopx/control_plane/coordination/todo_claim.ts";
+import {
   checkLegacyCoordinationWriteAllowed,
   engageLegacyCoordinationWriterFence,
   LEGACY_COORDINATION_WRITER_FENCE_ENGAGE_REQUEST_SCHEMA,
@@ -77,6 +81,40 @@ function todoRecord(overrides: Record<string, unknown> = {}): Record<string, unk
     source_section: "Agent Todo",
     ...overrides,
   };
+}
+
+async function claimSeededTodo(
+  root: string,
+  todo: Record<string, unknown>,
+  operationId: string,
+) {
+  const store = new FileAuthorityStore(join(root, "authority", "file-v0"), "goal-a");
+  await store.commitAuthority({
+    expected_provider_revision: null,
+    operation_id: "seed",
+    events: [],
+    next_projection: withTodoReadModel({
+      goal_id: "goal-a",
+      handoff_mode: "soft_claim",
+      todos: [todo],
+      leases: [],
+    }),
+    receipts: [],
+  });
+  const result = await claimLocalCoordinationTodo({
+    schema_version: LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+    todo_id: "todo_a",
+    role: "agent",
+    claimed_by: "agent-a",
+    actor_agent_id: "agent-a",
+    registered_agents: ["agent-a", "agent-b"],
+    operation_id: operationId,
+    observed_at: "2026-09-05T04:30:00Z",
+    dry_run: false,
+  });
+  return { result, receipt: await store.readReceipt(operationId) };
 }
 
 async function qualifiedShadow(root: string) {
@@ -472,6 +510,105 @@ test("provider-first Todo claim preserves the complete record and is replay-safe
   });
   assert.equal(repeated.status, "no_change");
   assert.equal(repeated.changed, false);
+});
+
+test("one TypeScript decision owns promoted and legacy Todo claims", () => {
+  const input = {
+    goal_id: "goal-a",
+    todo_id: "todo_a",
+    claimed_by: "agent-a",
+    actor_agent_id: "agent-a",
+    expected_role: "agent",
+    registered_agents: ["agent-a", "agent-b"],
+    operation_id: "decision-only",
+    dry_run: true,
+    now: new Date(0),
+  };
+  const accepted = evaluateCoordinationTodoClaimDecision(todoRecord(), input);
+  assert.equal(accepted.status, "accepted");
+  assert.equal(
+    (accepted.mutation_authority as Record<string, unknown>).mode,
+    "registered_peer_actor",
+  );
+
+  const rejected = evaluateCoordinationTodoClaimDecision(
+    todoRecord({ excluded_agents: [" Agent-A "] }),
+    input,
+  );
+  assert.equal(rejected.status, "rejected");
+  assert.equal(rejected.reason_code, "actor_excluded");
+
+  assert.throws(
+    () => evaluateCoordinationTodoClaimDecision(
+      todoRecord({ excluded_agents: ["agent-a", " Agent-A "] }),
+      input,
+    ),
+    /unique public-safe agent ids/,
+  );
+});
+
+test("the shared claim decision rejects every pre-commit lifecycle boundary", () => {
+  const base: Parameters<typeof evaluateCoordinationTodoClaimDecision>[1] = {
+    goal_id: "goal-a",
+    todo_id: "todo_a",
+    claimed_by: "agent-a",
+    actor_agent_id: "agent-a",
+    expected_role: "agent",
+    registered_agents: ["agent-a", "agent-b"],
+    operation_id: "decision-only",
+    dry_run: true,
+    now: new Date(0),
+  };
+  const cases: Array<[Record<string, unknown>, Partial<typeof base>, string]> = [
+    [{ status: "done" }, {}, "todo_not_open"],
+    [{ archive_state: "archive" }, {}, "todo_archived"],
+    [{ role: "user" }, { expected_role: "user" }, "todo_not_agent"],
+    [{ removed_continuation_policy: "author_reviewer_handoff" }, {},
+      "removed_continuation_policy"],
+    [{ claimed_by: "agent-b" }, {}, "claim_owner_mismatch"],
+    [{}, { actor_agent_id: "agent-b" }, "claim_actor_mismatch"],
+    [{}, { actor_agent_id: null }, "actor_required"],
+  ];
+  for (const [todoOverrides, inputOverrides, code] of cases) {
+    const result = evaluateCoordinationTodoClaimDecision(
+      todoRecord(todoOverrides),
+      { ...base, ...inputOverrides },
+    );
+    assert.equal(result.status, "rejected", code);
+    assert.equal(result.reason_code, code);
+  }
+});
+
+test("promoted claim rejection preserves the public result envelope", async () => {
+  const root = await mkdtemp(join(tmpdir(), "loopx-claim-rejection-envelope-"));
+  const { result: rejected, receipt } = await claimSeededTodo(
+    root,
+    todoRecord({ status: "done", done: true }),
+    "claim-rejected",
+  );
+
+  assert.equal(
+    rejected.schema_version,
+    COORDINATION_TODO_CLAIM_RESULT_SCHEMA,
+    JSON.stringify(rejected),
+  );
+  assert.equal(rejected.status, "failed");
+  assert.equal(rejected.reason_code, "todo_not_open", JSON.stringify(rejected));
+  assert.deepEqual(receipt, { status: "missing" });
+});
+
+test("promoted claim normalizes persisted excluded-agent identities", async () => {
+  const root = await mkdtemp(join(tmpdir(), "loopx-claim-excluded-normalize-"));
+  const { result: rejected, receipt } = await claimSeededTodo(
+    root,
+    todoRecord({ excluded_agents: [" Agent-A "] }),
+    "claim-excluded",
+  );
+
+  assert.equal(rejected.schema_version, COORDINATION_TODO_CLAIM_RESULT_SCHEMA);
+  assert.equal(rejected.status, "failed");
+  assert.equal(rejected.reason_code, "actor_excluded");
+  assert.deepEqual(receipt, { status: "missing" });
 });
 
 for (const native of [false, true]) {


### PR DESCRIPTION
## Summary

- make one discriminated TypeScript decision the semantic owner for Todo claim eligibility
- route both the default Markdown commit bridge and promoted provider transaction through that decision
- preserve Python only as the locked compatibility commit/projection bridge for the default path
- update the TypeScript and shared-authority RFCs with the replacement-first boundary

This does **not** promote an active Goal or claim that create/update/complete/archive and projection-outbox work are complete.

## Validation

- `npm run typecheck:control-plane` — passed
- `npm run test:control-plane` — 597 tests, 596 passed, 1 PostgreSQL test file skipped because that command has no database, 0 failed
- focused Python Todo authority/default/promoted tests — 59 passed
- isolated PostgreSQL 16.15 on a disposable synthetic database — `npm run test:postgresql-authority-store`: 18 passed, 0 skipped/failed; cluster stopped after the run
- Ruff on the changed Python bridge — passed
- `git diff --check` — passed
- standard LoopX premerge gate — passed: 4 direct checks and 18 catalog/risk/boundary checks, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan — clean across all 8 changed files

## Quality / deletion accounting

- exact-scope receipt: `cqr_3abc047b1a42fb278cf5`
- scope fingerprint: `3abc047b1a42fb278cf557168e10130ec0aa427836984571d8a47c4d21160758`
- bounded safe-fix: accepted/rejected claim decisions are now a discriminated union, and rejection details cannot overwrite the public result envelope
- duplicated Python claim-policy execution is removed from the active default claim path
- the generic Python mutation/commit core intentionally remains because create/update/complete/archive still use it; those are subsequent replacement-first slices

## Merge decision

Ready for independent exact-head review and CI. No active Goal state, provider promotion, writer fence, Todo, lease, or user runtime was mutated during validation.