### PR TITLE
fix(provider-routing): add dual Auto, Fast selectors and scoped quota recovery

### DIFF
--- a/packages/loopx-codex-provider-routing/OPERATOR.md
+++ b/packages/loopx-codex-provider-routing/OPERATOR.md
@@ -11,36 +11,49 @@ The operator's `abc-sol-astra` preset uses the existing `compile_catalog` ring
 contract. Its credentials, App catalog, validation and observations share the
 same selector definitions.
 
-| Entry | Sol and Astra candidate order | Terminal fallback |
+| Visible Auto | Sol and Astra candidate order | Terminal behavior |
 | --- | --- | --- |
-| Auto / Prefer A | A → B → C | Ark, for eligible Standard text requests |
-| Prefer B | B → C → A | Ark, for eligible Standard text requests |
-| Prefer C | C → A → B | Ark, for eligible Standard text requests |
-| Fast variants | Same account order | None |
-| Luna | A → B → C | None |
+| `auto/MODEL` | A → B → C | Report exhaustion; no model substitution |
+| `auto-with-ds/MODEL` | A → B → C → DeepSeek | Explicit Standard text fallback |
 
-Both Sol and Astra expose Auto, Prefer A/B/C and four Fast siblings. Together
-with Luna and four existing Ark/compatibility rows, the App catalog has 21 rows.
-Bare Sol/Astra identifiers are compatibility aliases and are not picker rows.
-A preferred account is an entrypoint, not an exclusive pin. Ineligible, cooling
-or exhausted accounts can be skipped. Auto affinity is a hint that CPA must
-revalidate against account availability, input modality and service tier.
+Sol and Astra each have these two visible options: four picker rows total.
+The catalog retains 19 hidden compatibility rows (Prefer A/B/C, Fast, Luna and
+manual Ark identifiers), so existing tasks keep their metadata and route ids.
+Legacy Standard, bare Sol/Astra and Prefer aliases now stay within A/B/C. Only
+`auto-with-ds/` aliases admit Ark. Existing tasks are not silently opted into it.
+The four-route picker does not advertise Fast; the three-account picker retains
+native speed tiers. Image-bearing history excludes the text-only fallback.
 
-Standard routes keep the existing heterogeneous fallback, so their model labels
-explicitly name Ark. Image history, effective priority tier and unsupported tool
-transport must not be silently sent to a text/function-only provider. Code Mode
-needs the CPA candidate's qualified `custom_tool_call` adaptation; the extension
-compiler alone cannot enforce a wire capability. Fast/Luna routes have no Ark
-alias at all. Transparent retry ends at the first visible output or tool call.
+A preferred legacy account remains an entrypoint, not an exclusive pin. Auto
+keeps an eligible subscription affinity for session stability; a recovered
+higher-priority subscription does not forcibly steal an eligible binding.
+Removing Ark aliases from the three-account routes prevents an old degraded
+binding from keeping those routes on DeepSeek.
 
-The pinned CPA runtime remains the only online router. The operator emits
-configuration and metadata; it does not reimplement request retries. Existing
-retry settings remain 10 CPA retries, up to a 65-second advised wait, and one
-account-ring traversal per selection pass. Outer App retries are separate and
-can start another request: one ring pass is **not** a bound on total turn time.
-Account A no longer bypasses cooling. Fresh quota resets and recovery probes
-remain CPA's responsibility; a cached quota observation is not permission to
-permanently disable an account.
+The four-route operator requires a CPA build with
+[custom-tool namespace recovery](https://github.com/huangruiteng/CLIProxyAPI/pull/1). Chat Completions encodes custom tools as functions
+with an `input` string. CPA must restore `custom_tool_call`, the original input,
+namespace and call id in streamed and non-streamed responses. Historical custom
+calls must replay under the same qualified name as the current declaration.
+An omitted namespace can be recovered only from a unique current declaration;
+exact names take precedence and ambiguous names must never be guessed.
+This fixes transport, not model behavior: DeepSeek can still choose poorer code
+or miss Code Mode's output instructions. Keep the three-subscription route as
+the default for coding tasks. Explicit Ark access remains available by id.
+
+CPA owns online retry and cooling. The operator retains 10 CPA retries and up
+to a 65-second advised wait. App retries are separate; a single ring traversal
+is not a bound on total turn time. Do not disable cooling globally to recover
+one account: it would repeatedly hit known exhausted subscriptions.
+
+If an upstream account recovers earlier than its previously reported reset,
+CPA may still cache the old cooldown. After confirming recovery, permit a new
+attempt with `reset-cooldown --slot b --execute` (see the runnable command
+below). This uses CPA's targeted management API, does not rotate OAuth tokens,
+restart other accounts, modify task stores, or claim that quota was replenished.
+It refuses disabled slots. Verify with a bounded live request and actual account
+selection; a successful cache reset alone is not a health check. This explicit
+operator action does not install a background polling loop.
 
 Fast rows set a picker default and the checksum-pinned request plugin forces
 `service_tier=priority` before alias mapping. Verify the provider-bound request,
@@ -118,8 +131,21 @@ refuses to signal a launchd-managed or unrelated process. For launchd, unload th
 specific configured service before changing its program, then load it again.
 The operator does not modify LaunchAgents, App bundles or App processes itself.
 Restart only the affected App after changing its model catalog, and verify the
-21-row readback. Model registration is not proof of account entitlement or a
+four-visible/19-hidden row readback. Model registration is not proof of account entitlement or a
 successful model call; perform a bounded live request separately.
+
+## Early quota recovery
+
+```sh
+# Plan first; the executed command clears only the named slot's CPA cooldown.
+loopx-cpa-operator --config /absolute/private/operator.json reset-cooldown --slot b
+loopx-cpa-operator --config /absolute/private/operator.json --execute reset-cooldown --slot b
+loopx-cpa-operator --config /absolute/private/operator.json --execute route-status
+```
+
+Run a bounded model request after the reset, then inspect route-status again.
+Its success must identify the recovered subscription; another account succeeding
+is not evidence for the named slot. A fresh limit response reinstates cooling.
 
 ## Rollback and disable
 

--- a/packages/loopx-codex-provider-routing/OPERATOR.md
+++ b/packages/loopx-codex-provider-routing/OPERATOR.md
@@ -17,9 +17,11 @@ same selector definitions.
 | `auto-with-ds/MODEL` | A → B → C → DeepSeek | Explicit Standard text fallback |
 
 Sol and Astra each have these two visible options: four picker rows total.
-The catalog retains 19 hidden compatibility rows (Prefer A/B/C, Fast, Luna and
+The catalog retains 21 hidden compatibility rows (bare model ids, Prefer A/B/C, Fast, Luna and
 manual Ark identifiers), so existing tasks keep their metadata and route ids.
-Legacy Standard, bare Sol/Astra and Prefer aliases now stay within A/B/C. Only
+Legacy Standard, bare Sol/Astra and Prefer aliases now stay within A/B/C.
+Auto OAuth aliases use `fork: true` to retain the original model ids in CPA;
+a self-alias alone does not retain them. Only
 `auto-with-ds/` aliases admit Ark. Existing tasks are not silently opted into it.
 The four-route picker does not advertise Fast; the three-account picker retains
 native speed tiers. Image-bearing history excludes the text-only fallback.
@@ -131,7 +133,7 @@ refuses to signal a launchd-managed or unrelated process. For launchd, unload th
 specific configured service before changing its program, then load it again.
 The operator does not modify LaunchAgents, App bundles or App processes itself.
 Restart only the affected App after changing its model catalog, and verify the
-four-visible/19-hidden row readback. Model registration is not proof of account entitlement or a
+four-visible/21-hidden row readback. Model registration is not proof of account entitlement or a
 successful model call; perform a bounded live request separately.
 
 ## Early quota recovery

--- a/packages/loopx-codex-provider-routing/OPERATOR.md
+++ b/packages/loopx-codex-provider-routing/OPERATOR.md
@@ -33,7 +33,7 @@ Removing Ark aliases from the three-account routes prevents an old degraded
 binding from keeping those routes on DeepSeek.
 
 The four-route operator requires a CPA build with
-[custom-tool namespace recovery](https://github.com/huangruiteng/CLIProxyAPI/pull/1). Chat Completions encodes custom tools as functions
+[custom-tool namespace recovery](https://github.com/router-for-me/CLIProxyAPI/pull/5558). Chat Completions encodes custom tools as functions
 with an `input` string. CPA must restore `custom_tool_call`, the original input,
 namespace and call id in streamed and non-streamed responses. Historical custom
 calls must replay under the same qualified name as the current declaration.
@@ -100,6 +100,21 @@ CPA must refresh its model definitions: an old `-local-model` catalog can omit a
 new model even when the App picker advertises it. The operator enables CPA's
 model-definition refresh while keeping the executable/plugin hashes pinned.
 Model-definition refresh and binary upgrade are separate operations.
+
+## Reuse outside this preset
+
+The package's reusable routing boundary is `compile_catalog(source)` and the
+managed [routing contract](CONTRACT.md): callers supply symbolic profiles,
+rings, routes and capability declarations. The A/B/C and Sol/Astra names in
+this operator are a concrete preset, not requirements of that contract.
+Changing a contract does not install a runtime or grant credential access.
+
+Tool identity recovery belongs to CPA's Responses translator and depends only
+on the current request's tool declarations, not account slots, model names or
+a particular compatibility provider. Early cooldown recovery uses CPA's
+existing management API; this operator resolves the configured symbolic slot
+locally and emits a credential-free receipt. Credential acquisition, service
+supervision and live availability verification remain explicit host actions.
 
 ## Commands
 

--- a/packages/loopx-codex-provider-routing/OPERATOR.md
+++ b/packages/loopx-codex-provider-routing/OPERATOR.md
@@ -34,7 +34,9 @@ binding from keeping those routes on DeepSeek.
 
 The four-route operator requires a CPA build with
 [custom-tool namespace recovery](https://github.com/router-for-me/CLIProxyAPI/pull/5558). Chat Completions encodes custom tools as functions
-with an `input` string. CPA must restore `custom_tool_call`, the original input,
+with an `input` string. Upstream adoption is tracked in
+[the maintainer issue](https://github.com/router-for-me/CLIProxyAPI/issues/5560)
+because the repository restricts direct translator PRs. CPA must restore `custom_tool_call`, the original input,
 namespace and call id in streamed and non-streamed responses. Historical custom
 calls must replay under the same qualified name as the current declaration.
 An omitted namespace can be recovered only from a unique current declaration;

--- a/packages/loopx-codex-provider-routing/OPERATOR.md
+++ b/packages/loopx-codex-provider-routing/OPERATOR.md
@@ -11,14 +11,18 @@ The operator's `abc-sol-astra` preset uses the existing `compile_catalog` ring
 contract. Its credentials, App catalog, validation and observations share the
 same selector definitions.
 
-| Visible Auto | Sol and Astra candidate order | Terminal behavior |
+| Visible selector | Candidate order | Terminal behavior |
 | --- | --- | --- |
 | `auto/MODEL` | A → B → C | Report exhaustion; no model substitution |
+| `fast/auto/MODEL` | A → B → C | Request native Fast; no model substitution |
 | `auto-with-ds/MODEL` | A → B → C → DeepSeek | Explicit Standard text fallback |
+| `gpt-5.6-luna` | A → B → C | Report exhaustion; no model substitution |
 
-Sol and Astra each have these two visible options: four picker rows total.
-The catalog retains 21 hidden compatibility rows (bare model ids, Prefer A/B/C, Fast, Luna and
-manual Ark identifiers), so existing tasks keep their metadata and route ids.
+Sol and Astra each have two Standard Auto options and a three-account Fast Auto
+option. Luna remains visible as a three-account route: seven picker rows total.
+The catalog retains 18 hidden compatibility rows (bare Sol/Astra model ids,
+Prefer A/B/C and their Fast variants, and manual Ark identifiers), so existing
+tasks keep their metadata and route ids.
 Legacy Standard, bare Sol/Astra and Prefer aliases now stay within A/B/C.
 Auto OAuth aliases use `fork: true` to retain the original model ids in CPA;
 a self-alias alone does not retain them. Only
@@ -150,7 +154,7 @@ refuses to signal a launchd-managed or unrelated process. For launchd, unload th
 specific configured service before changing its program, then load it again.
 The operator does not modify LaunchAgents, App bundles or App processes itself.
 Restart only the affected App after changing its model catalog, and verify the
-four-visible/21-hidden row readback. Model registration is not proof of account entitlement or a
+seven-visible/18-hidden row readback. Model registration is not proof of account entitlement or a
 successful model call; perform a bounded live request separately.
 
 ## Early quota recovery

--- a/packages/loopx-codex-provider-routing/extension.toml
+++ b/packages/loopx-codex-provider-routing/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-codex-provider-routing"
-version = "0.9.0"
+version = "0.10.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-codex-provider-routing/pyproject.toml
+++ b/packages/loopx-codex-provider-routing/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-codex-provider-routing"
-version = "0.9.0"
+version = "0.10.0"
 description = "Public-safe Codex multi-provider routing integration for LoopX"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
@@ -8,6 +8,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from loopx_codex_provider_routing.operator import rollback, run, snapshot
 from loopx_codex_provider_routing.operator_catalog import AppCatalog
@@ -19,6 +20,7 @@ from loopx_codex_provider_routing.operator_runtime import (
 from loopx_codex_provider_routing.operator_settings import OperatorSettings
 from loopx_codex_provider_routing.selectors import (
     ROUTES,
+    VISIBLE_SELECTORS,
     aliases_for_slot,
     compiled_routes,
 )
@@ -135,12 +137,73 @@ class OperatorTests(unittest.TestCase):
                     )
                     self.assertEqual(actual, order)
                     self.assertTrue(all(e["name"] == model for e in entries.values()))
-                    self.assertEqual(ROUTES[slug]["tail"], [] if fast else ["ark-text"])
+                    self.assertEqual(ROUTES[slug]["tail"], [])
         self.assertEqual(ROUTES["gpt-5.6-luna"]["tail"], [])
         compiled = compiled_routes()
         for row in compiled["selector_rows"]:
-            if row["slug"].startswith("fast/"):
-                self.assertNotIn("ark-text", row["candidates"])
+            expected_tail = (
+                ["ark-text"] if row["slug"].startswith("auto-with-ds/") else []
+            )
+            self.assertEqual(
+                [p for p in row["candidates"] if p == "ark-text"], expected_tail
+            )
+
+    def test_runtime_never_maps_subscription_selectors_to_ark(self):
+        config = self.runtime.runtime_config("fixture-key", management_secret="fixture")
+        compatibility = config.split("openai-compatibility:", 1)[1]
+        self.assertIn('alias: "ark/deepseek-v4-flash"', compatibility)
+        native_only = [slug for slug, route in ROUTES.items() if not route["tail"]]
+        for alias in (*native_only, "gpt-5.6-sol", "gpt-6-astra"):
+            self.assertNotIn(f'alias: "{alias}"', compatibility)
+        self.assertIn("disable-cooling: false", config)
+
+    def test_cooldown_reset_is_scoped_and_not_a_health_claim(self):
+        self.seed()
+        entry = {"name": "b.json", "auth_index": "fixture-index", "disabled": False}
+        with (
+            patch.object(
+                self.runtime, "fetch_management_auth_files", return_value=[entry]
+            ),
+            patch("urllib.request.urlopen") as urlopen,
+        ):
+            urlopen.return_value.__enter__.return_value = io.StringIO('{"status":"ok"}')
+            result = self.runtime.reset_cooldown("b")
+            request = urlopen.call_args.args[0]
+            self.assertTrue(request.full_url.endswith("/v0/management/reset-quota"))
+            self.assertEqual(json.loads(request.data), {"auth_index": "fixture-index"})
+            self.assertEqual(result["profile_id"], "codex-b")
+            self.assertTrue(result["live_verification_required"])
+            self.assertNotIn("fixture-index", json.dumps(result))
+
+    def test_cooldown_reset_rejects_disabled_missing_and_ambiguous_slots(self):
+        self.seed()
+        for entries in (
+            [],
+            [{"name": "b.json", "disabled": True, "auth_index": "fixture"}],
+            [{"name": "b.json"}],
+            [{"name": "b.json"}, {"name": "b.json"}],
+        ):
+            with (
+                patch.object(
+                    self.runtime, "fetch_management_auth_files", return_value=entries
+                ),
+                patch("urllib.request.urlopen") as urlopen,
+            ):
+                with self.assertRaises(RuntimeError):
+                    self.runtime.reset_cooldown("b")
+                urlopen.assert_not_called()
+
+    def test_cooldown_reset_requires_slot_and_explicit_execution(self):
+        with self.assertRaises(ValueError):
+            run(["--config", str(self.config), "reset-cooldown"])
+        with (
+            patch.object(CPAOperator, "reset_cooldown") as reset,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.assertEqual(
+                run(["--config", str(self.config), "reset-cooldown", "--slot", "b"]), 0
+            )
+            reset.assert_not_called()
 
     def test_reconcile_preserves_tokens_and_is_idempotent(self):
         self.seed()
@@ -215,7 +278,15 @@ class OperatorTests(unittest.TestCase):
             )
         catalog = AppCatalog(self.runtime)
         rows = {m["slug"]: m for m in catalog.generate_catalog()["models"]}
-        self.assertEqual(len(rows), 21)
+        self.assertEqual(len(rows), 23)
+        self.assertEqual(
+            {slug for slug, row in rows.items() if row["visibility"] == "list"},
+            VISIBLE_SELECTORS,
+        )
+        self.assertEqual(len(VISIBLE_SELECTORS), 4)
+        for slug in VISIBLE_SELECTORS:
+            if slug.startswith("auto-with-ds/"):
+                self.assertEqual(rows[slug]["service_tiers"], [])
         for slug, row in rows.items():
             self.assertEqual(
                 row["default_service_tier"],
@@ -257,8 +328,11 @@ class OperatorTests(unittest.TestCase):
             "deepseek-v4-flash-ga-260731",
             "deepseek-v4-pro-ga-260813",
         }
-        observation["visible_models"] = sorted(native | ark)
-        observation["hidden_models"] = ["gpt-5.6-sol", "gpt-6-astra"]
+        observation["visible_models"] = sorted(VISIBLE_SELECTORS)
+        observation["hidden_models"] = sorted((native | ark) - VISIBLE_SELECTORS) + [
+            "gpt-5.6-sol",
+            "gpt-6-astra",
+        ]
         observation["fast_models"] = sorted(
             slug for slug in native if slug.startswith("fast/")
         )
@@ -274,7 +348,7 @@ class OperatorTests(unittest.TestCase):
         for slug, route in ROUTES.items():
             observation["route_traversal"][slug] = {
                 "entrypoint": "affinity_then_first"
-                if slug.removeprefix("fast/").startswith("auto/")
+                if slug.removeprefix("fast/").startswith(("auto/", "auto-with-ds/"))
                 or slug == "gpt-5.6-luna"
                 else f"codex-{route['order'][0]}",
                 "ordered_candidates": [f"codex-{slot}" for slot in route["order"]]
@@ -283,6 +357,9 @@ class OperatorTests(unittest.TestCase):
                 "max_cycles": 1,
             }
         self.assertTrue(qualify_snapshot(observation)["qualified"])
+        visible_regression = deepcopy(observation)
+        visible_regression["visible_models"].append("codex-b/gpt-6-astra")
+        self.assertFalse(qualify_snapshot(visible_regression)["qualified"])
         broken = deepcopy(observation)
         broken["route_traversal"]["fast/codex-c/gpt-6-astra"][
             "ordered_candidates"
@@ -329,11 +406,12 @@ class OperatorTests(unittest.TestCase):
         self.assertEqual(data["refresh_token"], "fixture-refresh")
         self.assertNotIn("c", self.runtime.load_slots())
 
-    def test_config_has_all_normal_fallbacks_but_no_fast_or_luna(self):
+    def test_config_fallback_requires_explicit_four_route_opt_in(self):
         config = self.runtime.runtime_config(
             "fixture-only", management_secret="fixture-management"
         )
-        self.assertIn('alias: "codex-c/gpt-6-astra"', config)
+        self.assertIn('alias: "auto-with-ds/gpt-6-astra"', config)
+        self.assertNotIn('alias: "codex-c/gpt-6-astra"', config)
         self.assertNotIn('alias: "fast/', config)
         self.assertNotIn('alias: "gpt-5.6-luna"', config)
         self.assertIn('host: "127.0.0.1"', config)

--- a/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
@@ -138,6 +138,8 @@ class OperatorTests(unittest.TestCase):
                     self.assertEqual(actual, order)
                     self.assertTrue(all(e["name"] == model for e in entries.values()))
                     self.assertEqual(ROUTES[slug]["tail"], [])
+                    if prefix == "auto" and not fast:
+                        self.assertTrue(all(e["fork"] for e in entries.values()))
         self.assertEqual(ROUTES["gpt-5.6-luna"]["tail"], [])
         compiled = compiled_routes()
         for row in compiled["selector_rows"]:
@@ -267,6 +269,9 @@ class OperatorTests(unittest.TestCase):
                             {
                                 **base,
                                 "slug": model,
+                                "input_modalities": ["text"]
+                                if key == "ark_catalog"
+                                else ["text", "image"],
                                 "context_window": 100000
                                 if model == "gpt-6-astra"
                                 else 50000,
@@ -278,12 +283,16 @@ class OperatorTests(unittest.TestCase):
             )
         catalog = AppCatalog(self.runtime)
         rows = {m["slug"]: m for m in catalog.generate_catalog()["models"]}
-        self.assertEqual(len(rows), 23)
+        self.assertEqual(len(rows), 25)
         self.assertEqual(
             {slug for slug, row in rows.items() if row["visibility"] == "list"},
             VISIBLE_SELECTORS,
         )
         self.assertEqual(len(VISIBLE_SELECTORS), 4)
+        self.assertEqual(
+            rows["gpt-6-astra"]["context_window"],
+            rows["auto/gpt-6-astra"]["context_window"],
+        )
         for slug in VISIBLE_SELECTORS:
             if slug.startswith("auto-with-ds/"):
                 self.assertEqual(rows[slug]["service_tiers"], [])
@@ -309,6 +318,21 @@ class OperatorTests(unittest.TestCase):
         first = sha256(self.runtime.MODEL_CATALOG)
         catalog.write_catalog()
         self.assertEqual(first, sha256(self.runtime.MODEL_CATALOG))
+        with (
+            patch.object(self.runtime, "check_artifacts"),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.runtime.validate()
+            broken = json.loads(self.runtime.MODEL_CATALOG.read_text())
+            row = next(
+                row
+                for row in broken["models"]
+                if row["slug"] == "auto-with-ds/gpt-6-astra"
+            )
+            row["additional_speed_tiers"] = ["fast"]
+            write_private(self.runtime.MODEL_CATALOG, json.dumps(broken))
+            with self.assertRaisesRegex(RuntimeError, "standard-only"):
+                self.runtime.validate()
 
     def test_new_preset_qualification_and_negative_fast_admission(self):
         from copy import deepcopy

--- a/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
+++ b/packages/loopx-codex-provider-routing/smoke/operator_smoke.py
@@ -286,9 +286,16 @@ class OperatorTests(unittest.TestCase):
         self.assertEqual(len(rows), 25)
         self.assertEqual(
             {slug for slug, row in rows.items() if row["visibility"] == "list"},
-            VISIBLE_SELECTORS,
+            {
+                "auto/gpt-5.6-sol",
+                "fast/auto/gpt-5.6-sol",
+                "auto-with-ds/gpt-5.6-sol",
+                "auto/gpt-6-astra",
+                "fast/auto/gpt-6-astra",
+                "auto-with-ds/gpt-6-astra",
+                "gpt-5.6-luna",
+            },
         )
-        self.assertEqual(len(VISIBLE_SELECTORS), 4)
         self.assertEqual(
             rows["gpt-6-astra"]["context_window"],
             rows["auto/gpt-6-astra"]["context_window"],

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/contract.py
@@ -1604,18 +1604,20 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     if preset not in {"legacy-ab-sol", "abc-sol-astra"}:
         raise ValueError("unsupported snapshot routing preset")
     expected_hidden = {"gpt-5.6-sol"}
+    expected_rows = expected_visible
     if preset == "abc-sol-astra":
-        from .selectors import MODEL_FAMILIES, ROUTES
+        from .selectors import MODEL_FAMILIES, ROUTES, VISIBLE_SELECTORS
 
-        expected_visible = set(ROUTES) | {
+        expected_rows = set(ROUTES) | {
             "ark/deepseek-v4-flash",
             "deepseek-v4-flash",
             "deepseek-v4-flash-ga-260731",
             "deepseek-v4-pro-ga-260813",
         }
-        expected_hidden = set(MODEL_FAMILIES)
-    expected_fast = {slug for slug in expected_visible if slug.startswith("fast/")}
-    expected_native = {slug for slug in expected_visible if "gpt-" in slug}
+        expected_visible = set(VISIBLE_SELECTORS)
+        expected_hidden = set(MODEL_FAMILIES) | (expected_rows - expected_visible)
+    expected_fast = {slug for slug in expected_rows if slug.startswith("fast/")}
+    expected_native = {slug for slug in expected_rows if "gpt-" in slug}
     checks: list[dict[str, Any]] = []
 
     def check(check_id: str, passed: bool, detail: str) -> None:
@@ -1633,7 +1635,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     check(
         "hidden_alias",
         expected_hidden <= hidden,
-        "bare compatibility alias remains hidden",
+        "compatibility aliases remain hidden",
     )
     modalities = snapshot.get("input_modalities")
     if not isinstance(modalities, Mapping):
@@ -1655,12 +1657,12 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
     check(
         "fast_projection",
         fast_models == expected_fast,
-        "Fast is exposed as explicit sibling rows",
+        "Fast compatibility rows retain their tier metadata",
     )
     selector_tiers = snapshot.get("selector_default_service_tiers")
     if not isinstance(selector_tiers, Mapping):
         raise TypeError("snapshot.selector_default_service_tiers must be an object")
-    standard_selectors = expected_visible - fast_models
+    standard_selectors = expected_rows - fast_models
     check(
         "fast_default_off",
         snapshot.get("default_service_tier") == "default"
@@ -1733,7 +1735,7 @@ def qualify_snapshot(snapshot: Mapping[str, Any]) -> dict[str, Any]:
         expected_traversal = {
             slug: {
                 "entrypoint": "affinity_then_first"
-                if slug.removeprefix("fast/").startswith("auto/")
+                if slug.removeprefix("fast/").startswith(("auto/", "auto-with-ds/"))
                 or slug == "gpt-5.6-luna"
                 else f"codex-{route['order'][0]}",
                 "ordered_candidates": [f"codex-{slot}" for slot in route["order"]]

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator.py
@@ -32,6 +32,7 @@ COMMANDS = (
     "enroll",
     "snapshot",
     "rollback",
+    "reset-cooldown",
 )
 
 
@@ -204,8 +205,8 @@ def run(argv=None) -> int:
     parser.add_argument("--fast", action="store_true")
     args = parser.parse_args(argv)
     settings = OperatorSettings.read(args.config)
-    if args.command == "enroll" and not args.slot:
-        raise ValueError("enroll requires --slot")
+    if args.command in {"enroll", "reset-cooldown"} and not args.slot:
+        raise ValueError(f"{args.command} requires --slot")
     if args.command == "rollback" and not args.snapshot_id:
         raise ValueError("rollback requires --snapshot-id")
     receipt = {
@@ -238,10 +239,12 @@ def run(argv=None) -> int:
             result = catalog.probe()
             receipt["passed"] = result["passed"]
             receipt["model_count"] = len(result["projected_selectors"])
+            receipt["visible_selectors"] = result["visible_selectors"]
             receipt["checks"] = {
                 k: result[k]
                 for k in (
                     "missing",
+                    "unexpected_visible",
                     "hidden",
                     "cpa_missing",
                     "route_mismatches",
@@ -252,6 +255,8 @@ def run(argv=None) -> int:
             runtime.prepare()
             enroll(runtime, args.slot)
             receipt["enrolled_slot"] = args.slot
+        elif args.command == "reset-cooldown":
+            receipt["recovery"] = runtime.reset_cooldown(args.slot)
         elif args.command == "snapshot":
             receipt["rollback_snapshot"] = snapshot(runtime)
         elif args.command == "rollback":

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_catalog.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_catalog.py
@@ -18,6 +18,9 @@ from .selectors import FAST_MODELS, MODEL_FAMILIES, ROUTES, SLOTS, VISIBLE_SELEC
 
 SELECTORS = {slug: route["display_name"] for (slug, route) in ROUTES.items()}
 SELECTORS.update(
+    {model: f"{label} · Auto (legacy id)" for model, label in MODEL_FAMILIES.items()}
+)
+SELECTORS.update(
     {
         "ark/deepseek-v4-flash": "Ark · DeepSeek V4 Flash",
         "deepseek-v4-flash": "Ark · DeepSeek V4 Flash (legacy id)",
@@ -138,7 +141,7 @@ class AppCatalog:
         }
         entries = []
         for slug, label in SELECTORS.items():
-            route = ROUTES.get(slug)
+            route = ROUTES.get(slug, ROUTES.get(f"auto/{slug}"))
             if route:
                 source = deepcopy(sources[route["model"]])
                 if slug.removeprefix("fast/").startswith(("auto/", "auto-with-ds/")):

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_catalog.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_catalog.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from .selectors import FAST_MODELS, MODEL_FAMILIES, ROUTES, SLOTS
+from .selectors import FAST_MODELS, MODEL_FAMILIES, ROUTES, SLOTS, VISIBLE_SELECTORS
 
 SELECTORS = {slug: route["display_name"] for (slug, route) in ROUTES.items()}
 SELECTORS.update(
@@ -141,7 +141,7 @@ class AppCatalog:
             route = ROUTES.get(slug)
             if route:
                 source = deepcopy(sources[route["model"]])
-                if slug.removeprefix("fast/").startswith("auto/"):
+                if slug.removeprefix("fast/").startswith(("auto/", "auto-with-ds/")):
                     source["default_reasoning_level"] = "high"
                     source["supported_reasoning_levels"] = [
                         level
@@ -153,6 +153,10 @@ class AppCatalog:
                     slug if slug.endswith("260813") else "deepseek-v4-flash-ga-260731"
                 )
             entry = make_entry(source, slug, label, len(entries) + 1)
+            entry["visibility"] = "list" if slug in VISIBLE_SELECTORS else "hide"
+            if route and route["tail"]:
+                entry["additional_speed_tiers"] = []
+                entry["service_tiers"] = []
             entry["default_service_tier"] = "fast" if slug in FAST_SELECTORS else None
             entries.append(entry)
         return {"models": entries}
@@ -195,14 +199,8 @@ class AppCatalog:
             ordered = [member for (member, _) in members] + list(tail)
             rows[route] = {
                 "entrypoint": "affinity_then_first"
-                if route
-                in {
-                    "auto/gpt-5.6-sol",
-                    "fast/auto/gpt-5.6-sol",
-                    "auto/gpt-6-astra",
-                    "fast/auto/gpt-6-astra",
-                    "gpt-5.6-luna",
-                }
+                if route.removeprefix("fast/").startswith(("auto/", "auto-with-ds/"))
+                or route == "gpt-5.6-luna"
                 else ordered[0],
                 "ordered_candidates": ordered,
                 "fallback_tail": list(tail),
@@ -225,7 +223,7 @@ class AppCatalog:
                 f'model_catalog_json = "{self.OUTPUT}"',
                 "",
                 "[model_providers.cpa]",
-                'name = "CPA · Codex A → B → C → Ark"',
+                'name = "CPA · Auto"',
                 f'base_url = "http://127.0.0.1:{self.PORT}/v1"',
                 'wire_api = "responses"',
                 "requires_openai_auth = false",
@@ -285,7 +283,7 @@ class AppCatalog:
                         {
                             "method": "model/list",
                             "id": 2,
-                            "params": {"limit": 50, "includeHidden": False},
+                            "params": {"limit": 50, "includeHidden": True},
                         }
                     )
                     + "\n"
@@ -296,7 +294,7 @@ class AppCatalog:
                     (3, "auto/gpt-5.6-sol"),
                     (4, "fast/auto/gpt-5.6-sol"),
                     (5, "auto/gpt-6-astra"),
-                    (6, "fast/codex-c/gpt-6-astra"),
+                    (6, "auto-with-ds/gpt-6-astra"),
                 ):
                     process.stdin.write(
                         json.dumps(
@@ -325,6 +323,13 @@ class AppCatalog:
         if "error" in response:
             raise RuntimeError("app-server model/list returned an error")
         data = response.get("result", {}).get("data", [])
+        unexpected_visible = sorted(
+            str(row.get("id"))
+            for row in data
+            if isinstance(row, dict)
+            and not row.get("hidden")
+            and row.get("id") not in SELECTORS
+        )
         rows = {
             str(row.get("id")): {
                 "displayName": row.get("displayName"),
@@ -343,7 +348,11 @@ class AppCatalog:
             if isinstance(row, dict) and row.get("id") in SELECTORS
         }
         missing = sorted(set(SELECTORS) - set(rows))
-        hidden = sorted(key for (key, row) in rows.items() if row.get("hidden"))
+        hidden = sorted(
+            key
+            for key, row in rows.items()
+            if bool(row.get("hidden")) != (key not in VISIBLE_SELECTORS)
+        )
         wrong_display_names = sorted(
             key
             for (key, display_name) in SELECTORS.items()
@@ -383,8 +392,12 @@ class AppCatalog:
             "catalog_path": str(self.OUTPUT),
             "expected_selectors": sorted(SELECTORS),
             "projected_selectors": rows,
+            "visible_selectors": sorted(
+                key for key, row in rows.items() if not row.get("hidden")
+            ),
             "route_traversal": route_traversal,
             "missing": missing,
+            "unexpected_visible": unexpected_visible,
             "hidden": hidden,
             "wrong_display_names": wrong_display_names,
             "wrong_default_service_tiers": wrong_default_service_tiers,
@@ -396,6 +409,7 @@ class AppCatalog:
             "passed": not any(
                 (
                     missing,
+                    unexpected_visible,
                     hidden,
                     wrong_display_names,
                     wrong_default_service_tiers,

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_runtime.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_runtime.py
@@ -628,7 +628,10 @@ class CPAOperator(ObservationMixin):
                     for tier in item.get("service_tiers", [])
                     if isinstance(tier, dict)
                 }
-                if "fast" not in speed_tiers or "priority" not in service_tiers:
+                if ROUTES[model]["tail"]:
+                    if speed_tiers or service_tiers:
+                        errors.append(f"model-catalog-standard-only:{model}")
+                elif "fast" not in speed_tiers or "priority" not in service_tiers:
                     errors.append(f"model-catalog-fast-tier:{model}")
                 expected_default = "fast" if model in FAST_MODELS else None
                 if item.get("default_service_tier") != expected_default:
@@ -689,5 +692,5 @@ class CPAOperator(ObservationMixin):
                     "runtime model catalog missing: " + ",".join(missing)
                 )
         print(
-            "validate-ok slots=A,B,C models=Sol,Astra auto=A-B-C-Ark prefer-b=B-C-A-Ark prefer-c=C-A-B-Ark luna=A-B-C fast-routes=A-B-C"
+            "validate-ok slots=A,B,C models=Sol,Astra auto=A-B-C auto-with-ds=A-B-C-Ark"
         )

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_runtime.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/operator_runtime.py
@@ -153,16 +153,14 @@ class CPAOperator(ObservationMixin):
         return key
 
     def ark_fallback_models(self) -> list[str]:
-        aliases = [slug for (slug, route) in ROUTES.items() if route["tail"]] + list(
-            MODEL_FAMILIES
-        )
         lines = []
-        for alias in aliases:
-            route = ROUTES.get(alias, ROUTES.get(f"auto/{alias}"))
+        for slug, route in ROUTES.items():
+            if not route["tail"]:
+                continue
             lines.extend(
                 [
                     f"      - name: {yaml_quote(self.ARK_MODEL)}",
-                    f"        alias: {yaml_quote(alias)}",
+                    f"        alias: {yaml_quote(slug)}",
                     f"        display-name: {yaml_quote(route['display_name'])}",
                     "        force-mapping: true",
                     "        is-compat: true",
@@ -491,6 +489,50 @@ class CPAOperator(ObservationMixin):
                 "CPA management endpoint returned an invalid auth-file list"
             )
         return [item for item in files if isinstance(item, dict)]
+
+    def reset_cooldown(self, slot: str) -> dict[str, Any]:
+        """Permit a fresh attempt after an externally confirmed early quota recovery.
+
+        This clears only CPA routing memory; it does not replenish upstream quota
+        or declare the account healthy. The next request supplies fresh evidence.
+        """
+        if slot not in SLOTS:
+            raise ValueError("unknown OAuth slot")
+        name = self.load_slots().get(slot)
+        matches = [
+            entry
+            for entry in self.fetch_management_auth_files()
+            if name is not None and entry.get("name") == name
+        ]
+        if len(matches) != 1:
+            raise RuntimeError("expected exactly one registered slot credential")
+        entry = matches[0]
+        if entry.get("disabled"):
+            raise RuntimeError("refusing to recover an explicitly disabled slot")
+        auth_index = entry.get("auth_index")
+        if not isinstance(auth_index, str) or not auth_index.strip():
+            raise RuntimeError("registered slot has no management auth index")
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.PORT}/v0/management/reset-quota",
+            data=json.dumps({"auth_index": auth_index}).encode(),
+            headers={
+                "Authorization": "Bearer " + self.management_key(),
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.load(response)
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise RuntimeError("CPA cooldown reset failed") from error
+        if not isinstance(payload, dict) or payload.get("status") != "ok":
+            raise RuntimeError("CPA cooldown reset was not acknowledged")
+        return {
+            "profile_id": f"codex-{slot}",
+            "cooldown_cleared": True,
+            "live_verification_required": True,
+        }
 
     def fetch_management_plugins(self, port: int | None = None) -> list[dict[str, Any]]:
         if port is None:

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
@@ -62,6 +62,7 @@ def aliases_for_slot(slot):
                 "alias": slug,
                 "display-name": route["display_name"],
                 "force-mapping": True,
+                "fork": slug.startswith("auto/"),
                 "routing-priority": 400 - 100 * route["order"].index(slot),
             }
         )

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
@@ -21,12 +21,26 @@ for model, label in MODEL_FAMILIES.items():
                 "model": model,
                 "order": order,
                 "fast": fast,
-                "tail": [] if fast else ["ark-text"],
+                "tail": [],
                 "display_name": f"{label} · {title} · "
                 + ("Fast · " if fast else "")
-                + f"Codex {chain}"
-                + ("" if fast else " → Ark"),
+                + f"Codex {chain}",
             }
+# The second Auto is an explicit opt-in to a heterogeneous Standard fallback.
+for model, label in MODEL_FAMILIES.items():
+    ROUTES[f"auto-with-ds/{model}"] = {
+        "model": model,
+        "order": list(SLOTS),
+        "fast": False,
+        "tail": ["ark-text"],
+        "display_name": f"{label} · Auto · A → B → C → DeepSeek",
+    }
+VISIBLE_SELECTORS = {
+    f"{prefix}/{model}"
+    for model in MODEL_FAMILIES
+    for prefix in ("auto", "auto-with-ds")
+}
+
 ROUTES["gpt-5.6-luna"] = {
     "model": "gpt-5.6-luna",
     "order": list(SLOTS),
@@ -77,14 +91,14 @@ def routing_source():
             "priority": 100,
             "input_modalities": ["text"],
             "supports_fast": False,
-            "tool_transports": ["function_call"],
+            "tool_transports": ["function_call", "custom_tool_call"],
         }
     )
     routes = []
     for slug, spec in ROUTES.items():
         if spec["fast"]:
             continue
-        auto = slug.startswith("auto/") or slug == "gpt-5.6-luna"
+        auto = slug.startswith(("auto/", "auto-with-ds/")) or slug == "gpt-5.6-luna"
         route = {
             "slug": slug,
             "display_name": spec["display_name"],
@@ -95,7 +109,7 @@ def routing_source():
             else f"codex-{spec['order'][0]}",
             "fallback_tail": spec["tail"],
             "input_modalities": ["text", "image"],
-            "supports_fast": True,
+            "supports_fast": not bool(spec["tail"]),
             "reasoning_levels": ["low", "medium", "high", "xhigh", "max"],
         }
         fast = ROUTES.get(f"fast/{slug}")

--- a/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
+++ b/packages/loopx-codex-provider-routing/src/loopx_codex_provider_routing/selectors.py
@@ -38,8 +38,8 @@ for model, label in MODEL_FAMILIES.items():
 VISIBLE_SELECTORS = {
     f"{prefix}/{model}"
     for model in MODEL_FAMILIES
-    for prefix in ("auto", "auto-with-ds")
-}
+    for prefix in ("auto", "fast/auto", "auto-with-ds")
+} | {"gpt-5.6-luna"}
 
 ROUTES["gpt-5.6-luna"] = {
     "model": "gpt-5.6-luna",


### PR DESCRIPTION
Quota recovery can leave an account behind CPA's cached cooldown, while transparent cross-model fallback can strand Code Mode tools. The local operator now exposes two Auto choices per Sol/Astra family: A/B/C only by default, and an explicit A/B/C/DeepSeek route. Each family also exposes a native three-account Fast Auto, and Luna remains visible. Prefer and their Fast variants, bare model ids, and manual Ark compatibility ids retain hidden metadata; legacy and bare subscription selectors no longer map to Ark.

Add a slot-scoped `reset-cooldown` command using CPA's management API. It requires explicit execution, rejects disabled or ambiguous slots, and reports that live verification is still required. Update qualification and App readback for seven visible options and hidden compatibility rows. The managed extension remains read-only. The four-route operator requires [CPA custom-tool namespace recovery](https://github.com/router-for-me/CLIProxyAPI/pull/5558).

Validation: Ruff and all three package smoke entrypoints passed (19 local-operator tests). Installed App-server readback found exactly seven visible selectors and no missing routes. In an isolated runtime, three synthetic unavailable native credentials led to a real compatibility-provider custom-tool round trip for both model families; the three-account route failed at exhaustion as intended. An existing native task also completed a harmless exec check after recovery. The restored Fast Auto Sol/Astra and Luna selectors also completed live native requests. Fast metadata and routing passed validation; the upstream responses reported the default service tier, so this does not establish acceleration. Public-boundary scans excluded credentials, local state and raw logs.

Behavior change: the `abc-sol-astra` operator preset now has explicit opt-in heterogeneous fallback and a compact picker; legacy A/B qualification is unchanged. Four-route picker entries advertise Standard only. No background polling, task-store migration or service installation is added by the managed protocol.

The reusable translator fix is submitted upstream as [CPA #5558](https://github.com/router-for-me/CLIProxyAPI/pull/5558). Upstream requires maintainers to apply translator changes; [issue #5560](https://github.com/router-for-me/CLIProxyAPI/issues/5560) contains the reproduction, proposed implementation and validation evidence.
