### PR TITLE
docs(release): record the v1.0.0 Workspace milestone in the timeline

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -534,6 +534,14 @@ path, and canary route rather than as a user-facing release baseline.
   advances staged file, PostgreSQL, and NoKV shared-authority providers;
   completes the periodic-report lifecycle; makes the DSH plugin one-step ready; and adds
   public-safe benchmark study projection without granting upload authority.
+- `v1.0.0` on 2026-09-06 20:44 +08:00: the Workspace milestone release at the
+  matching `v1.0.0` tag (merge `d6e8387e`). The desktop companion gains signed
+  in-app updates with a paired runtime and a recovery path for interrupted
+  installs (#3994); Todo claim and update authority finishes its
+  claim-neutral correction through the TypeScript transaction (#4005, with
+  promoted claim retry identity from #3987); multi-agent Goal Channels ship
+  with per-agent connection resolution (#3969); and reward-memory recall
+  guides outbound messages behind a digest-bound review loop (#3968).
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.


### PR DESCRIPTION
## Summary

Completes the GH-C04 follow-through for the Workspace milestone: the public release timeline in `docs/product/release-readiness.md` now carries the `v1.0.0` entry at its authoritative tag timestamp (2026-09-06 20:44 +08:00, merge `d6e8387e`). The entry records what the milestone actually shipped: signed desktop in-app updates with a paired runtime and interrupted-install recovery (#3994), the claim-neutral Todo correction through the TypeScript transaction (#4005) together with promoted claim retry identity (#3987), multi-agent Goal Channels with per-agent connection resolution (#3969), and digest-bound reward-memory outbound recall (#3968).

Pure documentation: one timeline entry appended after `v0.5.4`; no runtime code, schema, or CLI surface touched.

## Issue Or Task

Continues contributor task GH-C04 (release docs alignment), following the merged v0.5.4 alignment in #3982 from the same task.

## Validation

- [x] `python3 examples/release/release-readiness-doc-smoke.py` → ok
- [x] `python3 examples/release/release-version-contract-smoke.py` → ok
- [x] `python3 examples/fresh-clone-quickstart-smoke.py` → ok
- [x] `python3 examples/loopx-update-smoke.py` → ok
- [x] `loopx check --scan-path docs/product/release-readiness.md --scan-path docs/development/contributor-tasks.md` → public boundary scan clean
- [x] Tag timestamp verified via `git log -1 --format=%ci v1.0.0`; merged-PR references verified against `upstream/main` history

## Type of Change

- [x] Documentation update

## LoopX Area

- [x] Docs / examples

## Technical Direction

- [x] Release governance
- Target base branch: main
- Direction tracker or promotion unit: GH-C04 follow-through

## Boundary Checklist

- [x] No .loopx/, credentials, private traces, raw sessions, or local machine paths committed
- [x] Change scoped to one timeline entry
- [x] Every commit includes a DCO Signed-off-by trailer