### PR TITLE
test: repair scheduler, followthrough and release-book smoke contracts

### DIFF
--- a/examples/dev-book-publication-smoke.py
+++ b/examples/dev-book-publication-smoke.py
@@ -331,6 +331,8 @@ def main() -> int:
 
     project_version = tomllib.loads(read(REPO_ROOT / "pyproject.toml"))["project"]["version"]
     release_tag = f"v{project_version}"
+    # Historical migration milestones must not move with the package version.
+    migration_baseline_tag = "v0.5.4"
     release_markers = {
         "index.md": (
             f"LoopX 发布锚点：`{release_tag}`",
@@ -410,7 +412,7 @@ def main() -> int:
         "chapters/03-one-turn.md",
         "en/chapters/03-one-turn.md",
         (
-            (f"`{release_tag}` 仍提供", f"`{release_tag}` still ships"),
+            (f"`{migration_baseline_tag}` 仍提供", f"`{migration_baseline_tag}` still ships"),
             ("显式 opt-in 集成", "explicit opt-in integrations"),
             ("Turn settlement", "Turn settlement"),
             ("Todo completion", "Todo completion"),
@@ -427,7 +429,7 @@ def main() -> int:
         "chapters/state-substrate.md",
         "en/chapters/state-substrate.md",
         (
-            (f"`{release_tag}` 的 shared-authority 工作", f"Shared-authority work in `{release_tag}`"),
+            (f"`{migration_baseline_tag}` 的 shared-authority 工作", f"Shared-authority work in `{migration_baseline_tag}`"),
             ("provider-neutral TypeScript `AuthorityStore` contract", "provider-neutral TypeScript `AuthorityStore` contract"),
             ("不自动获得 runtime authority", "do not acquire runtime authority automatically"),
             ("不应倒推成", "are not evidence that"),
@@ -448,7 +450,7 @@ def main() -> int:
         "chapters/source-protocol-map.md",
         "en/chapters/source-protocol-map.md",
         (
-            (f"在 `{release_tag}` 的迁移基线上", f"On the `{release_tag}` migration baseline"),
+            (f"在 `{migration_baseline_tag}` 的迁移基线上", f"On the `{migration_baseline_tag}` migration baseline"),
             ("bounded context 和实现语言是两个维度", "bounded context and implementation language are separate dimensions"),
             ("本地 task-lease lifecycle", "local task-lease lifecycle"),
             ("receipt-bound scheduler follow-up", "receipt-bound scheduler follow-up"),
@@ -472,7 +474,7 @@ def main() -> int:
         "en/chapters/appendix-reference.md",
         (
             ("loopx todo list --goal-id <goal-id> --thin --format json", "loopx todo list --goal-id <goal-id> --thin --format json"),
-            (f"`{release_tag}` 新增的 `todo list --thin`", f"The `todo list --thin` option added in `{release_tag}`"),
+            (f"`{migration_baseline_tag}` 新增的 `todo list --thin`", f"The `todo list --thin` option added in `{migration_baseline_tag}`"),
             ("不改变默认 list 的选择、排序、quota 或 lifecycle 语义", "without changing default selection, ordering, quota, or lifecycle semantics"),
         ),
     )

--- a/examples/external-scheduler-worker-smoke.py
+++ b/examples/external-scheduler-worker-smoke.py
@@ -244,24 +244,19 @@ def test_end_to_end_loop_stops_after_limit(tmp_path: Path) -> None:
     _write_fake_cli(fake_cli, [waiting("tok-a"), waiting("tok-a"), waiting("tok-a")])
 
     slept: list[float] = []
-    original_sleep = worker.time.sleep
-    worker.time.sleep = lambda seconds: slept.append(seconds)  # type: ignore[assignment]
-    try:
-        args = argparse.Namespace(
-            cli_bin=str(fake_cli),
-            registry=str(registry),
-            runtime_root=None,
-            runtime_profile="generic_cli",
-            goal_id="g",
-            agent_id="a",
-            state_file=str(state_file),
-            wake_cmd=None,
-            once=False,
-            error_backoff_seconds=5.0,
-        )
-        rc = run_worker(args)
-    finally:
-        worker.time.sleep = original_sleep  # type: ignore[assignment]
+    args = argparse.Namespace(
+        cli_bin=str(fake_cli),
+        registry=str(registry),
+        runtime_root=None,
+        runtime_profile="generic_cli",
+        goal_id="g",
+        agent_id="a",
+        state_file=str(state_file),
+        wake_cmd=None,
+        once=False,
+        error_backoff_seconds=5.0,
+    )
+    rc = run_worker(args, sleep=slept.append)
 
     assert rc == 0
     # Tick 1 waits at progression[0]; tick 2 reaches the limit and stops before
@@ -291,33 +286,27 @@ def test_end_to_end_token_change_resets_count(tmp_path: Path) -> None:
     )
 
     slept: list[float] = []
-    original_sleep = worker.time.sleep
-    worker.time.sleep = lambda seconds: slept.append(seconds)  # type: ignore[assignment]
+    args = argparse.Namespace(
+        cli_bin=str(fake_cli),
+        registry=str(registry),
+        runtime_root=None,
+        runtime_profile="generic_cli",
+        goal_id="g",
+        agent_id="a",
+        state_file=str(state_file),
+        wake_cmd=None,
+        once=False,
+        error_backoff_seconds=5.0,
+    )
+    # Stop after 4 real ticks by raising once sleep budget is exhausted.
+    def stop_after_four(seconds: float) -> None:
+        slept.append(seconds)
+        if len(slept) >= 4:
+            raise KeyboardInterrupt
     try:
-        args = argparse.Namespace(
-            cli_bin=str(fake_cli),
-            registry=str(registry),
-            runtime_root=None,
-            runtime_profile="generic_cli",
-            goal_id="g",
-            agent_id="a",
-            state_file=str(state_file),
-            wake_cmd=None,
-            once=False,
-            error_backoff_seconds=5.0,
-        )
-        # Stop after 4 real ticks by raising once sleep budget is exhausted.
-        def stop_after_four(seconds: float) -> None:
-            slept.append(seconds)
-            if len(slept) >= 4:
-                raise KeyboardInterrupt
-        worker.time.sleep = stop_after_four  # type: ignore[assignment]
-        try:
-            run_worker(args)
-        except KeyboardInterrupt:
-            pass
-    finally:
-        worker.time.sleep = original_sleep  # type: ignore[assignment]
+        run_worker(args, sleep=stop_after_four)
+    except KeyboardInterrupt:
+        pass
 
     # Tick1 marker a -> 10; tick2 marker b resets -> 10; later ticks -> 20.
     assert slept == [10 * 60, 10 * 60, 20 * 60, 20 * 60]
@@ -337,24 +326,19 @@ def test_end_to_end_terminal_stops_immediately(tmp_path: Path) -> None:
     _write_fake_cli(fake_cli, [terminal])
 
     slept: list[float] = []
-    original_sleep = worker.time.sleep
-    worker.time.sleep = lambda seconds: slept.append(seconds)  # type: ignore[assignment]
-    try:
-        args = argparse.Namespace(
-            cli_bin=str(fake_cli),
-            registry=str(registry),
-            runtime_root=None,
-            runtime_profile="generic_cli",
-            goal_id="g",
-            agent_id="a",
-            state_file=str(state_file),
-            wake_cmd=None,
-            once=False,
-            error_backoff_seconds=5.0,
-        )
-        rc = run_worker(args)
-    finally:
-        worker.time.sleep = original_sleep  # type: ignore[assignment]
+    args = argparse.Namespace(
+        cli_bin=str(fake_cli),
+        registry=str(registry),
+        runtime_root=None,
+        runtime_profile="generic_cli",
+        goal_id="g",
+        agent_id="a",
+        state_file=str(state_file),
+        wake_cmd=None,
+        once=False,
+        error_backoff_seconds=5.0,
+    )
+    rc = run_worker(args, sleep=slept.append)
 
     assert rc == 0
     assert slept == []
@@ -378,30 +362,25 @@ def test_end_to_end_should_run_invokes_wake_cmd(tmp_path: Path) -> None:
     marker = tmp_path / "wake" / "marker.txt"
     _write_fake_cli(fake_cli, [active])
 
-    original_sleep = worker.time.sleep
 
     def stop_after_one(seconds: float) -> None:
         raise KeyboardInterrupt
-    worker.time.sleep = stop_after_one  # type: ignore[assignment]
+    args = argparse.Namespace(
+        cli_bin=str(fake_cli),
+        registry=str(registry),
+        runtime_root=None,
+        runtime_profile="generic_cli",
+        goal_id="g",
+        agent_id="a",
+        state_file=str(state_file),
+        wake_cmd=f"echo woke > {shlex.quote(str(marker))}",
+        once=False,
+        error_backoff_seconds=5.0,
+    )
     try:
-        args = argparse.Namespace(
-            cli_bin=str(fake_cli),
-            registry=str(registry),
-            runtime_root=None,
-            runtime_profile="generic_cli",
-            goal_id="g",
-            agent_id="a",
-            state_file=str(state_file),
-            wake_cmd=f"echo woke > {shlex.quote(str(marker))}",
-            once=False,
-            error_backoff_seconds=5.0,
-        )
-        try:
-            run_worker(args)
-        except KeyboardInterrupt:
-            pass
-    finally:
-        worker.time.sleep = original_sleep  # type: ignore[assignment]
+        run_worker(args, sleep=stop_after_one)
+    except KeyboardInterrupt:
+        pass
 
     assert marker.exists()
     assert marker.read_text().strip() == "woke"
@@ -425,25 +404,22 @@ def test_end_to_end_failed_wake_returns_nonzero_once(tmp_path: Path) -> None:
     fake_cli = tmp_path / "wakefail" / "fake-loopx"
     _write_fake_cli(fake_cli, [active])
 
-    original_sleep = worker.time.sleep
-    worker.time.sleep = lambda seconds: None  # type: ignore[assignment]
-    try:
-        args = argparse.Namespace(
-            cli_bin=str(fake_cli),
-            registry=str(registry),
-            runtime_root=None,
-            runtime_profile="generic_cli",
-            goal_id="g",
-            agent_id="a",
-            state_file=str(state_file),
-            wake_cmd="exit 17",
-            once=True,
-            error_backoff_seconds=5.0,
-        )
-        rc = run_worker(args)
-    finally:
-        worker.time.sleep = original_sleep  # type: ignore[assignment]
+    slept: list[float] = []
+    args = argparse.Namespace(
+        cli_bin=str(fake_cli),
+        registry=str(registry),
+        runtime_root=None,
+        runtime_profile="generic_cli",
+        goal_id="g",
+        agent_id="a",
+        state_file=str(state_file),
+        wake_cmd="exit 17",
+        once=True,
+        error_backoff_seconds=5.0,
+    )
+    rc = run_worker(args, sleep=slept.append)
 
+    assert slept == []
     assert rc == 17  # propagate the wake command's non-zero exit
     persisted = json.loads(state_file.read_text())
     # The failed wake must not be counted as successful progress.

--- a/examples/outcome-followthrough-policy-smoke.py
+++ b/examples/outcome-followthrough-policy-smoke.py
@@ -7,7 +7,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.work_items.outcome_followthrough import build_outcome_followthrough_hint
+from loopx.control_plane.work_items.outcome_followthrough import build_outcome_followthrough_hint  # noqa: E402
 
 
 def assert_none(latest_run: dict[str, object] | None) -> None:
@@ -22,7 +22,8 @@ def assert_hint(
 ) -> None:
     hint = build_outcome_followthrough_hint(latest_run)
     assert hint is not None
-    assert hint == {
+    assert isinstance(hint["spend_policy"], str) and hint["spend_policy"].strip()
+    assert {key: value for key, value in hint.items() if key != "spend_policy"} == {
         "source": "post_handoff_latest_run",
         "required": True,
         "latest_classification": str(latest_run.get("classification") or "").strip(),
@@ -34,11 +35,6 @@ def assert_hint(
             "compact_evidence",
             "blocker_writeback",
         ],
-        "spend_policy": (
-            "do not spend for another contract/preparation-only slice; spend only "
-            "after validated product-path evidence, benchmark/case evidence, or a "
-            "precise blocker writeback"
-        ),
     }
 
 
@@ -69,11 +65,20 @@ def main() -> None:
             "classification": "blocked but explicitly requires followthrough",
         },
         outcome=None,
-        turn_kind="blocker_writeback",
+        turn_kind="unknown",
     )
     assert_hint(
-        {"classification": "contract-only preparation"},
+        {"classification": "done", "delivery_turn_kind": "contract_only_preparation"},
         outcome=None,
+        turn_kind="contract_only_preparation",
+    )
+    # Diagnostic prose must not create or suppress a machine obligation.
+    assert_none({"classification": "contract-only preparation"})
+    assert_none({"classification": "needs product evidence"})
+    assert_none({"delivery_turn_kind": "blocker_writeback"})
+    assert_hint(
+        {"delivery_outcome": "surface_only", "classification": "done"},
+        outcome="surface_only",
         turn_kind="contract_only_preparation",
     )
     print("outcome-followthrough-policy-smoke ok")


### PR DESCRIPTION
Release qualification exposed three stale smoke assumptions: the scheduler test patched a sleep function whose default was already bound; followthrough inferred authority from prose; and book validation treated historical migration milestones as the current package version.

Use the existing `sleep=` injection seam, preserve real CLI/state readback, and assert one-shot wake failure never sleeps. Assert typed followthrough obligations independently of advisory wording, including narrative-only negative cases. Keep current book anchors version-aware while preserving the historical v0.5.4 migration milestones. Production runtime behavior is unchanged.

Validation on `232fc306ceeeb245b8242b3cdb5d4e850de0a51e`: 12 scheduler checks, typed followthrough and book smokes, changed-file Ruff and diff hygiene passed. Goal-bound premerge: 6 checks passed, zero failures/skips/manual holds. Exact-scope receipt `cqr_69c174461f3fe5d4ac30` is valid. The integrated release source will be qualified separately.

中文：修复发布全量检查发现的三处测试漂移：使用现有时钟注入接口，按 typed 字段判断 followthrough，并区分当前发布锚点与历史迁移版本。保留真实 CLI/状态读回及负例，不改变生产行为。最终 head 的聚焦检查及六项 premerge 均通过。
