### PR TITLE
fix(desktop): discard the update journal when the app replacement fails

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -84,7 +84,9 @@ the native startup supervisor.
 
 An update journal resumes an approved runtime installation after restart.
 If the app replacement fails with the previous App verified still in place
-(bundle present, installed runtime still pairing with the bundled snapshot),
+(the installed bundle's layout and `codesign` signature both verify on the
+actual installed target, and the installed runtime still pairs with the
+bundled snapshot),
 the journal is discarded instead of resuming and the App keeps starting
 normally; a failure that cannot verify the previous App keeps the journal and
 surfaces the distinct `app_install_incomplete` recovery state, because the
@@ -95,8 +97,10 @@ start must then re-run the App/runtime pairing check the no-journal startup
 path enforces before services connect. Concurrent transactions and additional
 installs before a required restart are rejected. Service readiness is distinct
 from installer completion. macOS keeps
-a verified previous App for **Restore previous version**; restart restores its
-matching runtime too. Goal state is neither deleted nor migrated backwards by
+a verified previous App for **Restore previous version**; the backup copy is
+signature-verified before anything is swapped, while the damaged installation
+being repaired is only located, never required to be intact — that is the
+state rollback exists to fix. Restart restores its matching runtime too. Goal state is neither deleted nor migrated backwards by
 this action, so data-schema compatibility still governs rollback suitability.
 Older backup directories are retained for manual recovery and can consume disk.
 

--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -83,8 +83,11 @@ longer requires a second App restart. Reloading the WebView cannot terminate
 the native startup supervisor.
 
 An update journal resumes an approved runtime installation after restart.
-Concurrent transactions and additional installs before a required restart are
-rejected. Service readiness is distinct from installer completion. macOS keeps
+If the app replacement itself fails, the journal is discarded instead of
+resuming, so the previously installed App and runtime keep starting normally
+and a journal naming a version that never shipped cannot wedge startup into
+the recovery panel. Concurrent transactions and additional installs before a
+required restart are rejected. Service readiness is distinct from installer completion. macOS keeps
 a verified previous App for **Restore previous version**; restart restores its
 matching runtime too. Goal state is neither deleted nor migrated backwards by
 this action, so data-schema compatibility still governs rollback suitability.

--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -83,11 +83,18 @@ longer requires a second App restart. Reloading the WebView cannot terminate
 the native startup supervisor.
 
 An update journal resumes an approved runtime installation after restart.
-If the app replacement itself fails, the journal is discarded instead of
-resuming, so the previously installed App and runtime keep starting normally
-and a journal naming a version that never shipped cannot wedge startup into
-the recovery panel. Concurrent transactions and additional installs before a
-required restart are rejected. Service readiness is distinct from installer completion. macOS keeps
+If the app replacement fails with the previous App verified still in place
+(bundle present, installed runtime still pairing with the bundled snapshot),
+the journal is discarded instead of resuming and the App keeps starting
+normally; a failure that cannot verify the previous App keeps the journal and
+surfaces the distinct `app_install_incomplete` recovery state, because the
+macOS installer moves the old App away before installing the new one and an
+error alone does not prove the original location is intact. A journal naming a
+version that never shipped is likewise discarded on resume, but that same
+start must then re-run the App/runtime pairing check the no-journal startup
+path enforces before services connect. Concurrent transactions and additional
+installs before a required restart are rejected. Service readiness is distinct
+from installer completion. macOS keeps
 a verified previous App for **Restore previous version**; restart restores its
 matching runtime too. Goal state is neither deleted nor migrated backwards by
 this action, so data-schema compatibility still governs rollback suitability.

--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -67,14 +67,37 @@ pub fn resume_pending(app: &AppHandle) -> Result<(), String> {
             .map_err(|_| "update_state_invalid")?;
     // Never install runtime code from an App other than the approved target.
     if state["version"] != app.package_info().version.to_string() {
-        return Err("app_update_incomplete".into());
+        // A journal naming a different version means the approved installation
+        // never completed: the app update failed before replacing the app, or
+        // the app was rolled back. The running app still pairs with the
+        // runtime already on disk, so discard the stale journal instead of
+        // locking the next start into the recovery panel. The no-journal
+        // startup path re-validates that pairing.
+        discard_journal_at(&path)?;
+    } else {
+        let metadata = identity(app)?;
+        if !selected_revision_matches(&metadata) {
+            install(app)?;
+        }
+        fs::remove_file(&path).map_err(|_| "update_state_unavailable")?;
     }
-    let metadata = identity(app)?;
-    if !selected_revision_matches(&metadata) {
-        install(app)?;
-    }
-    fs::remove_file(path).map_err(|_| "update_state_unavailable")?;
     Ok(())
+}
+
+/// Remove a journal that names a runtime the on-disk app never became. Used
+/// when an app update fails after the journal was recorded: keeping it would
+/// wedge the next start into the recovery panel for an update that never
+/// shipped. Returns whether a journal file existed.
+pub fn discard_journal(app: &AppHandle) -> Result<bool, String> {
+    discard_journal_at(&journal(app)?)
+}
+
+fn discard_journal_at(path: &Path) -> Result<bool, String> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(_) => Err("update_state_unavailable".into()),
+    }
 }
 
 pub fn install(app: &AppHandle) -> Result<(), String> {
@@ -289,5 +312,26 @@ mod tests {
             assert!(extract(&bytes, dir.path()).is_ok(), "{deep}");
             assert_eq!(fs::read(dir.path().join(&deep)).unwrap(), b"hello!");
         }
+    }
+    #[test]
+    fn discarding_journal_reports_existence_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = dir.path().join("desktop-update.json");
+        fs::write(&journal, "{\"version\":\"1.2.3\"}").unwrap();
+        assert_eq!(discard_journal_at(&journal), Ok(true));
+        assert!(!journal.exists());
+        assert_eq!(discard_journal_at(&journal), Ok(false));
+    }
+    #[test]
+    fn undiscardable_journal_surfaces_state_error() {
+        let dir = tempfile::tempdir().unwrap();
+        // A directory cannot be removed as a file, standing in for any
+        // filesystem-level failure to clear the journal.
+        let path = dir.path().join("occupied");
+        fs::create_dir(&path).unwrap();
+        assert_eq!(
+            discard_journal_at(&path),
+            Err("update_state_unavailable".into())
+        );
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -57,31 +57,64 @@ pub fn record_pending(app: &AppHandle, version: &str, channel: &str) -> Result<(
     Ok(())
 }
 
-pub fn resume_pending(app: &AppHandle) -> Result<(), String> {
+/// Outcome of resolving the persisted update journal against the running App.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Resume {
+    /// No journal existed; nothing was resumed.
+    Absent,
+    /// The approved journal was applied and the bundled runtime installed.
+    Applied,
+    /// A journal naming another App version was discarded. The on-disk
+    /// runtime was not touched; the caller must re-run the App/runtime
+    /// pairing gate on this same start before any service connects.
+    StaleDiscarded,
+}
+
+pub fn resume_pending(app: &AppHandle) -> Result<Resume, String> {
     let path = journal(app)?;
+    match resolve_journal(&path, &app.package_info().version.to_string())? {
+        JournalResolution::Absent => Ok(Resume::Absent),
+        JournalResolution::StaleDiscarded => Ok(Resume::StaleDiscarded),
+        JournalResolution::Approved => {
+            let metadata = identity(app)?;
+            if !selected_revision_matches(&metadata) {
+                install(app)?;
+            }
+            fs::remove_file(&path).map_err(|_| "update_state_unavailable")?;
+            Ok(Resume::Applied)
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum JournalResolution {
+    Absent,
+    Approved,
+    StaleDiscarded,
+}
+
+// Path-level journal decision shared by the release startup entrance and the
+// repair action, and directly testable without an AppHandle. Never install
+// runtime code from an App other than the approved target.
+fn resolve_journal(path: &Path, running_version: &str) -> Result<JournalResolution, String> {
     if !path.exists() {
-        return Ok(());
+        return Ok(JournalResolution::Absent);
     }
     let state: Value =
-        serde_json::from_slice(&fs::read(&path).map_err(|_| "update_state_unavailable")?)
+        serde_json::from_slice(&fs::read(path).map_err(|_| "update_state_invalid")?)
             .map_err(|_| "update_state_invalid")?;
-    // Never install runtime code from an App other than the approved target.
-    if state["version"] != app.package_info().version.to_string() {
+    if state["version"] != running_version {
         // A journal naming a different version means the approved installation
         // never completed: the app update failed before replacing the app, or
-        // the app was rolled back. The running app still pairs with the
-        // runtime already on disk, so discard the stale journal instead of
-        // locking the next start into the recovery panel. The no-journal
-        // startup path re-validates that pairing.
-        discard_journal_at(&path)?;
-    } else {
-        let metadata = identity(app)?;
-        if !selected_revision_matches(&metadata) {
-            install(app)?;
-        }
-        fs::remove_file(&path).map_err(|_| "update_state_unavailable")?;
+        // the app was rolled back. Discard the stale journal instead of
+        // locking the next start into the recovery panel -- and report it as
+        // discarded so this start itself must clear the pairing gate the
+        // no-journal entrance enforces; a deleted file alone proves nothing
+        // about the runtime that is still on disk.
+        discard_journal_at(path)?;
+        return Ok(JournalResolution::StaleDiscarded);
     }
-    Ok(())
+    Ok(JournalResolution::Approved)
 }
 
 /// Remove a journal that names a runtime the on-disk app never became. Used
@@ -332,6 +365,38 @@ mod tests {
         assert_eq!(
             discard_journal_at(&path),
             Err("update_state_unavailable".into())
+        );
+    }
+    #[test]
+    fn stale_journal_is_discarded_durably_and_reports_the_gate() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = dir.path().join("desktop-update.json");
+        fs::write(&journal, "{\"version\":\"9.9.9\",\"channel\":\"stable\"}").unwrap();
+        assert_eq!(
+            resolve_journal(&journal, "1.2.3"),
+            Ok(JournalResolution::StaleDiscarded)
+        );
+        // Independent read-back: the discard is durable before the caller
+        // gates pairing, so no later start can resume the stale journal.
+        assert!(!journal.exists());
+    }
+    #[test]
+    fn journal_naming_the_running_app_is_approved_for_install() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = dir.path().join("desktop-update.json");
+        fs::write(&journal, "{\"version\":\"1.2.3\",\"channel\":\"stable\"}").unwrap();
+        assert_eq!(
+            resolve_journal(&journal, "1.2.3"),
+            Ok(JournalResolution::Approved)
+        );
+        assert!(journal.exists(), "approved journals resume, not vanish");
+    }
+    #[test]
+    fn absent_journal_resumes_without_installing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_journal(&dir.path().join("desktop-update.json"), "1.2.3"),
+            Ok(JournalResolution::Absent)
         );
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -100,9 +100,8 @@ fn resolve_journal(path: &Path, running_version: &str) -> Result<JournalResoluti
     if !path.exists() {
         return Ok(JournalResolution::Absent);
     }
-    let state: Value =
-        serde_json::from_slice(&fs::read(path).map_err(|_| "update_state_invalid")?)
-            .map_err(|_| "update_state_invalid")?;
+    let state: Value = serde_json::from_slice(&fs::read(path).map_err(|_| "update_state_invalid")?)
+        .map_err(|_| "update_state_invalid")?;
     if state["version"] != running_version {
         // A journal naming a different version means the approved installation
         // never completed: the app update failed before replacing the app, or
@@ -125,7 +124,7 @@ pub fn discard_journal(app: &AppHandle) -> Result<bool, String> {
     discard_journal_at(&journal(app)?)
 }
 
-fn discard_journal_at(path: &Path) -> Result<bool, String> {
+pub(crate) fn discard_journal_at(path: &Path) -> Result<bool, String> {
     match fs::remove_file(path) {
         Ok(()) => Ok(true),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -347,7 +347,7 @@ async fn perform(
         );
         if may_discard_journal {
             let discarded = bundled_runtime::discard_journal(app);
-            let discarded_ok = matches!(&discarded, Ok(_) );
+            let discarded_ok = discarded.is_ok();
             state.install_journal_discarded.store(discarded_ok, Ordering::Release);
             return Err(install_failure_state(true, discarded).into());
         }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -359,16 +359,36 @@ async fn perform(
 // A safe-restart promise after a failed app replacement requires the running
 // App's bundle to still be present -- the pinned macOS updater's install_inner
 // performs rename(old App -> temporary) before rename(new App -> original), so
-// the second rename failing leaves the original location empty -- and the
-// installed runtime to still pair with this App's bundled snapshot. Reuses the
-// rollback boundary's bundle verification instead of a second layout rule.
+// the second rename failing leaves the original location empty -- its actual
+// installed target to pass the same signature/integrity verification the
+// backup boundary uses (a surviving Info.plist and executable do not prove
+// sealed resources are intact), and the installed runtime to still pair with
+// this App's bundled snapshot. A verified backup copy can never substitute for
+// verifying the current installation.
 fn failed_install_left_previous_app_usable(app: &AppHandle) -> bool {
-    crate::update_backup::app_bundle().is_ok()
-        && runtime_revisions_pair(
-            bundled_runtime::identity(app).ok().as_ref(),
-            crate::services::runtime_identity_for_executable(&crate::services::loopx_executable())
-                .as_ref(),
-        )
+    let Ok(executable) = std::env::current_exe() else {
+        return false;
+    };
+    previous_installation_is_usable(
+        &executable,
+        bundled_runtime::identity(app).ok().as_ref(),
+        crate::services::runtime_identity_for_executable(&crate::services::loopx_executable())
+            .as_ref(),
+    )
+}
+
+// Path-level safe-restart predicate shared by the release failure path and
+// tests: the actual installed target (located from the executable, never a
+// caller path) must verify layout AND codesign integrity, and the installed
+// runtime must still pair with the bundled snapshot. Unverified keeps the
+// journal and the `app_install_incomplete` recovery state.
+fn previous_installation_is_usable(
+    executable: &std::path::Path,
+    bundled: Option<&Value>,
+    installed: Option<&Value>,
+) -> bool {
+    crate::update_backup::installed_bundle_verifies(executable)
+        && runtime_revisions_pair(bundled, installed)
 }
 
 // Recovery classification for a failed app replacement: only a verified
@@ -827,6 +847,67 @@ mod tests {
         assert!(!usable);
         assert_eq!(
             install_failure_recovery(usable),
+            ("app_install_incomplete", false)
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn safe_restart_promise_requires_a_signature_verified_paired_installation() {
+        // Review round 4: drive the production safe-restart predicate
+        // (previous_installation_is_usable — the same function the failed
+        // install path calls) over a real ad-hoc signed synthetic
+        // installation. Layout-only evidence accepted a bundle whose sealed
+        // resource was deleted; the shared codesign gate must reject it, and
+        // only a signature-intact, runtime-paired installation may discard
+        // the journal and carry the "可直接重启" (safe restart) promise.
+        use crate::update_backup::signed_app_test_support as support;
+
+        let dir = tempfile::tempdir().unwrap();
+        let bundled = |revision: &str| json!({"source_revision": revision});
+
+        // Complete signed installation + pairing runtime: safe restart, the
+        // journal may be discarded.
+        let intact = support::ad_hoc_signed_synthetic_app(dir.path(), "Intact.app");
+        let usable = previous_installation_is_usable(
+            &support::synthetic_executable(&intact),
+            Some(&bundled("a")),
+            Some(&bundled("a")),
+        );
+        assert!(usable);
+        assert_eq!(install_failure_recovery(usable), ("app_install_failed", true));
+
+        // Missing sealed resource (executable + Info.plist intact): layout
+        // passes, only the signature gate rejects. The journal is retained:
+        // may_discard_journal stays false, so `perform` never reaches
+        // discard_journal and the recovery panel keeps the rollback path.
+        let sealed_missing =
+            support::ad_hoc_signed_synthetic_app(dir.path(), "SealedMissing.app");
+        std::fs::remove_file(
+            sealed_missing.join("Contents/Resources/sealed-resource.txt"),
+        )
+        .unwrap();
+        let damaged = previous_installation_is_usable(
+            &support::synthetic_executable(&sealed_missing),
+            Some(&bundled("a")),
+            Some(&bundled("a")),
+        );
+        assert!(!damaged);
+        assert_eq!(
+            install_failure_recovery(damaged),
+            ("app_install_incomplete", false)
+        );
+
+        // Identity mismatch: the installation's signature is intact but the
+        // installed runtime no longer pairs with the bundled snapshot.
+        let mismatched = previous_installation_is_usable(
+            &support::synthetic_executable(&intact),
+            Some(&bundled("a")),
+            Some(&bundled("b")),
+        );
+        assert!(!mismatched);
+        assert_eq!(
+            install_failure_recovery(mismatched),
             ("app_install_incomplete", false)
         );
     }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -286,7 +286,7 @@ async fn perform(
             // Explicit repair must reinstall even when the manifest matches:
             // missing/corrupt runtime files are not an identity mismatch.
             bundled_runtime::install(&handle)?;
-            bundled_runtime::resume_pending(&handle)
+            bundled_runtime::resume_pending(&handle).map(|_| ())
         })
         .await
         .map_err(|_| "runtime_install_failed")??;
@@ -326,23 +326,130 @@ async fn perform(
         .map_err(|_| "backup_failed")??;
     bundled_runtime::record_pending(app, &update.version, channel)?;
     let target = update.version.clone();
-    let installed = tauri::async_runtime::spawn_blocking(move || update.install(bytes))
-        .await
-        .map_err(|_| "app_install_failed")?
-        .map_err(|_| "app_install_failed");
+    // A JoinError (task panic/cancellation) is an unknown-state failure just
+    // like an install error: both must clear the same verification below, so
+    // neither returns ahead of the recovery decision.
+    let installed: Result<(), String> =
+        tauri::async_runtime::spawn_blocking(move || update.install(bytes))
+            .await
+            .map_err(|_| "app_install_failed".to_string())
+            .and_then(|result| result.map_err(|_| "app_install_failed".to_string()));
     if installed.is_err() {
-        // The journal recorded before replacement names the approved runtime
-        // whose app never shipped. The on-disk app still pairs with the
-        // runtime already installed, so discard the journal instead of
-        // wedging the next start into the recovery panel.
-        state.install_journal_discarded.store(
-            matches!(bundled_runtime::discard_journal(app), Ok(true)),
-            Ordering::Release,
+        // The pinned macOS installer renames the old App away before moving
+        // the new one in, so a failed install does not by itself prove the
+        // previously installed App is still in place. Only a verified
+        // previous App (bundle present, runtime still pairing with it) may
+        // discard the journal and promise a safe restart; anything else keeps
+        // the journal and surfaces the distinct recovery state so the
+        // verified backup remains the rollback path.
+        let (code, may_discard_journal) = install_failure_recovery(
+            failed_install_left_previous_app_usable(app),
         );
-        return Err("app_install_failed".into());
+        if may_discard_journal {
+            state.install_journal_discarded.store(
+                matches!(bundled_runtime::discard_journal(app), Ok(true) | Ok(false)),
+                Ordering::Release,
+            );
+        }
+        return Err(code.into());
     }
     *state.pending.lock().unwrap() = None;
     Ok(state.publish("restart_required", json!({"version":target})))
+}
+// A safe-restart promise after a failed app replacement requires the running
+// App's bundle to still be present -- the pinned macOS updater's install_inner
+// performs rename(old App -> temporary) before rename(new App -> original), so
+// the second rename failing leaves the original location empty -- and the
+// installed runtime to still pair with this App's bundled snapshot. Reuses the
+// rollback boundary's bundle verification instead of a second layout rule.
+fn failed_install_left_previous_app_usable(app: &AppHandle) -> bool {
+    crate::update_backup::app_bundle().is_ok()
+        && runtime_revisions_pair(
+            bundled_runtime::identity(app).ok().as_ref(),
+            crate::services::runtime_identity_for_executable(&crate::services::loopx_executable())
+                .as_ref(),
+        )
+}
+
+// Recovery classification for a failed app replacement: only a verified
+// previous App may discard the journal and carry the safe-restart promise;
+// an unverified failure keeps the journal under the distinct incomplete code
+// so the recovery panel keeps offering the verified backup rollback.
+fn install_failure_recovery(previous_app_usable: bool) -> (&'static str, bool) {
+    if previous_app_usable {
+        ("app_install_failed", true)
+    } else {
+        ("app_install_incomplete", false)
+    }
+}
+pub fn resume(app: &AppHandle) -> Result<(), String> {
+    let result = resume_runtime(app);
+    if let Err(error) = &result {
+        if error != "runtime_setup_required" {
+            app.state::<Maintenance>()
+                .publish("error", json!({"code":error}));
+        }
+    }
+    result
+}
+
+// True when the installed runtime's source_revision equals the bundled
+// snapshot's. Any missing identity counts as unpaired: fail closed.
+fn runtime_revisions_pair(bundled: Option<&Value>, installed: Option<&Value>) -> bool {
+    match (bundled, installed) {
+        (Some(bundled), Some(installed)) => {
+            bundled["source_revision"] == installed["source_revision"]
+        }
+        _ => false,
+    }
+}
+
+// Shared App/runtime pairing gate for both release startup entrances: the
+// journal-absent path and the start that just discarded a stale journal may
+// connect only when the installed runtime pairs with the bundled snapshot.
+fn require_paired_runtime(state: &Maintenance, app: &AppHandle) -> Result<(), String> {
+    let bundled = bundled_runtime::identity(app)?;
+    let installed = crate::services::runtime_identity_for_executable(
+        &crate::services::loopx_executable(),
+    );
+    if !runtime_revisions_pair(Some(&bundled), installed.as_ref()) {
+        state.publish(
+            "runtime_required",
+            json!({
+                "code":"runtime_setup_required",
+                "installed_identity_available": installed.is_some(),
+                "revision_matches": false
+            }),
+        );
+        return Err("runtime_setup_required".into());
+    }
+    Ok(())
+}
+
+// Startup decision after the journal has been resolved. The pairing gate is
+// injected so headless tests drive the exact release startup branches: a
+// discarded stale journal may connect only through the same gate the
+// no-journal entrance enforces, and a failed gate leaves services stopped.
+fn startup_after_resume(
+    state: &Maintenance,
+    resolved: Result<bundled_runtime::Resume, String>,
+    pairing_gate: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
+    match resolved {
+        Ok(bundled_runtime::Resume::Applied) | Ok(bundled_runtime::Resume::Absent) => {
+            state.publish("connecting", json!({}));
+            Ok(())
+        }
+        Ok(bundled_runtime::Resume::StaleDiscarded) => {
+            pairing_gate()?;
+            state.publish("connecting", json!({}));
+            Ok(())
+        }
+        Err(error) => {
+            state.publish("error", json!({"code":error}));
+            Err(error)
+        }
+    }
 }
 fn resume_runtime(app: &AppHandle) -> Result<(), String> {
     // Development intentionally pairs a live frontend with a developer-selected
@@ -364,7 +471,11 @@ fn resume_runtime(app: &AppHandle) -> Result<(), String> {
         )
         .map_err(|_| "update_state_invalid")?;
         if pending["version"] != app.package_info().version.to_string() {
-            return Err("app_update_incomplete".into());
+            state.publish("installing_runtime", json!({}));
+            let resolved = bundled_runtime::resume_pending(app);
+            return startup_after_resume(&state, resolved, || {
+                require_paired_runtime(&state, app)
+            });
         }
     }
     state.prepare_runtime(matches, explicit_override, Instant::now(), || {
@@ -375,12 +486,12 @@ fn resume_runtime(app: &AppHandle) -> Result<(), String> {
                 "bundled",
             )?;
         }
-        bundled_runtime::resume_pending(app)
+        bundled_runtime::resume_pending(app).map(|_| ())
     })?;
     if journal.exists() {
         // Idempotent completion after a crash between promotion and journal
         // removal: do not reinstall an already matching runtime.
-        bundled_runtime::resume_pending(app)?;
+        bundled_runtime::resume_pending(app).map(|_| ())?;
     }
     Ok(())
 }
@@ -601,5 +712,93 @@ mod tests {
         // Unrelated failures leave the flag for the install failure that owns it.
         let install = state.publish_failure("app_install_failed", "stable");
         assert_eq!(install["details"]["journal_discarded"], true);
+    }
+
+    #[test]
+    fn pairing_requires_both_identities_to_agree() {
+        let bundled = |revision: &str| json!({"source_revision": revision});
+        assert!(runtime_revisions_pair(
+            Some(&bundled("a")),
+            Some(&bundled("a"))
+        ));
+        assert!(!runtime_revisions_pair(
+            Some(&bundled("a")),
+            Some(&bundled("b"))
+        ));
+        // A missing installed runtime identity (or a missing bundle identity)
+        // is never paired: fail closed.
+        assert!(!runtime_revisions_pair(Some(&bundled("a")), None));
+        assert!(!runtime_revisions_pair(None, Some(&bundled("a"))));
+    }
+
+    #[test]
+    fn stale_journal_start_connects_only_through_the_pairing_gate() {
+        // Stale journal + paired App/runtime: the start may connect.
+        let state = Maintenance::default();
+        assert!(startup_after_resume(
+            &state,
+            Ok(bundled_runtime::Resume::StaleDiscarded),
+            || Ok(())
+        )
+        .is_ok());
+        assert_eq!(state.snapshot.lock().unwrap()["phase"], "connecting");
+
+        // Stale journal + mismatched or missing runtime identity: no
+        // connecting; the gate's runtime_required state stands (an Err from
+        // resume keeps the service startup thread on the boot-failure path,
+        // so no service starts).
+        let state = Maintenance::default();
+        assert_eq!(
+            startup_after_resume(&state, Ok(bundled_runtime::Resume::StaleDiscarded), || {
+                Err("runtime_setup_required".into())
+            }),
+            Err("runtime_setup_required".into())
+        );
+        assert_ne!(
+            state.snapshot.lock().unwrap()["phase"],
+            json!("connecting")
+        );
+    }
+
+    #[test]
+    fn applied_journals_connect_and_resume_errors_surface_without_connecting() {
+        for resolved in [Ok(bundled_runtime::Resume::Applied), Ok(bundled_runtime::Resume::Absent)]
+        {
+            let state = Maintenance::default();
+            assert_eq!(
+                startup_after_resume(&state, resolved, || panic!("gate must not rerun")),
+                Ok(())
+            );
+            assert_eq!(state.snapshot.lock().unwrap()["phase"], "connecting");
+        }
+        let state = Maintenance::default();
+        assert_eq!(
+            startup_after_resume(&state, Err("update_state_invalid".into()), || Ok(())),
+            Err("update_state_invalid".into())
+        );
+        assert_eq!(
+            state.snapshot.lock().unwrap()["phase"],
+            json!("error")
+        );
+        assert_eq!(
+            state.snapshot.lock().unwrap()["details"]["code"],
+            json!("update_state_invalid")
+        );
+    }
+
+    #[test]
+    fn only_verified_previous_apps_keep_the_safe_restart_promise() {
+        // Verified App bundle + pairing runtime: safe-restart class, journal
+        // may be discarded.
+        assert_eq!(
+            install_failure_recovery(true),
+            ("app_install_failed", true)
+        );
+        // Unknown state (second rename failed, original location emptied, or
+        // identity unavailable): keep the journal under the recovery code.
+        assert_eq!(
+            install_failure_recovery(false),
+            ("app_install_incomplete", false)
+        );
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -801,4 +801,33 @@ mod tests {
             ("app_install_incomplete", false)
         );
     }
+
+    #[test]
+    fn partially_removed_app_keeps_the_journal_as_incomplete() {
+        // Review round 3 counterexample, through the same boundary the
+        // safe-restart predicate uses: the pinned macOS updater's failed
+        // replacement leaves Info.plist (and the runtime identity) behind
+        // while the executable is gone. The layout verification
+        // failed_install_left_previous_app_usable reuses must reject this
+        // bundle, so the failure classifies as app_install_incomplete and
+        // the journal is retained for the verified-backup rollback.
+        let dir = tempfile::tempdir().unwrap();
+        let contents = dir.path().join("Partial.app/Contents");
+        std::fs::create_dir_all(contents.join("MacOS")).unwrap();
+        std::fs::write(contents.join("Info.plist"), "plist").unwrap();
+        let executable = contents.join("MacOS/loopx-control-plane");
+        std::fs::write(&executable, "binary").unwrap();
+        assert!(crate::update_backup::app_bundle_at(&executable).is_ok());
+        // The partial removal: executable deleted, Info.plist survives.
+        std::fs::remove_file(&executable).unwrap();
+        // The predicate's bundle term fails exactly as it would for the
+        // running App's deleted binary, and the recovery classification
+        // keeps the journal instead of promising a safe restart.
+        let usable = crate::update_backup::app_bundle_at(&executable).is_ok();
+        assert!(!usable);
+        assert_eq!(
+            install_failure_recovery(usable),
+            ("app_install_incomplete", false)
+        );
+    }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -342,16 +342,12 @@ async fn perform(
         // discard the journal and promise a safe restart; anything else keeps
         // the journal and surfaces the distinct recovery state so the
         // verified backup remains the rollback path.
-        let (code, may_discard_journal) = install_failure_recovery(
+        return Err(finalize_install_failure(
+            &state,
             failed_install_left_previous_app_usable(app),
-        );
-        if may_discard_journal {
-            let discarded = bundled_runtime::discard_journal(app);
-            let discarded_ok = discarded.is_ok();
-            state.install_journal_discarded.store(discarded_ok, Ordering::Release);
-            return Err(install_failure_state(true, discarded).into());
-        }
-        return Err(code.into());
+            || bundled_runtime::discard_journal(app),
+        )
+        .into());
     }
     *state.pending.lock().unwrap() = None;
     Ok(state.publish("restart_required", json!({"version":target})))
@@ -404,10 +400,10 @@ fn install_failure_recovery(previous_app_usable: bool) -> (&'static str, bool) {
 }
 
 // The final install-failure state must fold in the journal effect: a usable
-// previous App only earns the safe-restart `app_install_failed` state when the
-// stale continuation journal was actually discarded; a failed discard keeps
-// the journal (the next boot would resume the abandoned install), so the
-// journal-preserving recovery state applies instead.
+// previous App earns the safe-restart `app_install_failed` state only when the
+// stale continuation journal is absent after the effect (removed or already
+// absent). A failed discard keeps the journal, so the journal-preserving
+// recovery state applies instead.
 fn install_failure_state(
     previous_app_usable: bool,
     journal_discarded: Result<bool, String>,
@@ -421,15 +417,25 @@ fn install_failure_state(
         Err(_) => "app_install_incomplete",
     }
 }
-pub fn resume(app: &AppHandle) -> Result<(), String> {
-    let result = resume_runtime(app);
-    if let Err(error) = &result {
-        if error != "runtime_setup_required" {
-            app.state::<Maintenance>()
-                .publish("error", json!({"code":error}));
-        }
+
+// Own the complete install-failure decision at one testable boundary. The
+// public diagnostic reports whether this call removed a file; safe restart is
+// a separate invariant and also accepts an already-absent journal.
+fn finalize_install_failure(
+    state: &Maintenance,
+    previous_app_usable: bool,
+    discard_journal: impl FnOnce() -> Result<bool, String>,
+) -> &'static str {
+    let (code, may_discard_journal) = install_failure_recovery(previous_app_usable);
+    if !may_discard_journal {
+        return code;
     }
-    result
+    let journal_result = discard_journal();
+    let journal_removed = journal_result.as_ref().is_ok_and(|removed| *removed);
+    state
+        .install_journal_discarded
+        .store(journal_removed, Ordering::Release);
+    install_failure_state(previous_app_usable, journal_result)
 }
 
 // True when the installed runtime's source_revision equals the bundled
@@ -448,9 +454,8 @@ fn runtime_revisions_pair(bundled: Option<&Value>, installed: Option<&Value>) ->
 // connect only when the installed runtime pairs with the bundled snapshot.
 fn require_paired_runtime(state: &Maintenance, app: &AppHandle) -> Result<(), String> {
     let bundled = bundled_runtime::identity(app)?;
-    let installed = crate::services::runtime_identity_for_executable(
-        &crate::services::loopx_executable(),
-    );
+    let installed =
+        crate::services::runtime_identity_for_executable(&crate::services::loopx_executable());
     if !runtime_revisions_pair(Some(&bundled), installed.as_ref()) {
         state.publish(
             "runtime_required",
@@ -512,9 +517,7 @@ fn resume_runtime(app: &AppHandle) -> Result<(), String> {
         if pending["version"] != app.package_info().version.to_string() {
             state.publish("installing_runtime", json!({}));
             let resolved = bundled_runtime::resume_pending(app);
-            return startup_after_resume(&state, resolved, || {
-                require_paired_runtime(&state, app)
-            });
+            return startup_after_resume(&state, resolved, || require_paired_runtime(&state, app));
         }
     }
     state.prepare_runtime(matches, explicit_override, Instant::now(), || {
@@ -734,7 +737,9 @@ mod tests {
     #[test]
     fn install_failures_report_journal_discard_exactly_once() {
         let state = Maintenance::default();
-        state.install_journal_discarded.store(true, Ordering::Release);
+        state
+            .install_journal_discarded
+            .store(true, Ordering::Release);
         let failure = state.publish_failure("app_install_failed", "stable");
         assert_eq!(failure["details"]["journal_discarded"], true);
         // The diagnostics flag is consumed with the failure it describes.
@@ -745,7 +750,9 @@ mod tests {
     #[test]
     fn unrelated_failures_do_not_report_journal_discard() {
         let state = Maintenance::default();
-        state.install_journal_discarded.store(true, Ordering::Release);
+        state
+            .install_journal_discarded
+            .store(true, Ordering::Release);
         let failure = state.publish_failure("update_network_failed", "stable");
         assert!(failure["details"].get("journal_discarded").is_none());
         // Unrelated failures leave the flag for the install failure that owns it.
@@ -774,12 +781,12 @@ mod tests {
     fn stale_journal_start_connects_only_through_the_pairing_gate() {
         // Stale journal + paired App/runtime: the start may connect.
         let state = Maintenance::default();
-        assert!(startup_after_resume(
-            &state,
-            Ok(bundled_runtime::Resume::StaleDiscarded),
-            || Ok(())
-        )
-        .is_ok());
+        assert!(
+            startup_after_resume(&state, Ok(bundled_runtime::Resume::StaleDiscarded), || Ok(
+                ()
+            ))
+            .is_ok()
+        );
         assert_eq!(state.snapshot.lock().unwrap()["phase"], "connecting");
 
         // Stale journal + mismatched or missing runtime identity: no
@@ -793,16 +800,15 @@ mod tests {
             }),
             Err("runtime_setup_required".into())
         );
-        assert_ne!(
-            state.snapshot.lock().unwrap()["phase"],
-            json!("connecting")
-        );
+        assert_ne!(state.snapshot.lock().unwrap()["phase"], json!("connecting"));
     }
 
     #[test]
     fn applied_journals_connect_and_resume_errors_surface_without_connecting() {
-        for resolved in [Ok(bundled_runtime::Resume::Applied), Ok(bundled_runtime::Resume::Absent)]
-        {
+        for resolved in [
+            Ok(bundled_runtime::Resume::Applied),
+            Ok(bundled_runtime::Resume::Absent),
+        ] {
             let state = Maintenance::default();
             assert_eq!(
                 startup_after_resume(&state, resolved, || panic!("gate must not rerun")),
@@ -815,10 +821,7 @@ mod tests {
             startup_after_resume(&state, Err("update_state_invalid".into()), || Ok(())),
             Err("update_state_invalid".into())
         );
-        assert_eq!(
-            state.snapshot.lock().unwrap()["phase"],
-            json!("error")
-        );
+        assert_eq!(state.snapshot.lock().unwrap()["phase"], json!("error"));
         assert_eq!(
             state.snapshot.lock().unwrap()["details"]["code"],
             json!("update_state_invalid")
@@ -829,10 +832,7 @@ mod tests {
     fn only_verified_previous_apps_keep_the_safe_restart_promise() {
         // Verified App bundle + pairing runtime: safe-restart class, journal
         // may be discarded.
-        assert_eq!(
-            install_failure_recovery(true),
-            ("app_install_failed", true)
-        );
+        assert_eq!(install_failure_recovery(true), ("app_install_failed", true));
         // Unknown state (second rename failed, original location emptied, or
         // identity unavailable): keep the journal under the recovery code.
         assert_eq!(
@@ -894,18 +894,18 @@ mod tests {
             Some(&bundled("a")),
         );
         assert!(usable);
-        assert_eq!(install_failure_recovery(usable), ("app_install_failed", true));
+        assert_eq!(
+            install_failure_recovery(usable),
+            ("app_install_failed", true)
+        );
 
         // Missing sealed resource (executable + Info.plist intact): layout
         // passes, only the signature gate rejects. The journal is retained:
         // may_discard_journal stays false, so `perform` never reaches
         // discard_journal and the recovery panel keeps the rollback path.
-        let sealed_missing =
-            support::ad_hoc_signed_synthetic_app(dir.path(), "SealedMissing.app");
-        std::fs::remove_file(
-            sealed_missing.join("Contents/Resources/sealed-resource.txt"),
-        )
-        .unwrap();
+        let sealed_missing = support::ad_hoc_signed_synthetic_app(dir.path(), "SealedMissing.app");
+        std::fs::remove_file(sealed_missing.join("Contents/Resources/sealed-resource.txt"))
+            .unwrap();
         let damaged = previous_installation_is_usable(
             &support::synthetic_executable(&sealed_missing),
             Some(&bundled("a")),
@@ -934,28 +934,70 @@ mod tests {
 
 #[cfg(test)]
 mod install_failure_state_tests {
-    use super::install_failure_state;
+    use super::{finalize_install_failure, Maintenance};
 
     #[test]
-    fn usable_app_with_discarded_journal_promises_safe_restart() {
-        assert_eq!(install_failure_state(true, Ok(true)), "app_install_failed");
-        assert_eq!(install_failure_state(true, Ok(false)), "app_install_failed");
+    fn existing_journal_is_removed_before_safe_restart_is_reported() {
+        let state = Maintenance::default();
+        let dir = tempfile::tempdir().unwrap();
+        let journal = dir.path().join("desktop-update.json");
+        std::fs::write(&journal, "{\"version\":\"1.2.3\"}").unwrap();
+
+        let code = finalize_install_failure(&state, true, || {
+            crate::bundled_runtime::discard_journal_at(&journal)
+        });
+
+        assert_eq!(code, "app_install_failed");
+        assert!(!journal.exists(), "the journal must be absent on readback");
+        let failure = state.publish_failure(code, "stable");
+        assert_eq!(failure["details"]["journal_discarded"], true);
     }
 
     #[test]
-    fn usable_app_with_failed_discard_keeps_the_journal_state() {
-        assert_eq!(
-            install_failure_state(true, Err("update_state_unavailable".into())),
-            "app_install_incomplete"
+    fn already_absent_journal_is_safe_but_not_reported_as_discarded() {
+        let state = Maintenance::default();
+        let dir = tempfile::tempdir().unwrap();
+        let journal = dir.path().join("desktop-update.json");
+
+        let code = finalize_install_failure(&state, true, || {
+            crate::bundled_runtime::discard_journal_at(&journal)
+        });
+
+        assert_eq!(code, "app_install_failed");
+        assert!(!journal.exists(), "absence must remain durable");
+        let failure = state.publish_failure(code, "stable");
+        assert_eq!(failure["details"]["journal_discarded"], false);
+    }
+
+    #[test]
+    fn failed_discard_keeps_the_journal_and_incomplete_state() {
+        let state = Maintenance::default();
+        let dir = tempfile::tempdir().unwrap();
+        let journal = dir.path().join("desktop-update.json");
+        std::fs::create_dir(&journal).unwrap();
+
+        let code = finalize_install_failure(&state, true, || {
+            crate::bundled_runtime::discard_journal_at(&journal)
+        });
+
+        assert_eq!(code, "app_install_incomplete");
+        assert!(
+            journal.exists(),
+            "the failed effect must preserve the journal"
+        );
+        let failure = state.publish_failure(code, "stable");
+        assert!(
+            failure["details"].get("journal_discarded").is_none(),
+            "incomplete recovery must not claim a completed discard"
         );
     }
 
     #[test]
-    fn unusable_app_never_promises_safe_restart() {
-        assert_eq!(install_failure_state(false, Ok(true)), "app_install_incomplete");
-        assert_eq!(
-            install_failure_state(false, Err("update_state_unavailable".into())),
-            "app_install_incomplete"
-        );
+    fn unusable_app_keeps_recovery_state_without_touching_the_journal() {
+        let state = Maintenance::default();
+        let code = finalize_install_failure(&state, false, || {
+            panic!("an unusable App must not discard recovery state")
+        });
+        assert_eq!(code, "app_install_incomplete");
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -19,6 +19,7 @@ pub struct Maintenance {
     pending: Mutex<Option<(String, Update)>>,
     last_failure: Mutex<Value>,
     runtime_retry: Mutex<RuntimeRetry>,
+    install_journal_discarded: AtomicBool,
 }
 
 #[derive(Default)]
@@ -210,9 +211,23 @@ pub async fn desktop_update(
     }
     let outcome = perform(&app, &action, &channel, url).await;
     if let Err(error) = &outcome {
-        state.publish("error", json!({"code":error,"channel":channel}));
+        state.publish_failure(error, &channel);
     }
     outcome
+}
+impl Maintenance {
+    // App-install failures discard the stale continuation journal (see
+    // perform); surface that in the failure diagnostics exactly once.
+    fn publish_failure(&self, code: &str, channel: &str) -> Value {
+        let mut details = json!({"code": code, "channel": channel});
+        if code == "app_install_failed" {
+            details["journal_discarded"] = self
+                .install_journal_discarded
+                .swap(false, Ordering::AcqRel)
+                .into();
+        }
+        self.publish("error", details)
+    }
 }
 async fn perform(
     app: &AppHandle,
@@ -311,10 +326,21 @@ async fn perform(
         .map_err(|_| "backup_failed")??;
     bundled_runtime::record_pending(app, &update.version, channel)?;
     let target = update.version.clone();
-    tauri::async_runtime::spawn_blocking(move || update.install(bytes))
+    let installed = tauri::async_runtime::spawn_blocking(move || update.install(bytes))
         .await
         .map_err(|_| "app_install_failed")?
-        .map_err(|_| "app_install_failed")?;
+        .map_err(|_| "app_install_failed");
+    if installed.is_err() {
+        // The journal recorded before replacement names the approved runtime
+        // whose app never shipped. The on-disk app still pairs with the
+        // runtime already installed, so discard the journal instead of
+        // wedging the next start into the recovery panel.
+        state.install_journal_discarded.store(
+            matches!(bundled_runtime::discard_journal(app), Ok(true)),
+            Ordering::Release,
+        );
+        return Err("app_install_failed".into());
+    }
     *state.pending.lock().unwrap() = None;
     Ok(state.publish("restart_required", json!({"version":target})))
 }
@@ -553,5 +579,27 @@ mod tests {
                 .unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn install_failures_report_journal_discard_exactly_once() {
+        let state = Maintenance::default();
+        state.install_journal_discarded.store(true, Ordering::Release);
+        let failure = state.publish_failure("app_install_failed", "stable");
+        assert_eq!(failure["details"]["journal_discarded"], true);
+        // The diagnostics flag is consumed with the failure it describes.
+        let repeat = state.publish_failure("app_install_failed", "stable");
+        assert_eq!(repeat["details"]["journal_discarded"], false);
+    }
+
+    #[test]
+    fn unrelated_failures_do_not_report_journal_discard() {
+        let state = Maintenance::default();
+        state.install_journal_discarded.store(true, Ordering::Release);
+        let failure = state.publish_failure("update_network_failed", "stable");
+        assert!(failure["details"].get("journal_discarded").is_none());
+        // Unrelated failures leave the flag for the install failure that owns it.
+        let install = state.publish_failure("app_install_failed", "stable");
+        assert_eq!(install["details"]["journal_discarded"], true);
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -346,10 +346,10 @@ async fn perform(
             failed_install_left_previous_app_usable(app),
         );
         if may_discard_journal {
-            state.install_journal_discarded.store(
-                matches!(bundled_runtime::discard_journal(app), Ok(true) | Ok(false)),
-                Ordering::Release,
-            );
+            let discarded = bundled_runtime::discard_journal(app);
+            let discarded_ok = matches!(&discarded, Ok(_) );
+            state.install_journal_discarded.store(discarded_ok, Ordering::Release);
+            return Err(install_failure_state(true, discarded).into());
         }
         return Err(code.into());
     }
@@ -400,6 +400,25 @@ fn install_failure_recovery(previous_app_usable: bool) -> (&'static str, bool) {
         ("app_install_failed", true)
     } else {
         ("app_install_incomplete", false)
+    }
+}
+
+// The final install-failure state must fold in the journal effect: a usable
+// previous App only earns the safe-restart `app_install_failed` state when the
+// stale continuation journal was actually discarded; a failed discard keeps
+// the journal (the next boot would resume the abandoned install), so the
+// journal-preserving recovery state applies instead.
+fn install_failure_state(
+    previous_app_usable: bool,
+    journal_discarded: Result<bool, String>,
+) -> &'static str {
+    let (code, may_discard_journal) = install_failure_recovery(previous_app_usable);
+    if !may_discard_journal {
+        return code;
+    }
+    match journal_discarded {
+        Ok(_) => code,
+        Err(_) => "app_install_incomplete",
     }
 }
 pub fn resume(app: &AppHandle) -> Result<(), String> {
@@ -909,6 +928,34 @@ mod tests {
         assert_eq!(
             install_failure_recovery(mismatched),
             ("app_install_incomplete", false)
+        );
+    }
+}
+
+#[cfg(test)]
+mod install_failure_state_tests {
+    use super::install_failure_state;
+
+    #[test]
+    fn usable_app_with_discarded_journal_promises_safe_restart() {
+        assert_eq!(install_failure_state(true, Ok(true)), "app_install_failed");
+        assert_eq!(install_failure_state(true, Ok(false)), "app_install_failed");
+    }
+
+    #[test]
+    fn usable_app_with_failed_discard_keeps_the_journal_state() {
+        assert_eq!(
+            install_failure_state(true, Err("update_state_unavailable".into())),
+            "app_install_incomplete"
+        );
+    }
+
+    #[test]
+    fn unusable_app_never_promises_safe_restart() {
+        assert_eq!(install_failure_state(false, Ok(true)), "app_install_incomplete");
+        assert_eq!(
+            install_failure_state(false, Err("update_state_unavailable".into())),
+            "app_install_incomplete"
         );
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
@@ -14,6 +14,13 @@ pub(crate) fn app_bundle() -> Result<PathBuf, String> {
 // one in, so callers that must verify the installed App is still in place
 // (failed replacement recovery) resolve it from the running executable.
 // Path-level so synthetic App layouts are testable without a signed build.
+//
+// This is a layout-and-runnability check, not a signature check: the bundle
+// must keep its Info.plist AND its executable. A partially removed bundle —
+// executable deleted while Info.plist (and the runtime identity) survives a
+// failed replacement — must not verify, or the safe-restart predicate would
+// discard the recovery journal over an unbootable App. Signature integrity
+// stays at the `copy` boundary's `codesign --verify` check.
 pub(crate) fn app_bundle_at(executable: &Path) -> Result<PathBuf, String> {
     let bundle = executable
         .parent()
@@ -22,10 +29,41 @@ pub(crate) fn app_bundle_at(executable: &Path) -> Result<PathBuf, String> {
         .ok_or("app_bundle_required")?;
     if bundle.extension().and_then(|s| s.to_str()) != Some("app")
         || !bundle.join("Contents/Info.plist").is_file()
+        || !bundle_executable_is_present(executable, bundle)
     {
         return Err("app_bundle_required".into());
     }
     Ok(bundle.to_path_buf())
+}
+
+// The running binary keeps executing after the updater deletes it, so a
+// missing file at the executable's own path is exactly the "old bundle was
+// moved away / partially removed" state layout verification must reject.
+// When Info.plist declares CFBundleExecutable, that declared binary must
+// exist too: the bundle launches what Info.plist names, not any surviving
+// neighbor. An unreadable (e.g. binary) plist skips the declared-name check
+// without weakening the executable-presence check above.
+fn bundle_executable_is_present(executable: &Path, bundle: &Path) -> bool {
+    if !executable.is_file() {
+        return false;
+    }
+    match declared_bundle_executable(bundle) {
+        Some(declared) => {
+            !declared.is_empty()
+                && bundle.join("Contents/MacOS").join(declared).is_file()
+        }
+        None => true,
+    }
+}
+
+fn declared_bundle_executable(bundle: &Path) -> Option<String> {
+    let plist = fs::read_to_string(bundle.join("Contents/Info.plist")).ok()?;
+    let key = "<key>CFBundleExecutable</key>";
+    let rest = &plist[plist.find(key)? + key.len()..];
+    let open = rest.find("<string>")? + "<string>".len();
+    let value = &rest[open..];
+    let close = value.find("</string>")?;
+    Some(value[..close].trim().to_string())
 }
 
 fn root(app: &AppHandle) -> Result<PathBuf, String> {
@@ -174,6 +212,60 @@ mod tests {
         fs::create_dir_all(loose.parent().unwrap()).unwrap();
         fs::write(&loose, "binary").unwrap();
         assert_eq!(app_bundle_at(&loose), Err("app_bundle_required".into()));
+    }
+
+    #[test]
+    fn executable_removal_while_info_plist_remains_stops_verifying() {
+        // Review round 3 counterexample: the pinned macOS updater's failed
+        // replacement can leave a partially removed bundle — Info.plist and
+        // the runtime identity survive while the executable is gone (a
+        // running process keeps executing its deleted binary, so the path
+        // simply stops existing). Layout verification must fail here so the
+        // safe-restart predicate cannot discard the journal and promise a
+        // safe restart over an unbootable App.
+        let dir = tempfile::tempdir().unwrap();
+        let contents = dir.path().join("Partial.app/Contents");
+        fs::create_dir_all(contents.join("MacOS")).unwrap();
+        fs::write(contents.join("Info.plist"), "plist").unwrap();
+        let executable = contents.join("MacOS/loopx-control-plane");
+        fs::write(&executable, "binary").unwrap();
+        assert!(app_bundle_at(&executable).is_ok());
+        fs::remove_file(&executable).unwrap();
+        assert_eq!(
+            app_bundle_at(&executable),
+            Err("app_bundle_required".into())
+        );
+    }
+
+    #[test]
+    fn declared_bundle_executable_must_be_present_when_plist_names_it() {
+        // When Info.plist declares CFBundleExecutable, that exact binary
+        // must exist in Contents/MacOS: a bundle whose declared executable
+        // was removed — even with another file left behind — cannot run the
+        // binary the bundle claims to launch.
+        let dir = tempfile::tempdir().unwrap();
+        let contents = dir.path().join("Declared.app/Contents");
+        fs::create_dir_all(contents.join("MacOS")).unwrap();
+        fs::write(
+            contents.join("Info.plist"),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <plist version=\"1.0\"><dict>\
+             <key>CFBundleExecutable</key><string>loopx-control-plane</string>\
+             </dict></plist>",
+        )
+        .unwrap();
+        let survivor = contents.join("MacOS/unrelated-helper");
+        fs::write(&survivor, "binary").unwrap();
+        assert_eq!(
+            app_bundle_at(&survivor),
+            Err("app_bundle_required".into())
+        );
+        // With the declared executable restored beside the survivor the
+        // bundle is a runnable layout again.
+        let declared = contents.join("MacOS/loopx-control-plane");
+        fs::write(&declared, "binary").unwrap();
+        assert!(app_bundle_at(&survivor).is_ok());
+        assert!(app_bundle_at(&declared).is_ok());
     }
 
     #[test]

--- a/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
@@ -10,6 +10,28 @@ pub(crate) fn app_bundle() -> Result<PathBuf, String> {
     app_bundle_at(&std::env::current_exe().map_err(|_| "app_bundle_required")?)
 }
 
+// Locate the trusted install target for the running executable: the nearest
+// `.app` ancestor directory. This is the target boundary rollback swaps into,
+// derived from the running executable the same way `app_bundle` derives the
+// verified bundle — never from a caller-supplied path.
+//
+// Boundary only: it must NOT require the installed App to be intact. Rollback
+// exists precisely to repair a damaged installation (missing executable,
+// missing sealed resource), so requiring the broken target to pass integrity
+// checks here would make the recovery button unable to fix the state it is
+// offered for.
+pub(crate) fn installed_bundle_at(executable: &Path) -> Result<PathBuf, String> {
+    let bundle = executable
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+        .ok_or("app_bundle_required")?;
+    if bundle.extension().and_then(|s| s.to_str()) != Some("app") {
+        return Err("app_bundle_required".into());
+    }
+    Ok(bundle.to_path_buf())
+}
+
 // The pinned macOS updater moves the old App bundle away before moving the new
 // one in, so callers that must verify the installed App is still in place
 // (failed replacement recovery) resolve it from the running executable.
@@ -19,21 +41,50 @@ pub(crate) fn app_bundle() -> Result<PathBuf, String> {
 // must keep its Info.plist AND its executable. A partially removed bundle —
 // executable deleted while Info.plist (and the runtime identity) survives a
 // failed replacement — must not verify, or the safe-restart predicate would
-// discard the recovery journal over an unbootable App. Signature integrity
-// stays at the `copy` boundary's `codesign --verify` check.
+// discard the recovery journal over an unbootable App. Signature integrity is
+// layered on top by `installed_bundle_verifies`, which shares the exact
+// `codesign --verify` check the backup `copy` boundary uses.
 pub(crate) fn app_bundle_at(executable: &Path) -> Result<PathBuf, String> {
-    let bundle = executable
-        .parent()
-        .and_then(Path::parent)
-        .and_then(Path::parent)
-        .ok_or("app_bundle_required")?;
-    if bundle.extension().and_then(|s| s.to_str()) != Some("app")
-        || !bundle.join("Contents/Info.plist").is_file()
-        || !bundle_executable_is_present(executable, bundle)
+    let bundle = installed_bundle_at(executable)?;
+    if !bundle.join("Contents/Info.plist").is_file()
+        || !bundle_executable_is_present(executable, &bundle)
     {
         return Err("app_bundle_required".into());
     }
-    Ok(bundle.to_path_buf())
+    Ok(bundle)
+}
+
+// Actual-installed-target integrity for the safe-restart predicate: layout
+// verification is necessary but not sufficient — a bundle whose Info.plist and
+// executable survive while a sealed resource was deleted still passes the
+// layout check, yet `codesign --verify --deep --strict` rejects it. This is
+// the same signature verification `copy` applies to a fresh backup, applied to
+// the installed App itself; a previous backup copy's verification can never
+// substitute for verifying the current installation.
+pub(crate) fn installed_bundle_verifies(executable: &Path) -> bool {
+    app_bundle_at(executable)
+        .map(|bundle| signature_verifies(&bundle))
+        .unwrap_or(false)
+}
+
+// Shared signature/integrity gate for both bundle consumers: the verified
+// backup `copy` writes, and the safe-restart predicate's verification of the
+// actually installed App.
+fn signature_verifies(bundle: &Path) -> bool {
+    Command::new("codesign")
+        .args(["--verify", "--deep", "--strict"])
+        .arg(bundle)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+pub(crate) fn signature_verifies_for_test(bundle: &Path) -> bool {
+    signature_verifies(bundle)
 }
 
 // The running binary keeps executing after the updater deletes it, so a
@@ -85,15 +136,7 @@ fn copy(source: &Path, destination: &Path) -> Result<(), String> {
     if !status.success() {
         return Err("backup_failed".into());
     }
-    let verified = Command::new("codesign")
-        .args(["--verify", "--deep", "--strict"])
-        .arg(destination)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map_err(|_| "backup_failed")?;
-    if !verified.success() {
+    if !signature_verifies(destination) {
         return Err("backup_failed".into());
     }
     Ok(())
@@ -139,19 +182,46 @@ pub fn restore(app: &AppHandle) -> Result<(), String> {
     if !available(app) {
         return Err("backup_unavailable".into());
     }
-    let bundle = app_bundle()?;
-    let staging = tempfile::tempdir_in(bundle.parent().ok_or("app_bundle_required")?)
+    // The trusted target boundary comes from the running executable — the
+    // same derivation the seam performs — never from a caller path. The
+    // damaged installed App is exactly what rollback repairs, so locating it
+    // must not require it to be intact; the verified backup source is what
+    // must pass verification (`copy` re-checks its codesign signature).
+    let executable = std::env::current_exe().map_err(|_| "app_bundle_required")?;
+    let previous = root(app)?.join("previous");
+    let version = fs::read_to_string(previous.join("version"))
+        .map_err(|_| "backup_unavailable")?;
+    let handle = app.clone();
+    restore_verified_backup(&executable, &previous, move || {
+        crate::bundled_runtime::record_pending(&handle, version.trim(), "rollback")
+    })
+}
+
+// The restore seam, entered from the running executable exactly like the
+// production `restore` so the locator decision itself is under test: locate
+// the trusted install target boundary (never requiring the damaged target to
+// be intact), copy the verified backup beside it, let the caller record its
+// continuation journal (`before_swap`), then swap. The backup source is
+// verified through `copy`'s shared signature gate before anything is swapped.
+pub(crate) fn restore_verified_backup(
+    executable: &Path,
+    previous: &Path,
+    before_swap: impl FnOnce() -> Result<(), String>,
+) -> Result<(), String> {
+    if !previous.join("LoopX.app/Contents/Info.plist").is_file() {
+        return Err("backup_unavailable".into());
+    }
+    let target = installed_bundle_at(executable)?;
+    let staging = tempfile::tempdir_in(target.parent().ok_or("app_bundle_required")?)
         .map_err(|_| "rollback_failed")?;
     let candidate = staging.path().join("LoopX.app");
-    copy(&root(app)?.join("previous/LoopX.app"), &candidate)?;
+    copy(&previous.join("LoopX.app"), &candidate)?;
     let failed = staging.path().join("failed.app");
-    let version = fs::read_to_string(root(app)?.join("previous/version"))
-        .map_err(|_| "backup_unavailable")?;
     // Once an installed App can move here, never let TempDir cleanup erase it
     // on a failed second rename (including a failed restoration rename).
     let _preserved = staging.keep();
-    crate::bundled_runtime::record_pending(app, version.trim(), "rollback")?;
-    replace_bundle(&bundle, &candidate, &failed)?;
+    before_swap()?;
+    replace_bundle(&target, &candidate, &failed)?;
     // Keep the failed App recoverable too. Never delete a user's installed App.
     Ok(())
 }
@@ -165,9 +235,64 @@ fn replace_bundle(bundle: &Path, candidate: &Path, failed: &Path) -> Result<(), 
     Ok(())
 }
 
+// Test-only synthetic App factory shared by the backup and maintenance test
+// modules: builds a real ad-hoc-signed bundle so the shared
+// `codesign --verify --deep --strict` gate is exercised exactly as it is on
+// the installed App.
+#[cfg(all(test, target_os = "macos"))]
+pub(crate) mod signed_app_test_support {
+    use std::{
+        fs, path::{Path, PathBuf},
+        process::{Command, Stdio},
+    };
+
+    // A real Mach-O executable (copied from the system shell), a declaring
+    // Info.plist, and one sealed resource, signed with `codesign --sign -`:
+    // deleting any sealed content must fail verification exactly as it would
+    // for the installed App.
+    pub(crate) fn ad_hoc_signed_synthetic_app(dir: &Path, name: &str) -> PathBuf {
+        let app = dir.join(name);
+        fs::create_dir_all(app.join("Contents/MacOS")).unwrap();
+        fs::create_dir_all(app.join("Contents/Resources")).unwrap();
+        fs::copy("/bin/sh", app.join("Contents/MacOS/loopx-control-plane")).unwrap();
+        fs::write(
+            app.join("Contents/Info.plist"),
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+             <plist version=\"1.0\"><dict>\
+             <key>CFBundleIdentifier</key><string>com.loopx.test.synthetic</string>\
+             <key>CFBundleExecutable</key><string>loopx-control-plane</string>\
+             </dict></plist>",
+        )
+        .unwrap();
+        fs::write(app.join("Contents/Resources/sealed-resource.txt"), "sealed").unwrap();
+        let signed = Command::new("codesign")
+            .args(["--sign", "-", "--force"])
+            .arg(&app)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap();
+        assert!(signed.success(), "ad-hoc codesign must succeed on the synthetic App");
+        assert!(
+            crate::update_backup::signature_verifies_for_test(&app),
+            "the freshly signed synthetic App must verify before damage is applied"
+        );
+        app
+    }
+
+    pub(crate) fn synthetic_executable(app: &Path) -> PathBuf {
+        app.join("Contents/MacOS/loopx-control-plane")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "macos")]
+    use super::signed_app_test_support::{
+        ad_hoc_signed_synthetic_app, synthetic_executable,
+    };
 
     #[test]
     fn failed_replacement_restores_original() {
@@ -278,5 +403,183 @@ mod tests {
         assert!(copied
             .join("Contents/Resources/runtime/identity.json")
             .is_file());
+    }
+
+    #[test]
+    fn locating_the_rollback_target_boundary_does_not_require_an_intact_bundle() {
+        // Rollback exists to repair a damaged installation, so target
+        // location must stay boundary-only: the nearest `.app` ancestor.
+        // Every state the safe-restart verification rejects below must still
+        // be locatable here, or the recovery button could not reach it.
+        let dir = tempfile::tempdir().unwrap();
+        let contents = dir.path().join("Damaged.app/Contents");
+        fs::create_dir_all(contents.join("MacOS")).unwrap();
+        fs::write(contents.join("Info.plist"), "plist").unwrap();
+        let executable = contents.join("MacOS/loopx-control-plane");
+        fs::write(&executable, "binary").unwrap();
+        assert!(installed_bundle_at(&executable).is_ok());
+        // Executable deleted, Info.plist survives: not intact, still locatable.
+        fs::remove_file(&executable).unwrap();
+        assert!(installed_bundle_at(&executable).is_ok());
+        assert_eq!(
+            app_bundle_at(&executable),
+            Err("app_bundle_required".into())
+        );
+        // Bundle moved away entirely: no `.app` ancestor, no boundary.
+        let loose = dir.path().join("bin/loopx-control-plane");
+        fs::create_dir_all(loose.parent().unwrap()).unwrap();
+        fs::write(&loose, "binary").unwrap();
+        assert_eq!(
+            installed_bundle_at(&loose),
+            Err("app_bundle_required".into())
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn installed_target_integrity_rejects_every_damage_mode() {
+        // Review round 4 counterexample: a bundle that keeps Info.plist and
+        // its executable while one sealed resource was deleted still passes
+        // the layout check, yet codesign --verify --deep --strict rejects it.
+        // The safe-restart evidence must run the shared signature gate on the
+        // actual installed target, not just the layout rules.
+        let dir = tempfile::tempdir().unwrap();
+
+        // Complete signed App: verifies.
+        let complete = ad_hoc_signed_synthetic_app(dir.path(), "Complete.app");
+        assert!(installed_bundle_verifies(&synthetic_executable(&complete)));
+
+        // Missing executable: layout alone rejects.
+        let no_binary = ad_hoc_signed_synthetic_app(dir.path(), "NoBinary.app");
+        fs::remove_file(synthetic_executable(&no_binary)).unwrap();
+        assert!(!installed_bundle_verifies(&synthetic_executable(&no_binary)));
+
+        // Missing sealed resource with executable and plist intact: layout
+        // still passes, only the shared signature gate rejects it.
+        let sealed_missing =
+            ad_hoc_signed_synthetic_app(dir.path(), "SealedMissing.app");
+        assert!(app_bundle_at(&synthetic_executable(&sealed_missing)).is_ok());
+        fs::remove_file(sealed_missing.join("Contents/Resources/sealed-resource.txt"))
+            .unwrap();
+        assert!(app_bundle_at(&synthetic_executable(&sealed_missing)).is_ok());
+        assert!(!installed_bundle_verifies(&synthetic_executable(&sealed_missing)));
+
+        // Unparseable (replaced, binary) Info.plist: layout's plist read
+        // degrades, the signature gate rejects the mutated bundle.
+        let plist_mutated =
+            ad_hoc_signed_synthetic_app(dir.path(), "PlistMutated.app");
+        fs::write(plist_mutated.join("Contents/Info.plist"), [0u8, 1, 2, 3]).unwrap();
+        assert!(!installed_bundle_verifies(&synthetic_executable(&plist_mutated)));
+
+        // Unsigned bundle (the pre-signing synthetic layouts): signature
+        // verification fails closed even though the layout is complete.
+        let unsigned_contents = dir.path().join("Unsigned.app/Contents");
+        fs::create_dir_all(unsigned_contents.join("MacOS")).unwrap();
+        fs::write(unsigned_contents.join("Info.plist"), "plist").unwrap();
+        let unsigned_exe = unsigned_contents.join("MacOS/loopx-control-plane");
+        fs::write(&unsigned_exe, "binary").unwrap();
+        assert!(app_bundle_at(&unsigned_exe).is_ok());
+        assert!(!installed_bundle_verifies(&unsigned_exe));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn restore_verified_backup_repairs_damaged_targets_but_not_a_moved_target() {
+        // The actual recovery seam: a verified (ad-hoc signed) backup must be
+        // able to replace a damaged installation — the exact state the
+        // recovery panel offers rollback for — while a target that was moved
+        // away entirely fails closed without deleting the backup.
+        let dir = tempfile::tempdir().unwrap();
+        let previous = dir.path().join("previous");
+        fs::create_dir_all(&previous).unwrap();
+        let backup_app = ad_hoc_signed_synthetic_app(dir.path(), "Backup.app");
+        fs::rename(&backup_app, previous.join("LoopX.app")).unwrap();
+
+        // Damaged target A: executable deleted, Info.plist survives (this
+        // round's restore counterexample — rollback must still repair it).
+        // The seam enters from the running executable exactly like the
+        // production restore, so the locator decision is under test: a
+        // layout-verifying locator would reject this target up front.
+        let target_a = ad_hoc_signed_synthetic_app(dir.path(), "Damaged.app");
+        fs::remove_file(synthetic_executable(&target_a)).unwrap();
+        assert_eq!(
+            app_bundle_at(&synthetic_executable(&target_a)),
+            Err("app_bundle_required".into())
+        );
+        assert!(restore_verified_backup(&synthetic_executable(&target_a), &previous, || Ok(())).is_ok());
+        assert!(target_a.join("Contents/Resources/sealed-resource.txt").is_file());
+        assert!(installed_bundle_verifies(&synthetic_executable(&target_a)));
+
+        // Damaged target B: a sealed resource deleted; rollback repairs it too.
+        let target_b = ad_hoc_signed_synthetic_app(dir.path(), "SealedDamaged.app");
+        fs::remove_file(target_b.join("Contents/Resources/sealed-resource.txt")).unwrap();
+        assert!(!installed_bundle_verifies(&synthetic_executable(&target_b)));
+        assert!(restore_verified_backup(&synthetic_executable(&target_b), &previous, || Ok(())).is_ok());
+        assert!(installed_bundle_verifies(&synthetic_executable(&target_b)));
+
+        // Moved-away target: the boundary is derived from the executable's
+        // path (the updater moved the bundle away; the running process keeps
+        // its old path), so location succeeds but the swap's first rename
+        // finds nothing there. The seam fails closed without deleting the
+        // verified backup, which stays in place for manual recovery.
+        let target_c = ad_hoc_signed_synthetic_app(dir.path(), "MovedAway.app");
+        fs::remove_dir_all(&target_c).unwrap();
+        assert_eq!(
+            restore_verified_backup(&synthetic_executable(&target_c), &previous, || Ok(())),
+            Err("rollback_failed".into())
+        );
+        assert!(previous.join("LoopX.app/Contents/Info.plist").is_file());
+
+        // Corrupted backup source: copy's signature gate rejects it before
+        // any swap, so a damaged backup can never replace an installation.
+        let target_d = ad_hoc_signed_synthetic_app(dir.path(), "Intact.app");
+        fs::write(
+            previous.join("LoopX.app/Contents/Resources/sealed-resource.txt"),
+            "tampered",
+        )
+        .unwrap();
+        assert_eq!(
+            restore_verified_backup(&synthetic_executable(&target_d), &previous, || Ok(())),
+            Err("backup_failed".into())
+        );
+        assert!(installed_bundle_verifies(&synthetic_executable(&target_d)));
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn restore_verified_backup_rolls_back_when_the_second_rename_fails() {
+        // Between the verified copy and the swap, the candidate can vanish
+        // (disk pressure, cleanup race): the first rename must be rolled
+        // back so the installed App is never left missing, and the preserved
+        // failed copy keeps the original recoverable.
+        let dir = tempfile::tempdir().unwrap();
+        let previous = dir.path().join("previous");
+        fs::create_dir_all(&previous).unwrap();
+        let backup_app = ad_hoc_signed_synthetic_app(dir.path(), "Backup.app");
+        fs::rename(&backup_app, previous.join("LoopX.app")).unwrap();
+        let target = ad_hoc_signed_synthetic_app(dir.path(), "Rollback.app");
+        let executable = synthetic_executable(&target);
+        let staging_root = target.parent().unwrap().to_path_buf();
+        let result = restore_verified_backup(&executable, &previous, || {
+            // Simulate the second rename failing: the verified candidate
+            // disappears from its staging directory before replace_bundle.
+            let candidate = fs::read_dir(&staging_root)
+                .into_iter()
+                .flatten()
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.path())
+                .find(|path| {
+                    path.file_name()
+                        .is_some_and(|name| name.to_string_lossy().starts_with(".tmp"))
+                        && path.join("LoopX.app").is_dir()
+                })
+                .expect("staged candidate must exist before the swap")
+                .join("LoopX.app");
+            fs::remove_dir_all(&candidate).unwrap();
+            Ok(())
+        });
+        assert_eq!(result, Err("rollback_failed".into()));
+        // The target itself survived the failed swap, still intact.
+        assert!(installed_bundle_verifies(&executable));
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
@@ -6,8 +6,15 @@ use std::{
 };
 use tauri::{AppHandle, Manager};
 
-fn app_bundle() -> Result<PathBuf, String> {
-    let executable = std::env::current_exe().map_err(|_| "app_bundle_required")?;
+pub(crate) fn app_bundle() -> Result<PathBuf, String> {
+    app_bundle_at(&std::env::current_exe().map_err(|_| "app_bundle_required")?)
+}
+
+// The pinned macOS updater moves the old App bundle away before moving the new
+// one in, so callers that must verify the installed App is still in place
+// (failed replacement recovery) resolve it from the running executable.
+// Path-level so synthetic App layouts are testable without a signed build.
+pub(crate) fn app_bundle_at(executable: &Path) -> Result<PathBuf, String> {
     let bundle = executable
         .parent()
         .and_then(Path::parent)
@@ -137,6 +144,36 @@ mod tests {
         )
         .is_err());
         assert_eq!(fs::read_to_string(app.join("original")).unwrap(), "keep");
+    }
+
+    #[test]
+    fn synthetic_app_layout_verifies_only_when_the_bundle_survives() {
+        // A synthetic App layout stands in for the second-rename failure of
+        // the pinned macOS installer: when the original location is emptied,
+        // the running executable's ancestor bundle must stop verifying, which
+        // is what blocks the safe-restart promise after a failed replacement.
+        let dir = tempfile::tempdir().unwrap();
+        let app = dir.path().join("Synthetic.app/Contents/MacOS");
+        fs::create_dir_all(&app).unwrap();
+        let executable = app.join("loopx-control-plane");
+        fs::write(&executable, "binary").unwrap();
+        fs::write(app.join("../Info.plist"), "plist").unwrap();
+        assert_eq!(
+            app_bundle_at(&executable),
+            Ok(dir.path().join("Synthetic.app"))
+        );
+        // The updater's first rename moved the original away: no bundle with
+        // an Info.plist remains at the executable's ancestors.
+        fs::remove_file(app.join("../Info.plist")).unwrap();
+        assert_eq!(
+            app_bundle_at(&executable),
+            Err("app_bundle_required".into())
+        );
+        // A bare executable outside any .app bundle never verifies.
+        let loose = dir.path().join("bin/loopx-control-plane");
+        fs::create_dir_all(loose.parent().unwrap()).unwrap();
+        fs::write(&loose, "binary").unwrap();
+        assert_eq!(app_bundle_at(&loose), Err("app_bundle_required".into()));
     }
 
     #[test]

--- a/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/update_backup.rs
@@ -100,8 +100,7 @@ fn bundle_executable_is_present(executable: &Path, bundle: &Path) -> bool {
     }
     match declared_bundle_executable(bundle) {
         Some(declared) => {
-            !declared.is_empty()
-                && bundle.join("Contents/MacOS").join(declared).is_file()
+            !declared.is_empty() && bundle.join("Contents/MacOS").join(declared).is_file()
         }
         None => true,
     }
@@ -189,8 +188,7 @@ pub fn restore(app: &AppHandle) -> Result<(), String> {
     // must pass verification (`copy` re-checks its codesign signature).
     let executable = std::env::current_exe().map_err(|_| "app_bundle_required")?;
     let previous = root(app)?.join("previous");
-    let version = fs::read_to_string(previous.join("version"))
-        .map_err(|_| "backup_unavailable")?;
+    let version = fs::read_to_string(previous.join("version")).map_err(|_| "backup_unavailable")?;
     let handle = app.clone();
     restore_verified_backup(&executable, &previous, move || {
         crate::bundled_runtime::record_pending(&handle, version.trim(), "rollback")
@@ -242,7 +240,8 @@ fn replace_bundle(bundle: &Path, candidate: &Path, failed: &Path) -> Result<(), 
 #[cfg(all(test, target_os = "macos"))]
 pub(crate) mod signed_app_test_support {
     use std::{
-        fs, path::{Path, PathBuf},
+        fs,
+        path::{Path, PathBuf},
         process::{Command, Stdio},
     };
 
@@ -273,7 +272,10 @@ pub(crate) mod signed_app_test_support {
             .stderr(Stdio::null())
             .status()
             .unwrap();
-        assert!(signed.success(), "ad-hoc codesign must succeed on the synthetic App");
+        assert!(
+            signed.success(),
+            "ad-hoc codesign must succeed on the synthetic App"
+        );
         assert!(
             crate::update_backup::signature_verifies_for_test(&app),
             "the freshly signed synthetic App must verify before damage is applied"
@@ -288,11 +290,9 @@ pub(crate) mod signed_app_test_support {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     #[cfg(target_os = "macos")]
-    use super::signed_app_test_support::{
-        ad_hoc_signed_synthetic_app, synthetic_executable,
-    };
+    use super::signed_app_test_support::{ad_hoc_signed_synthetic_app, synthetic_executable};
+    use super::*;
 
     #[test]
     fn failed_replacement_restores_original() {
@@ -381,10 +381,7 @@ mod tests {
         .unwrap();
         let survivor = contents.join("MacOS/unrelated-helper");
         fs::write(&survivor, "binary").unwrap();
-        assert_eq!(
-            app_bundle_at(&survivor),
-            Err("app_bundle_required".into())
-        );
+        assert_eq!(app_bundle_at(&survivor), Err("app_bundle_required".into()));
         // With the declared executable restored beside the survivor the
         // bundle is a runnable layout again.
         let declared = contents.join("MacOS/loopx-control-plane");
@@ -452,24 +449,27 @@ mod tests {
         // Missing executable: layout alone rejects.
         let no_binary = ad_hoc_signed_synthetic_app(dir.path(), "NoBinary.app");
         fs::remove_file(synthetic_executable(&no_binary)).unwrap();
-        assert!(!installed_bundle_verifies(&synthetic_executable(&no_binary)));
+        assert!(!installed_bundle_verifies(&synthetic_executable(
+            &no_binary
+        )));
 
         // Missing sealed resource with executable and plist intact: layout
         // still passes, only the shared signature gate rejects it.
-        let sealed_missing =
-            ad_hoc_signed_synthetic_app(dir.path(), "SealedMissing.app");
+        let sealed_missing = ad_hoc_signed_synthetic_app(dir.path(), "SealedMissing.app");
         assert!(app_bundle_at(&synthetic_executable(&sealed_missing)).is_ok());
-        fs::remove_file(sealed_missing.join("Contents/Resources/sealed-resource.txt"))
-            .unwrap();
+        fs::remove_file(sealed_missing.join("Contents/Resources/sealed-resource.txt")).unwrap();
         assert!(app_bundle_at(&synthetic_executable(&sealed_missing)).is_ok());
-        assert!(!installed_bundle_verifies(&synthetic_executable(&sealed_missing)));
+        assert!(!installed_bundle_verifies(&synthetic_executable(
+            &sealed_missing
+        )));
 
         // Unparseable (replaced, binary) Info.plist: layout's plist read
         // degrades, the signature gate rejects the mutated bundle.
-        let plist_mutated =
-            ad_hoc_signed_synthetic_app(dir.path(), "PlistMutated.app");
+        let plist_mutated = ad_hoc_signed_synthetic_app(dir.path(), "PlistMutated.app");
         fs::write(plist_mutated.join("Contents/Info.plist"), [0u8, 1, 2, 3]).unwrap();
-        assert!(!installed_bundle_verifies(&synthetic_executable(&plist_mutated)));
+        assert!(!installed_bundle_verifies(&synthetic_executable(
+            &plist_mutated
+        )));
 
         // Unsigned bundle (the pre-signing synthetic layouts): signature
         // verification fails closed even though the layout is complete.
@@ -506,15 +506,21 @@ mod tests {
             app_bundle_at(&synthetic_executable(&target_a)),
             Err("app_bundle_required".into())
         );
-        assert!(restore_verified_backup(&synthetic_executable(&target_a), &previous, || Ok(())).is_ok());
-        assert!(target_a.join("Contents/Resources/sealed-resource.txt").is_file());
+        assert!(
+            restore_verified_backup(&synthetic_executable(&target_a), &previous, || Ok(())).is_ok()
+        );
+        assert!(target_a
+            .join("Contents/Resources/sealed-resource.txt")
+            .is_file());
         assert!(installed_bundle_verifies(&synthetic_executable(&target_a)));
 
         // Damaged target B: a sealed resource deleted; rollback repairs it too.
         let target_b = ad_hoc_signed_synthetic_app(dir.path(), "SealedDamaged.app");
         fs::remove_file(target_b.join("Contents/Resources/sealed-resource.txt")).unwrap();
         assert!(!installed_bundle_verifies(&synthetic_executable(&target_b)));
-        assert!(restore_verified_backup(&synthetic_executable(&target_b), &previous, || Ok(())).is_ok());
+        assert!(
+            restore_verified_backup(&synthetic_executable(&target_b), &previous, || Ok(())).is_ok()
+        );
         assert!(installed_bundle_verifies(&synthetic_executable(&target_b)));
 
         // Moved-away target: the boundary is derived from the executable's

--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -54,6 +54,8 @@ const errors = {
   update_check_timeout: "检查更新超时。请稍后重试。",
   update_network_failed: "无法连接更新服务器。请检查网络后重试。",
   update_download_or_signature_failed: "更新包下载或签名校验失败，尚未安装。请重新检查更新。",
+  app_install_failed: "App 安装未能完成，本次更新未生效。可直接重启继续使用当前版本，或重新检查更新后再试。",
+  backup_failed: "无法备份当前版本，更新已停止。请检查磁盘空间后重试。",
 };
 function render(state) {
   if (!state?.phase) return;

--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -54,7 +54,8 @@ const errors = {
   update_check_timeout: "检查更新超时。请稍后重试。",
   update_network_failed: "无法连接更新服务器。请检查网络后重试。",
   update_download_or_signature_failed: "更新包下载或签名校验失败，尚未安装。请重新检查更新。",
-  app_install_failed: "App 安装未能完成，本次更新未生效。可直接重启继续使用当前版本，或重新检查更新后再试。",
+  app_install_failed: "App 安装未能完成，本次更新未生效；已确认当前版本完好且与运行时匹配，可直接重启继续使用，或重新检查更新后再试。",
+  app_install_incomplete: "App 安装中断，且无法确认当前版本是否完整，请勿直接重启。请在恢复与更新面板还原上一版本（或重新安装）后再试。",
   backup_failed: "无法备份当前版本，更新已停止。请检查磁盘空间后重试。",
 };
 function render(state) {


### PR DESCRIPTION
## Summary

An update journal is recorded before the app replacement so a restart can install the matching runtime. When the replacement itself fails, the journal keeps naming a version that never shipped while the on-disk app still pairs with the runtime already installed, so the next start wedges into the recovery panel with `app_update_incomplete` even though the previous app is fully usable.

This change discards the journal when `update.install` fails (surfacing `journal_discarded` in the failure diagnostics exactly once), and self-heals the same stale-journal shape on resume: `resume_pending` discards a journal naming a different app version instead of failing startup, which also covers journals left behind by a rolled-back app. The recovery screen copy gains the `app_install_failed` and `backup_failed` categories.

## Issue

Follow-up hardening from a post-merge review of the signed desktop update flow (#3994, #4004). No open issue yet — happy to file one if preferred.

## Validation

- `python3 scripts/desktop_runtime_bundle.py` succeeds on this revision.
- `cargo test --locked` in `apps/desktop/loopx-control-plane/src-tauri`: 29 passed, 0 failed (2 pre-existing ignored).
- `cargo clippy --all-targets --locked -- -D warnings`: clean.
- New unit tests: install failures report the journal discard exactly once and unrelated failures do not; journal discard reports existence and is idempotent; an undiscardable journal surfaces `update_state_unavailable`.
- `python3 -m unittest discover -s tests/desktop -p 'test_*.py'`: 9 passed.
- Manual end-to-end fault injection (corrupted update artifact) is not possible from a fork PR without the signing secret; the unit tests cover the discard semantics and the resume branch is exercised by the stale-journal test.

## Type

- [x] fix

## Area

- [x] desktop

## Direction

- [x] follow-up (post-merge review finding)

## Boundary

Only the desktop updater path changes (maintenance transaction, bundled-runtime journal, recovery copy, README journal semantics). No changes to the update feed, signing, backup retention, or service supervision.
