### PR TITLE
fix(desktop): make startup recover runtime and unresponsive services

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -64,6 +64,18 @@ Existing recovery controls remain available after that budget is exhausted,
 and externally corrected installations are still detected. A matching runtime
 completes a pending installation journal without reinstalling it.
 
+A listener that accepts TCP but does not answer HTTP is given a 15-second
+startup grace period. The supervisor can then replace it only after verifying
+its LoopX command, service kind and port, including a second PID readback before
+termination. Unknown listeners are retained and reported as startup errors.
+
+Chat begins serving its workspace and readiness endpoints independently of Lark
+binding discovery. Slow or permission-blocked project reads remain in one
+background initialization worker; discovery failures retry every five seconds.
+Closing the server fences late discovery results before any queue resumption
+or event consumer starts. Existing enabled bindings retain their routing and
+authorization rules.
+
 If startup cannot proceed, the embedded **Recovery & updates** screen stays
 available without a working HTTP service. **Repair this version** reinstalls
 the bundled runtime and then reconnects the same window automatically; it no

--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -50,6 +50,14 @@ mismatched override must be corrected by its owner.
 The installer and App-owned services use the same bounded tool search,
 including standard Homebrew locations on macOS, without loading interactive
 shell profiles. Finder launches therefore do not depend on terminal PATH setup.
+Installation uses `loopx doctor --deep --installation-only`: package ownership,
+representative imports/commands/files and the TypeScript runtime semantic probe
+remain required, but existing Goal projects are not traversed. Native runtime
+preparation also leaves host skills/slash commands and provider doctors alone;
+it cannot depend on a macOS Documents-folder consent prompt. Ordinary
+`loopx doctor` retains its full operator/integration diagnostics. Terminal
+installation still revalidates enabled extensions by default; the App sets
+`LOOPX_INSTALL_REVALIDATE_EXTENSIONS=0` for its bounded bootstrap.
 Failed runtime preparation remains supervised, with at most three automatic
 install attempts per App process and at least 30 seconds between attempts.
 Existing recovery controls remain available after that budget is exhausted,

--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -26,7 +26,7 @@ qualified. Browser/PWA users continue to use `loopx update`.
 ## Updates And Recovery
 
 The update panel is collapsed by default and opens above the sidebar without
-reducing the Goal list height. Automatic checks never install software. Its
+reducing the Goal list height. Automatic update checks never replace the App. Its
 advanced options expose stable/main channels, repair, and macOS rollback.
 The main channel points to the latest **complete signed build**, not arbitrary
 moving Git HEAD. A missing feed or failed signature is an error, not proof that
@@ -38,13 +38,29 @@ The bundled runtime owns the CLI, HTTP APIs and workspace assets. A runtime-only
 CLI update cannot patch native startup or updater bugs; those require an App
 update. The App update workflow packages both layers from one Git revision.
 
+On macOS, opening the App now automatically prepares its bundled runtime when
+the default CLI is missing or has a different source revision. This changes
+the previous startup behavior, which stopped at a manual repair gate. It can
+replace a separately updated default CLI with the App's matching snapshot;
+use an App update to move the paired installation forward. Automatic startup
+does not download another App or choose another update channel. Explicit
+`LOOPX_BIN` overrides are retained and are never replaced automatically: a
+mismatched override must be corrected by its owner.
+
+The installer and App-owned services use the same bounded tool search,
+including standard Homebrew locations on macOS, without loading interactive
+shell profiles. Finder launches therefore do not depend on terminal PATH setup.
+Failed runtime preparation remains supervised, with at most three automatic
+install attempts per App process and at least 30 seconds between attempts.
+Existing recovery controls remain available after that budget is exhausted,
+and externally corrected installations are still detected. A matching runtime
+completes a pending installation journal without reinstalling it.
+
 If startup cannot proceed, the embedded **Recovery & updates** screen stays
 available without a working HTTP service. **Repair this version** reinstalls
-the bundled runtime. It may replace a separately updated CLI with this App's
-matching snapshot, so it requires an explicit click. No automatic downgrade
-is performed when the selected runtime differs. Explicit `LOOPX_BIN` overrides
-are retained; an override that still selects another revision fails identity
-verification instead of reporting success.
+the bundled runtime and then reconnects the same window automatically; it no
+longer requires a second App restart. Reloading the WebView cannot terminate
+the native startup supervisor.
 
 An update journal resumes an approved runtime installation after restart.
 Concurrent transactions and additional installs before a required restart are

--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -132,6 +132,13 @@ fn install_snapshot(bytes: &[u8], metadata: &Value) -> Result<(), String> {
         .env("LOOPX_PROMOTE_DEFAULT", "1")
         // The archive staging directory is temporary, never a canary checkout.
         .env("LOOPX_INSTALL_CANARY", "0")
+        // Preparing the App runtime must not inspect/modify host integrations
+        // or invoke provider doctors that can request user-folder access.
+        .env("LOOPX_INSTALL_SKILL", "0")
+        .env("LOOPX_INSTALL_SLASH_COMMANDS", "0")
+        .env("LOOPX_INSTALL_CLAUDE", "0")
+        .env("LOOPX_INSTALL_OPENCODE", "0")
+        .env("LOOPX_INSTALL_REVALIDATE_EXTENSIONS", "0")
         .env_remove("LOOPX_ARCHIVE_URL")
         .env_remove("LOOPX_ARCHIVE_SHA256")
         .env("LOOPX_REPO", "huangruiteng/loopx")

--- a/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/bundled_runtime.rs
@@ -69,7 +69,10 @@ pub fn resume_pending(app: &AppHandle) -> Result<(), String> {
     if state["version"] != app.package_info().version.to_string() {
         return Err("app_update_incomplete".into());
     }
-    install(app)?;
+    let metadata = identity(app)?;
+    if !selected_revision_matches(&metadata) {
+        install(app)?;
+    }
     fs::remove_file(path).map_err(|_| "update_state_unavailable")?;
     Ok(())
 }
@@ -83,6 +86,13 @@ pub fn install(app: &AppHandle) -> Result<(), String> {
         .join("runtime/runtime-source.tar.gz");
     let bytes = fs::read(archive).map_err(|_| "runtime_bundle_missing")?;
     install_snapshot(&bytes, &metadata)
+}
+
+pub(crate) fn selected_revision_matches(metadata: &Value) -> bool {
+    crate::services::runtime_identity_for_executable(&crate::services::loopx_executable())
+        .as_ref()
+        .and_then(|value| value["source_revision"].as_str())
+        .is_some_and(|revision| metadata["source_revision"].as_str() == Some(revision))
 }
 
 fn install_snapshot(bytes: &[u8], metadata: &Value) -> Result<(), String> {
@@ -108,6 +118,7 @@ fn install_snapshot(bytes: &[u8], metadata: &Value) -> Result<(), String> {
             .arg(source.path().join("scripts/install-windows.ps1"));
         c
     };
+    crate::services::configure_runtime_environment(&mut command);
     // Preserve the working interpreter of an existing managed snapshot.
     if let Ok(executable) = fs::canonicalize(crate::services::loopx_executable()) {
         if let Some(release) = executable.parent().and_then(Path::parent) {

--- a/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
@@ -77,15 +77,25 @@ pub fn run() {
 
             let handle = app.handle().clone();
             std::thread::spawn(move || {
-                if maintenance::resume(&handle).is_err() {
-                    if let Some(window) = handle.get_webview_window("main") {
-                        let _ = window.eval(
-                            "window.loopxBootFailed('本机组件尚未就绪，请展开恢复与更新，检查更新或修复当前版本。')",
-                        );
-                    }
-                    return;
-                }
+                // Runtime preparation belongs to the same live supervisor as
+                // service startup. A failed install must not strand this window
+                // after a later repair, reload, or external runtime correction.
                 while !shutting_down_for_setup.load(Ordering::Acquire) {
+                    {
+                        let mut current = services_for_setup.lock().expect("service state lock");
+                        if current.is_some() {
+                            if maintenance::reconnect_requested(&handle) {
+                                // Runtime repair reuses this supervisor even
+                                // after the workspace has already been opened.
+                                // Drop only processes owned by this App.
+                                *current = None;
+                            } else {
+                                drop(current);
+                                std::thread::sleep(std::time::Duration::from_millis(200));
+                                continue;
+                            }
+                        }
+                    }
                     match maintenance::start_services(&handle) {
                         Ok(None) => {
                             std::thread::sleep(std::time::Duration::from_millis(200));
@@ -107,9 +117,8 @@ pub fn run() {
                                     .show();
                             }
                             if let Some(window) = handle.get_webview_window("main") {
-                                let _ = window.navigate(origin);
+                                let _ = window.navigate(origin.clone());
                             }
-                            return;
                         }
                         Err(error) => {
                             let message = "本地服务暂时无法启动，请检查安装或端口占用。";

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -6,7 +6,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Mutex,
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_updater::{Update, UpdaterExt};
@@ -18,6 +18,28 @@ pub struct Maintenance {
     snapshot: Mutex<Value>,
     pending: Mutex<Option<(String, Update)>>,
     last_failure: Mutex<Value>,
+    runtime_retry: Mutex<RuntimeRetry>,
+}
+
+#[derive(Default)]
+struct RuntimeRetry {
+    attempts: u8,
+    last_attempt: Option<Instant>,
+}
+
+impl RuntimeRetry {
+    fn admit(&mut self, now: Instant) -> bool {
+        if self.attempts >= 3
+            || self
+                .last_attempt
+                .is_some_and(|last| now.duration_since(last) < Duration::from_secs(30))
+        {
+            return false;
+        }
+        self.attempts += 1;
+        self.last_attempt = Some(now);
+        true
+    }
 }
 impl Maintenance {
     fn acquire(&self) -> Result<BusyGuard<'_>, String> {
@@ -33,6 +55,43 @@ impl Maintenance {
         }
         *self.snapshot.lock().unwrap() = value.clone();
         value
+    }
+
+    fn prepare_runtime(
+        &self,
+        matches: bool,
+        explicit_override: bool,
+        now: Instant,
+        install: impl FnOnce() -> Result<(), String>,
+    ) -> Result<(), String> {
+        if matches {
+            *self.runtime_retry.lock().unwrap() = RuntimeRetry::default();
+            return Ok(());
+        }
+        if explicit_override {
+            self.publish(
+                "runtime_required",
+                json!({"code":"runtime_identity_mismatch", "revision_matches":false}),
+            );
+            return Err("runtime_identity_mismatch".into());
+        }
+        if !self.runtime_retry.lock().unwrap().admit(now) {
+            // Keep the last actionable install error while the live supervisor
+            // observes external correction and permits an explicit repair.
+            return Err("runtime_setup_required".into());
+        }
+        self.publish("installing_runtime", json!({}));
+        match install() {
+            Ok(()) => {
+                *self.runtime_retry.lock().unwrap() = RuntimeRetry::default();
+                self.publish("connecting", json!({}));
+                Ok(())
+            }
+            Err(error) => {
+                self.publish("error", json!({"code":error}));
+                Err(error)
+            }
+        }
     }
 
     // Service supervision and maintenance must never replace/start different
@@ -57,16 +116,17 @@ impl Maintenance {
         if phase == "restart_required" {
             return Ok(None);
         }
-        let observing_update = matches!(phase.as_str(), "connecting" | "service_error");
         match start() {
             Ok(services) => {
-                if observing_update {
-                    self.publish("ready", json!({}));
-                }
+                self.publish("ready", json!({}));
                 Ok(Some(services))
             }
             Err(error) => {
-                if observing_update {
+                let runtime_error = matches!(
+                    self.snapshot.lock().unwrap()["phase"].as_str(),
+                    Some("error" | "runtime_required")
+                );
+                if !runtime_error {
                     self.publish("service_error", json!({"code":"service_start_failed"}));
                 }
                 Err(error)
@@ -208,11 +268,17 @@ async fn perform(
                 &handle.package_info().version.to_string(),
                 "bundled",
             )?;
+            // Explicit repair must reinstall even when the manifest matches:
+            // missing/corrupt runtime files are not an identity mismatch.
+            bundled_runtime::install(&handle)?;
             bundled_runtime::resume_pending(&handle)
         })
         .await
         .map_err(|_| "runtime_install_failed")??;
-        return Ok(state.publish("restart_required", json!({})));
+        *state.runtime_retry.lock().unwrap() = RuntimeRetry::default();
+        // Only replacing the App binary needs a process restart. The live
+        // supervisor will connect this same window after runtime repair.
+        return Ok(state.publish("connecting", json!({})));
     }
     let update = state
         .pending
@@ -252,17 +318,6 @@ async fn perform(
     *state.pending.lock().unwrap() = None;
     Ok(state.publish("restart_required", json!({"version":target})))
 }
-pub fn resume(app: &AppHandle) -> Result<(), String> {
-    let result = resume_runtime(app);
-    if let Err(error) = &result {
-        if error != "runtime_setup_required" {
-            app.state::<Maintenance>()
-                .publish("error", json!({"code":error}));
-        }
-    }
-    result
-}
-
 fn resume_runtime(app: &AppHandle) -> Result<(), String> {
     // Development intentionally pairs a live frontend with a developer-selected
     // runtime; it must neither replace itself nor force release installation.
@@ -271,49 +326,135 @@ fn resume_runtime(app: &AppHandle) -> Result<(), String> {
     }
     let state = app.state::<Maintenance>();
     let _guard = state.acquire()?;
-    if !bundled_runtime::journal(app)?.exists() {
-        {
-            let bundled = bundled_runtime::identity(app)?;
-            let installed = crate::services::runtime_identity_for_executable(
-                &crate::services::loopx_executable(),
-            );
-            if installed.as_ref().map(|v| &v["source_revision"])
-                != Some(&bundled["source_revision"])
-            {
-                state.publish(
-                    "runtime_required",
-                    json!({
-                        "code":"runtime_setup_required",
-                        "installed_identity_available": installed.is_some(),
-                        "revision_matches": false
-                    }),
-                );
-                return Err("runtime_setup_required".into());
-            }
-        }
-        return Ok(());
-    }
-    state.publish("installing_runtime", json!({}));
-    let result = bundled_runtime::resume_pending(app);
-    match result {
-        Ok(()) => {
-            state.publish("connecting", json!({}));
-            Ok(())
-        }
-        Err(error) => {
-            state.publish("error", json!({"code":error}));
-            Err(error)
+    let bundled = bundled_runtime::identity(app)?;
+    let matches = bundled_runtime::selected_revision_matches(&bundled);
+    let explicit_override = std::env::var("LOOPX_BIN").is_ok_and(|v| !v.trim().is_empty());
+    // Validate an existing approved target before any automatic installation.
+    // A journal for another App must never authorize this App's bundle.
+    let journal = bundled_runtime::journal(app)?;
+    if journal.exists() {
+        let pending: Value = serde_json::from_slice(
+            &std::fs::read(&journal).map_err(|_| "update_state_unavailable")?,
+        )
+        .map_err(|_| "update_state_invalid")?;
+        if pending["version"] != app.package_info().version.to_string() {
+            return Err("app_update_incomplete".into());
         }
     }
+    state.prepare_runtime(matches, explicit_override, Instant::now(), || {
+        if !journal.exists() {
+            bundled_runtime::record_pending(
+                app,
+                &app.package_info().version.to_string(),
+                "bundled",
+            )?;
+        }
+        bundled_runtime::resume_pending(app)
+    })?;
+    if journal.exists() {
+        // Idempotent completion after a crash between promotion and journal
+        // removal: do not reinstall an already matching runtime.
+        bundled_runtime::resume_pending(app)?;
+    }
+    Ok(())
 }
 pub fn start_services(app: &AppHandle) -> Result<Option<crate::services::ServiceSet>, String> {
-    app.state::<Maintenance>()
-        .reconcile_services(|| crate::services::ServiceSet::start().map_err(|e| e.to_string()))
+    app.state::<Maintenance>().reconcile_services(|| {
+        if let Err(error) = resume_runtime(app) {
+            if error != "runtime_setup_required" {
+                app.state::<Maintenance>()
+                    .publish("error", json!({"code":error}));
+            }
+            return Err(error);
+        }
+        crate::services::ServiceSet::start().map_err(|e| e.to_string())
+    })
+}
+
+pub fn reconnect_requested(app: &AppHandle) -> bool {
+    app.state::<Maintenance>().snapshot.lock().unwrap()["phase"] == "connecting"
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn runtime_failure_can_recover_without_restarting_the_supervisor() {
+        let state = Maintenance::default();
+        let now = Instant::now();
+        let attempt = |matches, now, install: fn() -> Result<(), String>| {
+            state.reconcile_services(|| {
+                state.prepare_runtime(matches, false, now, install)?;
+                Ok(())
+            })
+        };
+        assert!(attempt(false, now, || Err("runtime_install_exit_1".into())).is_err());
+        assert!(
+            state.acquire().is_ok(),
+            "failed automatic install releases maintenance"
+        );
+        assert!(attempt(false, now + Duration::from_secs(2), || panic!(
+            "backoff must not reinstall"
+        ))
+        .is_err());
+        assert_eq!(
+            state.snapshot.lock().unwrap()["details"]["code"],
+            "runtime_install_exit_1"
+        );
+        assert_eq!(
+            attempt(false, now + Duration::from_secs(31), || Ok(())).unwrap(),
+            Some(())
+        );
+        assert_eq!(state.snapshot.lock().unwrap()["phase"], "ready");
+        assert_eq!(
+            attempt(true, now + Duration::from_secs(32), || panic!(
+                "matching runtime must not reinstall"
+            ))
+            .unwrap(),
+            Some(())
+        );
+        assert_eq!(state.snapshot.lock().unwrap()["phase"], "ready");
+    }
+
+    #[test]
+    fn automatic_install_is_bounded_but_external_repair_is_still_observed() {
+        let state = Maintenance::default();
+        let now = Instant::now();
+        for seconds in [0, 31, 62] {
+            assert!(state
+                .prepare_runtime(false, false, now + Duration::from_secs(seconds), || Err(
+                    "runtime_install_exit_1".into()
+                ))
+                .is_err());
+        }
+        assert!(state
+            .prepare_runtime(false, false, now + Duration::from_secs(1000), || panic!(
+                "retry budget exhausted"
+            ))
+            .is_err());
+        assert!(state
+            .prepare_runtime(true, false, now + Duration::from_secs(1001), || panic!(
+                "external correction needs no install"
+            ))
+            .is_ok());
+    }
+
+    #[test]
+    fn explicit_runtime_override_is_never_replaced_automatically() {
+        let state = Maintenance::default();
+        assert_eq!(
+            state
+                .prepare_runtime(false, true, Instant::now(), || panic!(
+                    "explicit selection must be respected"
+                ))
+                .unwrap_err(),
+            "runtime_identity_mismatch"
+        );
+        assert!(state
+            .prepare_runtime(true, true, Instant::now(), || panic!("already matches"))
+            .is_ok());
+    }
+
     #[test]
     fn diagnostics_retain_failure_after_successful_update_check() {
         let state = Maintenance::default();

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -196,6 +196,7 @@ impl ServiceSet {
         }
 
         let mut command = Command::new(&executable);
+        configure_runtime_environment(&mut command);
         command
             .args(kind.command_args())
             .stdin(Stdio::null())
@@ -540,6 +541,43 @@ pub(crate) fn loopx_executable() -> String {
         .or_else(|| resolve_executable_path("loopx", env::var_os("PATH").as_deref()))
         .map(|candidate| candidate.to_string_lossy().into_owned())
         .unwrap_or_else(|| "loopx".to_string())
+}
+
+// Finder/launchd do not load a user's interactive shell profile. Use the same
+// bounded tool search for installation and owned services, without sourcing
+// arbitrary shell startup files or changing the parent process environment.
+pub(crate) fn configure_runtime_environment(command: &mut Command) {
+    command.env(
+        "PATH",
+        runtime_search_path(env::var_os("HOME"), env::var_os("PATH")),
+    );
+}
+
+fn runtime_search_path(
+    home: Option<std::ffi::OsString>,
+    inherited: Option<std::ffi::OsString>,
+) -> std::ffi::OsString {
+    let mut paths = Vec::new();
+    if let Some(home) = home {
+        paths.push(PathBuf::from(home).join(".local/bin"));
+    }
+    if cfg!(target_os = "macos") {
+        paths.extend([
+            PathBuf::from("/opt/homebrew/bin"),
+            PathBuf::from("/usr/local/bin"),
+        ]);
+    }
+    for path in inherited
+        .as_deref()
+        .map(env::split_paths)
+        .into_iter()
+        .flatten()
+    {
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
+    }
+    env::join_paths(paths).unwrap_or_else(|_| inherited.unwrap_or_default())
 }
 
 fn resolve_executable_path(executable: &str, search_path: Option<&OsStr>) -> Option<PathBuf> {

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -82,6 +82,7 @@ impl ServiceKind {
 enum Probe {
     Matching,
     Unavailable,
+    Unresponsive,
     Foreign,
     Stale,
 }
@@ -152,7 +153,7 @@ impl ServiceSet {
                     // service (KeepAlive + throttle) has time to restart on the
                     // current release; unknown (Foreign) processes keep the
                     // hard error.
-                    terminate_stale_listener(kind, &executable, kind.port())?;
+                    terminate_verified_listener(kind, &executable, kind.port())?;
                     self.healed = true;
                     if Instant::now() >= stale_deadline {
                         return Err(ServiceError(format!(
@@ -162,6 +163,18 @@ impl ServiceSet {
                         )));
                     }
                     thread::sleep(Duration::from_millis(200));
+                }
+                Probe::Unresponsive => {
+                    // A bound socket is not HTTP readiness. Give slow startup
+                    // a full grace period, then replace only a verified LoopX
+                    // listener; unknown processes still fail closed.
+                    if Instant::now() < stale_deadline {
+                        thread::sleep(Duration::from_millis(100));
+                        continue;
+                    }
+                    terminate_verified_listener(kind, &executable, kind.port())?;
+                    self.healed = true;
+                    break;
                 }
                 Probe::Unavailable => break,
             }
@@ -180,11 +193,11 @@ impl ServiceSet {
                         )));
                     }
                     Probe::Stale => {
-                        terminate_stale_listener(kind, &executable, kind.port())?;
+                        terminate_verified_listener(kind, &executable, kind.port())?;
                         self.healed = true;
                         request_platform_managed_start(kind);
                     }
-                    Probe::Unavailable => {}
+                    Probe::Unavailable | Probe::Unresponsive => {}
                 }
                 thread::sleep(Duration::from_millis(100));
             }
@@ -222,11 +235,13 @@ impl ServiceSet {
                     )));
                 }
                 Probe::Stale => {
-                    terminate_stale_listener(kind, &executable, kind.port())?;
+                    terminate_verified_listener(kind, &executable, kind.port())?;
                     self.healed = true;
                     thread::sleep(Duration::from_millis(200));
                 }
-                Probe::Unavailable => thread::sleep(Duration::from_millis(100)),
+                Probe::Unavailable | Probe::Unresponsive => {
+                    thread::sleep(Duration::from_millis(100))
+                }
             }
         }
         Err(ServiceError(format!(
@@ -318,7 +333,7 @@ const DYNAMIC_MODULE_LAUNCH_MARKER: &str = r#"runpy.run_module(module, run_name=
 const RELEASE_ARGV_ZERO_MARKER: &str =
     r#"sys.argv[0] = os.path.join(release_root, "scripts", "loopx")"#;
 
-fn terminate_stale_listener(
+fn terminate_verified_listener(
     kind: ServiceKind,
     loopx_executable: &str,
     port: u16,
@@ -657,15 +672,17 @@ fn probe_on_port(
         port
     );
     if stream.write_all(request.as_bytes()).is_err() {
-        return Probe::Foreign;
+        return Probe::Unresponsive;
     }
     let mut response = String::new();
     if stream
         .take(MAX_PROBE_RESPONSE_BYTES + 1)
         .read_to_string(&mut response)
         .is_err()
-        || response.len() as u64 > MAX_PROBE_RESPONSE_BYTES
     {
+        return Probe::Unresponsive;
+    }
+    if response.len() as u64 > MAX_PROBE_RESPONSE_BYTES {
         return Probe::Foreign;
     }
     classify_response(kind, &response, expected_runtime_identity)

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
@@ -37,6 +37,7 @@ fn spawn_listener_fixture(
     let source = format!(
         r#"#!/usr/bin/env python3
 import socket
+import time
 
 payload = {payload:?}.encode("utf-8")
 server = socket.socket()
@@ -46,6 +47,9 @@ server.listen(8)
 while True:
     connection, _ = server.accept()
     connection.recv(65536)
+    if not payload:
+        time.sleep(60)
+        continue
     response = (
         b"HTTP/1.1 200 OK\r\n"
         b"Content-Type: application/json\r\n"
@@ -305,7 +309,7 @@ fn service_supervisor_reuses_matching_replaces_stale_and_rejects_foreign() {
             )),
         "fixture process must classify as LoopX: {stale_processes:?}"
     );
-    terminate_stale_listener(
+    terminate_verified_listener(
         ServiceKind::Status,
         stale_executable.to_string_lossy().as_ref(),
         stale_port,
@@ -334,7 +338,7 @@ fn service_supervisor_reuses_matching_replaces_stale_and_rejects_foreign() {
         Some(&current_identity),
         Probe::Foreign,
     );
-    let error = terminate_stale_listener(
+    let error = terminate_verified_listener(
         ServiceKind::Status,
         stale_executable.to_string_lossy().as_ref(),
         foreign_port,
@@ -347,6 +351,36 @@ fn service_supervisor_reuses_matching_replaces_stale_and_rejects_foreign() {
         .is_none());
     foreign.kill().expect("stop foreign fixture");
     foreign.wait().expect("reap foreign fixture");
+
+    // A silent listener must be distinct from a foreign HTTP response. Only
+    // the expected LoopX process may be terminated after the startup grace.
+    for confirmed in [true, false] {
+        let port = reserve_loopback_port();
+        let executable = fixture_root.join(if confirmed { "loopx" } else { "silent-foreign" });
+        let mut silent = spawn_listener_fixture(&executable, "chat", port, "");
+        wait_for_probe(
+            ServiceKind::Chat,
+            port,
+            Some(&current_identity),
+            Probe::Unresponsive,
+        );
+        let result = terminate_verified_listener(
+            ServiceKind::Chat,
+            stale_executable.to_string_lossy().as_ref(),
+            port,
+        );
+        if confirmed {
+            result.expect("replace a confirmed but unresponsive LoopX service");
+        } else {
+            assert!(result.is_err());
+            assert!(silent
+                .try_wait()
+                .expect("foreign listener status")
+                .is_none());
+            silent.kill().expect("clean up foreign fixture");
+        }
+        silent.wait().expect("reap silent fixture");
+    }
 
     fs::remove_dir_all(&fixture_root).expect("remove service supervisor fixture");
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+#[test]
+#[cfg(target_os = "macos")]
+fn finder_runtime_path_includes_tools_without_loading_shell_profiles() {
+    let path = runtime_search_path(
+        Some("/fixture/user".into()),
+        Some("/usr/bin:/bin:/usr/sbin:/sbin".into()),
+    );
+    let paths: Vec<_> = env::split_paths(&path).collect();
+    assert_eq!(paths[0], PathBuf::from("/fixture/user/.local/bin"));
+    assert!(
+        paths
+            .iter()
+            .position(|p| p == Path::new("/opt/homebrew/bin"))
+            .unwrap()
+            < paths
+                .iter()
+                .position(|p| p == Path::new("/usr/bin"))
+                .unwrap()
+    );
+    assert!(paths.contains(&PathBuf::from("/usr/local/bin")));
+    assert!(paths.contains(&PathBuf::from("/sbin")));
+    let again = runtime_search_path(Some("/fixture/user".into()), Some(path.clone()));
+    assert_eq!(again, path, "tool search must be idempotent");
+}
+
 #[cfg(not(windows))]
 fn spawn_listener_fixture(
     executable: &Path,

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -738,27 +738,23 @@ class ChatRuntimeController:
         work_dir: Path,
         objective: str,
     ) -> None:
-        if self.closed.is_set():
-            return
-        session = self.store.load_session(session_id)
-        if session is None or session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
-            return
+        # Admission must not read session files: callers can hold their own
+        # lifecycle fence here. The worker validates the session before effects.
         with self.lock:
-            if session_id in self.session_queue_workers:
+            if self.closed.is_set() or session_id in self.session_queue_workers:
                 return
+            worker = threading.Thread(
+                target=self._drain_session_queue,
+                kwargs={
+                    "session_id": session_id,
+                    "work_dir": work_dir,
+                    "objective": objective,
+                },
+                daemon=True,
+            )
             self.session_queue_workers.add(session_id)
-        worker = threading.Thread(
-            target=self._drain_session_queue,
-            kwargs={
-                "session_id": session_id,
-                "work_dir": work_dir,
-                "objective": objective,
-            },
-            daemon=True,
-        )
-        with self.lock:
             self.session_queue_threads[session_id] = worker
-        worker.start()
+            worker.start()
 
     def _drain_session_queue(
         self,
@@ -770,7 +766,12 @@ class ChatRuntimeController:
         try:
             while not self.closed.is_set():
                 session = self.store.load_session(session_id)
-                if session is None or session.get("status") == "closed":
+                if (
+                    self.closed.is_set()
+                    or session is None
+                    or session.get("status") == "closed"
+                    or session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED
+                ):
                     return
                 active_turn_id = str(session.get("active_turn_id") or "")
                 if active_turn_id:

--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -1490,7 +1490,7 @@ def serve_chat(
         runtime_root=runtime_root,
         runtime_controller=server.runtime_controller,
     )
-    server.lark_goal_topic_runtime.refresh()
+    server.lark_goal_topic_runtime.start()
     url = f"http://{host}:{port}{DEFAULT_CHAT_PATH}"
     print(f"Serving LoopX Chat at {url}", flush=True)
     print("Agent boundary: local adapters, read-only sandbox, approval policy never", flush=True)

--- a/loopx/cli_commands/doctor.py
+++ b/loopx/cli_commands/doctor.py
@@ -28,7 +28,13 @@ def register_doctor_command(
         action="store_true",
         help="Run slower representative release-candidate checks.",
     )
-    parser.add_argument(
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument(
+        "--installation-only",
+        action="store_true",
+        help="Check the installed package and toolchain without inspecting user projects or integrations.",
+    )
+    scope.add_argument(
         "--agent-type",
         choices=SUPPORTED_AGENT_TYPES,
         help=(
@@ -43,6 +49,7 @@ def handle_doctor_command(args: argparse.Namespace, print_payload: PrintPayload)
     payload = collect_doctor(
         deep=bool(args.deep),
         agent_type=args.agent_type,
+        installation_only=bool(getattr(args, "installation_only", False)),
     )
     output_format = getattr(args, "subcommand_format", None) or args.format
     print_payload(payload, output_format, render_doctor_markdown)

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -878,6 +878,8 @@ def collect_doctor(
     installation_only: bool = False,
 ) -> dict[str, Any]:
     if installation_only:
+        from .release_candidate import collect_installation_doctor
+
         return collect_installation_doctor(deep=deep)
     from .control_plane.runtime.runtime_projection_route import (
         collect_runtime_projection_route_diagnostics,
@@ -1342,47 +1344,6 @@ def collect_doctor(
     return payload
 
 
-def collect_installation_doctor(*, deep: bool) -> dict[str, Any]:
-    """Validate the package/toolchain without opening registered user projects.
-
-    Installers must not depend on workspace availability or macOS folder
-    consent. Keep the same representative package and runtime semantic checks
-    as deep doctor; ambient Goal, skill and provider health is a separate read.
-    """
-    from .control_plane.effect_runtime import collect_effect_runtime_readiness
-    from .release_candidate import collect_deep_install_checks
-
-    invocation = current_script_invocation_path()
-    command = resolve_command_path("loopx") or invocation
-    package_root = Path(__file__).resolve().parents[1]
-    selected = os.environ.get("LOOPX_RELEASE_ROOT")
-    runtime = collect_effect_runtime_readiness(deep=deep)
-    checks = [
-        {"id": "command_available", "required": True, "ok": command is not None},
-        {"id": "typescript_effect_runtime_ready", "required": True,
-         "ok": bool(runtime.get("ready")), "detail": runtime.get("status")},
-    ]
-    payload: dict[str, Any] = {
-        "mode": "deep" if deep else "standard",
-        "scope": "installation_only",
-        "checks": checks,
-        "typescript_control_plane": runtime,
-        "path": {"loopx": str(command) if command else None},
-    }
-    if deep:
-        candidate = collect_deep_install_checks(
-            command_path=command,
-            invocation_path=invocation,
-            package_root=package_root,
-            invocation_root=Path(selected).expanduser().resolve() if selected else package_root,
-            distribution_root=python_distribution_install(Path(__file__).resolve()).get("root"),
-        )
-        checks.extend(candidate["checks"])
-        payload["release_candidate"] = candidate
-    payload["ok"] = all(check["ok"] for check in checks)
-    return payload
-
-
 def render_doctor_markdown(payload: dict[str, Any]) -> str:
     release_provenance = payload.get("release_provenance") or {}
     default_release = release_provenance.get("default_release") or {}
@@ -1514,11 +1475,6 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 "```",
             ]
         )
-    typescript_control_plane = (
-        payload.get("typescript_control_plane")
-        if isinstance(payload.get("typescript_control_plane"), dict)
-        else {}
-    )
     if typescript_control_plane:
         lines.extend(
             [

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -875,7 +875,10 @@ def collect_doctor(
     *,
     deep: bool = False,
     agent_type: str | None = None,
+    installation_only: bool = False,
 ) -> dict[str, Any]:
+    if installation_only:
+        return collect_installation_doctor(deep=deep)
     from .control_plane.runtime.runtime_projection_route import (
         collect_runtime_projection_route_diagnostics,
     )
@@ -1336,6 +1339,47 @@ def collect_doctor(
     }
     if deep_validation:
         payload["release_candidate"] = deep_validation
+    return payload
+
+
+def collect_installation_doctor(*, deep: bool) -> dict[str, Any]:
+    """Validate the package/toolchain without opening registered user projects.
+
+    Installers must not depend on workspace availability or macOS folder
+    consent. Keep the same representative package and runtime semantic checks
+    as deep doctor; ambient Goal, skill and provider health is a separate read.
+    """
+    from .control_plane.effect_runtime import collect_effect_runtime_readiness
+    from .release_candidate import collect_deep_install_checks
+
+    invocation = current_script_invocation_path()
+    command = resolve_command_path("loopx") or invocation
+    package_root = Path(__file__).resolve().parents[1]
+    selected = os.environ.get("LOOPX_RELEASE_ROOT")
+    runtime = collect_effect_runtime_readiness(deep=deep)
+    checks = [
+        {"id": "command_available", "required": True, "ok": command is not None},
+        {"id": "typescript_effect_runtime_ready", "required": True,
+         "ok": bool(runtime.get("ready")), "detail": runtime.get("status")},
+    ]
+    payload: dict[str, Any] = {
+        "mode": "deep" if deep else "standard",
+        "scope": "installation_only",
+        "checks": checks,
+        "typescript_control_plane": runtime,
+        "path": {"loopx": str(command) if command else None},
+    }
+    if deep:
+        candidate = collect_deep_install_checks(
+            command_path=command,
+            invocation_path=invocation,
+            package_root=package_root,
+            invocation_root=Path(selected).expanduser().resolve() if selected else package_root,
+            distribution_root=python_distribution_install(Path(__file__).resolve()).get("root"),
+        )
+        checks.extend(candidate["checks"])
+        payload["release_candidate"] = candidate
+    payload["ok"] = all(check["ok"] for check in checks)
     return payload
 
 

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -616,12 +616,14 @@ class LarkGoalTopicRuntimeService:
             return
         snapshot = self.snapshot_provider()
         desired = set(_active_profile_configs(snapshot))
+        if self._closed.is_set():
+            return
+        self._resume_session_queues(snapshot)
         # A filesystem read may outlive server shutdown (for example, while
         # waiting for OS directory consent). Never start effects after close.
         with self._lock:
             if self._closed.is_set():
                 return
-            self._resume_session_queues(snapshot)
             stale = set(self._workers) - desired
             missing = desired - set(self._workers)
             for profile in stale:
@@ -655,6 +657,8 @@ class LarkGoalTopicRuntimeService:
                 if not isinstance(payload, Mapping):
                     continue
                 for binding in bindings_for_goal(payload, str(goal_id)):
+                    if self._closed.is_set():
+                        return
                     raw_routing = binding.get("routing")
                     routing: Mapping[str, Any] = (
                         raw_routing if isinstance(raw_routing, Mapping) else {}
@@ -673,19 +677,25 @@ class LarkGoalTopicRuntimeService:
                     except KeyError:
                         has_queued_turns = False
                     if has_queued_turns and work_dir:
-                        self.runtime_controller.resume_session_queue(
-                            session_id=session_id,
-                            work_dir=Path(work_dir).expanduser().resolve(),
-                            objective=str(context.get("objective") or goal_id),
-                        )
+                        resolved_work_dir = Path(work_dir).expanduser().resolve()
+                        # Discovery is slow I/O; only cancellation and the
+                        # controller's I/O-free worker admission belong here.
+                        with self._lock:
+                            if self._closed.is_set():
+                                return
+                            self.runtime_controller.resume_session_queue(
+                                session_id=session_id,
+                                work_dir=resolved_work_dir,
+                                objective=str(context.get("objective") or goal_id),
+                            )
 
     def active_profiles(self) -> list[str]:
         with self._lock:
             return sorted(self._workers)
 
     def close(self) -> None:
+        self._closed.set()
         with self._lock:
-            self._closed.set()
             workers = list(self._workers.values())
             self._workers.clear()
         for stop, _thread in workers:

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 import subprocess
 import threading
@@ -470,6 +471,32 @@ class LarkGoalTopicRuntimeService:
         self._lock = threading.Lock()
         self._workers: dict[str, tuple[threading.Event, threading.Thread]] = {}
         self._health: dict[str, dict[str, Any]] = {}
+        self._closed = threading.Event()
+        self._startup_thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Discover existing bindings without blocking the HTTP readiness path."""
+
+        with self._lock:
+            if self._closed.is_set() or self._startup_thread is not None:
+                return
+            self._startup_thread = threading.Thread(
+                target=self._refresh_on_start,
+                name="loopx-lark-startup",
+                daemon=True,
+            )
+            self._startup_thread.start()
+
+    def _refresh_on_start(self) -> None:
+        while not self._closed.is_set():
+            try:
+                self.refresh()
+                return
+            except Exception:
+                logging.getLogger(__name__).warning(
+                    "Lark binding discovery failed; retrying in the background"
+                )
+            self._closed.wait(5)
 
     @staticmethod
     def _now() -> str:
@@ -585,8 +612,42 @@ class LarkGoalTopicRuntimeService:
         self._update_health(profile, status="stopped", error_code=None)
 
     def refresh(self) -> None:
+        if self._closed.is_set():
+            return
         snapshot = self.snapshot_provider()
         desired = set(_active_profile_configs(snapshot))
+        # A filesystem read may outlive server shutdown (for example, while
+        # waiting for OS directory consent). Never start effects after close.
+        with self._lock:
+            if self._closed.is_set():
+                return
+            self._resume_session_queues(snapshot)
+            stale = set(self._workers) - desired
+            missing = desired - set(self._workers)
+            for profile in stale:
+                stop, _thread = self._workers.pop(profile)
+                stop.set()
+            for profile in sorted(missing):
+                stop = threading.Event()
+                self._health[profile] = {
+                    "status": "starting",
+                    "event_count": 0,
+                    "replied_count": 0,
+                    "last_event_status": None,
+                    "error_code": None,
+                    "restart_count": 0,
+                    "updated_at": self._now(),
+                }
+                thread = threading.Thread(
+                    target=self._profile_poller,
+                    args=(profile, stop),
+                    name=f"loopx-lark-{profile}",
+                    daemon=True,
+                )
+                self._workers[profile] = (stop, thread)
+                thread.start()
+
+    def _resume_session_queues(self, snapshot: Mapping[str, Any]) -> None:
         binding_payloads = snapshot.get("binding_payloads")
         contexts = snapshot.get("goal_contexts")
         if isinstance(binding_payloads, Mapping) and isinstance(contexts, Mapping):
@@ -617,31 +678,6 @@ class LarkGoalTopicRuntimeService:
                             work_dir=Path(work_dir).expanduser().resolve(),
                             objective=str(context.get("objective") or goal_id),
                         )
-        with self._lock:
-            stale = set(self._workers) - desired
-            missing = desired - set(self._workers)
-            for profile in stale:
-                stop, _thread = self._workers.pop(profile)
-                stop.set()
-            for profile in sorted(missing):
-                stop = threading.Event()
-                self._health[profile] = {
-                    "status": "starting",
-                    "event_count": 0,
-                    "replied_count": 0,
-                    "last_event_status": None,
-                    "error_code": None,
-                    "restart_count": 0,
-                    "updated_at": self._now(),
-                }
-                thread = threading.Thread(
-                    target=self._profile_poller,
-                    args=(profile, stop),
-                    name=f"loopx-lark-{profile}",
-                    daemon=True,
-                )
-                self._workers[profile] = (stop, thread)
-                thread.start()
 
     def active_profiles(self) -> list[str]:
         with self._lock:
@@ -649,6 +685,7 @@ class LarkGoalTopicRuntimeService:
 
     def close(self) -> None:
         with self._lock:
+            self._closed.set()
             workers = list(self._workers.values())
             self._workers.clear()
         for stop, _thread in workers:

--- a/loopx/release_candidate.py
+++ b/loopx/release_candidate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 from importlib.metadata import PackageNotFoundError, distribution
 import subprocess
 from pathlib import Path
@@ -275,3 +276,45 @@ def collect_deep_install_checks(
         package_root=package_root,
         invocation_root=invocation_root,
     )
+
+
+def collect_installation_doctor(*, deep: bool) -> dict[str, Any]:
+    """Validate the package/toolchain without opening registered user projects.
+
+    Installers must not depend on workspace availability or macOS folder
+    consent. Keep the same representative package and runtime semantic checks
+    as deep doctor; ambient Goal, skill and provider health is a separate read.
+    """
+    from .control_plane.effect_runtime import collect_effect_runtime_readiness
+    from .command_invocation import resolve_command_path
+    from .doctor import current_script_invocation_path, python_distribution_install
+
+    invocation = current_script_invocation_path()
+    command = resolve_command_path("loopx") or invocation
+    package_root = Path(__file__).resolve().parents[1]
+    selected = os.environ.get("LOOPX_RELEASE_ROOT")
+    runtime = collect_effect_runtime_readiness(deep=deep)
+    checks = [
+        {"id": "command_available", "required": True, "ok": command is not None},
+        {"id": "typescript_effect_runtime_ready", "required": True,
+         "ok": bool(runtime.get("ready")), "detail": runtime.get("status")},
+    ]
+    payload: dict[str, Any] = {
+        "mode": "deep" if deep else "standard",
+        "scope": "installation_only",
+        "checks": checks,
+        "typescript_control_plane": runtime,
+        "path": {"loopx": str(command) if command else None},
+    }
+    if deep:
+        candidate = collect_deep_install_checks(
+            command_path=command,
+            invocation_path=invocation,
+            package_root=package_root,
+            invocation_root=Path(selected).expanduser().resolve() if selected else package_root,
+            distribution_root=python_distribution_install(Path(__file__).resolve()).get("root"),
+        )
+        checks.extend(candidate["checks"])
+        payload["release_candidate"] = candidate
+    payload["ok"] = all(check["ok"] for check in checks)
+    return payload

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -528,7 +528,7 @@ validate_release_candidate() {
   fi
 
   local doctor_json
-  if ! doctor_json="$(PATH="$candidate/scripts:$PATH" "$candidate_wrapper" --format json doctor --deep)"; then
+  if ! doctor_json="$(PATH="$candidate/scripts:$PATH" "$candidate_wrapper" --format json doctor --deep --installation-only)"; then
     echo "loopx installer error: release candidate doctor validation failed" >&2
     return 1
   fi
@@ -768,13 +768,13 @@ PY
 fi
 
 export PATH="$bin_dir:$PATH"
-"$bin_dir/loopx" doctor >/dev/null
-if ! "$bin_dir/loopx" --format json extension doctor --all-enabled --execute >/dev/null; then
+"$bin_dir/loopx" doctor --installation-only >/dev/null
+if [[ "${LOOPX_INSTALL_REVALIDATE_EXTENSIONS:-1}" != "0" ]] && ! "$bin_dir/loopx" --format json extension doctor --all-enabled --execute >/dev/null; then
   echo "loopx installer warning: one or more enabled extensions failed post-install doctor revalidation" >&2
   echo "Run 'loopx extension doctor --all-enabled --execute' after repairing the provider." >&2
 fi
 if [[ "$install_canary" != "0" ]]; then
-  "$bin_dir/loopx-canary" doctor >/dev/null
+  "$bin_dir/loopx-canary" doctor --installation-only >/dev/null
 fi
 
 install_workflow_skills "$release_dir/skills" "$release_dir" "$bin_dir/loopx"

--- a/skills/loopx-self-repair/references/repair-patterns.md
+++ b/skills/loopx-self-repair/references/repair-patterns.md
@@ -203,6 +203,10 @@ tool search for installer and child services, retain exact revision checks,
 bound automatic installation retries, and prove failed preparation followed by
 repair reaches service startup without recreating the App process. Only an App
 binary replacement requires restart; runtime repair resumes the same window.
+Installation readiness must not traverse registered Goal workspaces or run
+host/provider integration checks. Use `doctor --deep --installation-only` to
+retain package/toolchain validation without waiting on user-folder consent;
+full operator diagnostics remain available through ordinary `doctor`.
 
 For most repairs, capture:
 

--- a/skills/loopx-self-repair/references/repair-patterns.md
+++ b/skills/loopx-self-repair/references/repair-patterns.md
@@ -194,6 +194,16 @@ teaches a reusable control-plane lesson.
 
 ## Minimal Evidence Packet
 
+Desktop runtime preparation failures must remain inside the live startup
+supervisor. Compare the App's bundled revision, selected CLI revision and
+listener identities independently; a working terminal CLI is not proof of a
+working Finder launch. Reproduce installer validation with Finder's minimal
+PATH and isolated install/registry/runtime directories. Use a shared bounded
+tool search for installer and child services, retain exact revision checks,
+bound automatic installation retries, and prove failed preparation followed by
+repair reaches service startup without recreating the App process. Only an App
+binary replacement requires restart; runtime repair resumes the same window.
+
 For most repairs, capture:
 
 ```text

--- a/skills/loopx-self-repair/references/repair-patterns.md
+++ b/skills/loopx-self-repair/references/repair-patterns.md
@@ -207,6 +207,12 @@ Installation readiness must not traverse registered Goal workspaces or run
 host/provider integration checks. Use `doctor --deep --installation-only` to
 retain package/toolchain validation without waiting on user-folder consent;
 full operator diagnostics remain available through ordinary `doctor`.
+Prove HTTP readiness independently of optional integration discovery: a bound
+port may still have no serving loop. Block the snapshot reader in a real-server
+test, verify workspace/capability responses and shutdown, and fence late
+results from starting consumers or resuming queues after close. Distinguish
+silent sockets from foreign HTTP services; recovery must retain process and
+port ownership verification before restarting an unresponsive listener.
 
 For most repairs, capture:
 

--- a/tests/test_chat_startup_isolation.py
+++ b/tests/test_chat_startup_isolation.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+from urllib.request import urlopen
+
+import loopx.chat_server as chat
+from loopx.extensions.lark.cli_resolution import LarkCliResolution
+from loopx.extensions.lark.goal_topic_runtime import LarkGoalTopicRuntimeService
+
+
+def test_real_chat_entrypoint_serves_while_binding_discovery_is_blocked(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    servers: list[chat.ChatHTTPServer] = []
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({"goals": []}))
+    assets = tmp_path / "web"
+    assets.mkdir()
+    (assets / "index.html").write_text("<html>workspace fixture</html>")
+
+    class Server(chat.ChatHTTPServer):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            servers.append(self)
+
+    def blocked_snapshot(**_kwargs: Any) -> dict[str, Any]:
+        entered.set()
+        assert release.wait(10)
+        return {}
+
+    monkeypatch.setattr(chat, "ChatHTTPServer", Server)
+    monkeypatch.setattr(
+        chat, "build_lark_goal_topic_runtime_snapshot", blocked_snapshot
+    )
+    monkeypatch.setattr(
+        chat,
+        "resolve_lark_cli_for_runtime",
+        lambda **_kwargs: LarkCliResolution(
+            None, False, "missing", None, "lark_cli_not_installed"
+        ),
+    )
+    worker = threading.Thread(
+        target=chat.serve_chat,
+        kwargs={
+            "registry_path": registry,
+            "runtime_root_override": tmp_path / "runtime",
+            "scan_roots": [],
+            "port": 0,
+            "assets_dir": assets,
+            "codex_bin": "nonexistent-loopx-test-codex",
+            "claude_bin": "nonexistent-loopx-test-claude",
+        },
+        daemon=True,
+    )
+    worker.start()
+    try:
+        assert entered.wait(5)
+        base = f"http://127.0.0.1:{servers[0].server_port}"
+        for route in ("/healthz", "/api/chat/capabilities"):
+            with urlopen(base + route, timeout=2) as response:
+                assert json.load(response)["ok"] is True
+        with urlopen(base + chat.DEFAULT_CHAT_PATH, timeout=2) as response:
+            assert b"workspace fixture" in response.read()
+        servers[0].shutdown()
+        worker.join(2)
+        assert not worker.is_alive(), "shutdown must not wait for project access"
+    finally:
+        release.set()
+        if servers and worker.is_alive():
+            servers[0].shutdown()
+        worker.join(5)
+
+
+def test_late_discovery_cannot_resume_queues_or_start_consumers_after_close(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    applied: list[object] = []
+
+    def snapshot() -> dict[str, Any]:
+        entered.set()
+        assert release.wait(5)
+        return {}
+
+    service = LarkGoalTopicRuntimeService(
+        snapshot_provider=snapshot,
+        runtime_root=tmp_path,
+        runtime_controller=object(),
+        profile_poller=lambda *args: applied.append(args),
+    )
+    monkeypatch.setattr(service, "_resume_session_queues", applied.append)
+    service.start()
+    original = service._startup_thread
+    service.start()
+    assert service._startup_thread is original
+    try:
+        assert entered.wait(2)
+        service.close()
+    finally:
+        release.set()
+        assert original is not None
+        original.join(2)
+    service.refresh()
+    service.start()
+    assert not original.is_alive()
+    assert applied == []
+    assert service.active_profiles() == []
+
+
+def test_initial_discovery_failure_retries_without_an_app_restart(tmp_path: Path) -> None:
+    calls = []
+
+    def snapshot() -> dict[str, Any]:
+        calls.append(None)
+        if len(calls) == 1:
+            raise OSError("fixture unavailable")
+        return {}
+
+    service = LarkGoalTopicRuntimeService(
+        snapshot_provider=snapshot, runtime_root=tmp_path, runtime_controller=object(),
+    )
+    try:
+        service.start()
+        assert service._startup_thread is not None
+        service._startup_thread.join(7)
+        assert not service._startup_thread.is_alive()
+        assert len(calls) == 2
+        assert service.active_profiles() == []
+    finally:
+        service.close()

--- a/tests/test_chat_startup_isolation.py
+++ b/tests/test_chat_startup_isolation.py
@@ -115,7 +115,9 @@ def test_late_discovery_cannot_resume_queues_or_start_consumers_after_close(
     assert service.active_profiles() == []
 
 
-def test_initial_discovery_failure_retries_without_an_app_restart(tmp_path: Path) -> None:
+def test_initial_discovery_failure_retries_without_an_app_restart(
+    tmp_path: Path,
+) -> None:
     calls = []
 
     def snapshot() -> dict[str, Any]:
@@ -125,7 +127,9 @@ def test_initial_discovery_failure_retries_without_an_app_restart(tmp_path: Path
         return {}
 
     service = LarkGoalTopicRuntimeService(
-        snapshot_provider=snapshot, runtime_root=tmp_path, runtime_controller=object(),
+        snapshot_provider=snapshot,
+        runtime_root=tmp_path,
+        runtime_controller=object(),
     )
     try:
         service.start()
@@ -136,3 +140,139 @@ def test_initial_discovery_failure_retries_without_an_app_restart(tmp_path: Path
         assert service.active_profiles() == []
     finally:
         service.close()
+
+
+def test_close_does_not_wait_for_real_queue_file_read(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    from loopx.chat_runtime import ChatRuntimeController
+    from loopx.chat_store import ChatSessionStore
+
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="fixture",
+        agent_id="codex",
+        adapter_kind="codex",
+        upstream_thread_id="fixture",
+    )
+    session_id = session["session_id"]
+    turn, _ = store.create_queued_turn(
+        session_id, client_turn_id="queued", message="synthetic fixture"
+    )
+    target = store._turn_path(session_id, turn["turn_id"])
+    entered, release, closed = threading.Event(), threading.Event(), threading.Event()
+    original_read = Path.read_text
+
+    def slow_read(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path == target:
+            entered.set()
+            assert release.wait(5)
+        return original_read(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", slow_read)
+    controller = ChatRuntimeController(store=store, codex_bin="unavailable-fixture")
+    effects: list[Any] = []
+    monkeypatch.setattr(
+        controller, "resume_session_queue", lambda **kwargs: effects.append(kwargs)
+    )
+    snapshot = {
+        "target_payload": {
+            "targets": {
+                "bot": {
+                    "name": "bot",
+                    "provider": "lark",
+                    "enabled": True,
+                    "identity": {"sender_profile": "fixture"},
+                }
+            }
+        },
+        "binding_payloads": {
+            "fixture": {
+                "bindings": {
+                    "fixture": {
+                        "goal_id": "fixture",
+                        "provider": "lark",
+                        "enabled": True,
+                        "target_ref": "bot",
+                        "session_id": session_id,
+                        "routing": {"ingress_mode": "session_queue"},
+                    }
+                }
+            }
+        },
+        "goal_contexts": {"fixture": {"work_dir": str(tmp_path)}},
+    }
+    service = LarkGoalTopicRuntimeService(
+        snapshot_provider=lambda: snapshot,
+        runtime_root=tmp_path,
+        runtime_controller=controller,
+        profile_poller=lambda *args: effects.append(args),
+    )
+    service.start()
+    closer = threading.Thread(
+        target=lambda: (service.close(), closed.set()), daemon=True
+    )
+    try:
+        assert entered.wait(2), "the real queued-turn file must be read"
+        closer.start()
+        assert closed.wait(1), "close must return while queue I/O remains blocked"
+    finally:
+        release.set()
+        closer.join(2)
+        assert service._startup_thread is not None
+        service._startup_thread.join(2)
+        controller.close()
+    assert effects == []
+    assert service.active_profiles() == []
+
+
+def test_queue_worker_admission_is_io_free_and_close_fences_late_session_read(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    from loopx.chat_runtime import ChatRuntimeController
+    from loopx.chat_store import ChatSessionStore
+
+    store = ChatSessionStore(tmp_path)
+    session = store.create_session(
+        goal_id="fixture",
+        agent_id="codex",
+        adapter_kind="codex",
+        upstream_thread_id="fixture",
+    )
+    controller = ChatRuntimeController(store=store, codex_bin="unavailable-fixture")
+    entered, release, admitted = threading.Event(), threading.Event(), threading.Event()
+    effects: list[Any] = []
+    original_load = store.load_session
+
+    def slow_load(session_id: str) -> Any:
+        entered.set()
+        assert release.wait(5)
+        return original_load(session_id)
+
+    monkeypatch.setattr(store, "load_session", slow_load)
+    monkeypatch.setattr(
+        controller, "_ensure_adapter", lambda *args, **kwargs: effects.append(args)
+    )
+
+    def admit() -> None:
+        controller.resume_session_queue(
+            session_id=session["session_id"], work_dir=tmp_path, objective="fixture"
+        )
+        admitted.set()
+
+    admission = threading.Thread(target=admit, daemon=True)
+    admission.start()
+    try:
+        assert entered.wait(2)
+        assert admitted.wait(1), "worker admission must not wait for session files"
+        workers = list(controller.session_queue_threads.values())
+        controller.close()
+    finally:
+        release.set()
+        admission.join(2)
+        for worker in list(controller.session_queue_threads.values()):
+            worker.join(2)
+    for worker in workers:
+        worker.join(2)
+    assert effects == []
+    assert not controller.session_queue_workers

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -1144,7 +1144,7 @@ def test_doctor_accepts_subcommand_json_format(
     monkeypatch.setattr(
         doctor_command,
         "collect_doctor",
-        lambda *, deep=False, agent_type=None: {
+        lambda *, deep=False, agent_type=None, installation_only=False: {
             "ok": True,
             "deep": deep,
             "agent_type": agent_type,

--- a/tests/test_doctor_installation_scope.py
+++ b/tests/test_doctor_installation_scope.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx import doctor
+
+
+@pytest.mark.parametrize(
+    "failed_check",
+    [None, "typescript_effect_runtime_ready", "representative_cli_imports"],
+)
+def test_installation_scope_preserves_required_checks_without_opening_user_state(
+    monkeypatch, failed_check
+):
+    def forbidden(*args, **kwargs):
+        raise AssertionError(
+            "installation validation must not inspect user projects/integrations"
+        )
+
+    for name in [
+        "installed_skill_summary",
+        "probe_registry_write_path",
+        "latest_promotion_readiness_event",
+    ]:
+        monkeypatch.setattr(doctor, name, forbidden)
+    monkeypatch.setattr(
+        "loopx.control_plane.runtime.runtime_projection_route.collect_runtime_projection_route_diagnostics",
+        forbidden,
+    )
+    monkeypatch.setattr(
+        "loopx.control_plane.effect_runtime.collect_effect_runtime_readiness",
+        lambda *, deep: {
+            "ready": failed_check != "typescript_effect_runtime_ready",
+            "status": "ready"
+            if failed_check != "typescript_effect_runtime_ready"
+            else "missing",
+            "deep": deep,
+        },
+    )
+    required = [
+        "command_package_same_root",
+        "representative_cli_commands",
+        "representative_cli_imports",
+        "representative_package_paths",
+    ]
+    monkeypatch.setattr(
+        "loopx.release_candidate.collect_deep_install_checks",
+        lambda **kwargs: {
+            "checks": [
+                {"id": name, "required": True, "ok": name != failed_check}
+                for name in required
+            ]
+        },
+    )
+    result = doctor.collect_doctor(deep=True, installation_only=True)
+    assert result["scope"] == "installation_only"
+    assert result["mode"] == "deep"
+    assert result["ok"] is (failed_check is None)
+    assert result["typescript_control_plane"]["deep"] is True
+    assert set(required) <= {check["id"] for check in result["checks"]}
+
+
+def test_installation_scope_cannot_claim_host_integration_health():
+    from loopx.cli import build_parser
+
+    parser = build_parser()
+    assert parser.parse_args(
+        ["doctor", "--deep", "--installation-only"]
+    ).installation_only
+    with pytest.raises(SystemExit):
+        parser.parse_args(["doctor", "--installation-only", "--agent-type", "codex"])


### PR DESCRIPTION
Finder startup could remain on the recovery screen indefinitely: its minimal PATH prevented bundled runtime installation, an installation error terminated the native supervisor, and synchronous Goal Topic discovery could bind Chat’s port without ever starting its HTTP loop. A silent LoopX listener was then misclassified as a foreign service.

The App now keeps runtime preparation inside a persistent supervisor, automatically installs its exact bundled runtime when the default CLI differs, and reconnects the same window after runtime repair. Installer and owned services share a bounded executable search. Installation validation retains package ownership, representative imports/commands/files, and the TypeScript semantic probe through `doctor --deep --installation-only`, without scanning Goal workspaces or running host/provider integration doctors.

Chat serves its workspace/readiness endpoints while existing Lark bindings initialize in one background worker. Discovery failures retry; shutdown fences late results before queue resumption or consumer startup. Silent sockets are distinct from foreign HTTP responses: after a 15-second grace period, recovery may replace only a verified LoopX command on the expected port, with a second PID readback before termination.

**Default behavior and boundaries:** automatic preparation can replace a separately updated default CLI with the App’s paired revision. Explicit `LOOPX_BIN` overrides are preserved. Automatic installation is limited to three attempts per process with at least 30 seconds between attempts; no App update is downloaded. Ordinary operator `doctor` diagnostics and terminal extension revalidation defaults remain unchanged. Native bootstrap skips host skill and optional provider setup. Goal data, session ownership, existing Lark authorization, and unknown listeners are preserved. See the desktop README for operation and recovery details.

**Validation:**
- 162 focused Python tests pass, including the production Chat entrypoint serving real loopback HTTP while discovery is blocked, retry behavior, and shutdown fencing.
- 29 release Rust tests pass, including real silent-listener recovery and rejection of a silent foreign process. Release Clippy with warnings denied passes; doctest compilation passes after serializing shared-target Cargo jobs.
- `canary premerge --from-git-diff --timeout-seconds 180`: all 18 selected checks pass, plus four direct checks, with zero manual holds. Run with isolated HOME/CODEX_HOME so validation does not inspect operator projects. Installation, packaged install/update, release qualification, control-plane boundaries, and public/private scans are covered. Earlier ambient-home/parallel validation exposed a user-state timeout and a module-budget failure; the isolated run and validator ownership cleanup resolve those findings without relaxing gates.
- `doctor --deep --installation-only` passes all six required package/toolchain checks. Configured mypy and Ruff pass. Desktop recovery/update browser smokes pass.
- Rebuilt the exact commit as a locally ad-hoc signed macOS App, verified its signature, and launched it through LaunchServices with an existing mismatched installation. It automatically installed the paired runtime, cleared its installation journal, replaced old LoopX services, and rendered the native workspace. Both services report this commit. A second native launch reuses the same release and service PIDs, shows connected workspace state, and creates no installation transaction. No manual service termination or Goal/session data cleanup was used for this final readback.
- Two opt-in Rust integration cases and the externally signed-release fixture are excluded from the default suite; a real bundled install and native launch were separately exercised. This local build is not a notarized public release. Remote macOS/Windows desktop, sign-off and validation checks pass; the two full test shards are still running.

**Bounded refactor pass:** installation validation belongs with the existing release-candidate checks; remove duplicate doctor rendering logic, retain one native supervisor/tool search, and keep Lark lifecycle control with its existing runtime service. No new capability or provider is introduced.


**Review follow-up (`6a871df41`):** move queue discovery and path resolution outside the lifecycle lock, keep controller worker admission free of filesystem I/O, and recheck cancellation before effects. Two new real-store/admission regressions fail on the preceding head and pass on this commit. Final follow-up validation: 192 focused Python tests, 18 exact-head premerge checks, Ruff and configured mypy pass. Native startup evidence above was collected on `15255b2e2`; this follow-up does not change the native binary and does not claim a newly installed App.
