### PR TITLE
docs(site): publish an English-first bilingual LoopX blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?filter=v*&display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20active-brightgreen.svg)](docs/product/release-readiness.md)
 
-[Public website](https://huangruiteng.github.io/loopx/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Developer Book](https://huangruiteng.github.io/loopx/docs/book/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [简体中文](README.zh-CN.md)
+[Public website](https://huangruiteng.github.io/loopx/) · [Blog](https://huangruiteng.github.io/loopx/blog/) · [Docs](https://huangruiteng.github.io/loopx/docs/) · [Developer Book](https://huangruiteng.github.io/loopx/docs/book/en/) · [Try LoopX](#try-loopx) · [See real loops](#evidence) · [How it works](#why-loopx) · [简体中文](README.zh-CN.md)
 
 </div>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE) [![Release](https://img.shields.io/github/v/release/huangruiteng/loopx?filter=v*&display_name=tag)](https://github.com/huangruiteng/loopx/releases/latest) [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/XmGgQyCFZd) [![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml) [![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md) [![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20active-brightgreen.svg)](docs/product/release-readiness.md)
 
-[产品首页](https://huangruiteng.github.io/loopx/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [开发者手册](https://huangruiteng.github.io/loopx/docs/book/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [English](README.md)
+[产品首页](https://huangruiteng.github.io/loopx/) · [博客](https://huangruiteng.github.io/loopx/blog/zh/) · [文档](https://huangruiteng.github.io/loopx/docs/) · [开发者手册](https://huangruiteng.github.io/loopx/docs/book/) · [试用 LoopX](#试用-loopx) · [查看真实 Loop](#证据) · [理解工作原理](#为什么需要-loopx) · [English](README.md)
 
 </div>
 

--- a/apps/presentation/site/README.md
+++ b/apps/presentation/site/README.md
@@ -11,6 +11,20 @@ the repository Pages base (`/loopx/`) and in root-base local previews.
 The language switch keeps English as the default and provides a public-safe
 Chinese locale. `?lang=zh` is the shareable Chinese entry.
 
+The Blog is a static editorial section under `public/blog/`. `/blog/` and its
+articles default to English; `/blog/zh/` contains the paired Chinese editions.
+Each language has a direct URL, a matching language switch, canonical and
+alternate-language metadata, and the complete article in HTML. Reading and
+navigation work without JavaScript. Vite copies these pages into both the local
+build and the existing Pages export; no separate hosting or content service is
+needed. Relative navigation supports both root and repository base paths.
+
+Edit the paired HTML editions together, including their index summaries and
+metadata. Preserve matching section anchors and public source attribution.
+Keep source-document exports, private references, and unreviewed media outside
+the public tree. Follow `docs/development/design.md` and obtain first-screen
+review before changing the Blog or its homepage entry.
+
 The first-run CTA opens one setup dialog with a recommended Agent path and a
 manual Shell path. The Agent option copies the localized, public-safe setup
 contract; the Shell option copies the commands shown in the terminal section.

--- a/apps/presentation/site/public/blog/blog.css
+++ b/apps/presentation/site/public/blog/blog.css
@@ -1,0 +1,168 @@
+/* LoopX editorial surface; tokens follow docs/development/design.md. */
+:root {
+  --ink: #171717;
+  --body: #4d4d4d;
+  --canvas: #fafafa;
+  --surface: #fff;
+  --soft: #f2f2f2;
+  --border: #ebebeb;
+  --blue: #0070f3;
+  --font-mono: "Geist Mono", "JetBrains Mono", "SFMono-Regular", monospace;
+  font-family: "Geist", "Inter", "Helvetica Neue", Arial, sans-serif;
+  color: var(--ink);
+  background: var(--canvas);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; }
+a { color: inherit; text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 4px; }
+a:focus-visible, summary:focus-visible { outline: 2px solid var(--blue); outline-offset: 5px; border-radius: 2px; }
+.skip-link { position: absolute; top: 8px; left: 8px; padding: 12px; background: var(--surface); z-index: 10; transform: translateY(-150%); }
+.skip-link:focus { transform: none; }
+.site-header, .site-footer { max-width: 1200px; margin: 0 auto; display: flex; align-items: center; gap: 32px; }
+.site-header { min-height: 72px; border-bottom: 1px solid var(--border); }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-size: 18px; font-weight: 600; letter-spacing: -.03em; }
+.product-mark { position: relative; width: 26px; height: 26px; display: grid; place-items: center; }
+.product-mark i { position: absolute; width: 17px; height: 10px; border: 2px solid var(--ink); border-radius: 999px; transform: rotate(36deg); }
+.product-mark i:last-child { transform: rotate(-36deg); }
+.site-header nav { display: flex; margin-left: auto; gap: 32px; font-size: 14px; color: var(--body); }
+.site-header nav a, .language { display: inline-flex; min-height: 44px; align-items: center; }
+.site-header [aria-current] { color: var(--ink); font-weight: 600; }
+.header-actions { display: flex; align-items: center; gap: 24px; font-size: 14px; }
+.github { border-radius: 999px; min-height: 44px; padding: 12px 20px; color: white; background: var(--ink); }
+.language { min-width: 44px; justify-content: center; }
+.blog-index { max-width: 1000px; min-height: calc(100vh - 200px); margin: 0 auto; padding: 96px 0 64px; }
+.eyebrow { font: 500 12px/20px var(--font-mono); text-transform: uppercase; letter-spacing: .06em; color: var(--body); }
+h1 { font-size: clamp(36px, 4.4vw, 56px); line-height: 1.08; font-weight: 600; letter-spacing: -.045em; text-wrap: balance; }
+.index-heading h1 { margin: 20px 0 24px; }
+.lead { color: var(--body); font-size: 18px; line-height: 1.65; max-width: 760px; }
+.post-listing { margin-top: 64px; padding: 40px 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); display: grid; grid-template-columns: 220px 1fr; gap: 40px; }
+.post-listing h2 { margin: 0 0 20px; font-size: 32px; line-height: 1.25; font-weight: 600; letter-spacing: -.035em; text-wrap: balance; }
+.post-listing p:not(.eyebrow) { color: var(--body); font-size: 16px; line-height: 1.7; }
+.post-listing .listing-date { font-size: 14px; }
+.read-post { display: inline-flex; gap: 16px; align-items: center; min-height: 44px; font-size: 14px; font-weight: 500; }
+.index-note { display: flex; justify-content: space-between; gap: 24px; margin-top: 40px; color: var(--body); font-size: 14px; }
+.index-note a { min-height: 44px; }
+.article-heading { max-width: 1000px; margin: 0 auto; padding: 40px 0 48px; border-bottom: 1px solid var(--border); }
+.back { display: inline-flex; align-items: center; min-height: 44px; margin-bottom: 32px; font-size: 14px; color: var(--body); }
+.article-heading h1 { max-width: 920px; margin: 20px 0 24px; }
+.byline { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; margin-top: 32px; font-size: 12px; line-height: 1.6; color: var(--body); }
+.article-layout { display: grid; grid-template-columns: 220px minmax(0, 720px); gap: 60px; max-width: 1000px; margin: 0 auto; padding: 56px 0 96px; }
+.toc { font-size: 12px; line-height: 1.5; }
+.toc details { position: sticky; top: 32px; }
+.toc summary { min-height: 44px; font-weight: 600; cursor: pointer; }
+.toc nav { display: grid; gap: 8px; }
+.toc a { color: var(--body); display: block; padding: 8px 0; }
+.prose { min-width: 0; font-size: 16px; line-height: 1.8; color: var(--body); overflow-wrap: anywhere; }
+.prose section { scroll-margin-top: 32px; }
+.prose h2 { font-size: 28px; line-height: 1.35; font-weight: 600; letter-spacing: -.035em; color: var(--ink); margin: 64px 0 24px; text-wrap: balance; }
+.prose section:first-child h2 { margin-top: 0; }
+.prose h3 { font-size: 20px; line-height: 1.4; font-weight: 600; letter-spacing: -.02em; color: var(--ink); margin: 36px 0 16px; }
+.prose p { margin: 0 0 24px; }
+.prose strong, .prose b { color: var(--ink); font-weight: 600; }
+.prose a { color: #005cc5; text-decoration: underline; text-underline-offset: 3px; }
+.prose ul, .prose ol { padding-left: 24px; margin: 0 0 24px; }
+.prose li { margin-bottom: 8px; }
+.prose code { font: .86em/1.6 var(--font-mono); background: var(--soft); border-radius: 4px; padding: 2px 4px; }
+.prose pre { padding: 24px; margin: 32px 0; border: 1px solid var(--border); background: var(--surface); border-radius: 12px; overflow-x: auto; }
+.prose pre code { padding: 0; border-radius: 0; background: none; font-size: 13px; white-space: pre; overflow-wrap: normal; }
+figure { margin: 32px 0; }
+figcaption { margin-top: 16px; font-size: 12px; line-height: 1.7; color: var(--body); }
+.stack ol { list-style: none; padding: 0; margin: 0; border: 1px solid var(--border); border-radius: 12px; overflow: hidden; background: var(--surface); }
+.stack li { padding: 20px 24px; margin: 0; border-bottom: 1px solid var(--border); display: grid; gap: 4px; }
+.stack li:first-child { background: var(--ink); color: #fff; }
+.stack li:first-child b { color: #fff; }
+.stack li:last-child { border: 0; }
+.stack b { font-size: 14px; }
+.stack span { font-size: 13px; }
+.flow ol { display: grid; grid-template-columns: 1fr 1fr; list-style-position: inside; gap: 12px; padding: 0; margin: 0; }
+.flow li { margin: 0; padding: 16px; font-size: 13px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); }
+.prose details { margin: 24px 0; padding: 20px 24px; background: var(--soft); border-radius: 12px; }
+.prose summary { color: var(--ink); cursor: pointer; font-size: 14px; font-weight: 500; min-height: 24px; }
+.prose details ol { margin: 24px 0 0; }
+.table-scroll { overflow-x: auto; margin: 32px 0; }
+table { border-collapse: collapse; width: 100%; font-size: 14px; line-height: 1.6; }
+td, th { padding: 16px 12px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+th { color: var(--ink); background: var(--soft); font-weight: 500; }
+.prose .edition { margin: 48px 0 0; padding-top: 24px; border-top: 1px solid var(--border); font-size: 12px; }
+.case-note { margin: 32px 0; padding: 16px 24px; border-left: 2px solid var(--blue); background: var(--surface); }
+.case-note b { font-size: 14px; }
+.case-note p { margin: 8px 0 0; }
+.diagram { padding: 24px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+.diagram .diagram-label { margin: 0 0 24px; font: 500 11px/1.6 var(--font-mono); letter-spacing: .05em; text-transform: uppercase; color: var(--body); }
+.diagram-node { padding: 16px; border: 1px solid var(--border); border-radius: 6px; display: grid; gap: 6px; font-size: 14px; line-height: 1.6; background: var(--canvas); }
+.diagram-node span { font-size: 13px; }
+.diagram-node strong { margin-top: 8px; font: 500 13px/1.6 var(--font-mono); }
+.diagram-node.kernel { background: var(--ink); color: #eee; border-color: var(--ink); }
+.diagram-node.kernel b { color: #fff; }
+.connector { padding: 8px 0; text-align: center; font-size: 12px; color: #005cc5; }
+.diagram-pair, .diagram-branch { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.diagram-branch { padding: 12px 0; font-size: 12px; text-align: center; }
+.return-path { border-left: 2px solid var(--blue); padding: 8px 12px; margin-top: 16px; font-size: 12px; color: #005cc5; }
+.diagram .recovery-steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; list-style: none; padding: 0; margin: 0; }
+.recovery-steps li { display: grid; gap: 8px; padding: 12px; margin: 0; border-radius: 6px; font-size: 13px; line-height: 1.5; }
+.recovery-steps .committed { background: var(--ink); color: #fff; }
+.recovery-steps .committed b { color: #fff; }
+.recovery-steps .pending { border: 1px dashed #aaa; }
+.recovery-steps span { font: 500 10px/1.6 var(--font-mono); }
+.crash-marker { padding: 16px 0; font: 500 12px/1.6 var(--font-mono); }
+.diagram .timeline { padding: 0; list-style: none; margin: 0; }
+.timeline li { display: grid; grid-template-columns: 130px 1fr; column-gap: 16px; padding: 0 0 20px 20px; margin: 0; border-left: 1px solid #aaa; position: relative; font-size: 13px; }
+.timeline li::before { content: ''; position: absolute; top: 7px; left: -4px; width: 7px; height: 7px; border-radius: 50%; background: var(--ink); }
+.timeline li:last-child { padding-bottom: 0; }
+.timeline span { grid-column: 2; margin-top: 4px; }
+.timeline code { width: fit-content; }
+.extension-frame { padding: 16px; border: 1px dashed #aaa; border-radius: 6px; }
+.frame-label { display: block; font-size: 12px; margin-bottom: 12px; }
+caption { text-align: left; font-size: 12px; margin-bottom: 12px; color: var(--body); }
+.benchmark-table { font-variant-numeric: tabular-nums; }
+.benchmark-table td:not(:first-child) { white-space: nowrap; }
+@media (max-width: 520px) {
+  .diagram { padding: 20px 16px; }
+  .diagram-pair { grid-template-columns: 1fr; gap: 12px; }
+  .diagram-branch { display: block; text-align: left; }
+  .diagram-branch span { display: block; }
+  .diagram .recovery-steps { grid-template-columns: 1fr 1fr; }
+  .timeline li { grid-template-columns: 1fr; }
+  .timeline span { grid-column: 1; }
+  .timeline code { margin-top: 6px; }
+}
+.site-footer { padding: 32px 0; border-top: 1px solid var(--border); font-size: 12px; color: var(--body); }
+.site-footer p { margin-right: auto; }
+.site-footer > a { min-height: 44px; display: inline-flex; align-items: center; }
+@media (max-width: 1264px) { .site-header, .site-footer { margin-left: 32px; margin-right: 32px; } }
+@media (max-width: 1064px) {
+  .blog-index, .article-heading, .article-layout { margin-left: 32px; margin-right: 32px; }
+  .article-layout { grid-template-columns: 180px minmax(0, 1fr); gap: 32px; }
+}
+@media (max-width: 768px) {
+  .site-header, .site-footer, .blog-index, .article-heading, .article-layout { margin-left: 20px; margin-right: 20px; }
+  .site-header { gap: 16px; }
+  .site-header nav { gap: 16px; }
+  .header-actions { gap: 4px; }
+  .github { padding: 12px; }
+  .blog-index { padding: 64px 0 40px; }
+  .post-listing { grid-template-columns: 1fr; gap: 20px; margin-top: 40px; padding: 32px 0; }
+  .post-listing .eyebrow, .post-listing .listing-date { margin: 0 0 8px; }
+  .post-listing h2 { font-size: 28px; }
+  .article-heading { padding: 24px 0 32px; }
+  .back { margin-bottom: 24px; }
+  .lead { font-size: 16px; }
+  .article-layout { display: block; padding: 24px 0 64px; }
+  .toc { margin-bottom: 40px; padding-bottom: 24px; border-bottom: 1px solid var(--border); }
+  .toc details { position: static; }
+  .toc nav { grid-template-columns: 1fr 1fr; gap: 4px 24px; }
+  .toc a { min-height: 44px; }
+  .prose h2 { font-size: 26px; }
+  .site-footer { flex-wrap: wrap; gap: 12px 24px; }
+  .site-footer p { flex-basis: 100%; order: 3; margin: 0; }
+  .site-footer > a:last-child { margin-left: auto; }
+}
+@media (max-width: 380px) {
+  .site-header { gap: 10px; }
+  .site-header nav { gap: 10px; }
+  .github { padding: 12px 10px; font-size: 12px; }
+  .index-note { flex-direction: column; gap: 8px; }
+}

--- a/apps/presentation/site/public/blog/from-one-shot-agents-to-long-horizon-control/index.html
+++ b/apps/presentation/site/public/blog/from-one-shot-agents-to-long-horizon-control/index.html
@@ -1,0 +1,273 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#fafafa">
+  <title>From one-shot agents to long-horizon control · LoopX</title>
+  <meta name="description" content="How LoopX uses goals, a state kernel, and Effect Programs to carry work across sessions, preserve human judgment, and recover from interruptions.">
+  <link rel="canonical" href="https://huangruiteng.github.io/loopx/blog/from-one-shot-agents-to-long-horizon-control/">
+  <link rel="alternate" hreflang="en" href="https://huangruiteng.github.io/loopx/blog/from-one-shot-agents-to-long-horizon-control/">
+  <link rel="alternate" hreflang="zh-CN" href="https://huangruiteng.github.io/loopx/blog/zh/from-one-shot-agents-to-long-horizon-control/">
+  <link rel="alternate" hreflang="x-default" href="https://huangruiteng.github.io/loopx/blog/from-one-shot-agents-to-long-horizon-control/">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="LoopX">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="From one-shot agents to long-horizon control">
+  <meta property="og:description" content="How LoopX uses goals, a state kernel, and Effect Programs to carry work across sessions, preserve human judgment, and recover from interruptions.">
+  <meta property="og:url" content="https://huangruiteng.github.io/loopx/blog/from-one-shot-agents-to-long-horizon-control/">
+  <meta name="twitter:card" content="summary">
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="../../blog/blog.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="site-header">
+  <a class="brand" href="../../" aria-label="LoopX home"><span class="product-mark" aria-hidden="true"><i></i><i></i></span>LoopX</a>
+  <nav aria-label="Primary navigation">
+    <a href="../../blog/" aria-current="true">Blog</a>
+    <a href="../../docs/book/en/">Docs</a>
+  </nav>
+  <div class="header-actions"><a class="language" href="../../blog/zh/from-one-shot-agents-to-long-horizon-control/" lang="zh-CN" hreflang="zh-CN" aria-label="阅读中文版">中文</a><a class="github" href="https://github.com/huangruiteng/loopx">GitHub <span aria-hidden="true">↗</span></a></div>
+</header>
+<main id="main">
+<div class="article-heading">
+  <a class="back" href="../../blog/">← All posts</a>
+  <p class="eyebrow">Architecture · Design notes</p>
+  <h1>From one-shot agents to long-horizon control</h1>
+  <p class="lead">How LoopX uses goals, a state kernel, and Effect Programs to carry work across sessions, preserve human judgment, and recover from interruptions.</p>
+  <div class="byline"><a href="https://github.com/huangruiteng">Ruiteng Huang</a><span aria-hidden="true">·</span><span>September 2026</span><span aria-hidden="true">·</span><span>Goals, state, and Effect Programs</span></div>
+</div>
+<div class="article-layout">
+  <aside class="toc"><details open><summary>On this page</summary><nav aria-label="Table of contents"><a href="#objective">1. More useful work, less human attention</a>
+<a href="#control-plane">2. What a semantic control plane preserves</a>
+<a href="#state-kernel">3. External state, reconstructible views</a>
+<a href="#agent-interface">4. A CLI that helps agents make the next decision</a>
+<a href="#effects">5. Effect Programs: recovering what actually happened</a>
+<a href="#planning">6. Knowing when to work, wait, and replan</a>
+<a href="#human-attention">7. An interface for judgment</a>
+<a href="#multi-agent">8. Digital teams need explicit authority</a>
+<a href="#extensions">9. Let capabilities evolve around a stable kernel</a>
+<a href="#evidence">10. What the evidence can tell us</a>
+<a href="#start">11. Start with one real project</a>
+</nav></details></aside>
+  <article class="prose" aria-label="From one-shot agents to long-horizon control">
+  <section id="objective">
+<h2>1. More useful work, less human attention</h2>
+<p>I started LoopX with a practical goal: let agents take on more work, especially the work that otherwise keeps pulling a person back to the keyboard. As projects grew longer, the bottleneck shifted. A capable model could solve the next problem, but someone still had to remember the objective, route work, check evidence, resolve permissions, and tell it when to continue.</p>
+<p>LoopX optimizes two things together: useful agent output and the human attention required to obtain it. Output depends on model capability, useful parallelism, time utilization, and alignment with the goal. LoopX concentrates on the latter three, while the underlying harness and model execute the work.</p>
+<p>The engineering target is straightforward: keep working reliably when no human decision is needed, and improve the direction of the work when a person intervenes. That includes quiet waiting when facts have not changed, replanning when a route stops working, repairing contradictory control state, and stopping when acceptance is satisfied.</p>
+<p>This is a throughput problem. A fast reply matters, but a project also benefits when several independent tasks make progress while its owner is elsewhere. The useful measure is validated output per unit of compute and human attention.</p>
+
+<h3>Deliver a faster long-context inference backend</h3>
+<p>Imagine giving an agent team this goal: deliver a long-context attention acceleration backend for an open-source inference engine. The work spans a kernel repository and a serving repository. It needs a reproducible baseline, competing optimization hypotheses, remote GPU experiments, numerical checks, integration under concurrent traffic, and a release candidate with a rollback path. This constructed scenario illustrates the control contracts; the chosen host and providers supply the experiment tools.</p>
+<p>A kernel specialist can investigate memory movement while a serving specialist builds a realistic workload replay. A verification peer can challenge numerical tolerances and boundary cases. The owner authorizes development and a bounded experiment budget, and retains the decision to publish the release. Some work can proceed in parallel; other work must wait for a scarce GPU slot, a compatible kernel revision, or a result that invalidates the current hypothesis.</p>
+<p>Several days later, “the benchmark is green” tells us very little. Which model, hardware, input lengths, concurrency, and revision were measured? Did throughput improve at the expense of tail latency? Was an apparent gain caused by a changed workload? Did the remote experiment start before the submitting session lost its connection? The next worker must recover these distinctions.</p>
+<div class="case-note"><b>An illustrative acceptance contract</b><p>At least 20% lower p95 request latency on the agreed long-context workload; at most 5% regression on the short-context control; numerical error within the agreed tolerance; peak memory within budget; reproducible evidence and an authorized, reversible release. These are example targets, not reported LoopX results.</p></div>
+
+</section>
+<section id="control-plane">
+<h2>2. What a semantic control plane preserves</h2>
+<p>A model has a finite working context. Summarization and subagents can help manage it, but a summary alone cannot reliably enforce ownership, concurrency, permissions, or idempotency. A project that crosses sessions needs durable answers to a different set of questions:</p>
+<ul><li>What is the current objective, and what would count as acceptance?</li><li>Which facts and decisions are still current?</li><li>Who is responsible for each piece of work, and which actions are authorized?</li><li>Did an external operation actually happen?</li><li>Is another turn worth its cost, and what should happen after it?</li></ul>
+<p>These questions define the semantic control plane. A useful way to locate it in the agent stack is to separate four kinds of recovery.</p>
+<figure class="stack"><ol>
+<li><b>04 · Semantic control plane</b><span>Goals, evidence, authority, acceptance, replanning</span></li>
+<li><b>03 · Work coordination</b><span>Todos, claims, leases, handoffs</span></li>
+<li><b>02 · Durable workflow</b><span>Steps, retries, waiting, recovery</span></li>
+<li><b>01 · Execution substrate</b><span>Processes, containers, sessions, workspaces</span></li>
+</ol><figcaption>Each layer preserves a different part of the work. They can be composed.</figcaption></figure>
+<p>A runtime restores the execution environment. LoopX preserves what the agent is doing, why it is doing it, what has been proved, and whether the next step is permitted. Codex threads, Claude Code sessions, and CLI runners can act as replaceable workers around that shared state.</p>
+<p>Four terms keep the accounting precise:</p>
+<pre><code>Turn       = a bounded execution window
+Result     = an artifact or observation returned by a turn
+Transition = a validated, permitted state change
+Progress   = a durable transition relevant to acceptance</code></pre>
+<p>A convincing answer is a result. It becomes project progress when the relevant validation and state transition have been accepted. See the <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture.md">architecture and vocabulary</a>.</p>
+
+<h3>How this relates to workflow engines and memory</h3>
+<p>Existing systems already solve important parts of durability. <a href="https://docs.langchain.com/oss/python/langgraph/persistence">LangGraph checkpoints</a> preserve graph state for recovery, human intervention, and time travel. <a href="https://docs.temporal.io/activities">Temporal Activities</a> isolate external work and need application-specific idempotency for safe retries. LoopX adds a project-level interpretation: which evidence satisfies acceptance, which actor may commit a change, and whether the current route should continue.</p>
+<p>Memory helps retrieve a useful fact. Authority decides whether that fact can justify an action now. Remembering that an owner once approved a release is useful context; treating it as permission for every future release would be a bug. Likewise, faithfully resuming an obsolete plan can be operationally durable and still waste the entire remaining budget. Recovery needs to preserve the goal and re-evaluate the route.</p>
+
+</section>
+<section id="state-kernel">
+<h2>3. External state, reconstructible views</h2>
+<p>LoopX separates canonical state from projections. The registry identifies goals, project connections, policy, and authority sources. An append-only ledger records identified events. Run history and evidence connect execution to artifacts, validation, failures, and resource use. An active-state workbench provides a human-readable compatibility surface.</p>
+<p>Status, task graphs, review packets, and dashboards are projections of those facts. They can be rebuilt; their appearance does not independently authorize a transition. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/event-sourced-state-contract-v0.md">event-sourced state contract</a> defines replay and identity: replaying the same event is idempotent, while a conflicting event with the same identity must fail closed.</p>
+<p>An open Todo illustrates why this matters. It might be waiting for approval, for a pull request to merge, or for a monitor to observe a change. Another agent might have claimed it. Its host might lack a capability, its workspace might be wrong, or a later route might have superseded it. “Open” is insufficient to decide whether to execute it.</p>
+<pre><code>Open work
+  → dependencies and resume conditions
+  → scoped authority
+  → claim and lifecycle ownership
+  → host capability and workspace
+  → freshness and evidence
+  → quota and the current runnable frontier</code></pre>
+<p>Human decisions belong in the same durable model. “Wait for my review” or “This route may continue” has a particular scope. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/decision-scope-v0.md">Decision Scope contract</a> binds that authority to an action, lane, goal, or project. An independent authorized task can continue while one path waits.</p>
+<p>Completion also needs an explicit boundary. Closing a Todo supplies evidence about one piece of work; it does not automatically satisfy the goal. If the runnable frontier is exhausted while acceptance remains open, the control plane needs a new route or an evidence-backed explanation of why no follow-up is appropriate.</p>
+<figure class="diagram" aria-labelledby="truth-caption">
+<p class="diagram-label">01 / A shared source of truth</p>
+<div class="diagram-node"><b>Human goals and judgment</b><span>Acceptance criteria · scoped decisions</span></div>
+<div class="connector" aria-hidden="true">↓</div>
+<div class="diagram-node kernel"><b>Canonical state / kernel</b><span>Goal · evidence · authority · current route</span></div>
+<div class="diagram-branch"><span>↓ Selection and authority</span><span>↓ Read-only projection</span></div>
+<div class="diagram-pair"><div class="diagram-node"><b>Quota → agent → capability</b><span>Bounded work, followed by provider readback</span></div><div class="diagram-node"><b>Status / Dashboard</b><span>Displays facts; grants no authority of its own</span></div></div>
+<div class="return-path">↳ Observation → validated proposal → accepted kernel transition ↺</div>
+<figcaption id="truth-caption">Work returns to the same source of truth. A dashboard label or an agent narrative cannot substitute for an accepted transition.</figcaption></figure>
+<p>In the inference example, “wait before publishing” applies to the release. It does not erase the authorization to analyze profiles or validate compatibility. A useful projection can show three facts together: a kernel candidate meets its local checks, the service-level latency target remains unproved, and publication awaits a decision. A single “blocked” label would hide runnable analysis; “done” would hide the unclosed acceptance gap.</p>
+
+</section>
+<section id="agent-interface">
+<h2>4. A CLI that helps agents make the next decision</h2>
+<p>An executable Kanban is a useful picture of LoopX. Its cards have stable identities, dependencies, claims, scope, evidence, and successors. Moving a card means requesting a validated state transition. The board is a view of the contract.</p>
+<p>The CLI makes continuity part of the interaction. Completing work can create a successor, link an existing successor, or record a structured no-follow-up rationale when acceptance is satisfied. This keeps a locally successful action from leaving the larger task disconnected. The details live in the <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/project-agent-todo-contract.md">Todo contract</a>.</p>
+<p>The interaction contract separates what the person needs to hear from what the agent must do. A quiet notification channel can coexist with an obligation to execute a bounded piece of work. Conversely, a scheduled wake may legitimately produce no work when the state calls for waiting.</p>
+<p>This protects both sides from overload. The human-facing view highlights decisions that deserve attention. The agent-facing view gives the current authority, next action, validation, and stop conditions. Neither should require reading every old conversation to reconstruct the present.</p>
+<p>A host scheduler supplies wakeups; the LoopX CLI and lightweight skills supply the governed work contract. A scheduler prompt should preserve this lifecycle and obtain current decisions from state, rather than accumulate a second project plan in prose.</p>
+
+<h3>A handoff that contains a decision</h3>
+<p>The useful writeback for a kernel experiment names the exact candidate, comparison conditions, measured boundary, remaining gap, and successor. The following is an explanatory record, not a CLI payload or a claim about a real run:</p>
+<pre><code>Completed slice: evaluate attention kernel candidate A
+Evidence: pinned candidate + baseline + workload + result manifest
+Established: numerical checks pass; isolated kernel is faster
+Remaining gap: service p95 under concurrent traffic is unproved
+Successor: replay the fixed workload against both serving builds
+Authority: bounded experiments allowed; publication remains gated</code></pre>
+<p>Compare that with “attention optimization complete, benchmarks pass.” The explicit record prevents a local microbenchmark win from becoming an unsupported service-level claim. A result manifest should identify the code, environment, workload, and measurement method so a later peer can reproduce or challenge it.</p>
+<p>The actual <code>todo complete</code> interface supports <code>--next-agent-todo</code> for a successor and <code>--no-follow-up</code> with a rationale when appropriate. These are lifecycle operations: quota-bound repository advancement must first satisfy the matching writeback and spend receipts. Copying a completion command without its current interaction contract can violate that order. Let the host obtain the current contract, then execute the actions it specifies.</p>
+
+</section>
+<section id="effects">
+<h2>5. Effect Programs: recovering what actually happened</h2>
+<p>A pure function is often described as <code>A → B</code>. An agent action looks more like <code>A → F[B]</code>: it can involve permissions, persistence, time, budget, external calls, and failure. The model's proposal and the world's resulting state are distinct facts.</p>
+<pre><code>Goal state → effect request → authority / quota interpretation
+  → external operation → observation / readback → receipt
+  → durable transition → next goal state</code></pre>
+<p>An Effect Program gives those steps identity, order, receipts, and failure semantics. Without them, a crash after a successful external operation can lead to a duplicate retry. A delayed acknowledgment can settle the wrong turn. Different modules can gradually invent incompatible orders for writing state, recording spend, and closing work.</p>
+<p>The public <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/control_plane/effect_program.ts">EffectTurn implementation</a> describes an interaction through four serializable slots:</p>
+<pre><code>interface EffectTurn&lt;Context, Decision extends string&gt; {
+  request: EffectRequest&lt;Context&gt;;
+  interpretation: EffectInterpretation;
+  observation: EffectObservation&lt;Decision&gt;;
+  next_effect: EffectNext;
+}</code></pre>
+<p>Settlement has three mutually exclusive next actions: <code>failed</code>, <code>execute</code>, or <code>complete</code>. A selected turn follows a fixed order:</p>
+<figure class="flow"><ol><li>Validate</li><li>Durable writeback</li><li>Record quota spend</li><li>Close out, if terminal</li></ol><figcaption>A failure preserves the committed prefix and stops later steps.</figcaption></figure>
+<p>Settlement identity binds the goal, agent, and turn instance, plus the selected Todo or replan obligation. Matching receipts identify committed steps. Recovery checks that identity and continues from the uncommitted suffix. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/tests/control_plane_ts/effect_program.test.ts">effect-program tests</a> cover order, replay, failure, and committed prefixes.</p>
+<h3>A remote GPU experiment submitted just before a disconnect</h3>
+<p>An authorized experiment submission reaches the remote scheduler, but the agent’s connection drops before it records the response. Retrying blindly might launch a duplicate job and consume the budget twice. Recovery first uses the provider’s request identity or job identifier to read back whether the submission was accepted. If the provider cannot establish the outcome, that branch remains unresolved until it can be reconciled.</p>
+<p>A confirmed submission proves only that a job was accepted. It does not prove that the job finished or that the candidate met acceptance. The submission turn can settle its bounded outcome and create a monitor; a later validation turn evaluates the result manifest. Both turns need their own identities and receipts.</p>
+<details><summary>Walk through the recovery decisions</summary><ol>
+<li><b>Submission outcome unknown:</b> look up the request or job before considering a retry.</li>
+<li><b>Submission confirmed, writeback missing:</b> reconcile the accepted job with the matching effect identity and persist the submission outcome, plus its monitored successor.</li>
+<li><b>Writeback committed, spend missing:</b> preserve that committed prefix and resume quota settlement.</li>
+<li><b>Settlement complete:</b> replay the accepted result instead of charging again.</li>
+</ol></details>
+<p>This is a recovery contract for governed settlement. Exactly-once accounting inside the control plane does not make every arbitrary external API operation exactly-once; external operations still need provider-specific idempotency or readback. Effect Programs also preserve domain ownership: the settlement algebra does not replace goal planning with a universal executor.</p>
+<figure class="diagram" aria-labelledby="recovery-caption"><p class="diagram-label">02 / Resume at the first uncommitted step</p><ol class="recovery-steps"><li class="committed"><span>COMMITTED</span><b>Validation</b></li><li class="committed"><span>COMMITTED</span><b>Writeback</b></li><li class="pending"><span>PENDING</span><b>Quota spend</b></li><li class="pending"><span>PENDING</span><b>Closeout</b></li></ol><div class="crash-marker">× Process exits after writeback</div><div class="diagram-node"><b>Recovery checks identity and receipts</b><span>Same goal / agent / turn · same Todo or replan obligation</span></div><div class="return-path">Preserve committed prefix → resume spend → close out if terminal</div><figcaption id="recovery-caption">Here, recovery resumes with spend. If an external outcome is unknown, read it back first: no response does not mean no effect.</figcaption></figure>
+<p>There are two budgets to reconcile here: the external experiment budget and the control plane’s turn accounting. A LoopX spend receipt does not cancel a duplicate GPU job or prove that a remote charge was correct. The provider must establish the external outcome; the kernel must settle the matching turn. Keeping those responsibilities separate makes an expensive ambiguity diagnosable.</p>
+
+</section>
+<section id="planning">
+<h2>6. Knowing when to work, wait, and replan</h2>
+<h3>Quota compiles a decision</h3>
+<p><code>quota should-run</code> considers health and safety, operator gates, evidence waits, and focus waits before compute budget. It combines the selected work, capabilities, workspace, and scheduler state into an interaction contract. The result can authorize bounded work, identify a decision gate, preserve a wait, throttle delivery, or request repair. See <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/quota-allocation.md">quota allocation</a>.</p>
+<p>Validated durable writeback precedes quota spend. Quiet skips, preflight failures, and dry runs do not count as delivery spend. A spend record must remain attributable to the work just completed, even if a refresh has already selected a different next action.</p>
+<h3>A small planning horizon around the current task</h3>
+<p>A typed planning inventory supports several views. The action portfolio offers a few current candidates. The planning horizon shows nearby successors, dependencies, resume links, and acceptance gaps. On-demand Todo detail expands the cold path, while a task graph supports diagnosis.</p>
+<p>Visibility does not grant execution rights. A relevant task claimed by another agent is coordination context. A runnable unclaimed task still requires a claim and the normal checks. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/quota-planning-horizon-v0.md">planning-horizon protocol</a> keeps the read model separate from selection authority.</p>
+<p>For open-ended research, the <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/capabilities/explore/README.md">Explore capability</a> adds an evidence graph of questions, hypotheses, experiments, and findings. Its planning layer can organize branches; execution still follows the normal LoopX lifecycle. This preserves failed routes and reasons to try combinations without putting every exploration detail into the next prompt.</p>
+<h3>Wait for a new fact</h3>
+<p>A monitor-based resume condition needs a material change after waiting began. A generation fence compares the current monitor generation with the saved baseline. Old results, unchanged polls, and duplicate replay cannot count as a fresh signal. See the <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/control_plane/todos/resume_condition.ts">resume-condition implementation</a>.</p>
+<p>Independent fallback work can keep moving while a main path waits. Polling without new facts should back off; repeated lack of progress needs an explicit blocker, expiry, successor, or replanning decision.</p>
+<h3>Replanning has an identity and an outcome</h3>
+<p>Replanning becomes a machine-enforced obligation when the current route no longer supports acceptance. Its <code>obligation_id</code> identifies that generation of the problem. A late acknowledgment of an older obligation cannot close a newer one.</p>
+<p>Triggers include repeated semantic stagnation, broken Todo continuity, acceptance gaps, overly long task chains, periodic review, and an exhausted frontier. Legal waits and ordinary scheduler wakeups have their own semantics; they do not automatically imply replanning.</p>
+<p>Settlement requires the exact current obligation and an accepted semantic change: for example, a runnable successor, a concrete blocker, a new evidence-backed route, or a supported no-follow-up outcome. Rewording the plan or sending an acknowledgment alone does not satisfy it. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/goal-vision-replan-contract-v0.md">Goal / Vision / Replan contract</a> defines the boundary.</p>
+<figure class="diagram" aria-labelledby="wait-caption"><p class="diagram-label">03 / A wait is bound to a new fact</p><ol class="timeline"><li><b>Wait begins</b><code>Save generation = 12</code><span>Result not yet available</span></li><li><b>Poll again</b><code>Generation = 12</code><span>No new fact; keep waiting</span></li><li><b>New observation</b><code>Generation = 13</code><span>Result manifest changed; recheck resume conditions</span></li></ol><div class="return-path">Meanwhile: numerical analysis and rollback validation can continue →</div><figcaption id="wait-caption">Illustrative generations explain freshness. A new result can resume analysis; publication still requires its own authorization.</figcaption></figure>
+<h3>What a real replan changes</h3>
+<p>Suppose the new kernel improves isolated throughput, yet two serving experiments still miss the p95 target. Another kernel tuning pass may be the wrong next step. A useful replan records that the local speedup did not establish end-to-end value, proposes a competing hypothesis about scheduling or memory contention, and creates a controlled experiment that changes one factor. The integration route then depends on that result. These are illustrative observations, not measurements from a real run.</p>
+<div class="table-scroll"><table><caption>Replanning the inference acceleration route</caption><thead><tr><th>Current route</th><th>Accepted change</th></tr></thead><tbody><tr><td>Keep tuning kernel throughput while serving p95 regresses</td><td>Compare fixed workloads with one scheduling or memory variable changed</td></tr><tr><td>“Performance needs attention” in a summary</td><td>A discriminating experiment with pinned inputs and a result manifest</td></tr><tr><td>GPU results are pending; the main experiment route must wait</td><td>Numerical boundary analysis or rollback validation; experiment limits stay intact</td></tr></tbody></table></div>
+<p>The control plane can require a meaningful transition and reject a stale acknowledgment. The quality of the new hypothesis still depends on the model, tools, evidence, and human judgment. Typed obligations make a failure visible and recoverable; they do not manufacture insight.</p>
+
+</section>
+<section id="human-attention">
+<h2>7. An interface for judgment</h2>
+<p>As agents work across code, documents, research, and communication, an operator needs a concise view of the decisions ahead. Which project needs judgment? Which high-priority route is blocked? What can proceed independently? Has a monitor observed a meaningful change? Is recent activity producing useful progress?</p>
+<p>The intended loop is <strong>signal inbox → anchor selection → performance review</strong>. External signals enter a bounded inbox. People and agents choose a few valuable anchors. Results are reviewed for value, quality, control, cost, and learning, and that feedback informs the next round.</p>
+<p>Reports are an attention boundary. A meaningful delivery, stage closeout, route decision, or major blockage can justify an update. Ordinary refreshes and unchanged monitors should not repeatedly interrupt the owner. Related events can be grouped and deduplicated. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/capabilities/periodic_report/README.md">periodic-report capability</a> and <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture/rfcs/intelligent-review-presentation-surfaces-v0.zh-CN.md">presentation RFC</a> separate existing mechanisms from the broader product direction.</p>
+
+<h3>The owner supplies direction and a standard of quality</h3>
+<p>My experience with longer agent work changed where I spend time. Early on, I managed cards and repeatedly restarted sessions. As continuity improved, it became more valuable to inspect the artifact, sharpen the objective, and explain why an apparently acceptable result was still weak. “This diagram does not explain the failure boundary” is a better signal than another generic instruction to continue.</p>
+<p>For the inference project, the decisive intervention may be: “Our users care about interactive latency under mixed traffic; a higher offline throughput score is insufficient.” That judgment changes the workload, acceptance, and next experiment. It should survive the current conversation. Repeatedly pasting it into new sessions is a sign that the system is losing an important part of the project.</p>
+<p>I want the operator surface to make this kind of feedback cheap: show the artifact, the evidence, the unresolved choice, and the expected value of another turn. More parallel agents create value only when review and coordination do not grow at the same rate. Human attention is part of the operating budget.</p>
+
+</section>
+<section id="multi-agent">
+<h2>8. Digital teams need explicit authority</h2>
+<p>Parallel workers need a common goal, distinct work boundaries, and a reliable handoff. LoopX models equal peers: an agent identity describes a working role, not a permanent hierarchy. A temporary coordinator can route work without automatically gaining authority to complete or reassign another peer's tasks.</p>
+<div class="table-scroll"><table><thead><tr><th>Mechanism</th><th>What it establishes</th><th>What it does not grant</th></tr></thead><tbody>
+<tr><td>Claim</td><td>Which peer should take the work</td><td>A lock, liveness, or production permission</td></tr>
+<tr><td>Lease</td><td>A time-bounded execution occupancy</td><td>Permanent ownership or satisfied gates</td></tr>
+<tr><td>Lifecycle authority</td><td>Who may complete, supersede, reassign, or override</td><td>Authority inferred from a claim</td></tr>
+</tbody></table></div>
+<p>These distinctions become more important across hosts. Shared Goal Authority separates semantic transition rules from storage. The authority layer owns revisions, lease epochs, receipts, and conflict decisions. A storage provider supplies loading, compare-and-put, and durability. Storage generation, authority revision, and lease epoch describe different things and need separate identities.</p>
+<p>The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md">Shared Goal Authority RFC</a> and <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/control_plane/coordination/authority_store.ts">authority-store implementation</a> document this work. Cross-host productization remains an evolving validation area. The existence of an interface should not be read as a claim that arbitrary distributed teams are already a turnkey product.</p>
+<figure class="diagram" aria-labelledby="handoff-caption"><p class="diagram-label">04 / Hand off artifacts and boundaries</p><div class="diagram-pair"><div class="diagram-node"><b>Peer A / kernel repository</b><span>Pinned kernel · numerical envelope · performance manifest</span></div><div class="diagram-node"><b>Peer B / serving repository</b><span>Check API compatibility · replay concurrent workloads</span></div></div><div class="connector" aria-hidden="true">↓</div><div class="diagram-node kernel"><b>Shared goal / accepted evidence</b><span>Identity, claim, and scoped lifecycle authority are checked separately</span></div><div class="connector" aria-hidden="true">↓</div><div class="diagram-node"><b>Release / still requires its own authorization</b></div><figcaption id="handoff-caption">The consumer returns compatibility and workload evidence. A handoff does not grant completion authority over a peer’s task or permission to publish.</figcaption></figure>
+<p>A good handoff is an interface between work boundaries. In a cross-repository change, that may mean an API contract and a pinned revision, followed by a consumer compatibility check. It rarely means sending another agent the whole conversation and hoping it infers which decisions are current. Start parallelism where the acceptance boundaries can be separated; tightly coupled edits may be cheaper to keep with one worker.</p>
+
+</section>
+<section id="extensions">
+<h2>9. Let capabilities evolve around a stable kernel</h2>
+<p>LoopX keeps goal, Todo, gate, quota, evidence, recovery, and scheduling semantics in the kernel. Domain behavior evolves through three independent boundaries:</p>
+<ul><li><strong>Capability:</strong> the outcome promised to the caller, including domain policy and validation.</li><li><strong>Provider:</strong> the bounded local or external implementation, returning observations and readback.</li><li><strong>Extension:</strong> optional delivery and lifecycle, including installation, checks, enablement, upgrades, and rollback.</li></ul>
+<pre><code>Agent → Capability → Provider → external or local system
+Readback → Capability validation → Kernel transition</code></pre>
+<p>Installing an extension does not itself grant goal authority or external write permission. A provider does not decide whether the kernel accepts a transition. This distinction lets optional integrations coexist with a provider-neutral core. See <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/extensions.md">Extensions and Capabilities</a>.</p>
+<p>Hooks add bounded behavior at specific phases. A turn-start hook can obtain a scoped observation. An interaction-projection hook contributes a read-only view. A post-writeback hook can record an effect-free intent after the primary state has committed. That intent still needs its own authorized lifecycle before any external delivery.</p>
+<p>The practical route to code evolution begins with evidence from real work. Capture a small implementation seam, make its observations and failure boundary explicit, give it a separate lifecycle when needed, and stabilize a capability when the caller outcome is clear. Only recurring cross-domain invariants belong in the kernel. This gives experimentation room without duplicating the authority model.</p>
+<figure class="diagram" aria-labelledby="boundary-caption"><p class="diagram-label">05 / Outcome contracts and delivery boundaries</p><div class="extension-frame"><span class="frame-label">Extension / optional packaging and lifecycle</span><div class="diagram-node"><b>Provider</b><span>Call a local or remote system → read back the outcome</span></div></div><div class="connector">↓ Bounded observation</div><div class="diagram-node"><b>Capability</b><span>Validate the caller outcome → propose a state change</span></div><div class="connector">↓ Validated proposal</div><div class="diagram-node kernel"><b>Kernel</b><span>Check authority, identity, and transition rules → durable commit</span></div><figcaption id="boundary-caption">A provider can also be built in. The dashed enclosure denotes an optional lifecycle, not additional authority.</figcaption></figure>
+<p>In the inference scenario, a domain capability would own the experiment’s comparison contract and result validation. A GPU scheduler provider would own job submission, status readback, and cancellation within the authorized scope. Swapping a cluster provider should not change what counts as a valid comparison. This is a placement example, not a claim that a particular GPU integration ships with LoopX. An integration that only transports a result may need a provider and lifecycle without a new capability.</p>
+
+</section>
+<section id="evidence">
+<h2>10. What the evidence can tell us</h2>
+<p>A long-running project and a stronger benchmark result establish different things. A showcase can demonstrate continuity across turns, waits, reviews, and recovery. Its elapsed time is not uninterrupted model reasoning time. A benchmark asks what a particular system completes under specified conditions.</p>
+<p>The wider research makes the setup worth taking seriously. OpenAI reports that UK AISI’s cyber-range evaluation improved performance by up to 59% when token budgets increased from 10M to 100M. This concerns that tested setting; it is not a LoopX result or a promise that longer runs always help. It motivates measuring harness and budget together. See <a href="https://openai.com/index/trustworthy-third-party-evaluations-foundations/">OpenAI’s evaluation methodology discussion</a>.</p>
+<h3>SWE-Marathon: gains, cost, and a failed integration mode</h3>
+<p>The <a href="../../benchmarks/swe-marathon/">public LoopX study</a>, contributed by <a href="https://github.com/huangruiteng/loopx/pull/3838">BouwenZhou</a>, compared five modes on 15 matched SWE-Marathon v1.1 tasks: 75 trials, one per task and mode. It used GPT-5.6 Sol at high reasoning effort, Codex 0.151.0, LoopX 0.5.3, Harbor 0.20.0, and a timeout multiplier of 0.3. These are historical experiment versions, separate from the implementation revision discussed elsewhere in this article.</p>
+<div class="table-scroll"><table class="benchmark-table"><caption>One trial per cell; costs are totals across 15 tasks, rounded to USD</caption><thead><tr><th>Mode</th><th>Binary success</th><th>Mean partial score</th><th>Total cost</th></tr></thead><tbody>
+<tr><td>Plain Codex</td><td>4 / 15</td><td>0.710</td><td>$368</td></tr>
+<tr><td>Native Codex goal</td><td>4 / 15</td><td>0.767</td><td>$533</td></tr>
+<tr><td>Native goal + LoopX (SSH)</td><td>4 / 15</td><td>0.773</td><td>$696</td></tr>
+<tr><td>LoopX via codex-cli</td><td>3 / 15</td><td>0.655</td><td>$419</td></tr>
+<tr><td>LoopX + external heartbeat</td><td>5 / 15</td><td>0.778</td><td>$830</td></tr>
+</tbody></table></div>
+<p>The heartbeat arm completed one more task than the native goal baseline, with a 0.011 higher mean partial score and about 56% higher total cost. The codex-cli arm performed worse and included one build failure. That failure remains in the common denominator. The study describes a mismatch between an attended host mode and unattended continuation as a possible explanation; this is a hypothesis, not an isolated causal result. <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/benchmark/swe-marathon/README.md">Settings and limitations</a> · <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/benchmark/swe-marathon/data.json">Pinned aggregate data</a>.</p>
+<p>This is an exploratory comparison with multiple mechanisms changing together. There are no repeated trials in each cell from which to estimate variability. Much of the observed improvement over plain Codex was already present in the native goal baseline. The table supports investigating continuation and integration quality; it does not establish a universal LoopX uplift or the efficiency of every kernel mechanism.</p>
+<h3>A case where further verification mattered</h3>
+<p>The public case analysis, contributed through <a href="https://github.com/huangruiteng/loopx/pull/3887">Wanli-Lee’s case-insight projections</a>, offers a concrete example. On the zstd-decoder task, plain Codex stopped after 52 steps and six visible fixtures; its final evaluation passed 25 of 37 hidden checks. The SSH LoopX arm used 135 steps and passed 37 of 37. The heartbeat arm used 453 steps, developed a 156-check acceptance suite, and also passed 37 of 37. These counts come from the <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/benchmark/swe-marathon/case_insights.json">published aggregate case analysis</a>; they are observations of those runs.</p>
+<figure class="diagram" aria-labelledby="verification-caption"><p class="diagram-label">06 / More execution needs a better stopping rule</p><div class="diagram-pair"><div class="diagram-node"><b>Visible examples pass</b><span>Stop at the observed boundary</span><strong>Plain: 25 / 37 final checks</strong></div><div class="diagram-node"><b>Broaden verification</b><span>Probe requirements beyond visible examples</span><strong>SSH and heartbeat: 37 / 37</strong></div></div><figcaption id="verification-caption">A descriptive contrast within one task. Different step counts and verification strategies do not isolate which intervention caused the difference.</figcaption></figure>
+<p>The useful hypothesis is that extra turns help when they produce new evidence and repairs. Continuing to reread the same plan can consume more budget without improving the result. The engineering target is a stopping rule sensitive to acceptance gaps, failed hypotheses, and diminishing returns.</p>
+<p>The next experiments should repeat matched trials, report variance and cost per success, and separately vary continuation policy, evidence retention, and recovery. Interrupted effects and peer handoffs need dedicated tests too. The <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.zh-CN.md">research program</a> outlines that wider space. A promising case is a reason to test a mechanism more carefully.</p>
+</section>
+<section id="start">
+<h2>11. Start with one real project</h2>
+<p>Begin with the <a href="../../docs/book/en/">Developer Book</a> and the <a href="https://github.com/huangruiteng/loopx#quick-start">Quick Start</a>. Connect one project through your existing agent, inspect its goal and next safe action, and give it a bounded task with a visible acceptance condition. Add parallel peers and optional integrations as the work requires them.</p>
+<p>After installation, these commands inspect the setup and connected project:</p>
+<pre><code>loopx doctor
+loopx status</code></pre>
+
+<h3>Make the first loop small enough to judge</h3>
+<ol><li><b>Choose an observable outcome.</b> For the inference project, pin the workload, quality envelope, latency target, and baseline before delegating.</li><li><b>State the authority boundary.</b> Separate development, experiment spending, and publication authority. Give enough scope for useful independent work.</li><li><b>Inspect one complete cycle.</b> Follow selection, execution, validation, writeback, and the successor. Confirm that a fresh session can recover the current facts.</li><li><b>Test a wait and a correction.</b> Wait for a remote result, allow independent analysis, and correct an insufficient performance claim. Check that the next turn inherits both the wait and the feedback.</li><li><b>Expand where the evidence supports it.</b> Add peers for separable work. Watch coordination cost, repeat failures, and the amount of attention required.</li></ol>
+<p>A short, well-specified task that fits comfortably in one session may be best served by the agent you already use. LoopX becomes interesting when continuity, scoped decisions, evidence, and coordination become recurring work of their own. Its overhead should earn its place in the project.</p>
+<p>My ambition is a digital team that can carry useful work across projects and hosts while remaining understandable to the people directing it. That is a direction to build and test, not a claim that all the pieces are finished. Opening the project also changes the work: other developers bring different tasks, failure modes, and standards. The strongest version of LoopX will come from those concrete demands.</p>
+
+</section>
+
+  <p class="edition">Public blog edition. Implementation references are pinned to <a href="https://github.com/huangruiteng/loopx/tree/41a35880fc63ed8b51696e08ec1f17b5369b1a4b">41a3588</a>; use the current documentation for operating instructions.</p>
+  </article>
+</div>
+</main>
+<footer class="site-footer"><a class="brand" href="../../">LoopX</a><p>Keep the loop moving. Keep the judgment human.</p><a href="../../blog/">All posts ↑</a></footer>
+</body>
+</html>

--- a/apps/presentation/site/public/blog/index.html
+++ b/apps/presentation/site/public/blog/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#fafafa">
+  <title>LoopX Blog · LoopX</title>
+  <meta name="description" content="Design, engineering, and field notes on long-horizon agents.">
+  <link rel="canonical" href="https://huangruiteng.github.io/loopx/blog/">
+  <link rel="alternate" hreflang="en" href="https://huangruiteng.github.io/loopx/blog/">
+  <link rel="alternate" hreflang="zh-CN" href="https://huangruiteng.github.io/loopx/blog/zh/">
+  <link rel="alternate" hreflang="x-default" href="https://huangruiteng.github.io/loopx/blog/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="LoopX">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="LoopX Blog">
+  <meta property="og:description" content="Design, engineering, and field notes on long-horizon agents.">
+  <meta property="og:url" content="https://huangruiteng.github.io/loopx/blog/">
+  <meta name="twitter:card" content="summary">
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="../blog/blog.css">
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="site-header">
+  <a class="brand" href="../" aria-label="LoopX home"><span class="product-mark" aria-hidden="true"><i></i><i></i></span>LoopX</a>
+  <nav aria-label="Primary navigation">
+    <a href="../blog/" aria-current="page">Blog</a>
+    <a href="../docs/book/en/">Docs</a>
+  </nav>
+  <div class="header-actions"><a class="language" href="../blog/zh/" lang="zh-CN" hreflang="zh-CN" aria-label="阅读中文版">中文</a><a class="github" href="https://github.com/huangruiteng/loopx">GitHub <span aria-hidden="true">↗</span></a></div>
+</header>
+<main id="main" class="blog-index">
+  <div class="index-heading"><p class="eyebrow">LoopX · Blog</p><h1>Engineering the long run.</h1><p class="lead">Design, engineering, and field notes on long-horizon agents.</p></div>
+  <article class="post-listing">
+    <div><p class="eyebrow">Architecture · Design notes</p><p class="listing-date">September 2026</p></div>
+    <div><h2><a href="from-one-shot-agents-to-long-horizon-control/">From one-shot agents to long-horizon control</a></h2><p>How LoopX uses goals, a state kernel, and Effect Programs to carry work across sessions, preserve human judgment, and recover from interruptions.</p><a class="read-post" href="from-one-shot-agents-to-long-horizon-control/">Read the article <span aria-hidden="true">↗</span></a></div>
+  </article>
+  <div class="index-note"><span>Start using LoopX</span><a href="../docs/book/en/">Open the Developer Book →</a></div>
+</main>
+<footer class="site-footer"><a class="brand" href="../">LoopX</a><p>Keep the loop moving. Keep the judgment human.</p><a href="../blog/">All posts ↑</a></footer>
+</body>
+</html>

--- a/apps/presentation/site/public/blog/zh/from-one-shot-agents-to-long-horizon-control/index.html
+++ b/apps/presentation/site/public/blog/zh/from-one-shot-agents-to-long-horizon-control/index.html
@@ -1,0 +1,273 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#fafafa">
+  <title>从一次性 Agent 到长程控制面 · LoopX</title>
+  <meta name="description" content="LoopX 如何用目标、状态内核与 Effect Program，让工作跨越会话、吸收人类判断，并从中断中恢复。">
+  <link rel="canonical" href="https://huangruiteng.github.io/loopx/blog/zh/from-one-shot-agents-to-long-horizon-control/">
+  <link rel="alternate" hreflang="en" href="https://huangruiteng.github.io/loopx/blog/from-one-shot-agents-to-long-horizon-control/">
+  <link rel="alternate" hreflang="zh-CN" href="https://huangruiteng.github.io/loopx/blog/zh/from-one-shot-agents-to-long-horizon-control/">
+  <link rel="alternate" hreflang="x-default" href="https://huangruiteng.github.io/loopx/blog/from-one-shot-agents-to-long-horizon-control/">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="LoopX">
+  <meta property="og:locale" content="zh_CN">
+  <meta property="og:title" content="从一次性 Agent 到长程控制面">
+  <meta property="og:description" content="LoopX 如何用目标、状态内核与 Effect Program，让工作跨越会话、吸收人类判断，并从中断中恢复。">
+  <meta property="og:url" content="https://huangruiteng.github.io/loopx/blog/zh/from-one-shot-agents-to-long-horizon-control/">
+  <meta name="twitter:card" content="summary">
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="../../../blog/blog.css">
+</head>
+<body>
+<a class="skip-link" href="#main">跳至正文</a>
+<header class="site-header">
+  <a class="brand" href="../../../?lang=zh" aria-label="LoopX 首页"><span class="product-mark" aria-hidden="true"><i></i><i></i></span>LoopX</a>
+  <nav aria-label="主导航">
+    <a href="../../../blog/zh/" aria-current="true">Blog</a>
+    <a href="../../../docs/book/">文档</a>
+  </nav>
+  <div class="header-actions"><a class="language" href="../../../blog/from-one-shot-agents-to-long-horizon-control/" lang="en" hreflang="en" aria-label="Read in English">EN</a><a class="github" href="https://github.com/huangruiteng/loopx">GitHub <span aria-hidden="true">↗</span></a></div>
+</header>
+<main id="main">
+<div class="article-heading">
+  <a class="back" href="../../../blog/zh/">← 全部文章</a>
+  <p class="eyebrow">架构 · 设计笔记</p>
+  <h1>从一次性 Agent 到长程控制面</h1>
+  <p class="lead">LoopX 如何用目标、状态内核与 Effect Program，让工作跨越会话、吸收人类判断，并从中断中恢复。</p>
+  <div class="byline"><a href="https://github.com/huangruiteng">Ruiteng Huang</a><span aria-hidden="true">·</span><span>2026 年 9 月</span><span aria-hidden="true">·</span><span>目标、状态内核与 Effect Program</span></div>
+</div>
+<div class="article-layout">
+  <aside class="toc"><details open><summary>本文目录</summary><nav aria-label="文章目录"><a href="#objective">1. 最大化 Agent 产出，最小化人的注意力投入</a>
+<a href="#control-plane">2. 语义控制面要保存什么</a>
+<a href="#state-kernel">3. 外置状态，可重建的展示面</a>
+<a href="#agent-interface">4. 帮助 Agent 决定下一步的 CLI</a>
+<a href="#effects">5. Effect Program：恢复实际发生过的事</a>
+<a href="#planning">6. 何时执行、等待与重新规划</a>
+<a href="#human-attention">7. 为判断设计交互面</a>
+<a href="#multi-agent">8. 数字团队需要显式权限</a>
+<a href="#extensions">9. 围绕稳定内核演进垂域能力</a>
+<a href="#evidence">10. 证据能回答什么</a>
+<a href="#start">11. 从一个真实项目开始</a>
+</nav></details></aside>
+  <article class="prose" aria-label="从一次性 Agent 到长程控制面">
+  <section id="objective">
+<h2>1. 最大化 Agent 产出，最小化人的注意力投入</h2>
+<p>我做 LoopX 的动机很朴素：让 Agent 多干一些活，尤其是那些总把人拉回键盘前的工作。项目逐渐变长后，瓶颈发生了变化。模型可以解决眼前的问题，但仍然需要人记住目标、分配工作、检查证据、处理权限，再告诉它什么时候继续。</p>
+<p>LoopX 同时优化两个目标：Agent 的有效产出，以及获得这些产出所需的人类注意力。产出取决于模型能力、有效并行度、时间利用率和目标对齐程度。LoopX 主要改善后三项，具体工作仍由底层 Harness 和模型执行。</p>
+<p>技术目标是：<strong>无干预跑稳，有干预跑好。</strong>不需要人判断时持续推进，缺少新事实时安静等待，路线失效时重新规划，控制状态矛盾时自我修复，验收满足后停止。人的反馈应当改善后续方向，并成为下一轮可以继承的状态。</p>
+<p>这也是吞吐问题。快速回复有价值；多项独立工作能在人离开后继续推进，同样有价值。需要观察的是，每单位算力和人类注意力换来了多少经过验证的产出。</p>
+
+<h3>交付一条长上下文推理加速路径</h3>
+<p>设想把这样一个目标交给 Agent 团队：为开源推理引擎交付长上下文注意力加速后端。工作横跨内核与 Serving 两个仓库，需要建立可复现基线、比较优化假设、提交远程 GPU 实验、检查数值误差、验证并发流量下的集成表现，最后交付带回滚路径的候选版本。下面用这个构造场景解释控制契约，实验工具由选定的 Host 与 Provider 提供。</p>
+<p>内核方向的 Peer 研究数据搬运，Serving 方向的 Peer 构建接近真实负载的回放，验证方向的 Peer 检查数值容差与边界条件。Owner 授权开发和有界实验预算，保留发布决策。部分工作可以并行，部分必须等待稀缺 GPU 时隙、兼容的内核修订，或一份足以推翻当前假设的实验结果。</p>
+<p>几天后，“Benchmark 绿了”提供的信息远远不够：测的是哪个模型、硬件、输入长度、并发量和修订？吞吐提升是否牺牲了尾延迟？收益是否来自工作负载被悄悄改了？提交 Session 断连前，远程实验究竟有没有启动？下一位 Worker 需要恢复这些区别。</p>
+<div class="case-note"><b>示例验收契约</b><p>约定长上下文负载的请求 p95 延迟至少降低 20%；短上下文对照退化不超过 5%；数值误差满足约定容差；峰值显存不超预算；证据可复现，发布经过授权且可回滚。这些是示例目标，不是 LoopX 的实验成绩。</p></div>
+
+</section>
+<section id="control-plane">
+<h2>2. 语义控制面要保存什么</h2>
+<p>模型的工作上下文有限。压缩和 Subagent 可以缓解上下文压力，但一段总结无法可靠地执行所有权、并发、权限和幂等规则。跨 Session 的项目需要持续回答：</p>
+<ul><li>当前目标是什么，怎样才算验收通过？</li><li>哪些事实和人类决策仍然有效？</li><li>每项工作由谁负责，哪些动作已获得授权？</li><li>某个外部操作究竟有没有发生？</li><li>下一轮是否值得继续消耗资源，结束后又该做什么？</li></ul>
+<p>这些问题定义了 Semantic Control Plane。把 Agent Stack 按恢复对象分成四层，可以看清它的位置。</p>
+<figure class="stack"><ol>
+<li><b>04 · 语义控制面</b><span>目标、证据、权限、验收、重新规划</span></li>
+<li><b>03 · 工作协作</b><span>Todo、Claim、Lease、Handoff</span></li>
+<li><b>02 · 持久化工作流</b><span>步骤、重试、等待、恢复</span></li>
+<li><b>01 · 执行底座</b><span>进程、容器、会话、工作区</span></li>
+</ol><figcaption>每层保存不同的工作状态，可以组合使用。</figcaption></figure>
+<p>Runtime 恢复运行环境；LoopX 保存 Agent 正在做什么、为什么做、已经证明了什么，以及下一步是否合法。Codex Thread、Claude Code Session 和 CLI Runner 都可以成为这块共同事实面周围可替换的 Worker。</p>
+<p>四个概念有助于精确描述进展：</p>
+<pre><code>Turn       = 一次有界执行窗口
+Result     = 一轮返回的产物或观察
+Transition = 经过验证并获准写入的状态变化
+Progress   = 与验收相关的持久状态迁移</code></pre>
+<p>一段有说服力的回答属于 Result。相关验证和状态迁移被接受后，它才能成为项目进展。具体定义见<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture.md">架构与术语</a>。</p>
+
+<h3>与工作流引擎、Memory 的关系</h3>
+<p>已有系统解决了持久化的重要部分。<a href="https://docs.langchain.com/oss/python/langgraph/persistence">LangGraph 的 Checkpoint</a>保存图状态，支持恢复、人类介入与时间回溯；<a href="https://docs.temporal.io/activities">Temporal Activity</a>隔离外部工作，安全重试仍需应用自身的幂等设计。LoopX 增加项目层的判断：什么证据满足验收，哪个 Actor 有权提交变化，当前路线是否还值得继续。</p>
+<p>Memory 帮助找回有用的事实，Authority 决定该事实此刻能否支持行动。记住 Owner 曾批准一次发布，有助于理解上下文；把它当成以后每次发布的授权，就会出错。同样，忠实恢复一条已经过时的计划，可能在运行层面非常可靠，却耗尽剩余预算。恢复时需要保留目标，并重新判断路线。</p>
+
+</section>
+<section id="state-kernel">
+<h2>3. 外置状态，可重建的展示面</h2>
+<p>LoopX 将 Canonical State 与 Projection 分离。Registry 保存目标身份、项目连接、策略和权威来源；追加式 Ledger 记录带身份的事件；Run History 与 Evidence 把执行连接到产物、验证、失败和资源消耗；Active-state Workbench 提供人可读的兼容表面。</p>
+<p>Status、任务图、评审包和 Dashboard 都是这些事实的投影。它们可以重建，界面上的状态本身不会独立授予迁移权限。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/event-sourced-state-contract-v0.md">事件溯源状态契约</a>定义了 Replay 与 Identity：同一事件的重放保持幂等，相同身份但内容冲突的事件必须拒绝。</p>
+<p>一个 Open Todo 就足以说明复杂性。它可能在等审批、等 PR 合并、等 Monitor 发现变化，也可能被另一 Agent Claim，缺少 Host Capability，处于错误工作区，或被后来的路线替代。仅凭 Open 无法决定是否执行。</p>
+<pre><code>Open work
+  → 依赖与恢复条件
+  → 有范围的授权
+  → Claim 与生命周期所有权
+  → Host 能力与工作区
+  → 事实新鲜度与证据
+  → Quota 与当前可执行 Frontier</code></pre>
+<p>人的决策也进入同一套持久模型。“等我 Review”“这条路线可以继续”都有具体范围。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/decision-scope-v0.md">Decision Scope 契约</a>将权限绑定到 Action、Lane、Goal 或 Project。一条路径等待时，不依赖该决策且已经获得授权的工作仍可继续。</p>
+<p>完成同样需要明确边界。关闭 Todo 只是一个局部工作的证据，不会自动满足整个 Goal。如果可执行 Frontier 已经耗尽，Acceptance 仍然开放，系统需要新的路线，或者有证据支持的 No-follow-up 结论。</p>
+<figure class="diagram" aria-labelledby="truth-caption">
+<p class="diagram-label">01 / 共同事实面</p>
+<div class="diagram-node"><b>人的目标与判断</b><span>验收条件 · 有范围的决策</span></div>
+<div class="connector" aria-hidden="true">↓</div>
+<div class="diagram-node kernel"><b>Canonical State / 状态内核</b><span>目标 · 证据 · 权限 · 当前有效路线</span></div>
+<div class="diagram-branch"><span>↓ 选择与授权</span><span>↓ 只读投影</span></div>
+<div class="diagram-pair"><div class="diagram-node"><b>Quota → Agent → Capability</b><span>执行有界工作，获得 Provider 回读</span></div><div class="diagram-node"><b>Status / Dashboard</b><span>展示事实，不自行授予权限</span></div></div>
+<div class="return-path">↳ 观察 → 验证 Proposal → Kernel 接受迁移 ↺</div>
+<figcaption id="truth-caption">工作结果必须回到共同事实面。看板上的“完成”和 Agent 的叙述，都不能代替已接受的迁移。</figcaption></figure>
+<p>回到推理加速，“发布前等我确认”的范围是 Release，不会抹去分析 Profile 或验证兼容性的授权。一个有用的投影可以同时展示：内核候选通过局部检查、服务级延迟目标尚未证实、发布等待决策。一个“Blocked”会藏起可推进的分析，一个“Done”又会藏起尚未关闭的验收缺口。</p>
+
+</section>
+<section id="agent-interface">
+<h2>4. 帮助 Agent 决定下一步的 CLI</h2>
+<p>可以把 LoopX 直观理解为一张可执行 Kanban。卡片有稳定身份、依赖、Claim、Scope、Evidence 和 Successor。移动卡片意味着申请一次可验证的状态迁移，看板展示的是这份契约。</p>
+<p>CLI 将工作连续性写进交互。完成任务时，可以创建后继、链接已有后继，或在验收满足后记录结构化 No-follow-up 理由。这样，一次局部成功不会让更大的任务链断线。具体规则见 <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/project-agent-todo-contract.md">Todo Contract</a>。</p>
+<p>Interaction Contract 分开表达“人需要听到什么”和“Agent 必须做什么”。通知通道可以安静，同时要求 Agent 执行一段有界工作。反过来，状态要求等待时，调度器唤醒也可以合法地不产生工作。</p>
+<p>这同时保护 Human 和 Agent 的注意力。Human-facing View 突出值得判断的新问题；Agent-facing View 给出当前权限、下一步、验证和停止条件。双方都不应靠读完全部历史对话来重建当前事实。</p>
+<p>Host Scheduler 提供唤醒，LoopX CLI 与轻量 Skill 提供受治理的工作契约。调度 Prompt 应维护这条生命周期，并从状态读取当前决策，避免在自然语言里累积第二份项目计划。</p>
+
+<h3>一次交接里应该包含一个判断</h3>
+<p>内核实验的有效写回应当标明候选修订、对照条件、已测量边界、剩余缺口和后继。下面是解释用记录，不是 CLI Payload，也不是真实运行日志：</p>
+<pre><code>完成切片：评估注意力内核候选 A
+证据：固定的候选、基线、工作负载与结果清单
+已经证明：数值检查通过；孤立内核测试更快
+剩余缺口：尚未证明并发流量下的服务 p95
+后继：用固定负载回放两个 Serving 构建
+权限：允许有界实验；发布仍受 Gate 约束</code></pre>
+<p>相比“注意力优化完成，Benchmark 通过”，这份记录防止局部 Microbenchmark 的收益变成未经证实的服务级结论。结果清单应能识别代码、环境、负载和测量方法，让后续 Peer 可以复现，也可以提出质疑。</p>
+<p>实际的 <code>todo complete</code> 支持用 <code>--next-agent-todo</code> 指定后继，或在适用时用 <code>--no-follow-up</code> 记录理由。这些是生命周期操作：受 Quota 约束的仓库推进，需要先满足对应的 Writeback 与 Spend Receipt。脱离当前 Interaction Contract 复制完成命令，可能破坏顺序。应由 Host 读取当前契约，再执行它给出的动作。</p>
+
+</section>
+<section id="effects">
+<h2>5. Effect Program：恢复实际发生过的事</h2>
+<p>普通函数可以写成 <code>A → B</code>；Agent 操作更接近 <code>A → F[B]</code>，其中包含权限、持久化、时间、预算、外部调用和失败。模型提出动作，与真实世界发生变化，是两个不同事实。</p>
+<pre><code>Goal 状态 → Effect 请求 → 权限 / Quota 解释
+  → 外部操作 → Observation / Readback → Receipt
+  → 持久状态迁移 → 下一版 Goal 状态</code></pre>
+<p>Effect Program 为这些步骤建立 Identity、顺序、Receipt 和失败语义。缺少这些机制，外部操作成功后的崩溃可能导致重复重试；迟到的 ACK 可能结算错误的 Turn；不同模块也可能逐渐形成互不兼容的 Writeback、Spend 和 Closeout 顺序。</p>
+<p>公开的 <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/control_plane/effect_program.ts">EffectTurn 实现</a>用四个可序列化 Slot 描述一次交互：</p>
+<pre><code>interface EffectTurn&lt;Context, Decision extends string&gt; {
+  request: EffectRequest&lt;Context&gt;;
+  interpretation: EffectInterpretation;
+  observation: EffectObservation&lt;Decision&gt;;
+  next_effect: EffectNext;
+}</code></pre>
+<p>Settlement 的下一步是三个互斥分支：<code>failed</code>、<code>execute</code> 或 <code>complete</code>。已选中 Turn 的结算顺序固定为：</p>
+<figure class="flow"><ol><li>验证</li><li>持久写回</li><li>记录 Quota 消耗</li><li>终局时关闭</li></ol><figcaption>失败保留已提交前缀，并停止后续步骤。</figcaption></figure>
+<p>Settlement Identity 绑定 Goal、Agent、Turn Instance，以及选中的 Todo 或 Replan Obligation。Matching Receipt 标识已提交步骤。恢复时核对身份，从未提交的后缀继续。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/tests/control_plane_ts/effect_program.test.ts">Effect Program 测试</a>覆盖顺序、重放、失败和已提交前缀。</p>
+<h3>远程 GPU 实验刚提交，连接就断了</h3>
+<p>一次已授权的实验提交到达远程调度器，但 Agent 还没记录响应，连接就断开了。盲目重试可能启动重复 Job，花掉两份预算。恢复时，先用 Provider 的请求身份或 Job ID 回读提交是否被接受；如果 Provider 无法确定结果，这条分支就保留为待核对状态。</p>
+<p>确认提交，只能证明 Job 已被接受，不能证明它已完成，更不能证明候选满足验收。提交 Turn 可以结算自己的有界结果，并建立 Monitor；后续验证 Turn 再检查结果清单。两轮各自需要身份和 Receipt。</p>
+<details><summary>展开查看恢复时的判断</summary><ol>
+<li><b>提交结果未知：</b>先查询请求或 Job，再考虑是否重试。</li>
+<li><b>确认提交，尚未写回：</b>把已接受的 Job 关联到相同 Effect Identity，持久化提交结果，并建立负责观察的后继。</li>
+<li><b>写回已提交，尚未记账：</b>保留已提交前缀，继续 Quota Settlement。</li>
+<li><b>结算已完成：</b>重放已接受的结果，不重复计费。</li>
+</ol></details>
+<p>这是受治理结算的恢复契约。控制面内的 Exactly-once 记账，不意味着任意外部 API 都能 Exactly-once；外部操作仍需 Provider 级幂等或回读。Effect Program 也保留领域所有权：结算代数不会用一个通用 Executor 替代 Goal 规划。</p>
+<figure class="diagram" aria-labelledby="recovery-caption"><p class="diagram-label">02 / 从未提交的那一步继续</p><ol class="recovery-steps"><li class="committed"><span>已提交</span><b>验证通过</b></li><li class="committed"><span>已提交</span><b>持久写回</b></li><li class="pending"><span>待执行</span><b>记录消耗</b></li><li class="pending"><span>待执行</span><b>终局关闭</b></li></ol><div class="crash-marker">× 进程在写回之后退出</div><div class="diagram-node"><b>恢复时核对身份与 Receipt</b><span>相同 Goal / Agent / Turn · 相同 Todo 或 Replan Obligation</span></div><div class="return-path">保留已提交前缀 → 继续 Spend → 按需 Closeout</div><figcaption id="recovery-caption">图中从 Spend 继续。若外部动作结果未知，则先回读外部状态；不能把“没有收到响应”当作“没有执行”。</figcaption></figure>
+<p>这里有两份账需要核对：外部实验预算，以及控制面的 Turn 记账。LoopX Spend Receipt 不会取消重复 GPU Job，也不能证明远程计费正确。Provider 负责确定外部结果，Kernel 负责结算对应 Turn。把职责分开，昂贵的不确定状态才有办法诊断。</p>
+
+</section>
+<section id="planning">
+<h2>6. 何时执行、等待与重新规划</h2>
+<h3>Quota 编译本轮决策</h3>
+<p><code>quota should-run</code> 在算力预算之前，先处理健康与安全、Operator Gate、Evidence Wait 和 Focus Wait，再结合当前工作、Capability、Workspace 与 Scheduler 状态生成 Interaction Contract。结果可能允许有界工作、指出决策 Gate、保持等待、限制交付或要求修复。详见 <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/quota-allocation.md">Quota Allocation</a>。</p>
+<p>经过验证的持久写回先于 Quota Spend。Quiet Skip、Preflight Failure 和 Dry-run 不计为 Delivery Spend。即使 Refresh 已经选出下一项动作，Spend Record 仍应归因到刚完成的工作。</p>
+<h3>围绕当前任务的有界 Planning Horizon</h3>
+<p>Typed Planning Inventory 支撑多个视图。Action Portfolio 给出少量当前候选；Planning Horizon 展示附近的 Successor、依赖、Resume 关系和 Acceptance Gap；按需 Todo Detail 展开冷路径；Task Graph 提供诊断视图。</p>
+<p>可见性不授予执行权。被另一 Agent Claim 的相关任务是协调上下文；可运行但未领取的任务，仍需 Claim 和常规检查。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/quota-planning-horizon-v0.md">Planning Horizon 协议</a>将读模型与 Selection Authority 分开。</p>
+<p>对开放式研究，<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/capabilities/explore/README.md">Explore Capability</a>补充问题、假设、实验和 Finding 的证据图。规划层可以组织分支，执行仍走正常 LoopX 生命周期。失败路线和组合探索的理由由此保留下来，不必把所有细节塞进下一轮 Prompt。</p>
+<h3>等待一个新事实</h3>
+<p>Monitor Resume 需要等待开始之后发生的 Material Change。Generation Fence 比较当前 Monitor Generation 与保存的 Baseline；历史结果、无变化轮询和重复 Replay 都不能算新信号。实现见 <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/control_plane/todos/resume_condition.ts">Resume Condition</a>。</p>
+<p>主路径等待时，独立 Fallback 可以继续推进。没有新事实的轮询应退避；反复无进展时，需要具体 Blocker、Expiry、Successor 或 Replan 决策。</p>
+<h3>Replan 有身份，也必须有结果</h3>
+<p>当前路线无法继续支撑验收时，Replan 会成为机器执行的义务。<code>obligation_id</code> 标识这一代问题，旧义务的迟到 ACK 无法关闭新义务。</p>
+<p>触发原因包括重复语义停滞、Todo 连续性中断、验收缺口、任务链过长、周期复盘和 Frontier 耗尽。合法等待与普通 Scheduler Wake 有自己的语义，不会自动意味着必须 Replan。</p>
+<p>结算需要绑定当前 Exact Obligation，并产生已接受的语义变化，例如可运行 Successor、具体 Blocker、有新证据支持的路线，或有依据的 No-follow-up。只改计划文字、只发 ACK 无法满足它。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/protocols/goal-vision-replan-contract-v0.md">Goal / Vision / Replan 契约</a>定义了这条边界。</p>
+<figure class="diagram" aria-labelledby="wait-caption"><p class="diagram-label">03 / 等待绑定到新事实</p><ol class="timeline"><li><b>开始等待</b><code>保存 Generation = 12</code><span>实验结果尚未到达</span></li><li><b>再次轮询</b><code>Generation = 12</code><span>没有新事实，保持等待</span></li><li><b>新观察到达</b><code>Generation = 13</code><span>结果清单变化；重新检查恢复条件</span></li></ol><div class="return-path">等待期间：数值分析与回滚验证可以继续 →</div><figcaption id="wait-caption">示例 Generation 用于解释新鲜度。新结果可以唤醒分析，发布仍需对应授权。</figcaption></figure>
+<h3>一次有效 Replan 改变什么</h3>
+<p>假设新内核提升了孤立测试的吞吐，但连续两次 Serving 实验仍未达到 p95 目标。再做一轮内核调优，可能已经不是正确的下一步。有效 Replan 应记录“局部加速尚未转化为端到端价值”，提出调度或显存争用的竞争假设，建立只改变一个因素的对照实验，再让集成路线依赖结果。这里描述的是构造情境，不是真实运行的测量结果。</p>
+<div class="table-scroll"><table><caption>为推理加速路线重新规划</caption><thead><tr><th>当前路线</th><th>接受的变化</th></tr></thead><tbody><tr><td>服务 p95 退化，仍反复调优内核吞吐</td><td>固定负载，只改变一个调度或显存相关变量进行对照</td></tr><tr><td>在总结里写“性能需要关注”</td><td>建立能区分假设的实验，固定输入并产出结果清单</td></tr><tr><td>GPU 结果尚未返回，主实验路线必须等待</td><td>推进数值边界分析或回滚验证，同时保留实验预算边界</td></tr></tbody></table></div>
+<p>控制面可以要求有意义的迁移、拒绝过期 ACK。新假设的质量仍取决于模型、工具、证据和人的判断。Typed Obligation 让失败变得可见、可恢复，洞察本身仍需要做出来。</p>
+
+</section>
+<section id="human-attention">
+<h2>7. 为判断设计交互面</h2>
+<p>Agent 进入代码、文档、研究和沟通场景后，Operator 需要简洁的决策视图：哪个项目需要判断？哪条高优路线被阻塞？什么可以独立推进？Monitor 是否发现重要变化？最近的活动是否形成了有效进展？</p>
+<p>产品闭环是 <strong>Signal Inbox → Anchor Selection → Performance Review</strong>。外部信号进入有界 Inbox；Human 与 Agent 选择少数高价值锚点；再按 Value、Quality、Control、Cost、Learning 复盘结果，让反馈进入下一轮。</p>
+<p>汇报也是注意力边界。重要交付、阶段闭环、路线决策或主要阻塞值得更新；普通刷新和无变化 Monitor 不应反复打断人。相关事件可以合并、去重。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/capabilities/periodic_report/README.md">Periodic Report 能力</a>与<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture/rfcs/intelligent-review-presentation-surfaces-v0.zh-CN.md">智能展示面 RFC</a>分别描述已有机制和更完整的产品方向。</p>
+
+<h3>人的价值落在方向与质量标准上</h3>
+<p>长程 Agent 改变了我投入时间的位置。早期花很多精力管理卡片、重启 Session；连续性改善后，更值得做的是检查产物、收紧目标，并说明一个看似合格的结果为什么还不够好。“这张图没有解释失败边界”，比又一次泛泛地要求继续更有价值。</p>
+<p>对推理项目，关键干预可能是：“用户在意混合流量下的交互延迟，离线吞吐分数提高还不够。”这个判断会改变工作负载、验收和下一项实验，应当跨越当前对话。如果每开一个 Session 都要再贴一遍，说明系统还在丢失项目的重要部分。</p>
+<p>我希望 Operator Surface 降低这类反馈的成本：同时看到产物、证据、尚未决定的选择，以及再投入一轮的预期价值。更多并行 Agent 能创造价值，前提是 Review 与协调负担不以同样速度增长。人的注意力也是运行预算的一部分。</p>
+
+</section>
+<section id="multi-agent">
+<h2>8. 数字团队需要显式权限</h2>
+<p>并行 Worker 需要共同目标、独立的工作边界和可靠交接。LoopX 使用 Equal Peer 模型：Agent Identity 表示工作角色，不构成永久层级。临时 Coordinator 可以路由工作，但不会自动获得完成或重新分配其他 Peer 任务的权限。</p>
+<div class="table-scroll"><table><thead><tr><th>机制</th><th>确定什么</th><th>不会授予什么</th></tr></thead><tbody>
+<tr><td>Claim</td><td>哪位 Peer 优先接手工作</td><td>锁、存活证明或生产权限</td></tr>
+<tr><td>Lease</td><td>带时间边界的执行占用</td><td>永久所有权或 Gate 已满足</td></tr>
+<tr><td>Lifecycle Authority</td><td>谁能完成、替代、重新分配或覆盖</td><td>由 Claim 推导出的额外权限</td></tr>
+</tbody></table></div>
+<p>跨 Host 后，这些区别更重要。Shared Goal Authority 将语义迁移规则与存储分开：Authority 层拥有 Revision、Lease Epoch、Receipt 和冲突判断；Storage Provider 提供 Load、Compare-and-put 与 Durability。Storage Generation、Authority Revision 与 Lease Epoch 描述不同事实，需要分别标识。</p>
+<p><a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md">Shared Goal Authority RFC</a> 与 <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/loopx/control_plane/coordination/authority_store.ts">Authority Store 实现</a>记录了这项工作。跨 Host 产品化仍在持续验证；接口存在，不代表任意分布式数字团队已经成为开箱即用的产品。</p>
+<figure class="diagram" aria-labelledby="handoff-caption"><p class="diagram-label">04 / 交接产物与边界</p><div class="diagram-pair"><div class="diagram-node"><b>Peer A / 内核仓库</b><span>固定内核修订 · 数值边界 · 性能结果清单</span></div><div class="diagram-node"><b>Peer B / Serving 仓库</b><span>检查接口兼容性 · 回放并发负载</span></div></div><div class="connector" aria-hidden="true">↓</div><div class="diagram-node kernel"><b>共同目标 / 接受证据</b><span>身份、Claim 与有范围的生命周期权限分别检查</span></div><div class="connector" aria-hidden="true">↓</div><div class="diagram-node"><b>Release / 仍需对应授权</b></div><figcaption id="handoff-caption">消费方返回兼容性与负载证据。交接不会赋予完成 Peer 任务或发布版本的额外权限。</figcaption></figure>
+<p>好的 Handoff 是工作边界之间的接口。跨仓库变更中，它可以是一份 API 契约和固定修订，再由消费方完成兼容性验证。把整段对话转给另一 Agent，让它猜哪些决定仍然有效，交接成本会很高。应优先在验收边界可分离的地方并行；紧密耦合的修改，交给同一位 Worker 可能更省。</p>
+
+</section>
+<section id="extensions">
+<h2>9. 围绕稳定内核演进垂域能力</h2>
+<p>LoopX 将 Goal、Todo、Gate、Quota、Evidence、Recovery 和调度语义留在 Kernel。垂域行为沿三个独立边界演进：</p>
+<ul><li><strong>Capability：</strong>对调用者承诺的结果，包括领域策略与验证。</li><li><strong>Provider：</strong>有界的本地或外部实现，返回 Observation 与 Readback。</li><li><strong>Extension：</strong>可选交付与生命周期，包括安装、检查、启用、升级和回滚。</li></ul>
+<pre><code>Agent → Capability → Provider → 外部或本地系统
+Readback → Capability 验证 → Kernel 状态迁移</code></pre>
+<p>安装 Extension 本身不授予 Goal Authority 或外部写权限；Provider 不决定 Kernel 是否接受迁移。这让可选集成与 Provider-neutral Core 共存。详见 <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/reference/extensions.md">Extensions and Capabilities</a>。</p>
+<p>Hook 在特定阶段插入有界行为。Turn-start Hook 可以获取范围内的 Observation；Interaction-projection Hook 提供只读视图；Post-writeback Hook 可以在主状态提交后记录不含副作用的 Intent。Intent 仍需经过独立且获授权的生命周期，才能触发外部交付。</p>
+<p>Code Evolving 从真实工作的证据开始：固化最小实现切面，明确观察与失败边界，需要时独立交付，调用者结果稳定后再沉淀 Capability。只有跨领域反复出现的不变量才进入 Kernel。这样既能吸收实验，也能避免复制权限模型。</p>
+<figure class="diagram" aria-labelledby="boundary-caption"><p class="diagram-label">05 / 结果契约与交付边界</p><div class="extension-frame"><span class="frame-label">Extension / 可选的安装与生命周期</span><div class="diagram-node"><b>Provider</b><span>调用本地或远端系统 → 回读结果</span></div></div><div class="connector">↓ 有界 Observation</div><div class="diagram-node"><b>Capability</b><span>验证调用者需要的结果 → 提出状态变化</span></div><div class="connector">↓ 经过验证的 Proposal</div><div class="diagram-node kernel"><b>Kernel</b><span>检查权限、身份和迁移规则 → 持久提交</span></div><figcaption id="boundary-caption">Provider 也可以内置交付。虚线框表示可选生命周期，不表示 Extension 获得更大的权限。</figcaption></figure>
+<p>在推理场景中，垂域 Capability 可以拥有实验对照契约与结果验证，GPU 调度 Provider 负责授权范围内的 Job 提交、状态回读与取消。替换集群 Provider，不应改变什么算有效对照。这是职责放置示例，不代表 LoopX 已内置某个 GPU 集成。只负责传递结果的集成，可能只需要 Provider 与生命周期，无须增加新 Capability。</p>
+
+</section>
+<section id="evidence">
+<h2>10. 证据能回答什么</h2>
+<p>一个运行很久的项目，与一次更好的 Benchmark 结果，证明的是不同事情。Showcase 可以展示 Turn、等待、Review 和恢复之间的连续性，经过的项目时间不等于连续推理时间。Benchmark 回答某个系统在指定条件下完成了什么。</p>
+<p>更广泛的研究也说明设置值得认真对待。OpenAI 报告，UK AISI 的 Cyber Range 评测把 Token 预算从 10M 提高到 100M 后，性能提升最高达 59%。这是该评测设置下的结果，不是 LoopX 的结果，也不意味着运行越久一定越好；它支持把 Harness 与预算一起测量。参见 <a href="https://openai.com/index/trustworthy-third-party-evaluations-foundations/">OpenAI 的评测方法讨论</a>。</p>
+<h3>SWE-Marathon：收益、成本与失败的接入模式</h3>
+<p><a href="../../../benchmarks/swe-marathon/?lang=zh">LoopX 公开研究</a>由 <a href="https://github.com/huangruiteng/loopx/pull/3838">BouwenZhou 贡献</a>，在 SWE-Marathon v1.1 的 15 个匹配任务上比较五种模式，共 75 次 Trial，每个任务、每种模式各一次。模型为 GPT-5.6 Sol，Reasoning Effort 为 high；Codex 0.151.0、LoopX 0.5.3、Harbor 0.20.0，Timeout Multiplier 为 0.3。这是历史实验版本，与本文其他部分引用的实现修订分开理解。</p>
+<div class="table-scroll"><table class="benchmark-table"><caption>每格一次 Trial；成本为 15 个任务的美元总额，已取整</caption><thead><tr><th>模式</th><th>二值成功</th><th>平均连续分</th><th>总成本</th></tr></thead><tbody>
+<tr><td>裸 Codex</td><td>4 / 15</td><td>0.710</td><td>$368</td></tr>
+<tr><td>Codex 原生 Goal</td><td>4 / 15</td><td>0.767</td><td>$533</td></tr>
+<tr><td>原生 Goal + LoopX（SSH）</td><td>4 / 15</td><td>0.773</td><td>$696</td></tr>
+<tr><td>codex-cli 接入 LoopX</td><td>3 / 15</td><td>0.655</td><td>$419</td></tr>
+<tr><td>LoopX + 外部 Heartbeat</td><td>5 / 15</td><td>0.778</td><td>$830</td></tr>
+</tbody></table></div>
+<p>Heartbeat 相比原生 Goal 多完成一个任务，平均连续分提高 0.011，总成本增加约 56%。codex-cli 模式更差，并出现一次构建失败；该失败保留在共同分母中。研究提出，有人值守的 Host 模式与无人续跑之间的错配，可能解释部分表现，但这是待验证假设，没有被实验单独隔离。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/benchmark/swe-marathon/README.md">设置与局限</a> · <a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/benchmark/swe-marathon/data.json">固定版本的聚合数据</a>。</p>
+<p>这是多项机制同时变化的探索性比较。每格没有重复 Trial，无法据此估计波动；相对裸 Codex 的较大部分提升，在原生 Goal 基线中已经出现。表格支持继续研究续跑方式和接入质量，尚不足以证明 LoopX 的普遍增益，或每项内核机制的效率。</p>
+<h3>一个继续验证有价值的案例</h3>
+<p><a href="https://github.com/huangruiteng/loopx/pull/3887">Wanli-Lee 贡献的 Case Insight 投影</a>进一步给出了具体例子。zstd-decoder 任务中，裸 Codex 在 52 步、六个可见 Fixture 后停止，最终评测通过 37 个隐藏检查中的 25 个。SSH LoopX 模式用了 135 步，通过 37/37；Heartbeat 模式用了 453 步，构建 156 项验收检查，也通过 37/37。数字来自<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/benchmark/swe-marathon/case_insights.json">公开聚合 Case 分析</a>，描述的是这些运行中的观察。</p>
+<figure class="diagram" aria-labelledby="verification-caption"><p class="diagram-label">06 / 更多执行，需要更好的停止条件</p><div class="diagram-pair"><div class="diagram-node"><b>可见样例通过</b><span>在已观察的边界停下</span><strong>裸 Codex：25 / 37</strong></div><div class="diagram-node"><b>扩大验证范围</b><span>探查可见样例之外的要求</span><strong>SSH 与 Heartbeat：37 / 37</strong></div></div><figcaption id="verification-caption">同一任务中的描述性对照。步骤数量与验证策略同时变化，无法单独识别哪项干预造成差异。</figcaption></figure>
+<p>值得检验的假设是：额外 Turn 在产生新证据和修复时有价值。持续重读相同计划，也能消耗更多预算，却未必改善结果。工程目标是让停止条件对验收缺口、失败假设与边际收益下降敏感。</p>
+<p>后续实验需要重复匹配 Trial，报告波动与每次成功的成本，并分别改变续跑策略、证据保留和恢复机制。中断 Effect、Peer 交接也需要专项验证。<a href="https://github.com/huangruiteng/loopx/blob/41a35880fc63ed8b51696e08ec1f17b5369b1a4b/docs/architecture/rfcs/long-horizon-harness-benchmark-research-program-v0.zh-CN.md">研究计划</a>描述了更大的评测空间。一个有希望的案例，值得用更严谨的实验继续追问。</p>
+</section>
+<section id="start">
+<h2>11. 从一个真实项目开始</h2>
+<p>从<a href="../../../docs/book/">开发者手册</a>与 <a href="https://github.com/huangruiteng/loopx/blob/main/README.zh-CN.md#快速开始">Quick Start</a>进入。通过现有 Agent 连接一个项目，检查目标与下一步安全动作，再交给它一个验收条件可见的有界任务。并行 Peer 和可选集成，可以随工作需要逐渐加入。</p>
+<p>安装完成后，用以下命令检查环境与已连接项目：</p>
+<pre><code>loopx doctor
+loopx status</code></pre>
+
+<h3>让第一个闭环小到可以判断</h3>
+<ol><li><b>选择可观察的结果。</b>推理项目先固定工作负载、质量边界、延迟目标与基线，再交给 Agent。</li><li><b>说明权限边界。</b>分别约定开发、实验花费和发布权限，同时为独立工作提供足够范围。</li><li><b>检查一个完整周期。</b>看 Selection、执行、验证、Writeback 和 Successor；确认新 Session 能恢复当前事实。</li><li><b>试一次等待与纠偏。</b>等待远程结果时允许独立分析，并纠正一个不充分的性能结论；检查下一轮是否同时继承等待条件和反馈。</li><li><b>沿证据支持的方向扩展。</b>为可分离工作加入 Peer，观察协调成本、重复失败和注意力消耗。</li></ol>
+<p>短小、明确、能在一个 Session 内舒服完成的任务，现有 Agent 可能已经足够好。当连续性、有范围的决策、证据和协作本身变成反复要做的工作时，LoopX 才更有价值。它增加的开销，应当在真实项目里赚回来。</p>
+<p>我的长期愿望，是一支能跨项目、跨 Host 持续工作的数字团队，同时让指挥它的人看得懂、改得动。这是要继续建设和验证的方向，不代表所有环节都已完成。开源也改变了项目本身：其他开发者会带来不同任务、失败方式和质量标准。更好的 LoopX，应当从这些具体需求里长出来。</p>
+
+</section>
+
+  <p class="edition">本文为公开博客改编版。文中的实现引用固定到 <a href="https://github.com/huangruiteng/loopx/tree/41a35880fc63ed8b51696e08ec1f17b5369b1a4b">41a3588</a>；使用说明请以当前文档为准。</p>
+  </article>
+</div>
+</main>
+<footer class="site-footer"><a class="brand" href="../../../?lang=zh">LoopX</a><p>让工作持续推进，让判断由人掌握。</p><a href="../../../blog/zh/">全部文章 ↑</a></footer>
+</body>
+</html>

--- a/apps/presentation/site/public/blog/zh/index.html
+++ b/apps/presentation/site/public/blog/zh/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#fafafa">
+  <title>LoopX 博客 · LoopX</title>
+  <meta name="description" content="关于长程 Agent 的设计、工程与实践。">
+  <link rel="canonical" href="https://huangruiteng.github.io/loopx/blog/zh/">
+  <link rel="alternate" hreflang="en" href="https://huangruiteng.github.io/loopx/blog/">
+  <link rel="alternate" hreflang="zh-CN" href="https://huangruiteng.github.io/loopx/blog/zh/">
+  <link rel="alternate" hreflang="x-default" href="https://huangruiteng.github.io/loopx/blog/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="LoopX">
+  <meta property="og:locale" content="zh_CN">
+  <meta property="og:title" content="LoopX 博客">
+  <meta property="og:description" content="关于长程 Agent 的设计、工程与实践。">
+  <meta property="og:url" content="https://huangruiteng.github.io/loopx/blog/zh/">
+  <meta name="twitter:card" content="summary">
+  <link rel="icon" href="data:,">
+  <link rel="stylesheet" href="../../blog/blog.css">
+</head>
+<body>
+<a class="skip-link" href="#main">跳至正文</a>
+<header class="site-header">
+  <a class="brand" href="../../?lang=zh" aria-label="LoopX 首页"><span class="product-mark" aria-hidden="true"><i></i><i></i></span>LoopX</a>
+  <nav aria-label="主导航">
+    <a href="../../blog/zh/" aria-current="page">Blog</a>
+    <a href="../../docs/book/">文档</a>
+  </nav>
+  <div class="header-actions"><a class="language" href="../../blog/" lang="en" hreflang="en" aria-label="Read in English">EN</a><a class="github" href="https://github.com/huangruiteng/loopx">GitHub <span aria-hidden="true">↗</span></a></div>
+</header>
+<main id="main" class="blog-index">
+  <div class="index-heading"><p class="eyebrow">LoopX · 博客</p><h1>长程工作的工程实践。</h1><p class="lead">关于长程 Agent 的设计、工程与实践。</p></div>
+  <article class="post-listing">
+    <div><p class="eyebrow">架构 · 设计笔记</p><p class="listing-date">2026 年 9 月</p></div>
+    <div><h2><a href="from-one-shot-agents-to-long-horizon-control/">从一次性 Agent 到长程控制面</a></h2><p>LoopX 如何用目标、状态内核与 Effect Program，让工作跨越会话、吸收人类判断，并从中断中恢复。</p><a class="read-post" href="from-one-shot-agents-to-long-horizon-control/">阅读全文 <span aria-hidden="true">↗</span></a></div>
+  </article>
+  <div class="index-note"><span>开始使用 LoopX</span><a href="../../docs/book/">打开开发者手册 →</a></div>
+</main>
+<footer class="site-footer"><a class="brand" href="../../?lang=zh">LoopX</a><p>让工作持续推进，让判断由人掌握。</p><a href="../../blog/zh/">全部文章 ↑</a></footer>
+</body>
+</html>

--- a/apps/presentation/site/src/App.tsx
+++ b/apps/presentation/site/src/App.tsx
@@ -799,6 +799,7 @@ export function App() {
           <a href="#workflow">{copy.nav[1]}</a>
           <a href={`${basePath}docs/book/${language === "en" ? "en/" : ""}`}>{copy.nav[2]}</a>
           <a href="#showcases">{language === "zh" ? "案例" : "Showcases"}</a>
+          <a href={`${basePath}blog/${language === "zh" ? "zh/" : ""}`}>Blog</a>
           <a href={`${basePath}docs/`}>Docs</a>
         </nav>
         <div className="header-actions">
@@ -834,6 +835,7 @@ export function App() {
             <a href="#showcases" onClick={() => setMenuOpen(false)}>
               {language === "zh" ? "案例" : "Showcases"}
             </a>
+            <a href={`${basePath}blog/${language === "zh" ? "zh/" : ""}`}>Blog</a>
             <a href={`${basePath}docs/`}>Docs</a>
             <a href="https://github.com/huangruiteng/loopx">GitHub</a>
           </nav>
@@ -1107,6 +1109,7 @@ export function App() {
         <nav>
           <a href="https://github.com/huangruiteng/loopx">GitHub</a>
           <a href={`${basePath}benchmarks/swe-marathon/${language === "zh" ? "?lang=zh" : ""}`}>Research</a>
+          <a href={`${basePath}blog/${language === "zh" ? "zh/" : ""}`}>Blog</a>
           <a href={`${basePath}frontstage/`}>Frontstage</a>
           <a href={`${basePath}docs/`}>Docs</a>
         </nav>

--- a/apps/presentation/site/vite.config.ts
+++ b/apps/presentation/site/vite.config.ts
@@ -1,10 +1,24 @@
 import react from "@vitejs/plugin-react";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
 
 export default defineConfig({
   base: process.env.LOOPX_SITE_BASE ?? "/",
-  plugins: [react()],
+  plugins: [react(), {
+    name: "blog-directory-index",
+    configureServer(server) {
+      // Match static-host directory URLs before Vite's SPA fallback.
+      server.middlewares.use((request, _response, next) => {
+        const url = new URL(request.url ?? "/", "http://localhost");
+        if (url.pathname.startsWith("/blog/") && url.pathname.endsWith("/")) {
+          const index = new URL(`./public${url.pathname}index.html`, import.meta.url);
+          if (existsSync(fileURLToPath(index))) request.url = `${url.pathname}index.html${url.search}`;
+        }
+        next();
+      });
+    },
+  }],
   server: {
     fs: {
       allow: [fileURLToPath(new URL("../../..", import.meta.url))],

--- a/examples/frontstage-share-bundle-smoke.mjs
+++ b/examples/frontstage-share-bundle-smoke.mjs
@@ -102,6 +102,35 @@ const siteDir = resolve(outDir, "site");
 assertExists(resolve(siteDir, "index.html"));
 assertExists(resolve(siteDir, "frontstage/index.html"));
 assertExists(resolve(siteDir, "benchmarks/swe-marathon/index.html"));
+// Editorial pages must ship their text and locale navigation without an SPA
+// fallback or client-side execution, including on repository-base hosting.
+const blogArticle = "from-one-shot-agents-to-long-horizon-control/";
+for (const locale of ["", "zh/"]) {
+  for (const article of ["", blogArticle]) {
+    const pagePath = resolve(siteDir, "blog", locale, article, "index.html");
+    assertExists(pagePath);
+    const html = await readFile(pagePath, "utf8");
+    const language = locale ? "zh-CN" : "en";
+    if (!html.includes(`<html lang="${language}">`) || !html.includes("<h1>") || html.includes("<script")) {
+      throw new Error(`Blog must provide static content in ${language}: ${pagePath}`);
+    }
+    for (const hreflang of ["en", "zh-CN", "x-default"]) {
+      if (!html.includes(`hreflang="${hreflang}"`)) throw new Error(`Missing Blog language alternate: ${hreflang}`);
+    }
+    const stylesheet = html.match(/<link rel="stylesheet" href="([^"]+)"/);
+    if (!stylesheet) throw new Error("Blog stylesheet is missing");
+    assertExists(resolve(dirname(pagePath), stylesheet[1]));
+    for (const match of html.matchAll(/<a[^>]+href="([^"]+)"/g)) {
+      const href = match[1];
+      if (/^(https?:|#)/.test(href)) continue;
+      if (href.startsWith("/")) throw new Error("Blog navigation must preserve the hosting base");
+      const target = href.split(/[?#]/)[0];
+      // MkDocs pages are built later by the publication workflow.
+      if (target.includes("docs/")) continue;
+      assertExists(resolve(dirname(pagePath), target, "index.html"));
+    }
+  }
+}
 assertExists(resolve(siteDir, "install.sh"));
 assertExists(resolve(siteDir, "status.frontstage-share.json"));
 assertExists(resolve(outDir, "README.md"));


### PR DESCRIPTION
LoopX's public introduction needs a browser-readable entry on its own website. Add an English-first Blog with a paired Chinese edition, and link it from the homepage and both READMEs.

The opening article explains long-horizon control through an inference-acceleration scenario, eight diagrams, recovery and coordination examples, and the published SWE-Marathon comparison with costs, limitations, and contributor attribution. Implementation references are pinned; illustrative targets are distinguished from measured results. Both editions are complete static HTML with locale links and no JavaScript requirement.

Validation: site typecheck/build, the full repository-base frontstage export smoke, public-boundary scan, paired language/anchor/source checks, and desktop/mobile browser inspection including JavaScript-disabled navigation. The Vite development middleware serves the same Blog directory URLs as static hosting. Existing Pages deployment owns publication; no new content service or dependencies.
