### PR TITLE
fix(desktop): expose actionable recovery diagnostics

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -54,6 +54,15 @@ matching runtime too. Goal state is neither deleted nor migrated backwards by
 this action, so data-schema compatibility still governs rollback suitability.
 Older backup directories are retained for manual recovery and can consume disk.
 
+The embedded Recovery & updates section includes selectable, copyable diagnostics
+with the App version, last failure category, installer exit code when available,
+and runtime identity availability/match results. The last failure survives a
+subsequent update check within the same App process. Copying never includes raw
+installer output, environment variables, local paths, or Goal content. Installation
+failures, missing/corrupt bundles, and runtime mismatch show distinct recovery
+instructions. A terminal `loopx doctor` checks the terminal-selected runtime;
+it does not prove that Desktop selected the same installation or matching revision.
+
 The updater accepts only fixed official HTTPS channels, not browser-provided
 commands, paths or download URLs. Its signing private key is confined to the
 release secret; the App embeds the public key. PR validation has no signing

--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -153,7 +153,13 @@ fn install_snapshot(bytes: &[u8], metadata: &Value) -> Result<(), String> {
                         Err("runtime_identity_mismatch".into())
                     }
                 } else {
-                    Err("runtime_install_failed".into())
+                    Err(format!(
+                        "runtime_install_exit_{}",
+                        status
+                            .code()
+                            .map(|code| code.to_string())
+                            .unwrap_or_else(|| "signal".into())
+                    ))
                 }
             }
             Ok(None) if started.elapsed() < Duration::from_secs(600) => {

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -17,6 +17,7 @@ pub struct Maintenance {
     supervision: tauri::async_runtime::Mutex<()>,
     snapshot: Mutex<Value>,
     pending: Mutex<Option<(String, Update)>>,
+    last_failure: Mutex<Value>,
 }
 impl Maintenance {
     fn acquire(&self) -> Result<BusyGuard<'_>, String> {
@@ -27,6 +28,9 @@ impl Maintenance {
     }
     fn publish(&self, phase: &str, details: Value) -> Value {
         let value = json!({"phase": phase, "details": details});
+        if matches!(phase, "error" | "runtime_required" | "service_error") {
+            *self.last_failure.lock().unwrap() = value.clone();
+        }
         *self.snapshot.lock().unwrap() = value.clone();
         value
     }
@@ -107,7 +111,9 @@ fn check_error(error: tauri_plugin_updater::Error) -> &'static str {
 }
 #[tauri::command]
 pub fn desktop_update_status(app: AppHandle, state: State<'_, Maintenance>) -> Value {
-    json!({"state": state.snapshot.lock().unwrap().clone(), "app_version": app.package_info().version.to_string(), "runtime": bundled_runtime::identity(&app).ok(), "rollback_available": crate::update_backup::available(&app)})
+    let snapshot = state.snapshot.lock().unwrap().clone();
+    let last_failure = state.last_failure.lock().unwrap().clone();
+    json!({"state": snapshot, "last_failure": last_failure, "app_version": app.package_info().version.to_string(), "runtime": bundled_runtime::identity(&app).ok(), "rollback_available": crate::update_backup::available(&app)})
 }
 #[tauri::command]
 pub async fn desktop_update(
@@ -247,6 +253,17 @@ async fn perform(
     Ok(state.publish("restart_required", json!({"version":target})))
 }
 pub fn resume(app: &AppHandle) -> Result<(), String> {
+    let result = resume_runtime(app);
+    if let Err(error) = &result {
+        if error != "runtime_setup_required" {
+            app.state::<Maintenance>()
+                .publish("error", json!({"code":error}));
+        }
+    }
+    result
+}
+
+fn resume_runtime(app: &AppHandle) -> Result<(), String> {
     // Development intentionally pairs a live frontend with a developer-selected
     // runtime; it must neither replace itself nor force release installation.
     if cfg!(dev) || !cfg!(target_os = "macos") {
@@ -263,7 +280,14 @@ pub fn resume(app: &AppHandle) -> Result<(), String> {
             if installed.as_ref().map(|v| &v["source_revision"])
                 != Some(&bundled["source_revision"])
             {
-                state.publish("runtime_required", json!({}));
+                state.publish(
+                    "runtime_required",
+                    json!({
+                        "code":"runtime_setup_required",
+                        "installed_identity_available": installed.is_some(),
+                        "revision_matches": false
+                    }),
+                );
                 return Err("runtime_setup_required".into());
             }
         }
@@ -290,6 +314,16 @@ pub fn start_services(app: &AppHandle) -> Result<Option<crate::services::Service
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn diagnostics_retain_failure_after_successful_update_check() {
+        let state = Maintenance::default();
+        let failure = state.publish("error", json!({"code":"runtime_install_exit_23"}));
+        state.publish("checking", json!({}));
+        state.publish("up_to_date", json!({}));
+        assert_eq!(*state.last_failure.lock().unwrap(), failure);
+        let next = state.publish("runtime_required", json!({"code":"runtime_setup_required"}));
+        assert_eq!(*state.last_failure.lock().unwrap(), next);
+    }
     #[test]
     fn check_failures_preserve_actionable_categories_without_diagnostics() {
         use tauri_plugin_updater::Error;

--- a/apps/desktop/loopx-control-plane/static/boot.css
+++ b/apps/desktop/loopx-control-plane/static/boot.css
@@ -10,6 +10,7 @@ summary { cursor: pointer; padding: 10px 0; }
 button, select { min-height: 44px; padding: 8px 12px; margin-top: 8px; border: 1px solid #8f8f8f; border-radius: 6px; font: inherit; color: inherit; background: transparent; }
 label { display: block; margin-top: 12px; }
 button { cursor: pointer; }
+textarea { width: 100%; margin-top: 12px; padding: 12px; border: 1px solid #8f8f8f; border-radius: 6px; background: transparent; color: inherit; font: 12px/1.5 "Geist Mono", monospace; resize: vertical; }
 button:disabled { cursor: wait; opacity: .6; }
 :focus-visible { outline: 2px solid #0070f3; outline-offset: 2px; }
 p { margin: 16px 0 0; color: #4d4d4d; font-size: 14px; line-height: 1.55; }

--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -36,6 +36,18 @@ const labels = {
   error: "更新未完成。请重试检查，或修复当前版本。Goal 数据不会被删除。",
 };
 const errors = {
+  desktop_status_unavailable: "无法读取 App 诊断状态。请重启 App；若仍失败，请重新安装完整 App。",
+  runtime_setup_required: "App 与本机运行时不匹配，或找不到安装身份。请修复当前版本，成功后重启。",
+  runtime_bundle_missing: "App 缺少配套运行时文件。请重新下载完整 App。",
+  runtime_bundle_invalid: "App 配套运行时校验失败。请重新下载完整 App。",
+  runtime_installer_unavailable: "无法启动安装程序。请检查系统是否提供 bash（Windows 为 PowerShell）。",
+  runtime_install_failed: "运行时安装失败。请展开诊断信息，提供错误码以便排查。",
+  runtime_install_timeout: "运行时安装超过十分钟，已停止。请检查网络和安装依赖后重试。",
+  runtime_identity_mismatch: "安装已结束，但 App 仍选中了不同运行时。请检查是否设置了 LOOPX_BIN。",
+  runtime_staging_failed: "无法创建安装临时目录。请检查磁盘空间及写入权限。",
+  update_state_unavailable: "无法读写更新状态。请检查 App 数据目录的权限和磁盘空间。",
+  update_state_invalid: "更新状态无法读取。请保留诊断信息并反馈问题。",
+  app_update_incomplete: "App 更新尚未完成，无法安装配套运行时。请重新安装目标 App。",
   update_feed_unavailable: "此通道的更新源尚未就绪或暂时不可用。可稍后重新检查。",
   update_feed_invalid: "更新源格式异常。请稍后重新检查。",
   update_platform_unavailable: "此通道尚无适用于本机的更新包。",
@@ -53,19 +65,47 @@ function render(state) {
   channel.disabled = working || state.phase === "restart_required";
   nextAction = state.phase === "available" ? "apply" : state.phase === "restart_required" ? "restart" : "check";
   update.textContent = nextAction === "apply" ? "更新并准备重启 / Install update" : nextAction === "restart" ? "重启完成更新 / Restart" : "检查更新 / Check for updates";
-  updateStatus.textContent = state.phase === "error" && Object.hasOwn(errors, state.details?.code) ? errors[state.details.code] : labels[state.phase] || "";
+  const code = state.details?.code;
+  updateStatus.textContent = typeof code === "string" && /^runtime_install_exit_(\d+|signal)$/.test(code)
+    ? `安装程序退出（${code.slice("runtime_install_exit_".length)}）。请复制诊断信息反馈；修复没有完成。`
+    : Object.hasOwn(errors, code) ? errors[code] : labels[state.phase] || "";
 }
+const diagnostics = document.querySelector("#diagnostics");
+function safeCode(code) {
+  return typeof code === "string" && (Object.hasOwn(errors, code) || /^runtime_install_exit_(\d+|signal)$/.test(code) || ["service_start_failed", "update_failed"].includes(code)) ? code : "unknown";
+}
+function renderDiagnostics(result) {
+  const failure = result.last_failure ?? result.state;
+  const text = JSON.stringify({
+    schema_version: "desktop_recovery_diagnostics_v1",
+    failure_phase: ["error", "runtime_required", "service_error"].includes(failure?.phase) ? failure.phase : null,
+    app_version: /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(result.app_version) ? result.app_version : "unknown",
+    error_code: safeCode(failure?.details?.code),
+    installed_identity_available: typeof failure?.details?.installed_identity_available === "boolean" ? failure.details.installed_identity_available : null,
+    revision_matches: typeof failure?.details?.revision_matches === "boolean" ? failure.details.revision_matches : null,
+  }, null, 2);
+  if (diagnostics.value !== text) diagnostics.value = text;
+}
+document.querySelector("#copy-diagnostics").onclick = async () => {
+  try {
+    await navigator.clipboard.writeText(diagnostics.value);
+    document.querySelector("#copy-status").textContent = "已复制 / Copied";
+  } catch {
+    diagnostics.focus(); diagnostics.select();
+    document.querySelector("#copy-status").textContent = "请按 ⌘C / Ctrl+C 复制已选中的诊断。";
+  }
+};
 async function run(action) {
   if (working) return;
   render({phase: action === "check" ? "checking" : action === "repair" ? "installing_runtime" : "downloading"});
   try { render(await window.__TAURI__.core.invoke("desktop_update", {action,channel:channel.value})); }
-  catch (error) { render({phase:"error", details:{code: typeof error === "string" && Object.hasOwn(errors, error) ? error : "update_failed"}}); }
+  catch (error) { render({phase:"error", details:{code: safeCode(error)}}); }
 }
 update.onclick = () => run(nextAction);
 repair.onclick = () => run("repair");
 rollback.onclick = () => run("rollback");
 async function refresh() {
-  if (!window.__TAURI__) return;
+  if (!window.__TAURI__) { renderDiagnostics({state:{phase:"error",details:{code:"desktop_status_unavailable"}}}); return; }
   try {
     const result = await window.__TAURI__.core.invoke("desktop_update_status");
     if (!channelInitialized) {
@@ -73,8 +113,9 @@ async function refresh() {
       channelInitialized = true;
     }
     rollback.hidden = !result.rollback_available;
+    renderDiagnostics(result);
     render(result.state);
-  } catch { /* Static recovery instructions remain usable. */ }
+  } catch { renderDiagnostics({state:{phase:"error",details:{code:"desktop_status_unavailable"}}}); }
 }
 void refresh();
 setInterval(refresh,1000);

--- a/apps/desktop/loopx-control-plane/static/index.html
+++ b/apps/desktop/loopx-control-plane/static/index.html
@@ -21,7 +21,14 @@
         <p id="update-status" role="status"></p>
         <button id="repair" type="button">修复当前版本 / Repair this version</button>
         <button id="rollback" type="button" hidden>恢复上版并准备重启 / Restore previous version</button>
-        <p>仍失败时运行 <code>loopx doctor</code> 检查安装。不要删除 Goal 数据。</p>
+        <details>
+          <summary>诊断信息 / Diagnostics</summary>
+          <p>复制以下诊断用于问题反馈；不包含消息、环境变量或本机路径。</p>
+          <textarea id="diagnostics" readonly rows="9" aria-label="诊断信息 / Diagnostics"></textarea>
+          <button id="copy-diagnostics" type="button">复制诊断 / Copy diagnostics</button>
+          <p id="copy-status" role="status"></p>
+        </details>
+        <p><code>loopx doctor</code> 只检查终端选中的运行时，不能证明它与 App 匹配。不要删除 Goal 数据。</p>
       </details>
     </main>
     <script src="boot.js"></script>

--- a/examples/desktop-recovery-diagnostics-test.mjs
+++ b/examples/desktop-recovery-diagnostics-test.mjs
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const script = readFileSync(new URL('../apps/desktop/loopx-control-plane/static/boot.js', import.meta.url), 'utf8');
+function page() {
+  const elements = new Map();
+  const context = {
+    document: {querySelector(id) {
+      if (!elements.has(id)) elements.set(id, {dataset: {}, setAttribute() {}, focus() {}, select() {this.selected = true;}});
+      return elements.get(id);
+    }},
+    window: {}, navigator: {clipboard: {writeText: async () => {throw new Error('denied');}}},
+    setInterval() {},
+  };
+  runInNewContext(script, context);
+  return {context, elements};
+}
+test('export uses bounded fields and preserves the last failure after a check', () => {
+  const {context, elements} = page();
+  context.packet = {app_version: '1.0.0', state: {phase: 'up_to_date'}, last_failure: {
+    phase: 'runtime_required', details: {code: 'runtime_setup_required', installed_identity_available: false, revision_matches: false, content: 'PRIVATE', path: 'PRIVATE'},
+  }};
+  runInNewContext('renderDiagnostics(packet)', context);
+  const value = JSON.parse(elements.get('#diagnostics').value);
+  assert.equal(value.error_code, 'runtime_setup_required');
+  assert.equal(value.failure_phase, 'runtime_required');
+  assert.equal(value.installed_identity_available, false);
+  assert.ok(!JSON.stringify(value).includes('PRIVATE'));
+  context.packet.last_failure.details.code = 'PRIVATE';
+  context.packet.app_version = 'PRIVATE';
+  runInNewContext('renderDiagnostics(packet)', context);
+  assert.ok(!elements.get('#diagnostics').value.includes('PRIVATE'));
+});
+test('installer failure is actionable and clipboard denial leaves selectable text', async () => {
+  const {context, elements} = page();
+  runInNewContext('render({phase:"error",details:{code:"runtime_install_exit_23"}})', context);
+  assert.match(elements.get('#update-status').textContent, /23/);
+  assert.equal(elements.get('#repair').disabled, false);
+  await elements.get('#copy-diagnostics').onclick();
+  assert.equal(elements.get('#diagnostics').selected, true);
+});


### PR DESCRIPTION
## Problem and change

Desktop recovery previously reduced several startup/installation failures to a generic message, leaving a healthy terminal CLI insufficient to diagnose App startup (refs #4012).

The existing recovery section now shows actionable bundle, installer, timeout and identity failure messages plus selectable/copyable diagnostics. Native status retains the last failure across subsequent update checks within the App process. The export includes only App version, failure category, installer exit code and identity availability/match booleans; raw logs, environment variables, paths and Goal content are excluded. Clipboard denial falls back to selecting the text. Default collapsed startup layout is unchanged.

Ownership stays in Desktop maintenance and its existing IPC; installation, version matching, permissions and the decision kernel are unchanged. The related simplification pass uses bounded structured evidence rather than a raw-log redaction framework.

## Validation

- Rust library tests: 25 passed; existing opt-in real installer and signed backup qualification tests remain excluded. No live installation or signed release was performed.
- Clippy (all targets, warnings denied) and Rust formatting passed. First Clippy attempt exhausted local disk; passed after cleaning regenerable Desktop package build artifacts.
- Two Node regression tests passed (privacy allowlist, retained failure, installer exit message, clipboard fallback).
- Production static recovery page inspected in a real browser, including unavailable native IPC diagnostics.
- Public boundary scan and diff whitespace check passed.

This improves diagnosis; it does not claim to resolve the reporter's installation failure. Existing installed Apps need a newly built Desktop artifact to receive this native change.
