### PR TITLE
fix(task-lease): reject corrupt active expirations

### DIFF
--- a/loopx/control_plane/work_items/task_lease_acquire.ts
+++ b/loopx/control_plane/work_items/task_lease_acquire.ts
@@ -573,7 +573,7 @@ export function leaseEpoch(lease: LeaseRecord | null): number {
 }
 
 export function parseLeaseTimestamp(value: string): Date | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?$/u.exec(
+  const match = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?$/u.exec(
     value.trim(),
   );
   if (match === null) return null;
@@ -585,7 +585,7 @@ export function parseLeaseTimestamp(value: string): Date | null {
     hourText,
     minuteText,
     secondText ?? "0",
-    (fraction ?? "").padEnd(3, "0") || "0",
+    (fraction ?? "").slice(0, 3).padEnd(3, "0") || "0",
   ].map(Number);
   const calendar = new Date(Date.UTC(year, month - 1, day, hour, minute, second, millisecond));
   if (
@@ -595,6 +595,7 @@ export function parseLeaseTimestamp(value: string): Date | null {
     calendar.getUTCMilliseconds() !== millisecond
   ) return null;
   let text = value.trim().replace(" ", "T").replace(/z$/u, "Z");
+  if (fraction !== undefined) text = text.replace(`.${fraction}`, `.${fraction.slice(0, 3)}`);
   if (timezone === undefined) text += "Z";
   else text = text.replace(/([+-]\d{2})$/u, "$1:00");
   const parsed = new Date(text);

--- a/loopx/control_plane/work_items/task_lease_acquire.ts
+++ b/loopx/control_plane/work_items/task_lease_acquire.ts
@@ -589,9 +589,22 @@ export function leaseIsActive(lease: LeaseRecord | null, at: Date): boolean {
   ) {
     return false;
   }
-  if (typeof lease.expires_at !== "string") return false;
+  if (typeof lease.expires_at !== "string") {
+    throw new TaskLeaseAcquireError(
+      "active lease expires_at must be a valid timestamp",
+      "corrupt_lease",
+      { expires_at: lease.expires_at ?? null },
+    );
+  }
   const expiresAt = parseLeaseTimestamp(lease.expires_at);
-  return expiresAt !== null && expiresAt.valueOf() > at.valueOf();
+  if (expiresAt === null) {
+    throw new TaskLeaseAcquireError(
+      "active lease expires_at must be a valid timestamp",
+      "corrupt_lease",
+      { expires_at: lease.expires_at },
+    );
+  }
+  return expiresAt.valueOf() > at.valueOf();
 }
 
 export function utcIsoformat(value: Date): string {

--- a/loopx/control_plane/work_items/task_lease_acquire.ts
+++ b/loopx/control_plane/work_items/task_lease_acquire.ts
@@ -573,7 +573,7 @@ export function leaseEpoch(lease: LeaseRecord | null): number {
 }
 
 export function parseLeaseTimestamp(value: string): Date | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?$/u.exec(
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?)?$/u.exec(
     value.trim(),
   );
   if (match === null) return null;
@@ -582,18 +582,21 @@ export function parseLeaseTimestamp(value: string): Date | null {
     yearText,
     monthText,
     dayText,
-    hourText,
-    minuteText,
+    hourText ?? "0",
+    minuteText ?? "0",
     secondText ?? "0",
     (fraction ?? "").slice(0, 3).padEnd(3, "0") || "0",
   ].map(Number);
-  const calendar = new Date(Date.UTC(year, month - 1, day, hour, minute, second, millisecond));
+  const calendar = new Date(0);
+  calendar.setUTCHours(hour, minute, second, millisecond);
+  calendar.setUTCFullYear(year, month - 1, day);
   if (
     calendar.getUTCFullYear() !== year || calendar.getUTCMonth() !== month - 1 ||
     calendar.getUTCDate() !== day || calendar.getUTCHours() !== hour ||
     calendar.getUTCMinutes() !== minute || calendar.getUTCSeconds() !== second ||
     calendar.getUTCMilliseconds() !== millisecond
   ) return null;
+  if (hourText === undefined) return calendar;
   let text = value.trim().replace(" ", "T").replace(/z$/u, "Z");
   if (fraction !== undefined) text = text.replace(`.${fraction}`, `.${fraction.slice(0, 3)}`);
   if (timezone === undefined) text += "Z";

--- a/loopx/control_plane/work_items/task_lease_acquire.ts
+++ b/loopx/control_plane/work_items/task_lease_acquire.ts
@@ -573,12 +573,31 @@ export function leaseEpoch(lease: LeaseRecord | null): number {
 }
 
 export function parseLeaseTimestamp(value: string): Date | null {
-  let text = value.trim().replace(/z$/u, "Z");
-  if (!text) return null;
-  const hasTime = /[T ]\d{2}:\d{2}/u.test(text);
-  if (hasTime) text = text.replace(/([+-]\d{2})$/u, "$1:00");
-  const hasTimezone = /(?:Z|[+-]\d{2}(?::?\d{2})?)$/u.test(text);
-  const parsed = new Date(hasTime && !hasTimezone ? `${text}Z` : text);
+  const match = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?$/u.exec(
+    value.trim(),
+  );
+  if (match === null) return null;
+  const [, yearText, monthText, dayText, hourText, minuteText, secondText, fraction, timezone] = match;
+  const [year, month, day, hour, minute, second, millisecond] = [
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText ?? "0",
+    (fraction ?? "").padEnd(3, "0") || "0",
+  ].map(Number);
+  const calendar = new Date(Date.UTC(year, month - 1, day, hour, minute, second, millisecond));
+  if (
+    calendar.getUTCFullYear() !== year || calendar.getUTCMonth() !== month - 1 ||
+    calendar.getUTCDate() !== day || calendar.getUTCHours() !== hour ||
+    calendar.getUTCMinutes() !== minute || calendar.getUTCSeconds() !== second ||
+    calendar.getUTCMilliseconds() !== millisecond
+  ) return null;
+  let text = value.trim().replace(" ", "T").replace(/z$/u, "Z");
+  if (timezone === undefined) text += "Z";
+  else text = text.replace(/([+-]\d{2})$/u, "$1:00");
+  const parsed = new Date(text);
   return Number.isNaN(parsed.valueOf()) ? null : parsed;
 }
 

--- a/loopx/control_plane/work_items/task_lease_acquire.ts
+++ b/loopx/control_plane/work_items/task_lease_acquire.ts
@@ -573,7 +573,7 @@ export function leaseEpoch(lease: LeaseRecord | null): number {
 }
 
 export function parseLeaseTimestamp(value: string): Date | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,6}))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?)?$/u.exec(
+  const match = /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(Z|z|[+-]\d{2}(?::?\d{2})?)?)?$/u.exec(
     value.trim(),
   );
   if (match === null) return null;
@@ -587,12 +587,18 @@ export function parseLeaseTimestamp(value: string): Date | null {
     secondText ?? "0",
     (fraction ?? "").slice(0, 3).padEnd(3, "0") || "0",
   ].map(Number);
+  const endOfDay = hour === 24;
+  if (
+    endOfDay &&
+    (minute !== 0 || second !== 0 || (fraction !== undefined && /[1-9]/u.test(fraction)))
+  ) return null;
+  const calendarHour = endOfDay ? 0 : hour;
   const calendar = new Date(0);
-  calendar.setUTCHours(hour, minute, second, millisecond);
+  calendar.setUTCHours(calendarHour, minute, second, millisecond);
   calendar.setUTCFullYear(year, month - 1, day);
   if (
     calendar.getUTCFullYear() !== year || calendar.getUTCMonth() !== month - 1 ||
-    calendar.getUTCDate() !== day || calendar.getUTCHours() !== hour ||
+    calendar.getUTCDate() !== day || calendar.getUTCHours() !== calendarHour ||
     calendar.getUTCMinutes() !== minute || calendar.getUTCSeconds() !== second ||
     calendar.getUTCMilliseconds() !== millisecond
   ) return null;

--- a/tests/control_plane_ts/task_lease_acquire.test.ts
+++ b/tests/control_plane_ts/task_lease_acquire.test.ts
@@ -472,3 +472,27 @@ test("corrupt bool integers fail closed and legacy epoch advances", async (t) =>
   assert.equal(migrated.ok, true);
   assert.equal((await persistedLease(root)).lease_epoch, 2);
 });
+
+test("corrupt active expiration fails closed without replacing the lease", async (t) => {
+  const root = await workspace(t);
+  await mkdir(join(root, "runtime", "goals", "goal-a", "task-leases"), { recursive: true });
+  const existing = {
+    schema_version: "task_lease_v0",
+    goal_id: "goal-a",
+    todo_id: "todo_target",
+    owner: "agent-b",
+    idempotency_key: "existing-owner",
+    write_scopes: ["loopx/**"],
+    acquire_ttl_seconds: 120,
+    version: 1,
+    lease_epoch: 1,
+    status: "active",
+    expires_at: "not-a-timestamp",
+  };
+  await writeFile(leasePath(root), JSON.stringify(existing), "utf8");
+
+  const result = await executeTaskLeaseAcquire(await request(root), { now: () => FIXED_NOW });
+
+  assert.equal(result.error_code, "corrupt_lease");
+  assert.deepEqual(await persistedLease(root), existing);
+});

--- a/tests/control_plane_ts/task_lease_acquire.test.ts
+++ b/tests/control_plane_ts/task_lease_acquire.test.ts
@@ -473,26 +473,33 @@ test("corrupt bool integers fail closed and legacy epoch advances", async (t) =>
   assert.equal((await persistedLease(root)).lease_epoch, 2);
 });
 
-test("corrupt active expiration fails closed without replacing the lease", async (t) => {
-  const root = await workspace(t);
-  await mkdir(join(root, "runtime", "goals", "goal-a", "task-leases"), { recursive: true });
-  const existing = {
-    schema_version: "task_lease_v0",
-    goal_id: "goal-a",
-    todo_id: "todo_target",
-    owner: "agent-b",
-    idempotency_key: "existing-owner",
-    write_scopes: ["loopx/**"],
-    acquire_ttl_seconds: 120,
-    version: 1,
-    lease_epoch: 1,
-    status: "active",
-    expires_at: "not-a-timestamp",
-  };
-  await writeFile(leasePath(root), JSON.stringify(existing), "utf8");
+for (const expiresAt of [
+  "not-a-timestamp",
+  "0",
+  "2030-01-01junk",
+  "2099-02-30T00:00:00Z",
+]) {
+  test(`corrupt active expiration '${expiresAt}' fails closed`, async (t) => {
+    const root = await workspace(t);
+    await mkdir(join(root, "runtime", "goals", "goal-a", "task-leases"), { recursive: true });
+    const existing = {
+      schema_version: "task_lease_v0",
+      goal_id: "goal-a",
+      todo_id: "todo_target",
+      owner: "agent-b",
+      idempotency_key: "existing-owner",
+      write_scopes: ["loopx/**"],
+      acquire_ttl_seconds: 120,
+      version: 1,
+      lease_epoch: 1,
+      status: "active",
+      expires_at: expiresAt,
+    };
+    await writeFile(leasePath(root), JSON.stringify(existing), "utf8");
 
-  const result = await executeTaskLeaseAcquire(await request(root), { now: () => FIXED_NOW });
+    const result = await executeTaskLeaseAcquire(await request(root), { now: () => FIXED_NOW });
 
-  assert.equal(result.error_code, "corrupt_lease");
-  assert.deepEqual(await persistedLease(root), existing);
-});
+    assert.equal(result.error_code, "corrupt_lease");
+    assert.deepEqual(await persistedLease(root), existing);
+  });
+}

--- a/tests/control_plane_ts/task_lease_acquire.test.ts
+++ b/tests/control_plane_ts/task_lease_acquire.test.ts
@@ -505,6 +505,9 @@ for (const expiresAt of [
 }
 
 for (const { expiresAt, active } of [
+  { expiresAt: "2020-01-01", active: false },
+  { expiresAt: "2030-01-01", active: true },
+  { expiresAt: "0099-01-01T00:00:00Z", active: false },
   { expiresAt: "2026-08-27T02:59:59.123456", active: false },
   { expiresAt: "2026-08-27T02:59:59.123456+00:00", active: false },
   { expiresAt: "2026-08-27T03:00:00.123456", active: true },

--- a/tests/control_plane_ts/task_lease_acquire.test.ts
+++ b/tests/control_plane_ts/task_lease_acquire.test.ts
@@ -503,3 +503,43 @@ for (const expiresAt of [
     assert.deepEqual(await persistedLease(root), existing);
   });
 }
+
+for (const { expiresAt, active } of [
+  { expiresAt: "2026-08-27T02:59:59.123456", active: false },
+  { expiresAt: "2026-08-27T02:59:59.123456+00:00", active: false },
+  { expiresAt: "2026-08-27T03:00:00.123456", active: true },
+  { expiresAt: "2026-08-27T03:00:00.123456Z", active: true },
+  { expiresAt: "2026-08-27T03:00:01", active: true },
+  { expiresAt: "2026-08-27T03:00:01.1Z", active: true },
+  { expiresAt: "2026-08-27T03:00:01.12+00:00", active: true },
+  { expiresAt: "2026-08-27T03:00:01.123", active: true },
+]) {
+  test(`valid ${active ? "active" : "expired"} lease timestamp '${expiresAt}' remains compatible`, async (t) => {
+    const root = await workspace(t);
+    await mkdir(join(root, "runtime", "goals", "goal-a", "task-leases"), { recursive: true });
+    const existing = {
+      schema_version: "task_lease_v0",
+      goal_id: "goal-a",
+      todo_id: "todo_target",
+      owner: "agent-b",
+      idempotency_key: "existing-owner",
+      write_scopes: ["loopx/**"],
+      acquire_ttl_seconds: 120,
+      version: 1,
+      lease_epoch: 1,
+      status: "active",
+      expires_at: expiresAt,
+    };
+    await writeFile(leasePath(root), JSON.stringify(existing), "utf8");
+
+    const result = await executeTaskLeaseAcquire(await request(root), { now: () => FIXED_NOW });
+
+    if (active) {
+      assert.equal(result.error_code, "todo_lease_conflict");
+      assert.deepEqual(await persistedLease(root), existing);
+    } else {
+      assert.equal(result.ok, true);
+      assert.equal((await persistedLease(root)).owner, "agent-a");
+    }
+  });
+}

--- a/tests/control_plane_ts/task_lease_acquire.test.ts
+++ b/tests/control_plane_ts/task_lease_acquire.test.ts
@@ -478,6 +478,8 @@ for (const expiresAt of [
   "0",
   "2030-01-01junk",
   "2099-02-30T00:00:00Z",
+  "2026-08-26T24:01:00Z",
+  "2026-08-26T24:00:00.0000001Z",
 ]) {
   test(`corrupt active expiration '${expiresAt}' fails closed`, async (t) => {
     const root = await workspace(t);
@@ -510,12 +512,19 @@ for (const { expiresAt, active } of [
   { expiresAt: "0099-01-01T00:00:00Z", active: false },
   { expiresAt: "2026-08-27T02:59:59.123456", active: false },
   { expiresAt: "2026-08-27T02:59:59.123456+00:00", active: false },
+  { expiresAt: "2026-08-27T02:59:59.1234567Z", active: false },
+  { expiresAt: "2026-08-27T02:59:59.123456789+00:00", active: false },
   { expiresAt: "2026-08-27T03:00:00.123456", active: true },
   { expiresAt: "2026-08-27T03:00:00.123456Z", active: true },
+  { expiresAt: "2026-08-27T03:00:00.1234567", active: true },
+  { expiresAt: "2026-08-27T03:00:00.123456789Z", active: true },
   { expiresAt: "2026-08-27T03:00:01", active: true },
   { expiresAt: "2026-08-27T03:00:01.1Z", active: true },
   { expiresAt: "2026-08-27T03:00:01.12+00:00", active: true },
   { expiresAt: "2026-08-27T03:00:01.123", active: true },
+  { expiresAt: "2026-08-26T24:00:00Z", active: false },
+  { expiresAt: "2026-08-26T24:00:00.0000000Z", active: false },
+  { expiresAt: "2026-08-27T24:00Z", active: true },
 ]) {
   test(`valid ${active ? "active" : "expired"} lease timestamp '${expiresAt}' remains compatible`, async (t) => {
     const root = await workspace(t);

--- a/tests/control_plane_ts/task_lease_lifecycle.test.ts
+++ b/tests/control_plane_ts/task_lease_lifecycle.test.ts
@@ -369,6 +369,26 @@ test("lifecycle rejects stale versions and expired leases before writeback", asy
   assert.equal((await lease(root)).version, 1);
 });
 
+test("lifecycle accepts active leases with six-digit fractional seconds", async (t) => {
+  const root = await workspace(t);
+  await executeTaskLeaseAcquire(await acquireRequest(root), { now: () => ACQUIRE_NOW });
+  const existing = await lease(root);
+  existing.expires_at = "2026-09-01T03:10:00.123456Z";
+  await writeFile(
+    join(root, "runtime", "goals", "goal-a", "task-leases", "todo_target.json"),
+    JSON.stringify(existing),
+    "utf8",
+  );
+
+  const renewed = await executeTaskLeaseLifecycle(
+    await lifecycleRequest(root, "renew"),
+    { now: () => new Date("2026-09-01T03:01:00.000Z") },
+  );
+
+  assert.equal(renewed.ok, true);
+  assert.equal(renewed.renewed, true);
+});
+
 test("holder verification is hard-lease-only and fence close releases only its verified lease", async (t) => {
   const root = await workspace(t);
   const hardAuthority = await authority(root, {

--- a/tests/control_plane_ts/task_lease_lifecycle.test.ts
+++ b/tests/control_plane_ts/task_lease_lifecycle.test.ts
@@ -369,11 +369,11 @@ test("lifecycle rejects stale versions and expired leases before writeback", asy
   assert.equal((await lease(root)).version, 1);
 });
 
-test("lifecycle accepts active leases with six-digit fractional seconds", async (t) => {
+test("lifecycle accepts active leases with high-precision fractional seconds", async (t) => {
   const root = await workspace(t);
   await executeTaskLeaseAcquire(await acquireRequest(root), { now: () => ACQUIRE_NOW });
   const existing = await lease(root);
-  existing.expires_at = "2026-09-01T03:10:00.123456Z";
+  existing.expires_at = "2026-09-01T03:10:00.123456789Z";
   await writeFile(
     join(root, "runtime", "goals", "goal-a", "task-leases", "todo_target.json"),
     JSON.stringify(existing),


### PR DESCRIPTION
## Summary

- fail closed when an active task lease has a missing or malformed `expires_at`
- preserve the existing lease instead of treating corrupted authority state as expired and replacing it
- cover the overwrite regression with a deterministic native acquire test

## Validation

- `node --no-warnings --experimental-strip-types --test tests/control_plane_ts/task_lease_acquire.test.ts tests/control_plane_ts/task_lease_lifecycle.test.ts` (52 passed)
- `npm run test:control-plane` (614 passed, 1 PostgreSQL integration skipped)
- `npm run typecheck:control-plane`
- `uv run --with ruff ruff check loopx/control_plane/work_items/task_lease_acquire_adapter.py tests/control_plane/test_task_lease.py tests/control_plane/test_task_lease_cli_native.py`
- `npm audit` (0 vulnerabilities)
- `loopx canary premerge --from-git-diff` (13/13 passed, no manual holds)