### PR TITLE
fix(todo): allow deferred native creation

### DIFF
--- a/loopx/control_plane/coordination/todo_create.ts
+++ b/loopx/control_plane/coordination/todo_create.ts
@@ -97,9 +97,9 @@ function normalizeCreateInput(rawInput: CoordinationTodoCreateInput): Coordinati
   if (!(input.now instanceof Date) || Number.isNaN(input.now.valueOf())) {
     throw new AuthorityStoreProtocolError("now must be a valid Date");
   }
-  if (todo.status === "done" || todo.done || todo.archive_state !== "active") {
+  if (todo.status === "done" || todo.archive_state !== "active") {
     throw new AuthorityStoreProtocolError(
-      "Todo create requires a non-completed active record with coherent status",
+      "Todo create requires an active record that is not already done",
     );
   }
   if (todo.claimed_by !== undefined) {

--- a/tests/control_plane_ts/authority_store_conformance.ts
+++ b/tests/control_plane_ts/authority_store_conformance.ts
@@ -305,6 +305,14 @@ export function registerAuthorityStoreConformance(
           text: "Repeat terminal work"},
       });
       assert.equal(recreatedAfterDeferred.status, "applied");
+      const createdDeferred = await executeCoordinationTodoCreate(store, {
+        ...replayRequest,
+        operation_id: "create-deferred",
+        todo: {...replayRequest.todo, todo_id: "todo-new-deferred",
+          text: "Wait for the external dependency", status: "deferred", done: true,
+          resume_when: "material_change"},
+      });
+      assert.equal(createdDeferred.status, "applied");
       const inconsistentTerminal = await executeCoordinationTodoCreate(store, {
         ...replayRequest,
         operation_id: "reject-inconsistent-terminal",
@@ -321,7 +329,7 @@ export function registerAuthorityStoreConformance(
       assert.equal(created.created_by, "agent-a");
       assert.equal(created.last_actor_agent_id, "agent-a");
       assert.equal(created.updated_at, "2026-09-05T06:00:00Z");
-      assert.equal((loaded.head.todo_read_model as Record<string, unknown>).todo_count, 4);
+      assert.equal((loaded.head.todo_read_model as Record<string, unknown>).todo_count, 5);
       for (const invalid of [
         {...request, operation_id: "bad-actor", actor_agent_id: "agent-b"},
         {...request, operation_id: "bad-status", todo: {...todo, todo_id: "todo-done", status: "done", done: true}},


### PR DESCRIPTION
## Summary

- preserve the public `todo add --status deferred` contract after local-authority promotion
- continue rejecting already-done and archived records
- cover both legacy-compatible and native provider read models

## Root cause

The Python Todo API encodes deferred work as `status=deferred, done=true`, but the new native TypeScript create boundary rejected every record with `done=true`. Promotion therefore changed a supported Todo command into a failure.

## Validation

- red test reproduced twice before the fix (both provider read-model variants)
- `node --no-warnings --experimental-strip-types --test tests/control_plane_ts/authority_store.test.ts` (18 passed)
- `uv run --extra test pytest -q tests/control_plane/test_local_coordination_authority.py tests/test_ml_experiment_volc_packet.py` (18 passed)
- `npm run typecheck:control-plane`
- `npm run test:control-plane` (603 passed, 1 skipped)
- `npm audit` (0 vulnerabilities)
- `.venv/bin/loopx canary premerge --from-git-diff` (passed; 12/12 selected checks, no manual holds)
- `git diff --check`

## Known unrelated check noise

A full-repository Ruff scan reports six pre-existing findings in unrelated files; neither changed file is Python.

## Scope

The adjacent boundary needs no refactor: the one shared TypeScript create validator already owns this rule, so the fix remains a single-condition change plus one conformance case.