### PR TITLE
fix(todo): preserve claim-neutral correction after promotion

### DIFF
--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -31,6 +31,15 @@ native creation, archival, receipt replay, and store reopen are tested without
 Markdown metadata. Python only adapts the typed read result to the compatibility
 summary. This is a contract checkpoint, not a completed CLI lifecycle cutover.
 
+Provider-first `todo update --text/--note` preserves claim-neutral correction:
+a registered, non-excluded actor may edit an unclaimed active, non-completed
+agent Todo, subject to its agent binding. It must not introduce `claimed_by`.
+Another claim owner's Todo remains rejected. Only text/note may be patched or
+cleared; governance fields and hard-lease execution authority are not granted.
+The TS transaction owns eligibility, CAS, and receipt replay; promotion must
+not turn a copy correction into a claim. Provider conformance covers both
+native and v0 records, and the production CLI is tested without Markdown.
+
 The default Markdown and explicitly promoted `todo claim` paths now share one
 TypeScript claim decision for actor, registration, role, status, archive,
 exclusion, and existing-owner checks; the Python legacy writer only commits

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -28,6 +28,13 @@ coordination 路径使用同一份语言中立的 `coordination_state_contract_v
 仅将 typed read result 适配为兼容 summary。这是 contract 检查点，不是已经完成的
 CLI lifecycle cutover。
 
+Provider-first `todo update --text/--note` 保留不改变认领关系的文案修正：
+已注册、未被排除且符合 agent binding 的 actor，可以编辑未认领、active 且未完成的
+agent Todo，不得因此写入 `claimed_by`；其他 claim owner 的 Todo 仍拒绝修改。
+只允许 patch/clear text 与 note，不授予治理字段修改权或 hard-lease 执行权。
+资格检查、CAS 与 receipt replay 由 TS 事务持有；promotion 不应把文案修正变成认领。
+Provider conformance 同时覆盖原生与 v0 记录，真实 CLI 在无 Markdown 时验证该行为。
+
 默认 Markdown 与显式 promotion 两条 `todo claim` 路径现在都由同一个 TS claim
 decision 处理 actor、registration、role、status、archive、exclusion 与现有 owner
 检查；Python legacy writer 只在持锁后提交该 decision。显式 promotion 后，claim

--- a/loopx/control_plane/coordination/todo_update.ts
+++ b/loopx/control_plane/coordination/todo_update.ts
@@ -155,8 +155,16 @@ function targetRejection(
     return failure("unsupported_todo_update_target",
       "native metadata update currently requires a non-completed agent Todo");
   }
-  if (todo.claimed_by !== input.actor_agent_id) {
-    return failure("update_owner_mismatch", "Todo update requires the current claim owner");
+  if (Array.isArray(todo.excluded_agents) && todo.excluded_agents.includes(input.actor_agent_id)) {
+    return failure("actor_excluded", "Todo update actor is excluded from this Todo");
+  }
+  if (todo.bound_agent && todo.bound_agent !== input.actor_agent_id) {
+    return failure("bound_agent_mismatch", "Todo update requires the bound agent");
+  }
+  // Text/note correction is not a claim or an execution transition. Registered
+  // peers may edit unclaimed work, but must not edit another owner's work.
+  if (todo.claimed_by && todo.claimed_by !== input.actor_agent_id) {
+    return failure("update_owner_mismatch", "Todo update cannot edit another claim owner's work");
   }
   // Lease-bearing updates need an execution-instance fence in addition to the
   // actor identity. Until the native request carries that proof, fail closed.

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -506,6 +506,25 @@ def test_real_shadow_projection_promotes_complete_complex_todo_semantics(
     assert by_id["todo_successor"]["completion_continuation"] == "no_followup"
     assert result["authority_read"]["todo_read_model"]["todo_count"] == 3
 
+    # The public compatibility CLI must retain claim-neutral text correction
+    # after promotion; it must not reconstruct or write the Markdown source.
+    correction_command = [
+        sys.executable, "-m", "loopx.cli", "--format", "json",
+        "--registry", str(registry_path), "todo", "update", "--goal-id", "goal-a",
+        "--todo-id", "todo_claimable", "--agent-id", "agent-b",
+        "--text", "Corrected before claiming",
+    ]
+    correction = subprocess.run(correction_command, capture_output=True, text=True,
+                                check=True, timeout=30)
+    assert json.loads(correction.stdout)["ok"] is True
+    corrected = list_goal_todos(registry_path=registry_path, goal_id="goal-a")
+    corrected_item = next(item for item in corrected["todos"]
+                          if item["todo_id"] == "todo_claimable")
+    assert corrected_item["text"] == "Corrected before claiming"
+    assert not corrected_item.get("claimed_by")
+    assert corrected_item["last_actor_agent_id"] == "agent-b"
+    assert not state_file.exists()
+
     claim_command = [
         sys.executable, "-m", "loopx.cli", "--format", "json",
         "--registry", str(registry_path), "todo", "claim", "--goal-id", "goal-a",

--- a/tests/control_plane/test_todo_mutation_authority.py
+++ b/tests/control_plane/test_todo_mutation_authority.py
@@ -224,6 +224,20 @@ def test_multi_agent_update_requires_actor_and_is_atomic(tmp_path: Path) -> None
     assert state.read_text(encoding="utf-8") == before
 
 
+def test_registered_actor_can_correct_unclaimed_todo_without_claim(tmp_path: Path) -> None:
+    registry, state = _write_fixture(tmp_path)
+    todo = _add_agent_todo(registry, claimed_by=None)
+    result = update_goal_todo(
+        registry_path=registry, goal_id=GOAL_ID, todo_id=todo["todo_id"],
+        agent_id=AUTHOR_AGENT, text="Correct unclaimed copy", note="Correct note",
+    )
+    assert result["mutation_authority"]["mode"] == "registered_peer_actor"
+    corrected = _agent_todo(state, todo["todo_id"])
+    assert corrected["text"] == "Correct unclaimed copy"
+    assert corrected["note"] == "Correct note"
+    assert not corrected.get("claimed_by")
+
+
 def test_excluded_actor_cannot_mutate_unclaimed_todo(tmp_path: Path) -> None:
     registry, state = _write_fixture(tmp_path)
     todo = _add_agent_todo(

--- a/tests/control_plane_ts/authority_store_conformance.ts
+++ b/tests/control_plane_ts/authority_store_conformance.ts
@@ -526,12 +526,27 @@ export function registerAuthorityStoreConformance(
         events: [], receipts: [], next_projection: todoClaimProjection(goalId, native),
       });
       assert.equal(initialized.status, "applied");
+      const correction = {goal_id: goalId, todo_id: "todo-claim", expected_role: "agent",
+        actor_agent_id: "agent-b", registered_agents: ["agent-a", "agent-b"],
+        operation_id: "correct-unclaimed", patch: {text: "Correct unclaimed copy", note: "Correct note"},
+        clear_fields: [], dry_run: false, now: new Date("2026-09-05T05:00:00Z")};
+      assert.equal((await executeCoordinationTodoUpdate(store, correction)).status, "applied");
+      assert.equal((await executeCoordinationTodoUpdate(contender, correction)).status, "replayed");
+      const corrected = await store.loadAuthority();
+      assert.equal(corrected.status, "loaded");
+      if (corrected.status !== "loaded") return;
+      const correctedTodo = (corrected.head.todos as Record<string, unknown>[])[0]!;
+      assert.equal(correctedTodo.claimed_by, undefined);
+      assert.equal(correctedTodo.note, "Correct note");
+      assert.equal(correctedTodo.last_actor_agent_id, "agent-b");
       assert.equal((await executeCoordinationTodoClaim(store, {
         goal_id: goalId, todo_id: "todo-claim", claimed_by: "agent-a",
         actor_agent_id: "agent-a", expected_role: "agent",
         registered_agents: ["agent-a", "agent-b"], operation_id: "claim-before-update",
         dry_run: false, now: new Date("2026-09-05T05:15:00Z"),
       })).status, "applied");
+      assert.equal((await executeCoordinationTodoUpdate(store, {...correction,
+        operation_id: "correct-after-another-agent-claims"})).reason_code, "update_owner_mismatch");
       const request = {goal_id: goalId, todo_id: "todo-claim", expected_role: "agent",
         actor_agent_id: "agent-a", registered_agents: ["agent-a", "agent-b"],
         operation_id: "update-native", patch: {text: "Updated provider-neutrally"},

--- a/tests/control_plane_ts/todo_update.test.ts
+++ b/tests/control_plane_ts/todo_update.test.ts
@@ -17,10 +17,11 @@ function todo(overrides: Record<string, unknown> = {}) {
     claimed_by: "agent-a", note: "old note", ...overrides};
 }
 
-async function seeded() {
+async function seeded(overrides: Record<string, unknown> = {}) {
   const root = await mkdtemp(join(tmpdir(), "loopx-todo-update-"));
   const store = new FileAuthorityStore(root, "goal-a");
-  const records = [todo()];
+  const records = [todo(overrides)];
+  if (records[0]!.claimed_by === null) Reflect.deleteProperty(records[0]!, "claimed_by");
   await store.commitAuthority({operation_id: "seed", expected_provider_revision: null,
     events: [], receipts: [], next_projection: {goal_id: "goal-a", todos: records, leases: [],
       todo_read_model: {schema_version: TODO_DOMAIN_READ_RECORD_SCHEMA, todo_count: 1,
@@ -52,6 +53,40 @@ test("provider-first update commits complete record and replays by intent", asyn
     patch: {text: "Different"}})).reason_code, "coordination_operation_identity_mismatch");
 });
 
+test("unclaimed text edits are claim-neutral, including preview and replay", async () => {
+  const {store, request} = await seeded({claimed_by: null});
+  const before = await store.loadAuthority();
+  for (const actor_agent_id of [null, "unknown"]) {
+    assert.equal((await executeCoordinationTodoUpdate(store, {...request, actor_agent_id})).reason_code,
+      "actor_not_registered");
+  }
+  assert.equal((await executeCoordinationTodoUpdate(store, {...request, dry_run: true})).status, "planned");
+  assert.deepEqual(await store.loadAuthority(), before);
+  assert.equal((await executeCoordinationTodoUpdate(store, request)).status, "applied");
+  assert.equal((await executeCoordinationTodoUpdate(store, request)).status, "replayed");
+  const after = await store.loadAuthority();
+  assert.equal(after.status, "loaded");
+  if (after.status !== "loaded") return;
+  const updated = (after.head.todos as Record<string, unknown>[])[0]!;
+  assert.equal(updated.text, "New text");
+  assert.equal(updated.note, undefined);
+  assert.equal(Object.hasOwn(updated, "claimed_by"), false);
+  assert.equal(updated.last_actor_agent_id, "agent-a");
+});
+
+test("unclaimed edits preserve actor exclusion and binding fences", async () => {
+  for (const [overrides, reason] of [
+    [{excluded_agents: ["agent-a"]}, "actor_excluded"],
+    [{bound_agent: "agent-b"}, "bound_agent_mismatch"],
+  ] as const) {
+    const {store, request} = await seeded({claimed_by: null, ...overrides});
+    const before = await store.loadAuthority();
+    assert.equal((await executeCoordinationTodoUpdate(store, request)).reason_code, reason);
+    assert.deepEqual(await store.loadAuthority(), before);
+    assert.equal((await store.readReceipt(request.operation_id)).status, "missing");
+  }
+});
+
 test("provider-first update rejects authority and lifecycle escalation", async () => {
   const {store, request} = await seeded();
   assert.equal((await executeCoordinationTodoUpdate(store, {...request,
@@ -74,8 +109,9 @@ test("provider-first update rejects authority and lifecycle escalation", async (
   }
 });
 
-test("provider-first update fails closed without a hard-lease execution proof", async () => {
-  const {store, request} = await seeded();
+for (const claimed_by of ["agent-a", null]) {
+test(`provider-first update fails closed without a hard-lease execution proof (${claimed_by ?? "unclaimed"})`, async () => {
+  const {store, request} = await seeded({claimed_by});
   const head = await store.loadAuthority();
   assert.equal(head.status, "loaded");
   if (head.status !== "loaded") return;
@@ -89,6 +125,7 @@ test("provider-first update fails closed without a hard-lease execution proof", 
   assert.equal(result.reason_code, "update_lease_unsupported");
   assert.equal((await store.readReceipt(request.operation_id)).status, "missing");
 });
+}
 
 test("provider-first update records no-change identity without state mutation", async () => {
   const {store, request} = await seeded();


### PR DESCRIPTION
## Summary

Restore claim-neutral `todo update --text/--note` after authority promotion, addressing the regression reported by @now-ing on #3974.

- A registered, non-excluded actor satisfying the Todo's binding can correct unclaimed active, non-completed agent work without becoming its owner.
- Keep another-owner rejection, the text/note-only allowlist, lifecycle checks, and hard-lease fail-closed behavior. Explicitly enforce exclusion and binding at the native boundary before relaxing the claim check.
- Retain the existing TypeScript transaction as the sole native eligibility/CAS/receipt owner; no Python authorization workaround, new provider API, or automatic promotion.
- Document the correction contract in both migration RFC languages.

## Validation

- Regression reproduced before the production fix: unclaimed preview failed with `update_owner_mismatch`.
- TypeScript typecheck passed; 7 focused native update tests passed.
- 102 provider/transport tests passed across File, NoKV envelope, NoKV JSON-lines process, and PostgreSQL, including native/v0 correction, claim neutrality, later claim-owner rejection, concurrent CAS, and replay.
- PostgreSQL integration ran against a freshly initialized isolated PostgreSQL 16 server with synthetic tenants, not an in-memory substitute or active Goal database; no integration skips. Server stopped afterward.
- 8 local-authority Python tests passed, including real promotion -> production CLI unclaimed update -> claim -> owner update without recreating Markdown.
- 52 legacy mutation-authority tests passed, including explicit unclaimed text/note correction and exclusion rejection.
- Diff whitespace and public/private boundary scans passed. Full unrelated Python/TS suites and live model qualification were not run; no model-facing prompt or execution policy was changed.

## Review boundaries

Changed surfaces: native Todo text/note eligibility, provider conformance, production compatibility CLI regression, and bilingual contract documentation. The behavior change restores the unclaimed correction path; it does not grant execution, governance mutation, or delegated editing of another owner's work. Default Markdown implementation is unchanged and its parity case is pinned separately.

Future-facing pass: kept the rule in the existing `targetRejection` boundary, adding the exclusion/binding fences there. A generalized mutation-authority framework would be disproportionate for this fix. Public fixtures contain synthetic identities only; no local state or raw logs are included. This is a follow-up to an already merged PR and is left for review, not self-merged.
