### PR TITLE
fix(desktop): qualify runtime bundle entry types at build time

### DIFF
--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -246,4 +246,30 @@ mod tests {
         assert!(extract(&bytes, dir.path()).is_err());
         assert!(!dir.path().join("escape").exists());
     }
+    #[test]
+    fn long_path_metadata_headers_install_as_plain_files() {
+        // `git archive` emits a PAX local header ('x') for paths beyond ustar
+        // capacity; GNU writers emit longname records ('L') instead. This
+        // non-raw iterator folds both into the entry that follows, so such
+        // snapshots are exactly what the App installs: this test is the
+        // extractor half of the acceptance matrix the build-side gate in
+        // scripts/desktop_runtime_bundle.py mirrors. An ustar header makes
+        // the builder fall back to a PAX record; a GNU header to longname.
+        use flate2::{write::GzEncoder, Compression};
+        for new_header in [tar::Header::new_ustar, tar::Header::new_gnu] {
+            let deep = format!("docs/{}long-path.md", "very/deep/".repeat(16));
+            let compressed = GzEncoder::new(Vec::new(), Compression::default());
+            let mut archive = tar::Builder::new(compressed);
+            let mut header = new_header();
+            header.set_size(6);
+            header.set_mode(0o644);
+            archive
+                .append_data(&mut header, &deep, &b"hello!"[..])
+                .unwrap();
+            let bytes = archive.into_inner().unwrap().finish().unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            assert!(extract(&bytes, dir.path()).is_ok(), "{deep}");
+            assert_eq!(fs::read(dir.path().join(&deep)).unwrap(), b"hello!");
+        }
+    }
 }

--- a/scripts/desktop_runtime_bundle.py
+++ b/scripts/desktop_runtime_bundle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import gzip
 import subprocess
 
 
@@ -21,13 +22,46 @@ def build(root: Path) -> None:
         "loopx", "scripts", "skills", "docs", "man", "examples", "apps/presentation",
         ".github", "README.md", "LICENSE", "pyproject.toml",
     ], cwd=root, check=True)
+    entries = qualify_archive(archive)
     identity = {
         "schema_version": "desktop_runtime_bundle_v1",
         "source_revision": revision,
         "sha256": hashlib.sha256(archive.read_bytes()).hexdigest(),
     }
     (destination / "identity.json").write_text(json.dumps(identity, indent=2) + "\n")
-    print(f"Prepared exact desktop runtime: {revision[:12]}")
+    print(f"Prepared exact desktop runtime: {revision[:12]} ({entries} installable entries)")
+
+
+def qualify_archive(archive: Path) -> int:
+    """Fail the release build when the App-side extractor could never install it.
+
+    The Rust extractor accepts plain files and directories and skips the global
+    PAX header only. Git emits other entry types as soon as the snapshot gains a
+    symlink or a path the ustar header cannot carry; every client would then
+    fail the post-restart install (and repair) with ``runtime_bundle_invalid``
+    while the feed keeps advertising the update, so the release pipeline must
+    reject the snapshot here instead. Raw typeflag bytes are inspected because
+    tar readers silently fold extended headers into the entry that follows.
+    """
+    entries = 0
+    with gzip.open(archive, "rb") as bundle:
+        while True:
+            header = bundle.read(512)
+            if len(header) < 512 or header.count(0) == 512:
+                break
+            typeflag = header[156:157]
+            name = header[:100].rstrip(b"\0").decode("utf-8", "replace")
+            if typeflag not in (b"0", b"\0", b"5", b"g"):
+                raise SystemExit(
+                    f"runtime bundle entry is neither a file nor a directory, "
+                    f"which the App cannot install: {name!r} "
+                    f"(tar typeflag {typeflag!r})"
+                )
+            if typeflag != b"g":
+                entries += 1
+            size = int((header[124:136].rstrip(b"\0 ") or b"0").decode("ascii") or "0", 8)
+            bundle.read((size + 511) // 512 * 512)
+    return entries
 
 
 if __name__ == "__main__":

--- a/scripts/desktop_runtime_bundle.py
+++ b/scripts/desktop_runtime_bundle.py
@@ -35,14 +35,20 @@ def build(root: Path) -> None:
 def qualify_archive(archive: Path) -> int:
     """Fail the release build when the App-side extractor could never install it.
 
-    The Rust extractor accepts plain files and directories and skips the global
-    PAX header only. Git emits other entry types as soon as the snapshot gains a
-    symlink or a path the ustar header cannot carry; every client would then
-    fail the post-restart install (and repair) with ``runtime_bundle_invalid``
-    while the feed keeps advertising the update, so the release pipeline must
-    reject the snapshot here instead. Raw typeflag bytes are inspected because
-    tar readers silently fold extended headers into the entry that follows.
+    The Rust extractor iterates logical entries with the pinned tar crate's
+    non-raw iterator: PAX local headers ('x', emitted by ``git archive`` for
+    paths beyond ustar capacity), PAX global headers ('g') and GNU
+    longname/longlink records ('L'/'K') carry path metadata for the entry that
+    follows and are folded away before the App's ``is_file``/``is_dir`` checks
+    run. The gate must therefore accept those metadata carriers and reject only
+    entries that survive as real links, devices or reserved types -- shapes
+    every client would fail the post-restart install (and repair) with
+    ``runtime_bundle_invalid`` while the feed keeps advertising the update.
+    Raw typeflag bytes are inspected precisely because tar readers silently
+    fold extended headers; see bundled_runtime.rs tests for the matching
+    extractor-side acceptance matrix.
     """
+    metadata_typeflags = (b"g", b"x", b"L", b"K")
     entries = 0
     with gzip.open(archive, "rb") as bundle:
         while True:
@@ -51,13 +57,13 @@ def qualify_archive(archive: Path) -> int:
                 break
             typeflag = header[156:157]
             name = header[:100].rstrip(b"\0").decode("utf-8", "replace")
-            if typeflag not in (b"0", b"\0", b"5", b"g"):
+            if typeflag not in (b"0", b"\0", b"5") and typeflag not in metadata_typeflags:
                 raise SystemExit(
                     f"runtime bundle entry is neither a file nor a directory, "
                     f"which the App cannot install: {name!r} "
                     f"(tar typeflag {typeflag!r})"
                 )
-            if typeflag != b"g":
+            if typeflag in (b"0", b"\0", b"5"):
                 entries += 1
             size = int((header[124:136].rstrip(b"\0 ") or b"0").decode("ascii") or "0", 8)
             bundle.read((size + 511) // 512 * 512)

--- a/tests/desktop/test_runtime_bundle.py
+++ b/tests/desktop/test_runtime_bundle.py
@@ -54,16 +54,74 @@ class ArchiveQualificationTests(unittest.TestCase):
             bundle.qualify_archive(archive)
         self.assertIn("scripts/link", str(rejected.exception))
 
-    def test_pax_local_headers_fail_the_release_build(self):
+    def test_pax_local_headers_carry_long_paths_and_qualify(self):
+        # `git archive` emits a PAX local header ('x') whenever a path exceeds
+        # ustar capacity. The pinned tar crate's non-raw iterator folds it into
+        # the entry that follows, so the App installs the snapshot fine and the
+        # build gate must accept the same shape (and not count it as an entry).
         archive = self.write_archive(
             tar_header(b"docs/deep-path.md", b"x", size=512),
             b"21 path=docs/deep-path.md\n".ljust(512, b"\0"),
             tar_header(b"docs/deep-path.md", b"0"),
             b"\0" * 1024,
         )
+        self.assertEqual(bundle.qualify_archive(archive), 1)
+
+    def test_gnu_longname_headers_carry_long_paths_and_qualify(self):
+        # GNU longname records ('L') are the other path-metadata carrier the
+        # non-raw iterator folds away; accept them like the App does.
+        archive = self.write_archive(
+            tar_header(b"././@LongLink", b"L", size=512),
+            b"docs/deep-path.md".ljust(512, b"\0"),
+            tar_header(b"docs/deep-path.md", b"0"),
+            b"\0" * 1024,
+        )
+        self.assertEqual(bundle.qualify_archive(archive), 1)
+
+    def test_metadata_headers_do_not_smuggle_links_through(self):
+        # Accepting path-metadata headers must not weaken the link rejection:
+        # the entry that follows the metadata is still type-checked.
+        archive = self.write_archive(
+            tar_header(b"docs/deep-path.md", b"x", size=512),
+            b"21 path=docs/deep-path.md\n".ljust(512, b"\0"),
+            tar_header(b"scripts/link", b"2"),
+            b"\0" * 1024,
+        )
         with self.assertRaises(SystemExit) as rejected:
             bundle.qualify_archive(archive)
-        self.assertIn("typeflag b'x'", str(rejected.exception))
+        self.assertIn("scripts/link", str(rejected.exception))
+
+    def test_real_git_long_path_archive_qualifies(self):
+        # Mirror of the reviewer's synthetic reproduction: a real
+        # `git archive` of a snapshot whose path exceeds ustar capacity emits
+        # PAX local headers that the gate must not reject.
+        import subprocess
+
+        repo = self.root / "repo"
+        deep = repo / ("docs/" + "very-deep-directory-name/" * 6 + "long-path.md")
+        deep.parent.mkdir(parents=True)
+        deep.write_text("# beyond ustar capacity\n")
+
+        def git(*args: str) -> None:
+            subprocess.run(
+                ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+            )
+
+        git("init", "-q")
+        git("config", "user.email", "build-gate@example.invalid")
+        git("config", "user.name", "build gate")
+        git("add", ".")
+        git("commit", "-qm", "long-path snapshot")
+        archive = self.root / "real-runtime-source.tar.gz"
+        subprocess.run(
+            [
+                "git", "archive", "--format=tar.gz",
+                f"--output={archive}", "HEAD",
+            ],
+            cwd=repo,
+            check=True,
+        )
+        self.assertGreaterEqual(bundle.qualify_archive(archive), 1)
 
     def test_pax_global_headers_are_skipped_like_the_app_extractor(self):
         archive = self.write_archive(

--- a/tests/desktop/test_runtime_bundle.py
+++ b/tests/desktop/test_runtime_bundle.py
@@ -1,0 +1,79 @@
+"""Reject runtime snapshots the App-side installer could never unpack."""
+import gzip
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "desktop_bundle", Path(__file__).resolve().parents[2] / "scripts/desktop_runtime_bundle.py"
+)
+bundle = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bundle)
+
+
+def tar_header(name: bytes, typeflag: bytes, size: int = 0) -> bytes:
+    """One 512-byte ustar header with a checksum, ready for the raw scanner."""
+    header = bytearray(512)
+    header[:len(name)] = name
+    header[156:157] = typeflag
+    header[124:136] = f"{size:011o}\0".encode()
+    header[148:156] = b"        "
+    checksum = sum(header)
+    header[148:156] = f"{checksum:06o}\0 ".encode()
+    return bytes(header)
+
+
+class ArchiveQualificationTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+
+    def write_archive(self, *blocks: bytes) -> Path:
+        archive = self.root / "runtime-source.tar.gz"
+        with gzip.open(archive, "wb") as compressed:
+            for block in blocks:
+                compressed.write(block)
+        return archive
+
+    def test_files_and_directories_qualify(self):
+        archive = self.write_archive(
+            tar_header(b"loopx/", b"5"),
+            tar_header(b"loopx/cli.py", b"0"),
+            b"\0" * 1024,
+        )
+        self.assertEqual(bundle.qualify_archive(archive), 2)
+
+    def test_symlinks_fail_the_release_build(self):
+        archive = self.write_archive(
+            tar_header(b"scripts/link", b"2"),
+            b"\0" * 1024,
+        )
+        with self.assertRaises(SystemExit) as rejected:
+            bundle.qualify_archive(archive)
+        self.assertIn("scripts/link", str(rejected.exception))
+
+    def test_pax_local_headers_fail_the_release_build(self):
+        archive = self.write_archive(
+            tar_header(b"docs/deep-path.md", b"x", size=512),
+            b"21 path=docs/deep-path.md\n".ljust(512, b"\0"),
+            tar_header(b"docs/deep-path.md", b"0"),
+            b"\0" * 1024,
+        )
+        with self.assertRaises(SystemExit) as rejected:
+            bundle.qualify_archive(archive)
+        self.assertIn("typeflag b'x'", str(rejected.exception))
+
+    def test_pax_global_headers_are_skipped_like_the_app_extractor(self):
+        archive = self.write_archive(
+            tar_header(b"pax_global_header", b"g", size=512),
+            b"52 comment=qualify desktop runtime\n".ljust(512, b"\0"),
+            tar_header(b"loopx/cli.py", b"0"),
+            b"\0" * 1024,
+        )
+        self.assertEqual(bundle.qualify_archive(archive), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The App-side runtime extractor accepts plain files and directories and skips the global PAX header only. As soon as the repository snapshot gains a symlink or a path the ustar header cannot carry, `git archive` emits other entry types, and every client would then fail the post-restart install (repair shares the same path) with `runtime_bundle_invalid` while the feed keeps advertising the update — a whole-channel outage that the release pipeline currently cannot see.

This change scans the produced archive's raw typeflags right after generation and fails the build on any entry the extractor could not install (symlinks, PAX local headers, GNU longname, devices). Raw bytes are inspected because tar readers silently fold extended headers into the entry that follows, hiding exactly the shapes the Rust extractor rejects.

## Issue

Follow-up hardening from a post-merge review of the signed desktop update flow (#3994). No open issue yet — happy to file one if preferred.

## Validation

- `python3 scripts/desktop_runtime_bundle.py` succeeds on this revision and reports `2592 installable entries` (current snapshot: 200 dirs + 2392 files, no other types).
- `python3 -m unittest discover -s tests/desktop -p 'test_*.py'`: 9 passed (5 existing feed tests + 4 new qualification tests: files/dirs qualify, symlinks fail, PAX local headers fail, global headers are skipped like the app extractor).
- New tests build tar archives byte-by-byte so the rejected typeflags are actually present in the stream rather than folded away by a tar reader.

## Type

- [x] fix

## Area

- [x] desktop

## Direction

- [x] follow-up (post-merge review finding)

## Boundary

Only the release-side bundle script and its desktop unit tests change. The App-side extractor, update feed, and signing flow are untouched.
