### PR TITLE
docs(post-writeback): narrow the canonical JSON parity claim

### DIFF
--- a/loopx/control_plane/post_writeback_hook_transaction.ts
+++ b/loopx/control_plane/post_writeback_hook_transaction.ts
@@ -191,7 +191,13 @@ function stripPythonWhitespace(value: string): string {
   return value.slice(start, end);
 }
 
-/** Match Python json.dumps(sort_keys=True, separators=(",", ":")) identity bytes. */
+/**
+ * Match Python json.dumps(sort_keys=True, separators=(",", ":")) identity
+ * bytes for the string, boolean, and null shapes this contract carries.
+ * Floats and integers beyond Number.MAX_SAFE_INTEGER differ from CPython's
+ * repr (exponent zero-padding and format thresholds), so cross-language
+ * digest equality must not rely on those shapes.
+ */
 function pythonCanonicalJson(value: unknown): string {
   const chunks: string[] = [];
   const tasks: CanonicalJsonTask[] = [{ kind: "value", value }];


### PR DESCRIPTION
## Summary

The canonical JSON encoder in the post-writeback transaction layer documents itself as matching `Python json.dumps(sort_keys=True, separators=(",", ":"))` identity bytes. Cross-checked byte-for-byte, that holds for the string/boolean/null shapes this contract carries, but the two encoders disagree on:

- floats — `1e-7` encodes as `1e-7` in TypeScript and `1e-07` in CPython (which zero-pads the exponent to two digits); `0.000001` stays decimal in TypeScript and becomes `1e-06` in CPython (different exponent-switch thresholds);
- integers beyond `Number.MAX_SAFE_INTEGER` — CPython keeps full precision, the JavaScript side has already rounded through a double.

String escaping (including surrogate pairs for non-BMP characters) is byte-identical in both directions.

The digests produced from these bytes (`pwr_`/`pwh_`/`pwtx_` hashes, receipt equality) are only consumed inside the TypeScript process today, so there is no behavioral impact — this change narrows the docstring claim so a future cross-language consumer (a Python re-implementation, an audit tool, or an operator recomputing a `dispatch_id` from Python) does not rely on equality that does not hold for float and large-integer payloads.

## Issue

Cross-language contract debt surfaced while auditing the TypeScript transaction layer from #3847 against its Python counterpart.

## Validation

- `node --experimental-strip-types --test tests/control_plane_ts/post_writeback_hook_transaction.test.ts`: 27 passed, 0 failed.
- The divergence samples above were produced by direct encoder comparison on both sides.

## Type

- [x] docs

## Area

- [x] control-plane

## Direction

- [x] follow-up (contract documentation)

## Boundary

One docstring. No runtime behavior changes.
