### PR TITLE
fix(lark): verify bot mentions and preserve default member-read scope

### DIFF
--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -347,11 +347,14 @@ def main() -> None:
                     return successful_runner(args)
                 if args[3:6] == ["im", "chats", "get"]:
                     return {"returncode": 0, "stdout": "{}", "stderr": ""}
-                if args[3:6] == ["im", "chat.members", "get"]:
+                if args[3:5] == ["im", "+chat-members-list"]:
                     return {
                         "returncode": 0,
                         "stdout": json.dumps(
-                            {"items": [{"member_id": "ou_reviewer_fixture"}]}
+                            {
+                                "users": [],
+                                "bots": [{"member_id": "ou_reviewer_fixture"}],
+                            }
                         ),
                         "stderr": "",
                     }

--- a/examples/lark-event-inbox-smoke.py
+++ b/examples/lark-event-inbox-smoke.py
@@ -352,8 +352,16 @@ def main() -> None:
                         "returncode": 0,
                         "stdout": json.dumps(
                             {
-                                "users": [],
-                                "bots": [{"member_id": "ou_reviewer_fixture"}],
+                                "ok": True,
+                                "data": {
+                                    "users": [],
+                                    "bots": [
+                                        {
+                                            "app_id": "cli_reviewer_fixture",
+                                            "member_id": "ou_reviewer_fixture",
+                                        }
+                                    ],
+                                },
                             }
                         ),
                         "stderr": "",
@@ -383,10 +391,7 @@ def main() -> None:
                                         "mentions": [
                                             {
                                                 "key": "@_user_1",
-                                                "id": {
-                                                    "open_id": readback_open_id,
-                                                    "user_id": "fixture-user-id",
-                                                },
+                                                "id": readback_open_id,
                                                 "name": "Reviewer",
                                             }
                                         ],
@@ -401,14 +406,14 @@ def main() -> None:
 
             return run
 
-        mention_reply = '<at user_id="ou_reviewer_fixture">Reviewer</at> 已记录并修正。'
+        mention_reply = '<at open_id="ou_reviewer_fixture">Reviewer</at> 已记录并修正。'
         normalized_mention = reply_lark_event_inbox(
             project=project,
             config_path=config,
             message_id="om_review_2",
             text=mention_reply,
             execute=True,
-            runner=mention_runner(readback_open_id="ou_reviewer_fixture"),
+            runner=mention_runner(readback_open_id="cli_reviewer_fixture"),
         )
         assert normalized_mention["status"] == "sent_verified", normalized_mention
 

--- a/loopx/extensions/lark/README.md
+++ b/loopx/extensions/lark/README.md
@@ -247,6 +247,14 @@ permission or silently enables an external write.
   `im:message.p2p_msg:readonly`
 - 交互/文档 sink：`cardkit:card:read/write`、`docs:document.comment:read/create/delete`
 
+`im:chat.members:read` 是原生 @ 身份校验的核心权限，也适用于 @ 机器人。
+发送前使用 `im +chat-members-list --member-types user,bot --page-all` 查询
+精确成员身份；旧的 `chat.members get` 不能作为机器人不在群内的证据。
+默认权限清单不代表已有应用已获授权：旧应用仍需在开发者后台申请并完成审核，
+LoopX 不会自动授予权限，也不会在成员读取失败时绕过 @ 校验。
+若消息回读将机器人标为 `app_id`，仅接受当前群机器人列表中已验证且无歧义的
+`member_id` ↔ `app_id` 映射；名称相同不构成身份验证。
+
 拿到 App ID（`cli_xxx`）后，可在开发者后台一键批量申请：
 
 ```text

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -275,6 +275,7 @@ def _deliver_lark_inbox_outbound(
         )
 
     expected_mentions = expected_lark_mention_identities(reply_text)
+    bot_alias_candidates: dict[str, set[str]] = {}
     if expected_mentions:
         member_identity_sets: dict[str, set[str]] = {}
         membership_failed = False
@@ -284,10 +285,11 @@ def _deliver_lark_inbox_outbound(
                 base
                 + [
                     "im",
-                    "chat.members",
-                    "get",
+                    "+chat-members-list",
                     "--chat-id",
                     chat_id,
+                    "--member-types",
+                    "user,bot",
                     "--member-id-type",
                     identity_kind,
                     "--page-all",
@@ -300,9 +302,18 @@ def _deliver_lark_inbox_outbound(
             if members.get("returncode") != 0:
                 membership_failed = True
                 break
-            member_identity_sets[identity_kind] = lark_member_identities(
-                _json_object(members.get("stdout"))
+            member_payload = _json_object(members.get("stdout"))
+            member_identity_sets[identity_kind] = lark_member_identities(member_payload)
+            member_data = member_payload.get("data", member_payload)
+            bots = (
+                member_data.get("bots", []) if isinstance(member_data, Mapping) else []
             )
+            for member in bots if isinstance(bots, list) else []:
+                if not isinstance(member, Mapping):
+                    continue
+                app_id, member_id = member.get("app_id"), member.get("member_id")
+                if isinstance(app_id, str) and app_id and isinstance(member_id, str):
+                    bot_alias_candidates.setdefault(app_id, set()).add(member_id)
         if membership_failed or any(
             identity not in member_identity_sets.get(identity_kind, set())
             for identity, identity_kind in expected_mentions.items()
@@ -470,6 +481,13 @@ def _deliver_lark_inbox_outbound(
         and lark_readback_matches_outbound(
             outbound_text=reply_text,
             message=readback_message,
+            # mget may report a bot's app_id instead of its member_id. Only
+            # accept an unambiguous mapping from this chat's verified bot bucket.
+            verified_bot_aliases={
+                app_id: next(iter(identities))
+                for app_id, identities in bot_alias_candidates.items()
+                if len(identities) == 1 and next(iter(identities)) in expected_mentions
+            },
         )
     )
     reaction_cleanup = (

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -280,6 +280,11 @@ def _deliver_lark_inbox_outbound(
         member_identity_sets: dict[str, set[str]] = {}
         membership_failed = False
         for identity_kind in sorted(set(expected_mentions.values())):
+            expected_identities = {
+                identity
+                for identity, declared_kind in expected_mentions.items()
+                if declared_kind == identity_kind
+            }
             members = _call(
                 runner,
                 base
@@ -312,7 +317,12 @@ def _deliver_lark_inbox_outbound(
                 if not isinstance(member, Mapping):
                     continue
                 app_id, member_id = member.get("app_id"), member.get("member_id")
-                if isinstance(app_id, str) and app_id and isinstance(member_id, str):
+                if (
+                    isinstance(app_id, str)
+                    and app_id
+                    and isinstance(member_id, str)
+                    and member_id in expected_identities
+                ):
                     bot_alias_candidates.setdefault(app_id, set()).add(member_id)
         if membership_failed or any(
             identity not in member_identity_sets.get(identity_kind, set())
@@ -482,7 +492,7 @@ def _deliver_lark_inbox_outbound(
             outbound_text=reply_text,
             message=readback_message,
             # mget may report a bot's app_id instead of its member_id. Only
-            # accept an unambiguous mapping from this chat's verified bot bucket.
+            # accept an unambiguous mapping verified for the mention's declared kind.
             verified_bot_aliases={
                 app_id: next(iter(identities))
                 for app_id, identities in bot_alias_candidates.items()

--- a/loopx/extensions/lark/outbound.py
+++ b/loopx/extensions/lark/outbound.py
@@ -198,7 +198,10 @@ def lark_provider_preview_matches_outbound(
 
 
 def lark_readback_matches_outbound(
-    *, outbound_text: str, message: Mapping[str, Any]
+    *,
+    outbound_text: str,
+    message: Mapping[str, Any],
+    verified_bot_aliases: Mapping[str, str] | None = None,
 ) -> bool:
     expected_text, identity_tokens = _canonical_expected_text(outbound_text)
     actual_text = _message_text(message)
@@ -222,7 +225,13 @@ def lark_readback_matches_outbound(
         if not isinstance(mention, Mapping):
             return False
         key = str(mention.get("key") or "")
-        matches = _mention_identities(mention).intersection(identity_tokens)
+        identities = _mention_identities(mention)
+        identities.update(
+            (verified_bot_aliases or {})[identity]
+            for identity in tuple(identities)
+            if identity in (verified_bot_aliases or {})
+        )
+        matches = identities.intersection(identity_tokens)
         if not key or len(matches) != 1:
             return False
         identity = next(iter(matches))

--- a/tests/extensions/test_lark_bot_scopes.py
+++ b/tests/extensions/test_lark_bot_scopes.py
@@ -1,0 +1,17 @@
+"""Default bot setup must include native mention identity verification."""
+
+from urllib.parse import parse_qs, urlparse
+
+from loopx.extensions.lark.bot_scopes import (
+    CORE_BOT_SCOPES,
+    RECOMMENDED_BOT_SCOPES,
+    recommended_bot_scope_apply_url,
+)
+
+
+def test_default_bot_scope_bundle_and_apply_url_include_member_read() -> None:
+    scope = "im:chat.members:read"
+    assert scope in CORE_BOT_SCOPES
+    assert scope in RECOMMENDED_BOT_SCOPES
+    query = parse_qs(urlparse(recommended_bot_scope_apply_url("cli_example")).query)
+    assert scope in query["scopes"][0].split(",")

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -325,6 +325,8 @@ class ReplyRunner:
         readback_text: str | None = None,
         readback_mentions: list[dict[str, Any]] | None = None,
         include_mentioned_member: bool = True,
+        member_bucket: str = "users",
+        member_read_denied: bool = False,
     ) -> None:
         self.calls: list[list[str]] = []
         self.matching_readback = matching_readback
@@ -332,6 +334,8 @@ class ReplyRunner:
         self.readback_text = readback_text
         self.readback_mentions = readback_mentions
         self.include_mentioned_member = include_mentioned_member
+        self.member_bucket = member_bucket
+        self.member_read_denied = member_read_denied
 
     def __call__(self, args: Sequence[str]) -> dict[str, Any]:
         call = list(args)
@@ -354,20 +358,26 @@ class ReplyRunner:
             }
         if call[3:6] == ["im", "chats", "get"]:
             return {"returncode": 0, "stdout": "{}", "stderr": ""}
-        if "chat.members" in call and "get" in call:
+        if "+chat-members-list" in call:
+            if self.member_read_denied:
+                return {"returncode": 1, "stdout": "", "stderr": "missing_scope"}
             return {
                 "returncode": 0,
                 "stdout": json.dumps(
                     {
-                        "items": [
-                            {
-                                "member_id": (
-                                    "ou_public_reviewer"
-                                    if self.include_mentioned_member
-                                    else "ou_someone_else"
-                                )
-                            }
-                        ]
+                        "ok": True,
+                        "data": {
+                            self.member_bucket: [
+                                {
+                                    "app_id": "cli_public_reviewer",
+                                    "member_id": (
+                                        "ou_public_reviewer"
+                                        if self.include_mentioned_member
+                                        else "ou_someone_else"
+                                    ),
+                                }
+                            ]
+                        },
                     }
                 ),
                 "stderr": "",
@@ -930,8 +940,107 @@ def test_structured_mention_queries_the_declared_member_identity_kind(
     )
 
     assert result["ok"] is True
-    member_call = next(call for call in runner.calls if "chat.members" in call)
+    member_call = next(call for call in runner.calls if "+chat-members-list" in call)
     assert member_call[member_call.index("--member-id-type") + 1] == "open_id"
+
+
+@pytest.mark.parametrize("placement", ["reply", "chat_root"])
+@pytest.mark.parametrize("member_read_denied", [False, True])
+@pytest.mark.parametrize("member_bucket", ["users", "bots"])
+@pytest.mark.parametrize(
+    "readback_id", ["ou_public_reviewer", "cli_public_reviewer", "cli_unrelated"]
+)
+def test_bot_mention_uses_bot_member_bucket_without_bypassing_scope(
+    tmp_path: Path,
+    placement: str,
+    member_read_denied: bool,
+    readback_id: str,
+    member_bucket: str,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        member_bucket=member_bucket,
+        member_read_denied=member_read_denied,
+        readback_text="@_user_1 please review",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Public Reviewer",
+                "id": readback_id,
+            }
+        ],
+    )
+    kwargs = dict(
+        project=project,
+        config_path=config,
+        text='<at open_id="ou_public_reviewer">Public Reviewer</at> please review',
+        execute=True,
+        runner=runner,
+    )
+    result = (
+        reply_lark_event_inbox(message_id="om_reaction_fixture", **kwargs)
+        if placement == "reply"
+        else send_lark_inbox_message(**kwargs)
+    )
+
+    member_call = next(call for call in runner.calls if "+chat-members-list" in call)
+    assert member_call[member_call.index("--member-types") + 1] == "user,bot"
+    assert member_call[member_call.index("--member-id-type") + 1] == "open_id"
+    assert member_call[member_call.index("--as") + 1] == "bot"
+    assert "--page-all" in member_call
+    assert not any("chat.members" in call for call in runner.calls)
+    if member_read_denied:
+        assert result["status"] == "gate_required"
+        assert not any(
+            "+messages-send" in call or "+messages-reply" in call
+            for call in runner.calls
+        )
+    elif readback_id == "cli_unrelated" or (
+        member_bucket == "users" and readback_id == "cli_public_reviewer"
+    ):
+        assert result["status"] == "sent_unverified"
+        assert result["reply_verified"] is False
+    else:
+        assert result["ok"] is True
+        assert result["reply_verified"] is True
+
+
+def test_bot_mention_rejects_ambiguous_app_id_mapping(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        member_bucket="bots",
+        readback_text="@_user_1 please review",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Public Reviewer",
+                "id": "cli_public_reviewer",
+            }
+        ],
+    )
+
+    def ambiguous_runner(args: Sequence[str]) -> dict[str, Any]:
+        result = runner(args)
+        if "+chat-members-list" in args:
+            payload = json.loads(result["stdout"])
+            payload["data"]["bots"].append(
+                {
+                    "app_id": "cli_public_reviewer",
+                    "member_id": "ou_someone_else",
+                }
+            )
+            result["stdout"] = json.dumps(payload)
+        return result
+
+    result = send_lark_inbox_message(
+        project=project,
+        config_path=config,
+        text='<at open_id="ou_public_reviewer">Public Reviewer</at> please review',
+        execute=True,
+        runner=ambiguous_runner,
+    )
+    assert result["status"] == "sent_unverified"
+    assert result["reply_verified"] is False
 
 
 def test_plain_reply_rejects_unexpected_provider_mention(tmp_path: Path) -> None:

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -1009,13 +1009,18 @@ def test_bot_mention_rejects_ambiguous_app_id_mapping(tmp_path: Path) -> None:
     config, _, project = _fixture(tmp_path, lifecycle=False)
     runner = ReplyRunner(
         member_bucket="bots",
-        readback_text="@_user_1 please review",
+        readback_text="@_user_1 and @_user_2 please review",
         readback_mentions=[
             {
                 "key": "@_user_1",
                 "name": "Public Reviewer",
                 "id": "cli_public_reviewer",
-            }
+            },
+            {
+                "key": "@_user_2",
+                "name": "Other Reviewer",
+                "id": "cli_public_reviewer",
+            },
         ],
     )
 
@@ -1026,7 +1031,7 @@ def test_bot_mention_rejects_ambiguous_app_id_mapping(tmp_path: Path) -> None:
             payload["data"]["bots"].append(
                 {
                     "app_id": "cli_public_reviewer",
-                    "member_id": "ou_someone_else",
+                    "member_id": "ou_other_reviewer",
                 }
             )
             result["stdout"] = json.dumps(payload)
@@ -1035,12 +1040,78 @@ def test_bot_mention_rejects_ambiguous_app_id_mapping(tmp_path: Path) -> None:
     result = send_lark_inbox_message(
         project=project,
         config_path=config,
-        text='<at open_id="ou_public_reviewer">Public Reviewer</at> please review',
+        text=(
+            '<at open_id="ou_public_reviewer">Public Reviewer</at> and '
+            '<at open_id="ou_other_reviewer">Other Reviewer</at> please review'
+        ),
         execute=True,
         runner=ambiguous_runner,
     )
     assert result["status"] == "sent_unverified"
     assert result["reply_verified"] is False
+
+
+def test_bot_alias_is_scoped_to_its_declared_identity_kind(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(
+        readback_text="@_user_1 please review with @_user_2",
+        readback_mentions=[
+            {
+                "key": "@_user_1",
+                "name": "Review Bot",
+                "id": "cli_review_bot",
+            },
+            {
+                "key": "@_user_2",
+                "name": "Human Reviewer",
+                "id": {"user_id": "u_human_reviewer"},
+            },
+        ],
+    )
+
+    def mixed_identity_runner(args: Sequence[str]) -> dict[str, Any]:
+        if "+chat-members-list" not in args:
+            return runner(args)
+        runner.calls.append(list(args))
+        identity_kind = args[args.index("--member-id-type") + 1]
+        member_data = {
+            "open_id": {
+                "users": [],
+                "bots": [
+                    {"app_id": "cli_review_bot", "member_id": "ou_review_bot"}
+                ],
+            },
+            "user_id": {
+                "users": [{"member_id": "u_human_reviewer"}],
+                "bots": [
+                    {"app_id": "cli_review_bot", "member_id": "u_review_bot"}
+                ],
+            },
+        }
+        return {
+            "returncode": 0,
+            "stdout": json.dumps({"ok": True, "data": member_data[identity_kind]}),
+            "stderr": "",
+        }
+
+    result = send_lark_inbox_message(
+        project=project,
+        config_path=config,
+        text=(
+            '<at open_id="ou_review_bot">Review Bot</at> please review with '
+            '<at user_id="u_human_reviewer">Human Reviewer</at>'
+        ),
+        execute=True,
+        runner=mixed_identity_runner,
+    )
+
+    assert result["status"] == "sent_verified"
+    assert result["reply_verified"] is True
+    assert {
+        call[call.index("--member-id-type") + 1]
+        for call in runner.calls
+        if "+chat-members-list" in call
+    } == {"open_id", "user_id"}
 
 
 def test_plain_reply_rejects_unexpected_provider_mention(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Verify native mention targets with `im +chat-members-list --member-types user,bot`, preserving the declared ID type, bot identity, exact chat and pagination. The legacy member endpoint does not establish bot absence.
- Accept bot app-ID readback only through an unambiguous mapping from the same chat's verified bot-member bucket. Unknown IDs, human-bucket aliases, ambiguous mappings and denied member reads still fail closed.
- Document that `im:chat.members:read` is already in the canonical core/recommended bundle, and lock both the bundle and generated approval URL with a regression test. Configuration is not provider authorization; existing apps still require approval.

## Commit grouping and placement

Runtime + behavior tests/smoke, followed by default-scope contract test + docs. Owned by the existing bundled Lark extension's outbound inbox boundary; no new capability or global permissions added. Future-facing pass retained the existing shared readback matcher with an optional verified alias input; no speculative abstraction.

## Validation

- 122 focused tests passed (inbox reactions/delivery, bot scopes, group history, goal channel).
- Event inbox smoke passed.
- Ruff passed for runtime/tests; smoke passes with its existing E402 bootstrap exception (unfiltered Ruff reports two pre-existing import-order errors).
- git diff --check passed.
- LoopX check: six public files clean, zero errors; three unrelated local registry/history warnings.
- Authorized live provider preflight passed. One message was sent; independent readback confirmed its native mention and complete body. Live mget uses app_id while chat history uses open_id; the repaired matcher verified the saved intent using a freshly read same-chat bot mapping, without resending.

## Review hold / boundaries

Requires separate review: changes an identity-verification path. Not self-merged or globally installed. No permission grants, recipient-name fallback, production operations, or repeated outbound messages. Private identifiers, content, logs, local state and credentials are excluded. Existing runtime remains untouched; qualified worktree used for the bounded validation.