### PR TITLE
fix(desktop): preview the phase each recovery action actually enters

### DIFF
--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -97,7 +97,10 @@ document.querySelector("#copy-diagnostics").onclick = async () => {
 };
 async function run(action) {
   if (working) return;
-  render({phase: action === "check" ? "checking" : action === "repair" ? "installing_runtime" : "downloading"});
+  // Match the phase the backend publishes for each action (rollback restores
+  // the previous app; restart keeps the required-restart state) instead of
+  // previewing a download that is not happening.
+  render({phase: action === "check" ? "checking" : action === "repair" ? "installing_runtime" : action === "rollback" ? "installing_app" : action === "restart" ? "restart_required" : "downloading"});
   try { render(await window.__TAURI__.core.invoke("desktop_update", {action,channel:channel.value})); }
   catch (error) { render({phase:"error", details:{code: safeCode(error)}}); }
 }


### PR DESCRIPTION
## Summary

The optimistic render in the embedded recovery screen mapped every action that is not `check` or `repair` to the `downloading` phase, so clicking **Restore previous version** or **Restart** displayed "downloading and verifying signatures…" while the app was actually restoring a local backup or waiting for a restart — on a slow connection that reads as the rollback being stuck.

Map `rollback` to `installing_app` (the phase the maintenance transaction publishes for it) and keep `restart` in the `restart_required` state, matching what the backend reports for each action.

## Issue

Follow-up polish from a post-merge review of the recovery screen flow (#3994). No open issue yet — happy to file one if preferred.

## Validation

- `node --check` on the modified `boot.js`: syntax clean.
- The phase names map one-to-one onto `labels` already present in the file; no other references to the optimistic render exist (`rg` confirms `downloading` only appears in the label table and the render call).
- The desktop unit suite does not cover static assets; `python3 -m unittest discover -s tests/desktop -p 'test_*.py'` remains 9 passed.

## Type

- [x] fix

## Area

- [x] desktop

## Direction

- [x] follow-up (post-merge review finding)

## Boundary

One optimistic-render mapping in `static/boot.js`. No backend, Rust, or diagnostics changes.
