### PR TITLE
fix(post-writeback): project typed source rejections as composition failures

### DIFF
--- a/loopx/cli_commands/post_writeback.py
+++ b/loopx/cli_commands/post_writeback.py
@@ -7,6 +7,7 @@ from typing import Any, Callable
 from ..control_plane.capability_hooks import (
     POST_WRITEBACK_HOOK_DISPATCH_SCHEMA_VERSION,
     PostWritebackHookRegistration,
+    PostWritebackSourceRejected,
     dispatch_post_writeback_hooks,
 )
 from ..control_plane.post_writeback_composition_retry import (
@@ -219,6 +220,13 @@ def dispatch_committed_cli_post_writeback_hooks(
                 "projection": projection,
             },
             runtime_root=runtime_root,
+        )
+    except PostWritebackSourceRejected:
+        # A deterministic decoder verdict cannot succeed on replay. Preserve
+        # the composition failure category without creating misleading
+        # retry work; the typed runtime remains the source-field authority.
+        return _composition_failure_dispatch(
+            hooks, error_code="source_projection_failed", receipt_ref=None
         )
     except Exception:  # An unexpected transport collapse stays retryable.
         return _recorded_composition_failure(

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -72,6 +72,10 @@ TurnStartProducer = Callable[[], Mapping[str, Any]]
 PostWritebackProducer = Callable[[Mapping[str, Any]], Mapping[str, Any]]
 
 
+class PostWritebackSourceRejected(ValueError):
+    """The typed runtime rejected deterministic source construction."""
+
+
 @dataclass(frozen=True, slots=True)
 class InteractionProjectionHookRegistration:
     """One read-only capability contribution to an interaction contract."""
@@ -797,8 +801,7 @@ def dispatch_post_writeback_hooks(
     except (EffectRuntimeRejected, OSError, RuntimeError, TypeError, ValueError) as exc:
         if (
             isinstance(exc, EffectRuntimeRejected)
-            and exc.diagnostic_code
-            == POST_WRITEBACK_SOURCE_REJECTION_DIAGNOSTIC_CODE
+            and exc.diagnostic_code == POST_WRITEBACK_SOURCE_REJECTION_DIAGNOSTIC_CODE
         ):
             # The TypeScript decoder owns source legality. Its typed
             # input-construction rejection crosses this boundary as the
@@ -806,7 +809,7 @@ def dispatch_post_writeback_hooks(
             # source_projection_failed failure instead of per-hook
             # runtime_result_invalid noise; every other rejection stays a
             # runtime failure without string matching or field copies.
-            raise ValueError(
+            raise PostWritebackSourceRejected(
                 "post-writeback hooks require committed source identity fields"
             ) from exc
         return _post_writeback_failure_dispatch(

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -669,6 +669,26 @@ def dispatch_post_writeback_hooks(
             ordered_registrations,
             error_code="registration_or_input_rejected",
         )
+    if source is not None:
+        source_identity = source.get("identity") or {}
+        if any(
+            not str(source_identity.get(field) or "").strip()
+            for field in (
+                "goal_id",
+                "agent_id",
+                "todo_id",
+                "turn_instance_id",
+                "effect_id",
+            )
+        ):
+            # Keep the pre-transaction caller contract: missing writeback
+            # identity is a composition failure (the caller reports it as one
+            # source_projection_failed failure), not per-hook
+            # runtime_result_invalid noise from the TypeScript decoder.
+            raise ValueError(
+                "post-writeback hooks require committed "
+                "goal/agent/todo/turn/effect identity"
+            )
     invoked_count = 0
     runtime_phase = "preflight"
     try:

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -57,6 +57,11 @@ POST_WRITEBACK_HOOK_DISPATCH_SCHEMA_VERSION = (
 POST_WRITEBACK_HOOK_RECEIPT_SCHEMA_VERSION = (
     CAPABILITY_HOOK_POST_WRITEBACK_RECEIPT_SCHEMA
 )
+# Diagnostic code the TypeScript source decoder stamps on every source
+# input-construction rejection. The decoder owns the field rules; this
+# adapter only maps the typed category back to the legacy composition
+# failure boundary and never re-validates the fields itself.
+POST_WRITEBACK_SOURCE_REJECTION_DIAGNOSTIC_CODE = "post_writeback_source_invalid"
 _LEGACY_LOCK_SAFE_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,199}")
 _POST_WRITEBACK_DISPATCH_ID_RE = re.compile(r"pwh_[0-9a-f]{64}")
 _POST_WRITEBACK_RECEIPT_SNAPSHOT_RE = re.compile(r"(?:missing|sha256:[0-9a-f]{64})")
@@ -669,26 +674,6 @@ def dispatch_post_writeback_hooks(
             ordered_registrations,
             error_code="registration_or_input_rejected",
         )
-    if source is not None:
-        source_identity = source.get("identity") or {}
-        if any(
-            not str(source_identity.get(field) or "").strip()
-            for field in (
-                "goal_id",
-                "agent_id",
-                "todo_id",
-                "turn_instance_id",
-                "effect_id",
-            )
-        ):
-            # Keep the pre-transaction caller contract: missing writeback
-            # identity is a composition failure (the caller reports it as one
-            # source_projection_failed failure), not per-hook
-            # runtime_result_invalid noise from the TypeScript decoder.
-            raise ValueError(
-                "post-writeback hooks require committed "
-                "goal/agent/todo/turn/effect identity"
-            )
     invoked_count = 0
     runtime_phase = "preflight"
     try:
@@ -810,6 +795,20 @@ def dispatch_post_writeback_hooks(
                 raise ValueError("post-writeback transaction result is invalid")
             return dict(finalized["dispatch"])
     except (EffectRuntimeRejected, OSError, RuntimeError, TypeError, ValueError) as exc:
+        if (
+            isinstance(exc, EffectRuntimeRejected)
+            and exc.diagnostic_code
+            == POST_WRITEBACK_SOURCE_REJECTION_DIAGNOSTIC_CODE
+        ):
+            # The TypeScript decoder owns source legality. Its typed
+            # input-construction rejection crosses this boundary as the
+            # legacy composition ValueError, so callers keep reporting one
+            # source_projection_failed failure instead of per-hook
+            # runtime_result_invalid noise; every other rejection stays a
+            # runtime failure without string matching or field copies.
+            raise ValueError(
+                "post-writeback hooks require committed source identity fields"
+            ) from exc
         return _post_writeback_failure_dispatch(
             ordered_registrations,
             error_code="runtime_result_invalid",

--- a/loopx/control_plane/post_writeback_hook_transaction.ts
+++ b/loopx/control_plane/post_writeback_hook_transaction.ts
@@ -29,6 +29,12 @@ import {
 
 export const POST_WRITEBACK_HOOK_SOURCE_SCHEMA_VERSION =
   "loopx_post_writeback_hook_source_v0";
+// Source decoding rejections are one bounded input-construction category,
+// distinguishable from every other runtime/transport fault so the Python
+// adapter can project them as composition failures without re-owning the
+// source field rules, which stay owned by this decoder alone.
+export const POST_WRITEBACK_SOURCE_REJECTION_CODE =
+  "post_writeback_source_invalid";
 export const POST_WRITEBACK_HOOK_TRANSACTION_REQUEST_SCHEMA_VERSION =
   "loopx_post_writeback_hook_transaction_request_v0";
 export const POST_WRITEBACK_HOOK_TRANSACTION_RESULT_SCHEMA_VERSION =
@@ -358,7 +364,7 @@ function exactObjectFields(
   }
 }
 
-function decodeSource(value: unknown): PostWritebackSource {
+function decodeSourceFields(value: unknown): PostWritebackSource {
   const source = requireJsonObject(value, "source");
   exactObjectFields(
     source,
@@ -421,6 +427,22 @@ function decodeSource(value: unknown): PostWritebackSource {
     ),
     projection: requireJsonObject(source.projection, "source.projection"),
   };
+}
+
+function decodeSource(value: unknown): PostWritebackSource {
+  try {
+    return decodeSourceFields(value);
+  } catch (error) {
+    if (error instanceof EffectRuntimeRequestError) {
+      // Every field/type/emptiness rejection from the source decoder carries
+      // one dedicated code; message text stays free to evolve.
+      throw new EffectRuntimeRequestError(
+        error.message,
+        POST_WRITEBACK_SOURCE_REJECTION_CODE,
+      );
+    }
+    throw error;
+  }
 }
 
 function decodeRuntimeRoot(value: unknown): string | null {

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -15,6 +15,9 @@ from unittest.mock import Mock
 import pytest
 
 import loopx.control_plane.capability_hooks as capability_hooks
+from loopx.cli_commands.post_writeback import (
+    dispatch_committed_cli_post_writeback_hooks,
+)
 from loopx.control_plane.capability_hooks import (
     POST_WRITEBACK_HOOK_INPUT_SCHEMA_VERSION,
     POST_WRITEBACK_HOOK_RECEIPT_SCHEMA_VERSION,
@@ -179,19 +182,169 @@ def _source() -> dict[str, object]:
     }
 
 
-def test_post_writeback_empty_source_identity_raises_composition_error() -> None:
-    source = _source()
-    source["identity"] = dict(source["identity"])  # type: ignore[typeddict-item]
-    source["identity"]["agent_id"] = ""  # type: ignore[typeddict-item]
+def _mutated_source(mutation: str) -> dict[str, object]:
+    """Apply one bounded input-construction defect to a valid source."""
+
+    source = dict(_source())
+    identity = dict(source["identity"])  # type: ignore[typeddict-item]
+    source["identity"] = identity
+    if mutation in {
+        "goal_id",
+        "agent_id",
+        "todo_id",
+        "turn_instance_id",
+        "effect_id",
+    }:
+        identity[mutation] = ""  # type: ignore[typeddict-item]
+    elif mutation in {"event_kind", "state_version", "committed_at"}:
+        source[mutation] = ""
+    elif mutation == "todo_id_not_a_string":
+        identity["todo_id"] = 123  # type: ignore[typeddict-item]
+    elif mutation == "identity_not_an_object":
+        source["identity"] = 123
+    elif mutation == "durable_not_a_boolean":
+        source["durable"] = "committed"
+    elif mutation == "unknown_source_field":
+        source["extra_field"] = True
+    elif mutation == "empty_agent_id_and_state_version":
+        identity["agent_id"] = ""  # type: ignore[typeddict-item]
+        source["state_version"] = ""
+    else:  # pragma: no cover - guards against typo'd mutation ids.
+        raise AssertionError(f"unknown source mutation: {mutation}")
+    return source
+
+
+# The TypeScript source decoder owns every field rule; these parameters are
+# the full legacy caller inventory of input-construction defects (the five
+# identity fields plus event_kind/state_version/committed_at all lived in
+# one composition rejection before #3847). An empty todo_id is currently a
+# rejection too: if the typed owner later adopts nullable-Todo semantics,
+# that verdict flips in the decoder and in this table first, never in a
+# second Python validator.
+_SOURCE_REJECTION_MUTATIONS = [
+    "goal_id",
+    "agent_id",
+    "todo_id",
+    "turn_instance_id",
+    "effect_id",
+    "event_kind",
+    "state_version",
+    "committed_at",
+    "todo_id_not_a_string",
+    "identity_not_an_object",
+    "durable_not_a_boolean",
+    "unknown_source_field",
+    "empty_agent_id_and_state_version",
+]
+
+
+@pytest.mark.parametrize("mutation", _SOURCE_REJECTION_MUTATIONS)
+def test_incomplete_source_is_one_typed_composition_rejection(
+    tmp_path: Path, mutation: str
+) -> None:
+    """Every decode-boundary rejection maps to the legacy ValueError."""
+
+    producer_calls: list[int] = []
     with pytest.raises(ValueError, match="require committed"):
         dispatch_post_writeback_hooks(
-            [_hook()],
-            source=source,  # type: ignore[arg-type]
+            [_hook(producer_calls=producer_calls)],
+            source=_mutated_source(mutation),  # type: ignore[arg-type]
+            runtime_root=tmp_path,
         )
+    assert producer_calls == []
+    receipt_dir = tmp_path / "goals" / "goal-1" / "post_writeback_hooks"
+    assert not receipt_dir.is_dir() or not list(receipt_dir.glob("*.json"))
 
 
-def _hook(*, key: str = "periodic-report:stage-123") -> PostWritebackHookRegistration:
+def test_valid_source_dispatches_the_provider_and_writes_a_receipt(
+    tmp_path: Path,
+) -> None:
+    producer_calls: list[int] = []
+    dispatch = dispatch_post_writeback_hooks(
+        [_hook(producer_calls=producer_calls)],
+        source=_source(),  # type: ignore[arg-type]
+        runtime_root=tmp_path,
+    )
+    assert dispatch["failures"] == []
+    assert dispatch["intent_count"] == 1
+    assert producer_calls == [1]
+    receipt_dir = tmp_path / "goals" / "goal-1" / "post_writeback_hooks"
+    assert list(receipt_dir.glob("*.json"))
+
+
+def test_zero_registrations_never_reaches_the_runtime() -> None:
+    """Zero hooks dispatch vacuously without touching the decoder."""
+
+    dispatch = dispatch_post_writeback_hooks(
+        [],
+        source=_mutated_source("agent_id"),  # type: ignore[arg-type]
+    )
+    assert dispatch["failures"] == []
+    assert dispatch["invoked_count"] == 0
+    assert dispatch["intent_count"] == 0
+    assert dispatch["primary_writeback_preserved"] is True
+
+
+def test_bridge_projects_source_rejection_as_one_composition_failure(
+    tmp_path: Path,
+) -> None:
+    """The CLI bridge keeps the legacy single-failure projection."""
+
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    registry_path = tmp_path / "registry.global.json"
+    registry_path.write_text(
+        json.dumps(
+            {"common_runtime_root": str(runtime_root), "goals": [{"id": "goal-1"}]}
+        ),
+        encoding="utf-8",
+    )
+    producer_calls: list[int] = []
+    dispatch = dispatch_committed_cli_post_writeback_hooks(
+        payload={"ok": True, "completed": True},
+        registry_path=registry_path,
+        runtime_root_arg=None,
+        goal_id="goal-1",
+        event_kind="refresh_state",
+        identity={
+            "agent_id": "",
+            "todo_id": "todo-1",
+            "turn_instance_id": "turn-1",
+            "effect_id": "goal-1:agent-1:todo-1:turn-1",
+        },
+        state_version="2026-09-06T00:00:00Z",
+        committed_at="2026-09-06T00:00:00Z",
+        hooks=(
+            _hook(key="periodic-report:stage-123", producer_calls=producer_calls),
+            _hook(key="periodic-report:stage-456", producer_calls=producer_calls),
+        ),
+        projection_builder=lambda **_kwargs: {
+            "stage_completion": {
+                "schema_version": "periodic_report_stage_completion_receipt_v0",
+                "stage_identity": "stage-123",
+            }
+        },
+    )
+    assert dispatch["failures"] == [
+        {
+            "hook_id": "composition",
+            "capability_id": "unknown",
+            "error_code": "source_projection_failed",
+        }
+    ]
+    assert dispatch["primary_writeback_preserved"] is True
+    assert dispatch["external_writes_performed"] is False
+    assert producer_calls == []
+    receipt_dir = runtime_root / "goals" / "goal-1" / "post_writeback_hooks"
+    assert not receipt_dir.is_dir() or not list(receipt_dir.glob("*.json"))
+
+
+def _hook(
+    *, key: str = "periodic-report:stage-123", producer_calls: list[int] | None = None
+) -> PostWritebackHookRegistration:
     def producer(value: object) -> dict[str, object]:
+        if producer_calls is not None:
+            producer_calls.append(1)
         assert isinstance(value, dict)
         receipt = value["receipt"]
         assert isinstance(receipt, dict)

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -179,6 +179,17 @@ def _source() -> dict[str, object]:
     }
 
 
+def test_post_writeback_empty_source_identity_raises_composition_error() -> None:
+    source = _source()
+    source["identity"] = dict(source["identity"])  # type: ignore[typeddict-item]
+    source["identity"]["agent_id"] = ""  # type: ignore[typeddict-item]
+    with pytest.raises(ValueError, match="require committed"):
+        dispatch_post_writeback_hooks(
+            [_hook()],
+            source=source,  # type: ignore[arg-type]
+        )
+
+
 def _hook(*, key: str = "periodic-report:stage-123") -> PostWritebackHookRegistration:
     def producer(value: object) -> dict[str, object]:
         assert isinstance(value, dict)
@@ -1357,6 +1368,7 @@ def test_periodic_report_projection_evaluates_turn_capabilities_absent_and_prese
     ]
     assert next_actions_present == ["todo:todo_capacity"]
 
+
 def _published_report_goal_fixtures(
     tmp_path,
     *,
@@ -1379,7 +1391,11 @@ def _published_report_goal_fixtures(
     registry_path = tmp_path / "registry.json"
     registry_path.write_text(
         json.dumps(
-            {"goals": [{"id": "goal-1", "repo": str(tmp_path), "state_file": "goal.md"}]}
+            {
+                "goals": [
+                    {"id": "goal-1", "repo": str(tmp_path), "state_file": "goal.md"}
+                ]
+            }
         ),
         encoding="utf-8",
     )
@@ -1419,7 +1435,9 @@ def test_periodic_report_hook_accepts_projection_after_a_published_report(
                 "schema_version": "goal_vision_replan_contract_v0",
                 "agent_id": "agent-1",
                 "state": "vision_closed",
-                "vision_patch": {"acceptance_summary": "Initial slice accepted and reported."},
+                "vision_patch": {
+                    "acceptance_summary": "Initial slice accepted and reported."
+                },
             },
             "vision_checkpoint": {
                 "schema_version": "vision_checkpoint_v0",
@@ -1843,7 +1861,9 @@ def test_post_writeback_legacy_lock_timeout_isolates_other_hooks(
     assert len(receipts) == 1
 
 
-@pytest.mark.parametrize("controlled_clock", [False, True], ids=["real-clock", "budget"])
+@pytest.mark.parametrize(
+    "controlled_clock", [False, True], ids=["real-clock", "budget"]
+)
 def test_post_writeback_legacy_locks_share_one_batch_deadline(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -191,7 +191,6 @@ def _mutated_source(mutation: str) -> dict[str, object]:
     if mutation in {
         "goal_id",
         "agent_id",
-        "todo_id",
         "turn_instance_id",
         "effect_id",
     }:
@@ -215,16 +214,15 @@ def _mutated_source(mutation: str) -> dict[str, object]:
 
 
 # The TypeScript source decoder owns every field rule; these parameters are
-# the full legacy caller inventory of input-construction defects (the five
-# identity fields plus event_kind/state_version/committed_at all lived in
-# one composition rejection before #3847). An empty todo_id is currently a
-# rejection too: if the typed owner later adopts nullable-Todo semantics,
-# that verdict flips in the decoder and in this table first, never in a
+# the full legacy caller inventory of input-construction defects (the four
+# required identity fields plus event_kind/state_version/committed_at all
+# lived in one composition rejection before #3847). Todo-less writebacks are
+# intentionally valid, while a non-string Todo identity remains a decoder
+# rejection. Those verdicts live here and in the typed decoder, never in a
 # second Python validator.
 _SOURCE_REJECTION_MUTATIONS = [
     "goal_id",
     "agent_id",
-    "todo_id",
     "turn_instance_id",
     "effect_id",
     "event_kind",
@@ -285,7 +283,7 @@ def test_zero_registrations_never_reaches_the_runtime() -> None:
     assert dispatch["primary_writeback_preserved"] is True
 
 
-def test_bridge_projects_source_rejection_as_one_composition_failure(
+def test_bridge_projects_source_rejection_as_hook_attributed_composition_failures(
     tmp_path: Path,
 ) -> None:
     """The CLI bridge keeps the legacy single-failure projection."""
@@ -315,8 +313,16 @@ def test_bridge_projects_source_rejection_as_one_composition_failure(
         state_version="2026-09-06T00:00:00Z",
         committed_at="2026-09-06T00:00:00Z",
         hooks=(
-            _hook(key="periodic-report:stage-123", producer_calls=producer_calls),
-            _hook(key="periodic-report:stage-456", producer_calls=producer_calls),
+            _hook(
+                hook_id="periodic_report.stage_completion",
+                key="periodic-report:stage-123",
+                producer_calls=producer_calls,
+            ),
+            _hook(
+                hook_id="periodic_report.vision_completion",
+                key="periodic-report:stage-456",
+                producer_calls=producer_calls,
+            ),
         ),
         projection_builder=lambda **_kwargs: {
             "stage_completion": {
@@ -327,10 +333,15 @@ def test_bridge_projects_source_rejection_as_one_composition_failure(
     )
     assert dispatch["failures"] == [
         {
-            "hook_id": "composition",
-            "capability_id": "unknown",
+            "hook_id": "periodic_report.stage_completion",
+            "capability_id": "periodic-report",
             "error_code": "source_projection_failed",
-        }
+        },
+        {
+            "hook_id": "periodic_report.vision_completion",
+            "capability_id": "periodic-report",
+            "error_code": "source_projection_failed",
+        },
     ]
     assert dispatch["primary_writeback_preserved"] is True
     assert dispatch["external_writes_performed"] is False
@@ -340,7 +351,10 @@ def test_bridge_projects_source_rejection_as_one_composition_failure(
 
 
 def _hook(
-    *, key: str = "periodic-report:stage-123", producer_calls: list[int] | None = None
+    *,
+    hook_id: str = "periodic_report.stage_completion",
+    key: str = "periodic-report:stage-123",
+    producer_calls: list[int] | None = None,
 ) -> PostWritebackHookRegistration:
     def producer(value: object) -> dict[str, object]:
         if producer_calls is not None:
@@ -350,7 +364,7 @@ def _hook(
         assert isinstance(receipt, dict)
         return {
             "schema_version": POST_WRITEBACK_HOOK_RESULT_SCHEMA_VERSION,
-            "hook_id": "periodic_report.stage_completion",
+            "hook_id": hook_id,
             "capability_id": "periodic-report",
             "phase": "post_writeback",
             "status": "intent",
@@ -365,7 +379,7 @@ def _hook(
         }
 
     return PostWritebackHookRegistration(
-        hook_id="periodic_report.stage_completion",
+        hook_id=hook_id,
         capability_id="periodic-report",
         event_kinds=("refresh_state",),
         intent_kinds=("periodic_report.trigger_evaluation",),
@@ -424,11 +438,14 @@ def test_post_writeback_dispatch_returns_one_effect_free_intent() -> None:
     assert dispatch["external_writes_performed"] is False
 
 
-def test_post_writeback_dispatch_accepts_todoless_replan_identity() -> None:
+@pytest.mark.parametrize("todo_id", [None, ""], ids=["null", "empty-string"])
+def test_post_writeback_dispatch_accepts_todoless_replan_identity(
+    todo_id: object,
+) -> None:
     source = _source()
     identity = source["identity"]
     assert isinstance(identity, dict)
-    identity["todo_id"] = None
+    identity["todo_id"] = todo_id
 
     dispatch = dispatch_post_writeback_hooks([_hook()], source=source)
 
@@ -437,13 +454,21 @@ def test_post_writeback_dispatch_accepts_todoless_replan_identity() -> None:
     assert dispatch["failures"] == []
 
 
-def test_post_writeback_runtime_failure_identifies_rejected_preflight() -> None:
-    source = _source()
-    identity = source["identity"]
-    assert isinstance(identity, dict)
-    identity["todo_id"] = 7
+def test_post_writeback_runtime_failure_identifies_rejected_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        capability_hooks,
+        "effect_runtime_result",
+        Mock(
+            side_effect=capability_hooks.EffectRuntimeRejected(
+                "transaction request is invalid",
+                diagnostic_code="invalid_request",
+            )
+        ),
+    )
 
-    dispatch = dispatch_post_writeback_hooks([_hook()], source=source)
+    dispatch = dispatch_post_writeback_hooks([_hook()], source=_source())
 
     assert dispatch["invoked_count"] == 0
     assert dispatch["failures"][0]["error_code"] == "runtime_result_invalid"


### PR DESCRIPTION
## Summary

Restore the pre-transaction distinction between deterministic post-writeback source-construction failures and runtime/provider failures without recreating source-field authority in Python.

- The TypeScript source decoder assigns `post_writeback_source_invalid` to every rejected source shape, type, or required value.
- The Python adapter maps only that typed diagnostic to `PostWritebackSourceRejected` (a `ValueError` compatibility subtype); it does not copy or re-evaluate the field rules.
- The current CLI bridge projects the rejection as hook-attributed `source_projection_failed` failures and does not create a misleading retry receipt. Other preflight/runtime/transport failures retain the structured `runtime_failure` and composition-retry behavior added on `main`.
- Todo-less writebacks remain legal with `todo_id: null` or `""`; a non-string Todo identity still fails at the typed decoder.

No provider runs, no intent or durable hook receipt is produced, the primary writeback remains preserved, and no external write is reported for rejected source construction.

## Main integration

Rebased onto `5a779b1ca`. The conflict was semantic rather than mechanical: current `main` added Todo-less periodic-report identity, hook-attributed composition retry receipts, and structured runtime failure diagnostics. The resolution preserves all three newer contracts while keeping this PR's TypeScript-owned rejection classification.

## Validation

- `pytest -q tests/control_plane/test_post_writeback_capability_hooks.py tests/cli_commands/test_periodic_report_intent_capability_chain.py tests/cli_commands/test_todo_complete_settlement_capabilities.py`: **64 passed**
- `npm run test:control-plane`: **688 passed, 1 skipped, 0 failed** (689 tests)
- `npm run typecheck:control-plane`: passed
- `ruff check` on changed Python/test files: passed
- `loopx canary premerge --from-git-diff --format json`: **12/12 selected checks passed**, no warnings or manual holds
- `git diff --check` and DCO sign-off: passed

The diff contains only public control-plane code and focused regression tests; no credentials, local state, private URLs, or generated evidence are included.

## Type

- [x] fix

## Area

- [x] control-plane

## Direction

- [x] follow-up (post-merge drift fix)
