### PR TITLE
fix(reward-memory): add destination recall and required guidance checks

### DIFF
--- a/loopx/capabilities/context_providers/openviking.py
+++ b/loopx/capabilities/context_providers/openviking.py
@@ -198,7 +198,10 @@ class OpenVikingContextProvider:
         namespace = _compact(namespace, limit=120)
         query = _compact(query, limit=500)
         query_summary = _compact(query_summary, limit=220)
-        requested_limit = min(max(1, int(max_results)), MAX_OPENVIKING_RESULTS)
+        requested_limit = min(
+            max(1, int(max_results)),
+            24 if namespace == "reward_memory" else MAX_OPENVIKING_RESULTS,
+        )
         if not namespace or not query or not query_summary:
             raise ValueError("namespace, query, and query_summary are required")
         if not scope_ref.startswith("viking://"):
@@ -221,6 +224,9 @@ class OpenVikingContextProvider:
             )
 
         try:
+            # Reward records require full structured bodies. Summaries and
+            # duplicate chunks must not consume their final result budget.
+            reward_records = namespace == "reward_memory"
             search_result = self._run(
                 [
                     "search",
@@ -228,7 +234,12 @@ class OpenVikingContextProvider:
                     "-u",
                     scope_ref,
                     "-n",
-                    str(requested_limit),
+                    str(
+                        min(32, requested_limit * 4)
+                        if reward_records
+                        else requested_limit
+                    ),
+                    *(["-L", "2"] if reward_records else []),
                     "-o",
                     "json",
                     "-c",
@@ -278,6 +289,13 @@ class OpenVikingContextProvider:
         read_attempted = False
         for row in rows:
             resource_ref = _resource_ref(row)
+            if reward_records:
+                resource_ref = resource_ref.split("#", 1)[0]
+                if row.get("level") in (0, 1) or resource_ref.rsplit("/", 1)[-1] in {
+                    ".overview.md",
+                    ".abstract.md",
+                }:
+                    continue
             if not resource_ref or not (
                 resource_ref == scope_ref
                 or resource_ref.startswith(scope_ref.rstrip("/") + "/")
@@ -303,6 +321,16 @@ class OpenVikingContextProvider:
                 continue
             if not content:
                 continue
+            if reward_records:
+                try:
+                    record = json.loads(content)
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    not isinstance(record, Mapping)
+                    or record.get("schema_version") != "reward_memory_active_record_v0"
+                ):
+                    continue
             items.append(
                 ContextProviderItem(
                     resource_ref=resource_ref,

--- a/loopx/capabilities/reward_memory/OUTBOUND.md
+++ b/loopx/capabilities/reward_memory/OUTBOUND.md
@@ -78,6 +78,14 @@ an explicit **required-read contract**, not a text-based permission classifier:
 the agent must still obey prohibitions, and acknowledging a digest does not
 grant permission. It does not enforce bans through unrelated senders.
 
+Enabled agents with missing/invalid configuration or inconsistent corpus scope
+now receive `configuration_error` and zero sends, before any memory-provider call.
+Previously these failures silently removed the hook. Neither urgency nor an old
+review digest waives the error. Repair and check `reward-memory experiment-status`;
+do not discard invalid required fields or automatically disable the capability.
+Explicitly disabled agents, valid `automatic_recall: false` configurations and
+valid configurations without this surface still preserve the original sender.
+
 OpenViking reward retrieval requests L2 bodies and overfetches at most 32 hits,
 canonicalizes chunk URIs, and skips summaries, unreadable and malformed records
 before filling the bounded result budget. Other provider namespaces retain their

--- a/loopx/capabilities/reward_memory/OUTBOUND.md
+++ b/loopx/capabilities/reward_memory/OUTBOUND.md
@@ -43,15 +43,62 @@ scope, sender, destination, placement and message. Changes invalidate it.
 It proves acknowledgement, not the quality or truth of the agent's reasoning.
 Transport idempotency and readback remain owned by the existing sender.
 
+## Destination recall and required guidance
+
+For a verified destination, send and reply now run two separate bounded recall
+boundaries: destination experiences first, then message-purpose guidance. Each
+uses the existing one-query profile. Results are merged by candidate reference;
+the receipt reports the total calls and all application receipts. This changes
+enabled outbound recall from one query to two; feature-off behavior is unchanged.
+
+Add optional `destinations` to the outbound surface configuration:
+
+```json
+"destinations": [{
+  "destination_digest": "<64 lowercase hex characters: SHA-256 of the exact chat ID>",
+  "query_label": "Example Team",
+  "required_candidate_refs": ["candidate:reviewed-record"]
+}]
+```
+
+The sender binds the actual verified chat ID, not a caller-supplied group name.
+Only its hash and the explicitly configured query label enter retrieval; labels
+must be appropriate for the configured provider. A renamed group keeps the same
+identity; same-named groups have distinct digests. Update the label when renamed.
+Without a label, the destination hash is still queried. Store that identifier or
+label in relevant reviewed guidance so destination search can find it.
+
+Up to three required references get independent exact-reference queries. Every
+reference must resolve to an active, in-scope record and reach the merged output.
+Missing records or a provider failure that leaves one missing return
+`required_guidance_missing` and stop delivery, including urgent messages and
+reused review digests. Present required guidance always requires agent review,
+even for urgent messages. At most five recall boundaries run per send. This is
+an explicit **required-read contract**, not a text-based permission classifier:
+the agent must still obey prohibitions, and acknowledging a digest does not
+grant permission. It does not enforce bans through unrelated senders.
+
+OpenViking reward retrieval requests L2 bodies and overfetches at most 32 hits,
+canonicalizes chunk URIs, and skips summaries, unreadable and malformed records
+before filling the bounded result budget. Other provider namespaces retain their
+previous retrieval behavior. Scope/lifecycle checks and candidate deduplication
+precede the final guidance limit; this is bounded refill, not an exhaustive scan.
+
+Validate with the real destination and purpose preview above, without putting
+the desired answer or candidate ID in the message. Check that required refs are
+present, `required_guidance_complete` is true, and external writes remain false.
+Ingest-verification search alone does not prove this business recall path.
+
 Purposes are `help`, `progress`, `urgent`, and default `unspecified`; there is
 no substring inference from message text. Urgent notices recall guidance but
-do not wait for review. Empty/unavailable memory preserves the existing send
+do not wait for review unless required guidance is configured. Empty/unavailable
+advisory memory preserves the existing send
 path and never asks the user to repair the provider. Permission or sender
 validation failures still block normally. Hard-policy memories are not
 interpreted by this advisory adapter.
 
 The generic implementation lives in `reward_memory.outbound`; the Lark adapter
-receives a callback over an opaque intent digest. It owns no memory store or
+receives a callback over an opaque intent digest with optional destination binding. It owns no memory store or
 project-specific escalation rule. Raw text, chat ids and sender profiles never
 enter the recall query. Guidance is returned in the caller's private response,
 not sent to the recipient or persisted into the public registry.

--- a/loopx/capabilities/reward_memory/OUTBOUND.zh-CN.md
+++ b/loopx/capabilities/reward_memory/OUTBOUND.zh-CN.md
@@ -2,6 +2,13 @@
 
 [English](OUTBOUND.md)
 
+已启用 Agent 的配置缺失、无效或 corpus 作用域不一致时，现在返回
+`configuration_error`，在调用记忆 provider 前停止发送。此前这些错误会静默移除
+hook。urgent 和旧确认摘要都不能豁免；需修正配置并通过
+`reward-memory experiment-status` 核验，不能通过丢弃无效必读字段或自动关闭能力来修复。
+明确关闭的 Agent、有效的 `automatic_recall: false` 配置、有效但未包含此 surface
+的配置仍保留原发送行为。
+
 这个可选的 Reward Memory surface 会在 Agent 发送消息前召回已经审阅过的
 操作偏好。它不是消息传输、文本分类器或发送权限。首个正式调用方是绑定
 Goal/Agent 的 `loopx lark-inbox send` 和 `reply`；本次集成不拦截其他工具，

--- a/loopx/capabilities/reward_memory/OUTBOUND.zh-CN.md
+++ b/loopx/capabilities/reward_memory/OUTBOUND.zh-CN.md
@@ -38,8 +38,38 @@ Provider preflight 先校验身份、群成员、mention 和 provider dry-run，
 让旧摘要失效。它只能证明 Agent 确认过指导，不能证明推理质量。原发送器继续
 负责幂等和 readback。
 
+## 目标群召回与必读记录
+
+启用后，send/reply 根据已验证的实际群 ID 分别执行“目标群经验”和“消息用途”
+两路召回，每路沿用一次查询的 profile，合并时按 candidate 引用去重。
+这是启用状态下从一次到两次查询的行为变化；未启用时保持原行为。
+
+在 outbound surface 中可配置 `destinations` 数组，每项包含：
+
+- `destination_digest`：实际群 ID 的 SHA-256，小写十六进制 64 位。
+- `query_label`：适合交给当前 provider 检索的群名或别名，最多 120 字符。
+- `required_candidate_refs`：最多三个必须读取的已审核 candidate 引用。
+
+群名只辅助检索，实际绑定依赖发送器验证过的群 ID。改名后身份不变，同名群
+不共享必读配置；改名时应更新标签。未配置标签时仍以目标摘要查询。相关经验
+需要包含该标签或摘要，才能支持目标检索。具体 JSON 见英文文档。
+
+每条必读记录另有一次精确引用查询，必须通过 active、scope 和正文校验并进入
+最终指导列表。缺失时返回 `required_guidance_missing` 并停止发送，urgent 或
+复用旧 review digest 也不能跳过；完整时 urgent 也必须审阅。这是明确配置的
+必读契约，不是通过关键词判断禁令的分类器。Agent 仍需遵守记忆中的禁发要求，
+确认摘要不授予发送权，也不拦截其他发送工具。总计最多五路有界召回。
+
+OpenViking 的 Reward Memory 查询只取 L2 正文，最多多取 32 个候选；先规范化
+chunk URI、排除摘要和不可读或格式错误的记录，再填充结果上限。应用层按 scope、
+有效期和 candidate 去重后截取。其他 namespace 的查询保持原行为；这不是全量扫描。
+
+验收应使用真实目标和消息用途的只读 preflight，检查必读记录实际出现、
+`required_guidance_complete=true` 且无外部写入；不要在消息中塞入待召回答案。
+写入后按自身内容验证能搜到，不能代替这项验收。
+
 用途包括 `help`、`progress`、`urgent` 和默认的 `unspecified`，不根据消息
-文本猜测用途。紧急通知会召回指导但不会等待复审；记忆为空或 provider 不可用
+文本猜测用途。未配置必读记录时，紧急通知会召回指导但不会等待复审；普通指导为空或 provider 不可用
 时保留既有发送路径，不会生成用户卡点。原有权限或发送方校验仍会正常阻断。
 本适配器不把 hard-policy 记忆解释成软性指导。
 

--- a/loopx/capabilities/reward_memory/application.py
+++ b/loopx/capabilities/reward_memory/application.py
@@ -588,7 +588,9 @@ def execute_reward_memory_recall(
                 scope_ref=binding["scope_ref"],
                 query=query["query"],
                 query_summary=query["query_summary"],
-                max_results=request["limit"],
+                # Leave room for scope/lifecycle rejection and duplicate
+                # candidates before applying the caller's final record limit.
+                max_results=min(24, request["limit"] * 3),
                 timeout_seconds=float(binding["timeout_seconds"]),
                 observed_at=request["observed_at"],
             )
@@ -605,8 +607,6 @@ def execute_reward_memory_recall(
             reason_code = "provider_result_readback_unverified"
             break
         for provider_item in retrieval.items:
-            if provider_item.resource_ref in seen:
-                continue
             active = _active_item(
                 provider_item,
                 corpus,
@@ -615,7 +615,9 @@ def execute_reward_memory_recall(
             )
             if active is None:
                 continue
-            seen.add(provider_item.resource_ref)
+            if active.candidate_ref in seen:
+                continue
+            seen.add(active.candidate_ref)
             results.append(active)
             if len(results) >= request["limit"]:
                 break

--- a/loopx/capabilities/reward_memory/experiment.py
+++ b/loopx/capabilities/reward_memory/experiment.py
@@ -46,6 +46,7 @@ _SURFACE_FIELDS = {
     "corpus_ids",
     "ingest_corpus_id",
     "recall_profile",
+    "destinations",
 }
 _RECALL_PROFILE_FIELDS = {"profile_id", "mode", "max_queries", "limit"}
 _AUTOMATION_FIELDS = {"automatic_recall", "automatic_ingest", "fail_open"}
@@ -325,6 +326,55 @@ def _normalize_v1(raw: Mapping[str, Any]) -> dict[str, Any]:
                 ),
             },
         }
+        if "destinations" in surface:
+            if surface_id != "outbound_message.before_send":
+                raise ValueError("destinations require the outbound surface")
+            destinations = {}
+            for destination in _bounded_objects(
+                surface["destinations"], label="destinations", maximum=20
+            ):
+                entry = _strict_object(
+                    destination,
+                    label="destination",
+                    allowed={
+                        "destination_digest",
+                        "query_label",
+                        "required_candidate_refs",
+                    },
+                )
+                digest = str(entry.get("destination_digest") or "")
+                if len(digest) != 64 or any(
+                    c not in "0123456789abcdef" for c in digest
+                ):
+                    raise ValueError("destination_digest must be a SHA-256 hex digest")
+                if digest in destinations:
+                    raise ValueError("destination_digest must be unique")
+                label = entry.get("query_label", "")
+                if not isinstance(label, str) or len(label) > 120:
+                    raise ValueError(
+                        "destination query_label must be at most 120 characters"
+                    )
+                refs = entry.get("required_candidate_refs", [])
+                if (
+                    not isinstance(refs, list)
+                    or len(refs) > 3
+                    or any(
+                        not isinstance(ref, str)
+                        or not ref.startswith("candidate:")
+                        or len(ref) > 100
+                        or any(c.isspace() for c in ref)
+                        for ref in refs
+                    )
+                    or len(set(refs)) != len(refs)
+                ):
+                    raise ValueError(
+                        "required_candidate_refs must contain up to three unique candidate refs"
+                    )
+                destinations[digest] = {
+                    "query_label": label,
+                    "required_candidate_refs": refs,
+                }
+            surfaces[surface_id]["destinations"] = destinations
         referenced_corpora.update(corpus_ids)
     if referenced_corpora != set(corpora):
         raise ValueError(

--- a/loopx/capabilities/reward_memory/outbound.py
+++ b/loopx/capabilities/reward_memory/outbound.py
@@ -36,9 +36,13 @@ def outbound_guidance_hook(
     if not goal_id or not agent_id:
         return None
     normalized_agent_id = normalize_todo_claimed_by(agent_id) or ""
-    _, config = resolve_reward_memory_experiment(
+    resolution, config = resolve_reward_memory_experiment(
         registry_path=registry_path, goal_id=goal_id, agent_id=agent_id
     )
+    # An enabled but unreadable contract is not evidence that recall is off.
+    # Do not inspect invalid config fragments to guess whether reads are required.
+    if resolution.get("status") in {"config_invalid", "config_missing"}:
+        return _configuration_failure_hook(resolution["status"])
     if config is None or not config["automation"]["automatic_recall"]:
         return None
     if SURFACE not in config["surfaces"]:
@@ -60,9 +64,9 @@ def outbound_guidance_hook(
             )
         }
         if current["peer_ref"] != f"agent:{normalized_agent_id}":
-            return None
+            return _configuration_failure_hook("scope_mismatch")
         if identity is not None and identity != current:
-            return None
+            return _configuration_failure_hook("scope_mismatch")
         identity = current
         checkpoints[corpus["corpus_id"]] = {
             **{k: v for k, v in current.items() if v is not None},
@@ -213,3 +217,25 @@ def outbound_guidance_hook(
         lambda chat_id: lambda digest: recall(digest, chat_id),
     )
     return recall
+
+
+def _configuration_failure_hook(reason: str):
+    def blocked(intent_digest: str) -> dict[str, Any]:
+        return {
+            "schema_version": "outbound_guidance_review_v0",
+            "status": "configuration_error",
+            "reason_code": reason,
+            "guidance": [],
+            "agent_review_required": True,
+            "continue_delivery": False,
+            "provider_failure_is_user_gate": False,
+            "grants_new_action_authority": False,
+            "required_guidance_complete": False,
+            "recommended_action": (
+                "Repair the enabled Reward Memory configuration and verify it with "
+                "reward-memory experiment-status before retrying. Review acknowledgement "
+                "cannot waive this error; explicit disable remains an owner decision."
+            ),
+        }
+
+    return blocked

--- a/loopx/capabilities/reward_memory/outbound.py
+++ b/loopx/capabilities/reward_memory/outbound.py
@@ -73,7 +73,7 @@ def outbound_guidance_hook(
             "source_ref": f"registry:{goal_id}:reward-memory",
         }
 
-    def recall(intent_digest: str) -> dict[str, Any]:
+    def recall(intent_digest: str, destination_id: str | None = None) -> dict[str, Any]:
         def apply(base, items):
             guidance = [
                 {"candidate_ref": i.candidate_ref, "content_summary": i.content_summary}
@@ -90,31 +90,76 @@ def outbound_guidance_hook(
                 "current_artifact_verified": True,
             }
 
-        result = run_reward_memory_automatic_recall_hook(
-            config,
-            surface_id=SURFACE,
-            base_output={"guidance": []},
-            **identity,
-            revision_ref=intent_digest,
-            artifact_ref=intent_digest,
-            queries=[
-                {
-                    "query": f"Reviewed guidance before an outbound {purpose} message: alternatives, evidence, recipient and escalation",
-                    "query_summary": "outbound communication guidance",
-                }
-            ],
-            observed_at=datetime.now(timezone.utc).isoformat(),
-            freshness_context={
-                "source_truth_current": True,
-                "source_revision": intent_digest,
-                "age_seconds": 0,
-            },
-            conflict_state="clear",
-            read_authority_checkpoints=checkpoints,
-            application_id="outbound-guidance",
-            apply_memory=apply,
+        destination_digest = (
+            hashlib.sha256(destination_id.encode()).hexdigest()
+            if destination_id
+            else None
         )
-        guidance = result.get("output", {}).get("guidance", [])
+        destination = (
+            config["surfaces"][SURFACE]
+            .get("destinations", {})
+            .get(destination_digest, {})
+        )
+        required_refs = destination.get("required_candidate_refs", [])
+        queries = []
+        # Required records have their own bounded lookup and are checked after
+        # merge. Similarity ranking cannot silently remove a required record.
+        queries.extend(
+            {"query": ref, "query_summary": "required destination guidance"}
+            for ref in required_refs
+        )
+        if destination_digest:
+            queries.append(
+                {
+                    "query": f"Group {destination.get('query_label', '')} destination:{destination_digest} communication experiences, owner instructions and restrictions",
+                    "query_summary": "destination communication guidance",
+                }
+            )
+        queries.append(
+            {
+                "query": f"Reviewed guidance before an outbound {purpose} message: alternatives, evidence, recipient and escalation",
+                "query_summary": "outbound communication guidance",
+            }
+        )
+        results = []
+        for query in queries:
+            results.append(
+                run_reward_memory_automatic_recall_hook(
+                    config,
+                    surface_id=SURFACE,
+                    base_output={"guidance": []},
+                    **identity,
+                    revision_ref=intent_digest,
+                    artifact_ref=intent_digest,
+                    queries=[query],
+                    observed_at=datetime.now(timezone.utc).isoformat(),
+                    freshness_context={
+                        "source_truth_current": True,
+                        "source_revision": intent_digest,
+                        "age_seconds": 0,
+                    },
+                    conflict_state="clear",
+                    read_authority_checkpoints=checkpoints,
+                    application_id="outbound-guidance",
+                    apply_memory=apply,
+                )
+            )
+        # Merge records, not overview/file URIs. Required lookups come first.
+        by_candidate = {}
+        for result in results:
+            for item in result.get("output", {}).get("guidance", []):
+                by_candidate.setdefault(item["candidate_ref"], item)
+        guidance = [by_candidate[ref] for ref in required_refs if ref in by_candidate]
+        guidance.extend(
+            item for ref, item in by_candidate.items() if ref not in required_refs
+        )
+        missing_required = sorted(set(required_refs) - set(by_candidate))
+        result = results[-1]
+        telemetry = dict(result.get("telemetry") or {})
+        for key in ("provider_call_count", "provider_call_cap", "query_count"):
+            telemetry[key] = sum(
+                int(r.get("telemetry", {}).get(key, 0)) for r in results
+            )
         digest = (
             "sha256:"
             + hashlib.sha256(
@@ -123,6 +168,8 @@ def outbound_guidance_hook(
                         "intent": intent_digest,
                         "identity": identity,
                         "purpose": purpose,
+                        "destination_digest": destination_digest,
+                        "required_candidate_refs": required_refs,
                         "guidance": guidance,
                     },
                     sort_keys=True,
@@ -132,13 +179,18 @@ def outbound_guidance_hook(
             ).hexdigest()
         )
         # This acknowledgement is by the executing agent, never a user gate.
-        # Urgent notices and unavailable providers preserve the existing path.
+        # Advisory-only urgent/failure behavior is unchanged. Explicit required
+        # reads cannot be waived by urgency or an old acknowledgement.
         review_required = (
-            bool(guidance) and purpose != "urgent" and reviewed_digest != digest
-        )
+            bool(guidance)
+            and (purpose != "urgent" or bool(required_refs))
+            and reviewed_digest != digest
+        ) or bool(missing_required)
         return {
             "schema_version": "outbound_guidance_review_v0",
-            "status": result["status"],
+            "status": "required_guidance_missing"
+            if missing_required
+            else ("applied" if guidance else result["status"]),
             "guidance": guidance,
             "review_digest": digest,
             "agent_review_required": review_required,
@@ -146,8 +198,18 @@ def outbound_guidance_hook(
             "urgent_notice": purpose == "urgent",
             "provider_failure_is_user_gate": False,
             "grants_new_action_authority": False,
+            "required_guidance_complete": not missing_required,
+            "missing_required_candidate_refs": missing_required,
             "application": result.get("application"),
-            "telemetry": result.get("telemetry"),
+            "applications": [r.get("application") for r in results],
+            "telemetry": telemetry,
         }
 
+    # Preserve the one-argument callback for existing callers. The sender binds
+    # the actual verified chat, never an agent-supplied display name.
+    setattr(
+        recall,
+        "for_destination",
+        lambda chat_id: lambda digest: recall(digest, chat_id),
+    )
     return recall

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -375,14 +375,16 @@ def _deliver_lark_inbox_outbound(
     guidance = None
     if before_send is not None:
         # Bind review to destination/profile as well as content and placement.
-        # None of these private values are supplied to the memory provider.
+        # The optional binder hashes the verified destination before retrieval.
         intent_digest = (
             "sha256:"
             + hashlib.sha256(
                 json.dumps([profile, chat_id, receipt]).encode("utf-8")
             ).hexdigest()
         )
-        guidance = before_send(intent_digest)
+        bind_destination = getattr(before_send, "for_destination", None)
+        scoped_hook = bind_destination(chat_id) if bind_destination else before_send
+        guidance = scoped_hook(intent_digest)
         if guidance.get("continue_delivery") is not True or not execute:
             return _result(
                 status="agent_review_required"

--- a/tests/capabilities/test_outbound_guidance.py
+++ b/tests/capabilities/test_outbound_guidance.py
@@ -80,7 +80,9 @@ def test_disabled_urgent_failure_and_wrong_peer(tmp_path, monkeypatch):
     assert outbound.outbound_guidance_hook(**kwargs, purpose="urgent")("intent")[
         "continue_delivery"
     ]
-    assert outbound.outbound_guidance_hook(**(kwargs | {"agent_id": "other"})) is None
+    wrong_peer = outbound.outbound_guidance_hook(**(kwargs | {"agent_id": "other"}))
+    assert wrong_peer("intent")["status"] == "configuration_error"
+    assert not wrong_peer("intent")["continue_delivery"]
     config["automation"]["automatic_recall"] = False
     assert outbound.outbound_guidance_hook(**kwargs) is None
     configure(tmp_path, monkeypatch, unavailable=True)
@@ -288,8 +290,8 @@ def test_cli_installs_hook_at_real_sender(tmp_path, monkeypatch, command):
     assert "not a request for user approval" in cli._render(results[0])
 
 
-def test_unnormalized_agent_id_and_scope_drift_fail_open(tmp_path, monkeypatch):
-    """Build-stage scope problems must never crash the send path."""
+def test_agent_id_normalization_preserves_valid_scope(tmp_path, monkeypatch):
+    """Equivalent agent identifiers retain the valid scoped hook."""
 
     configure(tmp_path, monkeypatch)
     kwargs = dict(registry_path=tmp_path / "registry.json", goal_id="goal")
@@ -425,3 +427,106 @@ def test_destination_config_roundtrip(tmp_path):
         "query_label": "Example Team",
         "required_candidate_refs": ["candidate:rule"],
     }
+
+
+@pytest.mark.parametrize("reply", [False, True])
+@pytest.mark.parametrize("purpose", ["help", "urgent"])
+@pytest.mark.parametrize(
+    "state",
+    [
+        "valid",
+        "invalid",
+        "missing",
+        "disabled",
+        "agent_off",
+        "recall_off",
+        "surface_off",
+        "scope_mismatch",
+    ],
+)
+def test_real_resolver_sender_configuration_boundary(
+    tmp_path, monkeypatch, reply, purpose, state
+):
+    from loopx.capabilities.reward_memory import application
+
+    raw = turn.raw_config()
+    raw["corpora"][0]["corpus"]["scope"]["surface_ids"] = [outbound.SURFACE]
+    raw["surfaces"][0]["surface_id"] = outbound.SURFACE
+    raw["surfaces"][0]["destinations"] = [
+        {
+            "destination_digest": hashlib.sha256(b"oc_project_review").hexdigest(),
+            "query_label": "x" * 121 if state == "invalid" else "Example Team",
+            "required_candidate_refs": ["candidate:missing"],
+        }
+    ]
+    if state == "recall_off":
+        raw["automation"]["automatic_recall"] = False
+    if state == "surface_off":
+        raw = turn.raw_config()
+    if state == "scope_mismatch":
+        raw["corpora"][0]["corpus"]["scope"]["peer_ref"] = "agent:other"
+    (tmp_path / "memory.json").write_text(json.dumps(raw))
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "goal",
+                        "repo": str(tmp_path),
+                        "coordination": {"registered_agents": ["pilot"]},
+                        "control_plane": {
+                            "reward_memory": {
+                                "enabled": state != "disabled",
+                                "experimental": True,
+                                "enabled_agents": []
+                                if state == "agent_off"
+                                else ["pilot"],
+                                "config_path": None
+                                if state == "missing"
+                                else "memory.json",
+                            }
+                        },
+                    }
+                ]
+            }
+        )
+    )
+    provider = turn.RecallProvider("{}")
+    monkeypatch.setattr(application, "build_context_provider", lambda value: provider)
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    sender = reply_lark_event_inbox if reply else send_lark_inbox_message
+    runner = ReplyRunner(readback_text="done")
+    hook = outbound.outbound_guidance_hook(
+        registry_path=registry,
+        goal_id="goal",
+        agent_id="pilot",
+        purpose=purpose,
+        reviewed_digest="sha256:previously-reviewed",
+    )
+    result = sender(
+        project=project,
+        config_path=config,
+        text="done",
+        execute=True,
+        runner=runner,
+        before_send=hook,
+        **({"message_id": "om_reaction_fixture"} if reply else {}),
+    )
+    disabled = state in {"disabled", "agent_off", "recall_off", "surface_off"}
+    assert result["external_write_performed"] is disabled
+    if disabled:
+        assert result["reply_verified"] and "outbound_guidance" not in result
+        assert provider.calls == 0
+    else:
+        guidance = result["outbound_guidance"]
+        assert guidance["status"] == (
+            "required_guidance_missing" if state == "valid" else "configuration_error"
+        )
+        assert not guidance["continue_delivery"]
+        assert not any(
+            ("+messages-send" in c or "+messages-reply" in c) and "--dry-run" not in c
+            for c in runner.calls
+        )
+        if state != "valid":
+            assert provider.calls == 0

--- a/tests/capabilities/test_outbound_guidance.py
+++ b/tests/capabilities/test_outbound_guidance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from datetime import datetime
 
@@ -300,3 +301,127 @@ def test_unnormalized_agent_id_and_scope_drift_fail_open(tmp_path, monkeypatch):
             f"agent_id={raw_agent_id!r} must normalize to the configured scope"
         )
         assert hook("sha256:intent")["status"] == "applied"
+
+
+def test_destination_and_purpose_queries_merge_without_private_id(
+    tmp_path, monkeypatch
+):
+    config, provider = configure(tmp_path, monkeypatch)
+    chat = "oc_example_group"
+    digest = hashlib.sha256(chat.encode()).hexdigest()
+    config["surfaces"][outbound.SURFACE]["destinations"] = {
+        digest: {"query_label": "Example Team", "required_candidate_refs": []}
+    }
+    hook = outbound.outbound_guidance_hook(
+        registry_path=tmp_path / "registry.json", goal_id="goal", agent_id="pilot"
+    )
+    result = hook.for_destination(chat)("intent")
+    assert provider.calls == 2
+    assert "Example Team" in provider.queries[0]
+    assert digest in provider.queries[0]
+    assert all(chat not in q for q in provider.queries)
+    assert len(result["guidance"]) == 1
+    assert result["telemetry"]["provider_call_count"] == 2
+    other = hook.for_destination("oc_other_group")("intent")
+    assert "Example Team" not in provider.queries[2]
+    assert other["review_digest"] != result["review_digest"]
+
+
+@pytest.mark.parametrize("unavailable", [False, True])
+def test_required_guidance_missing_blocks_urgent_and_review_override(
+    tmp_path, monkeypatch, unavailable
+):
+    config, _ = configure(tmp_path, monkeypatch, unavailable=unavailable)
+    chat = "oc_example_group"
+    config["surfaces"][outbound.SURFACE]["destinations"] = {
+        hashlib.sha256(chat.encode()).hexdigest(): {
+            "query_label": "Example Team",
+            "required_candidate_refs": ["candidate:missing"],
+        }
+    }
+    kwargs = dict(
+        registry_path=tmp_path / "registry.json",
+        goal_id="goal",
+        agent_id="pilot",
+        purpose="urgent",
+    )
+    first = outbound.outbound_guidance_hook(**kwargs).for_destination(chat)("intent")
+    assert first["status"] == "required_guidance_missing"
+    assert not first["continue_delivery"]
+    again = outbound.outbound_guidance_hook(
+        **kwargs, reviewed_digest=first["review_digest"]
+    ).for_destination(chat)("intent")
+    assert not again["continue_delivery"]
+    # A restriction on one destination cannot silently constrain another.
+    assert outbound.outbound_guidance_hook(**kwargs).for_destination("oc_other")(
+        "intent"
+    )["continue_delivery"]
+
+
+def test_required_guidance_has_separate_lookup_and_review(tmp_path, monkeypatch):
+    config, provider = configure(tmp_path, monkeypatch)
+    chat = "oc_example_group"
+    config["surfaces"][outbound.SURFACE]["destinations"] = {
+        hashlib.sha256(chat.encode()).hexdigest(): {
+            "query_label": "Example Team",
+            "required_candidate_refs": ["candidate:guidance"],
+        }
+    }
+    hook = outbound.outbound_guidance_hook(
+        registry_path=tmp_path / "registry.json",
+        goal_id="goal",
+        agent_id="pilot",
+        purpose="urgent",
+    )
+    result = hook.for_destination(chat)("intent")
+    assert provider.queries[0] == "candidate:guidance"
+    assert result["required_guidance_complete"]
+    assert result["agent_review_required"]
+    assert len(result["guidance"]) == 1
+
+
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        {"destination_digest": "group-name"},
+        {
+            "destination_digest": "a" * 64,
+            "required_candidate_refs": ["not-a-candidate"],
+        },
+        {
+            "destination_digest": "a" * 64,
+            "required_candidate_refs": ["candidate:x"] * 2,
+        },
+    ],
+)
+def test_destination_config_rejects_ambiguous_identity(tmp_path, invalid):
+    raw = turn.raw_config()
+    raw["corpora"][0]["corpus"]["scope"]["surface_ids"] = [outbound.SURFACE]
+    raw["surfaces"][0]["surface_id"] = outbound.SURFACE
+    raw["surfaces"][0]["destinations"] = [invalid]
+    (tmp_path / "memory.json").write_text(json.dumps(raw))
+    with pytest.raises(ValueError):
+        load_reward_memory_experiment_config(
+            project=tmp_path, config_path="memory.json"
+        )
+
+
+def test_destination_config_roundtrip(tmp_path):
+    raw = turn.raw_config()
+    raw["corpora"][0]["corpus"]["scope"]["surface_ids"] = [outbound.SURFACE]
+    raw["surfaces"][0]["surface_id"] = outbound.SURFACE
+    raw["surfaces"][0]["destinations"] = [
+        {
+            "destination_digest": "a" * 64,
+            "query_label": "Example Team",
+            "required_candidate_refs": ["candidate:rule"],
+        }
+    ]
+    (tmp_path / "memory.json").write_text(json.dumps(raw))
+    config = load_reward_memory_experiment_config(
+        project=tmp_path, config_path="memory.json"
+    )
+    assert config["surfaces"][outbound.SURFACE]["destinations"]["a" * 64] == {
+        "query_label": "Example Team",
+        "required_candidate_refs": ["candidate:rule"],
+    }

--- a/tests/capabilities/test_reward_memory_provider_retrieval.py
+++ b/tests/capabilities/test_reward_memory_provider_retrieval.py
@@ -1,0 +1,85 @@
+"""Structured guidance survives summary/chunk noise without changing other clients."""
+
+import json
+import subprocess
+
+from loopx.capabilities.context_providers.openviking import OpenVikingContextProvider
+
+
+def test_reward_retrieval_uses_bodies_and_refills_after_unusable_hits():
+    root = "viking://resources/example"
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append(command)
+        if command[1] == "--version":
+            output = "OpenViking 0.4.9"
+        elif command[1] == "status":
+            output = "{}"
+        elif command[1] == "search":
+            assert "-L" in command and command[command.index("-L") + 1] == "2"
+            assert command[command.index("-n") + 1] == "8"
+            output = json.dumps(
+                {
+                    "resources": [
+                        {"uri": root + "/.overview.md", "level": 1},
+                        {"uri": root + "/bad", "level": 2},
+                        {"uri": root + "/one#chunk_0001", "level": 2},
+                        {"uri": root + "/one#chunk_0002", "level": 2},
+                        {"uri": root + "/two", "level": 2},
+                    ]
+                }
+            )
+        else:
+            assert command[1] == "read"
+            assert "#" not in command[2] and "overview" not in command[2]
+            output = json.dumps(
+                {
+                    "content": "not a record"
+                    if command[2].endswith("bad")
+                    else json.dumps(
+                        {"schema_version": "reward_memory_active_record_v0"}
+                    )
+                }
+            )
+        return subprocess.CompletedProcess(command, 0, output)
+
+    provider = OpenVikingContextProvider(runner=runner)
+    result = provider.retrieve(
+        namespace="reward_memory",
+        scope_ref=root,
+        query="example destination guidance",
+        query_summary="guidance",
+        max_results=2,
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+    )
+    assert [item.resource_ref for item in result.items] == [
+        root + "/one",
+        root + "/two",
+    ]
+    assert sum(c[1:3] == ["read", root + "/one"] for c in calls) == 1
+
+
+def test_other_namespaces_keep_original_search_contract():
+    def runner(command, **kwargs):
+        if command[1] == "--version":
+            output = "OpenViking 0.4.9"
+        elif command[1] == "search":
+            assert "-L" not in command
+            assert command[command.index("-n") + 1] == "2"
+            output = '{"resources": []}'
+        else:
+            output = "{}"
+        return subprocess.CompletedProcess(command, 0, output)
+
+    result = OpenVikingContextProvider(runner=runner).retrieve(
+        namespace="ordinary_context",
+        scope_ref="viking://resources/example",
+        query="context",
+        query_summary="context",
+        max_results=2,
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+    )
+    assert result.status == "completed" and not result.items


### PR DESCRIPTION
Outbound Reward Memory searched only generic message-purpose guidance, so destination-specific instructions could be missed. OpenViking summary and duplicate chunk hits also consumed the result budget before valid records reached the agent.

This adds a separate destination query bound to the sender-verified chat ID, with an optional configured group label. It merges candidate records across queries and retrieves L2 bodies with bounded overfetch and chunk deduplication. Optional per-destination required candidate references receive dedicated lookups and must appear in the active, scoped guidance before delivery; missing records cannot be waived by urgency or a reviewed digest. The adapter does not interpret prose as a permission policy.

Enabled sends now use two recall boundaries, up to five with three required references. Unconfigured agents retain existing behavior; advisory-only urgency and provider failures remain fail-open. Required-read configurations intentionally stop on missing records. Other sender tools and automatic topic replies are outside this integration.

Validation: 145 related tests passed, including send/reply integration, destination isolation, required-read failure and urgent cases, config validation, and other-provider namespace parity. Ruff and diff checks passed. Public boundary scan passed; three existing global registry warnings were unrelated. A read-only run against the configured live OpenViking backend returned the required record with complete readback and stopped for agent review; no message was sent. Follow-up ordering validation also passed.

Placement: existing reward_memory capability and bundled OpenViking provider, with the verified-destination binding at the existing Lark sender. The adjacent cleanup deduplicates by candidate identity after scope validation; no new store or permission classifier was added. No runtime installation or merge is included.
