### PR TITLE
fix(reward-memory): reject unsatisfiable required refs and render repair hints

### DIFF
--- a/loopx/capabilities/reward_memory/experiment.py
+++ b/loopx/capabilities/reward_memory/experiment.py
@@ -8,7 +8,7 @@ from typing import Any
 from ...agent_registry import normalize_registered_agents
 from ...control_plane.reward_memory import reward_memory_goal_policy
 from ...control_plane.todos.contract import normalize_todo_claimed_by
-from .application import normalize_reward_memory_provider_binding
+from .application import TOKEN_RE, normalize_reward_memory_provider_binding
 from .ingestion import normalize_reward_memory_standing_policy
 from .registry import MAX_CORPORA, normalize_reward_memory_corpus
 from .scoped_feedback import SCOPED_FEEDBACK_ADAPTER
@@ -363,12 +363,18 @@ def _normalize_v1(raw: Mapping[str, Any]) -> dict[str, Any]:
                         or not ref.startswith("candidate:")
                         or len(ref) > 100
                         or any(c.isspace() for c in ref)
+                        # A ref outside the application token charset can never
+                        # match an emitted candidate_ref, so requiring it would
+                        # permanently block every message for this destination.
+                        or TOKEN_RE.fullmatch(ref) is None
                         for ref in refs
                     )
                     or len(set(refs)) != len(refs)
                 ):
                     raise ValueError(
-                        "required_candidate_refs must contain up to three unique candidate refs"
+                        "required_candidate_refs must contain up to three unique "
+                        "public-safe candidate refs matching the application token "
+                        "charset"
                     )
                 destinations[digest] = {
                     "query_label": label,

--- a/loopx/cli_commands/lark_inbox.py
+++ b/loopx/cli_commands/lark_inbox.py
@@ -550,12 +550,23 @@ def _render(payload: dict[str, object]) -> str:
         for item in guidance.get("guidance") or []:
             lines.append(f"- guidance: {item.get('content_summary')}")
         if guidance.get("agent_review_required"):
-            lines.append(
-                "Agent: assess this guidance against current evidence and safe alternatives; "
-                "only if sending is still appropriate, rerun with --reviewed-guidance-digest "
-                + str(guidance.get("review_digest"))
-                + ". This is not a request for user approval."
-            )
+            review_digest = guidance.get("review_digest")
+            if isinstance(review_digest, str) and review_digest:
+                lines.append(
+                    "Agent: assess this guidance against current evidence and safe alternatives; "
+                    "only if sending is still appropriate, rerun with --reviewed-guidance-digest "
+                    + review_digest
+                    + ". This is not a request for user approval."
+                )
+            else:
+                # configuration_error blocks carry no digest (review cannot
+                # waive them); surface the repair hint instead of a None
+                # placeholder that would send the agent into a retry loop.
+                action = guidance.get("recommended_action")
+                lines.append(
+                    "Agent: guidance review is required but no digest was produced"
+                    + (f"; {action}" if isinstance(action, str) and action else ".")
+                )
     feedback = payload.get("reward_memory_feedback_review")
     if isinstance(feedback, dict):
         lines.append(f"- Reward Memory (advisory): {feedback['instruction']}")

--- a/tests/capabilities/test_outbound_guidance.py
+++ b/tests/capabilities/test_outbound_guidance.py
@@ -394,6 +394,17 @@ def test_required_guidance_has_separate_lookup_and_review(tmp_path, monkeypatch)
             "destination_digest": "a" * 64,
             "required_candidate_refs": ["candidate:x"] * 2,
         },
+        # Refs outside the application token charset can never match an
+        # emitted candidate_ref, so requiring them would permanently block
+        # the destination.
+        {
+            "destination_digest": "a" * 64,
+            "required_candidate_refs": ["candidate:中文规则"],
+        },
+        {
+            "destination_digest": "a" * 64,
+            "required_candidate_refs": ["candidate:a$b"],
+        },
     ],
 )
 def test_destination_config_rejects_ambiguous_identity(tmp_path, invalid):

--- a/tests/extensions/test_lark_outbound_render.py
+++ b/tests/extensions/test_lark_outbound_render.py
@@ -1,0 +1,49 @@
+"""The inbox renderer must not point agents at a nonexistent review digest."""
+
+from loopx.cli_commands.lark_inbox import _render
+
+
+def _payload(guidance: dict[str, object]) -> dict[str, object]:
+    return {
+        "ok": True,
+        "enabled": True,
+        "pending_count": 0,
+        "write_performed": False,
+        "items": [],
+        "outbound_guidance": guidance,
+    }
+
+
+def test_review_required_renders_the_digest_hint():
+    rendered = _render(
+        _payload(
+            {
+                "status": "required_guidance_missing",
+                "agent_review_required": True,
+                "guidance": [{"content_summary": "prefer short confirmations"}],
+                "review_digest": "sha256:abc123",
+            }
+        )
+    )
+    assert "--reviewed-guidance-digest sha256:abc123" in rendered
+    assert "guidance: prefer short confirmations" in rendered
+
+
+def test_configuration_error_renders_repair_hint_instead_of_none_digest():
+    rendered = _render(
+        _payload(
+            {
+                "status": "configuration_error",
+                "reason_code": "scope_mismatch",
+                "guidance": [],
+                "agent_review_required": True,
+                "recommended_action": (
+                    "Repair the enabled Reward Memory configuration and verify it with "
+                    "reward-memory experiment-status before retrying."
+                ),
+            }
+        )
+    )
+    assert "None" not in rendered
+    assert "--reviewed-guidance-digest" not in rendered
+    assert "Repair the enabled Reward Memory configuration" in rendered


### PR DESCRIPTION
## Summary

Two gaps in the required-guidance path found while auditing #4018 post-merge:

**Unsatisfiable required refs pass validation.** `required_candidate_refs` entries were only checked for the `candidate:` prefix, length, whitespace, and uniqueness. But the application layer extracts every emitted `candidate_ref` through `TOKEN_RE`, so a ref containing characters outside that charset (CJK text, `$`, `,`) can be configured yet can never match any record. One such ref permanently blocks every message for that destination — urgent notices included — and review acknowledgement cannot waive it, so nothing ever points at the configuration error. Destination validation now applies the same `TOKEN_RE` at config load.

**The configuration-error hint pointed at a nonexistent digest.** For a blocked (configuration_error) guidance result the inbox renderer printed `rerun with --reviewed-guidance-digest None`, sending the agent into a retry loop that review can never satisfy; the blocked result's `recommended_action` repair hint was never rendered. The renderer now emits the repair hint for digest-less blocks and keeps the digest hint only when a real digest exists.

## Issue

Post-merge audit of #4018 (destination recall and required guidance checks). No open issue yet — happy to file one if preferred.

## Validation

- New parametrized cases in `test_destination_config_rejects_ambiguous_identity`: refs with CJK text and with `$` are rejected at load (red when the TOKEN_RE check is disabled, green with it).
- New `tests/extensions/test_lark_outbound_render.py`: the digest hint renders when a digest exists; a configuration-error block renders `recommended_action` and contains neither `None` nor a digest hint.
- `pytest tests/extensions/ tests/capabilities/test_outbound_guidance.py tests/capabilities/test_reward_memory_experiment.py tests/capabilities/test_reward_memory_feedback_hint.py`: 101 passed.
- `ruff check` and `ruff format` clean.

## Type

- [x] fix

## Area

- [x] capabilities

## Direction

- [x] follow-up (post-merge audit of #4018)

## Boundary

Only destination-ref validation, the inbox renderer's guidance block, and their tests change. The recall path, review semantics, and the configuration-error statuses themselves are untouched.
