### PR TITLE
fix(state): refresh event store reads

### DIFF
--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -568,12 +568,8 @@ def make_state_event(
 @dataclass
 class AppendOnlyStateEventStore:
     path: Path
-    _events: list[dict[str, Any]] = field(default_factory=list)
-    _loaded: bool = False
 
     def load(self) -> list[dict[str, Any]]:
-        if self._loaded:
-            return list(self._events)
         events: list[dict[str, Any]] = []
         if self.path.exists():
             for line_number, line in enumerate(self.path.read_text(encoding="utf-8").splitlines(), start=1):
@@ -584,13 +580,10 @@ class AppendOnlyStateEventStore:
                 except json.JSONDecodeError as exc:
                     raise StateEventError(f"invalid JSONL at line {line_number}: {exc}") from exc
                 events.append(normalize_state_event(raw))
-        self._events = _dedupe_events(events)
-        self._loaded = True
-        return list(self._events)
+        return _dedupe_events(events)
 
     def append(self, event: dict[str, Any]) -> dict[str, Any]:
         with exclusive_file_lock(self.path):
-            self._loaded = False
             events = self.load()
             existing = {item["event_id"]: item for item in events}
             next_sequence = max((int(item["append_sequence"]) for item in events), default=0) + 1
@@ -604,7 +597,6 @@ class AppendOnlyStateEventStore:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             with self.path.open("a", encoding="utf-8") as stream:
                 stream.write(json.dumps(normalized, sort_keys=True, ensure_ascii=False) + "\n")
-            self._events.append(normalized)
             return normalized
 
     def append_many(self, events: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/test_event_sourced_state_store.py
+++ b/tests/test_event_sourced_state_store.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from loopx.event_sourced_state import (
+    TODO_ADDED,
+    AppendOnlyStateEventStore,
+    make_state_event,
+)
+
+
+def test_load_observes_events_appended_by_another_store(tmp_path: Path) -> None:
+    event_log = tmp_path / "events.jsonl"
+    reader = AppendOnlyStateEventStore(event_log)
+    writer = AppendOnlyStateEventStore(event_log)
+    assert reader.load() == []
+
+    appended = writer.append(
+        make_state_event(
+            event_id="evt-concurrent-writer",
+            goal_id="goal-a",
+            event_type=TODO_ADDED,
+            refs={"todo_id": "todo_concurrent_writer"},
+            payload={"role": "agent", "title": "Observe the durable event."},
+            recorded_at="2026-09-06T00:00:00Z",
+        )
+    )
+
+    assert reader.load() == [appended]


### PR DESCRIPTION
## Summary

- remove the process-local event cache from `AppendOnlyStateEventStore`
- make repeated `load()` calls observe events appended by another store/process
- add a deterministic cross-instance regression test

## Root cause

The store cached its first read forever. File locking kept appends serialized, but it did not invalidate already-loaded peer instances, so a long-lived reader could return stale canonical state indefinitely.

## Validation

- regression reproduced twice before the fix
- 136 focused event-store/Todo/shared-goal tests passed
- related Ruff and Python compile checks passed
- `loopx canary premerge --from-git-diff` passed 4/4 selected checks with no manual holds
- `git diff --check` passed