### PR TITLE
feat(coordination): atomically claim Todo ownership

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -1421,6 +1421,19 @@ projection-plus-receipt commit, CAS contention, historical receipt replay,
 operation fencing, ordered cursor scans, isolation of returned values, and
 pre-write rejection of malformed JSON.
 
+Promoted `hard_lease` authority also supports one optional ownership
+transaction through the existing Todo-claim caller contract. When the caller
+supplies a task-lease idempotency key and optional expected version, the
+TypeScript owner reads the canonical Todo and its required write scopes,
+reuses the typed lease-acquire decision, and commits the lease, claim, and
+receipt under one provider CAS. Omitting those fields preserves the existing
+claim behavior, and an unpromoted goal rejects the atomic-only options rather
+than attempting a legacy write. File, NoKV, and real PostgreSQL conformance
+includes competing-owner coverage: exactly one complete claim-plus-lease
+tuple wins, the loser receives no receipt, and the winner replays by its exact
+operation identity. This is a cohesive promotion of the existing contract,
+not a second `claim_work` abstraction.
+
 The PostgreSQL adapter also applies one provider-local resource guard before it
 opens a connection: a commit whose canonical envelope exceeds the configured
 `max_commit_bytes` is rejected as typed `store_capacity_exhausted`. The default
@@ -1917,6 +1930,25 @@ it does not promote any provider or complete the Stage 2C promotion.
 - distributed quota reservation/accounting;
 - provider promotion, authentication, service recovery, HA, and multi-tenancy;
 - receipt retention or segmentation beyond `retain_all_v0`.
+
+#### TypeScript-first burden-reduction order
+
+Prefer preparatory TypeScript work when it removes authority that the next
+shared-authority stage would otherwise have to migrate under provider pressure.
+The order is deliberately narrow:
+
+1. characterize the caller-observable Python behavior and illegal transitions;
+2. move one already-shipped ownership transaction at a time into the existing
+   TypeScript boundary, starting with atomic claim-plus-lease, followed by
+   completion-plus-successor and the remaining lease lifecycle decisions;
+3. qualify that exact transaction against file, NoKV, and a real isolated
+   PostgreSQL server before changing provider selection;
+4. only then advance binding, migration, canary, and production promotion.
+
+This is not permission for a broad framework rewrite. A preparatory refactor
+belongs in this sequence only when the next RFC stage consumes it directly, it
+removes duplicate decision authority, and caller-visible parity plus rollback
+remain reviewable in the same bounded slice.
 
 ## 12. What the Owner Still Needs to Decide
 

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -1140,6 +1140,15 @@ conformance suite，覆盖 projection-plus-receipt 原子提交、CAS contention
 replay、operation fencing、有序 cursor scan、返回值隔离，以及 malformed JSON 在写前
 被拒绝。
 
+已晋升的 `hard_lease` authority 也通过既有 Todo claim caller contract 提供一条可选的
+ownership transaction。Caller 传入 task-lease idempotency key 和可选 expected version
+后，TypeScript owner 从 canonical head 读取 Todo 及其 required write scopes，复用 typed
+lease-acquire decision，并在一次 provider CAS 中共同提交 lease、claim 与 receipt。省略
+这些字段会保持既有 claim 行为；未晋升 Goal 则拒绝 atomic-only 参数，不尝试 legacy 写入。
+File、NoKV 与真实 PostgreSQL conformance 都覆盖了竞争 owner：只能有一个完整的
+claim-plus-lease tuple 获胜，失败方不会得到 receipt，获胜方按精确 operation identity
+重放。这是既有合同的一次内聚晋升，不是第二套 `claim_work` 抽象。
+
 PostgreSQL adapter 还会在打开连接之前执行一项 provider-local 资源门禁：canonical commit
 envelope 超过配置的 `max_commit_bytes` 时，写入以 typed
 `store_capacity_exhausted` 被拒绝。默认值为 16 MiB，部署可以调低。它只是单笔原子操作的
@@ -1533,6 +1542,23 @@ Live 行按环境门控（`LOOPX_TEST_POSTGRES_URL`；`NOKV_COORDINATION_LIVE=1`
 - distributed quota reservation/accounting；
 - provider promotion、authentication、service recovery、HA 与 multi-tenancy；
 - `retain_all_v0` 之后的 receipt retention 或 segmentation。
+
+#### TypeScript 优先的减负顺序
+
+如果一项前置 TypeScript 工作能消除下一阶段 shared authority 在 provider 压力下还要
+迁移的重复权威，就应优先做，但顺序必须保持收敛：
+
+1. 先刻画 Python 路径对 caller 可观察的行为与非法 transition；
+2. 每次只把一个已交付的 ownership transaction 移入既有 TypeScript boundary，先做
+   atomic claim-plus-lease，再做 completion-plus-successor，最后收敛剩余 lease
+   lifecycle decision；
+3. 改变 provider selection 之前，让该精确 transaction 同时通过 file、NoKV 与真实隔离
+   PostgreSQL server 的 qualification；
+4. 最后才推进 binding、migration、canary 与 production promotion。
+
+这不是 broad framework rewrite 的许可。只有下一阶段 RFC 会直接消费、能够移除重复
+decision authority，并且 caller-visible parity 与 rollback 能在同一有界切片内完成 review
+的前置重构，才进入这条顺序。
 
 ## 12. 还需要 Owner 决定什么
 

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -138,7 +138,11 @@ The cutover is deliberately section-sized, not document-sized:
 
 The first write using this boundary is Todo claim. It exercises a complete
 provider-neutral TypeScript transaction while leaving the default local path
-unchanged. After promotion, `loopx todo project-markdown` can explicitly
+unchanged. On promoted `hard_lease` authority, the same claim command may
+supply a task-lease idempotency key and optional expected version so the claim,
+canonical lease, and durable receipt commit in one provider transaction; the
+write scopes come from the canonical Todo rather than caller input. After
+promotion, `loopx todo project-markdown` can explicitly
 regenerate the two active Todo sections from the exact provider revision. It
 never runs before promotion and never turns Markdown back into authority.
 

--- a/docs/reference/protocols/host-integration-surface-v0.md
+++ b/docs/reference/protocols/host-integration-surface-v0.md
@@ -288,8 +288,18 @@ loopx quota spend-slot --goal-id <goal-id> --todo-id <selected-todo-id> --slots 
 ```
 
 When a host explicitly advertises `task_lease_v0`, it must also expose the
-equivalent CLI fallback. Acquiring a hard lease does not replace todo claim,
-quota, capability, write-scope, or workspace guards:
+equivalent CLI fallback. After canonical authority promotion, a `hard_lease`
+host can acquire the lease and claim atomically; LoopX derives write scopes
+from the canonical Todo:
+
+```bash
+loopx todo claim --goal-id <goal-id> --todo-id <todo_id> --claimed-by <agent-id> --agent-id <agent-id> --claim-operation-id <operation-id> --task-lease-idempotency-key <turn-key> --task-lease-expected-version <lease-version>
+```
+
+The atomic options fail closed before promotion. The existing two-command
+fallback remains available where the lease is acquired separately. Acquiring
+a hard lease does not replace quota, capability, write-scope, or workspace
+guards:
 
 ```bash
 loopx task-lease acquire --goal-id <goal-id> --todo-id <todo_id> --owner <agent-id> --idempotency-key <turn-key> --write-scope <scope>

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -509,6 +509,8 @@ def handle_todo_command(
                 agent_id=args.agent_id,
                 claim_only=True,
                 claim_operation_id=args.claim_operation_id,
+                task_lease_idempotency_key=args.task_lease_idempotency_key,
+                task_lease_expected_version=args.task_lease_expected_version,
                 **_todo_path_args(args),
                 dry_run=bool(args.dry_run),
             )

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -333,10 +333,19 @@ def validate_todo_claim_options(args: argparse.Namespace) -> None:
         )
     _validate_todo_option_subset(
         args,
-        {"role", "todo_id", "claimed_by", "agent_id", "state_file", "claim_operation_id"},
+        {
+            "role", "todo_id", "claimed_by", "agent_id", "state_file",
+            "claim_operation_id", "task_lease_idempotency_key",
+            "task_lease_expected_version",
+        },
         "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
-        "--claim-operation-id, --project, --state-file, and --dry-run; unsupported: ",
+        "--claim-operation-id, --task-lease-idempotency-key, "
+        "--task-lease-expected-version, --project, --state-file, and --dry-run; unsupported: ",
     )
+    if args.task_lease_expected_version is not None and not args.task_lease_idempotency_key:
+        raise ValueError(
+            "--task-lease-expected-version requires --task-lease-idempotency-key"
+        )
 
 
 def validate_todo_update_options(args: argparse.Namespace) -> None:
@@ -517,7 +526,7 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
             "--replan-obligation-id is supported only by todo add"
         )
     if (
-        args.todo_command not in {"complete", "supersede"}
+        args.todo_command not in {"claim", "complete", "supersede"}
         and (
             args.task_lease_idempotency_key
             or args.task_lease_expected_version is not None
@@ -525,7 +534,7 @@ def validate_shared_todo_options(args: argparse.Namespace) -> None:
     ):
         raise ValueError(
             "--task-lease-idempotency-key and --task-lease-expected-version "
-            "are supported only by todo complete and todo supersede"
+            "are supported only by todo claim, todo complete, and todo supersede"
         )
     if args.capability_binding_ref and args.todo_command != "add":
         raise ValueError(

--- a/loopx/cli_commands/todo_registration.py
+++ b/loopx/cli_commands/todo_registration.py
@@ -278,18 +278,18 @@ def register_todo_command(
     todo_parser.add_argument(
         "--task-lease-idempotency-key",
         help=(
-            "For todo complete and todo supersede, prove the execution instance "
-            "that owns an active hard task lease. Required when that todo has an "
-            "effective lease."
+            "For todo claim on promoted hard-lease authority, atomically acquire "
+            "the canonical lease and claim; for complete and supersede, prove the "
+            "execution instance that owns the active lease."
         ),
     )
     todo_parser.add_argument(
         "--task-lease-expected-version",
         type=int,
         help=(
-            "For todo complete and todo supersede, supply the active hard task "
-            "lease version. Required with --task-lease-idempotency-key when the "
-            "lease is effective."
+            "For promoted todo claim, optionally compare-and-set the canonical "
+            "lease version; for complete and supersede, supply the active lease "
+            "version when it is effective."
         ),
     )
     todo_parser.add_argument(

--- a/loopx/control_plane/coordination/local_authority.py
+++ b/loopx/control_plane/coordination/local_authority.py
@@ -72,6 +72,8 @@ def claim_canonical_todo_if_promoted(
     actor_agent_id: str | None,
     dry_run: bool,
     operation_id: str | None = None,
+    task_lease_idempotency_key: str | None = None,
+    task_lease_expected_version: int | None = None,
 ) -> dict[str, Any] | None:
     """Route a post-cutover claim to the TypeScript transaction owner."""
 
@@ -91,6 +93,15 @@ def claim_canonical_todo_if_promoted(
                 registry_path, goal_id
             ),
             "operation_id": operation_id if operation_id is not None else f"todo-claim:{goal_id}:{todo_id}:{uuid4().hex}",
+            "lease_request": (
+                {
+                    "idempotency_key": task_lease_idempotency_key,
+                    "expected_version": task_lease_expected_version,
+                    "ttl_seconds": None,
+                }
+                if task_lease_idempotency_key is not None
+                else None
+            ),
             "observed_at": now_local(),
             "dry_run": dry_run,
         },

--- a/loopx/control_plane/coordination/local_authority_runtime.ts
+++ b/loopx/control_plane/coordination/local_authority_runtime.ts
@@ -51,6 +51,10 @@ import {
   executeCoordinationTodoUpdate,
 } from "./todo_update.ts";
 import { editCoordinationTodo, TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA } from "./todo_compatibility_edit.ts";
+import {
+  normalizeIdempotencyKey,
+  normalizeTtl,
+} from "../work_items/task_lease_acquire.ts";
 
 export const LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_claim_request_v0";
@@ -560,6 +564,24 @@ export async function claimLocalCoordinationTodo(
     const registeredAgents = input.registered_agents.map(
       (value) => claimAgentValue(value, "registered agent"),
     );
+    const leaseRequestValue = input.lease_request;
+    const leaseRequest = leaseRequestValue === null || leaseRequestValue === undefined
+      ? null
+      : (() => {
+        const request = requireJsonObject(leaseRequestValue, "lease_request");
+        const expectedVersion = request.expected_version;
+        if (expectedVersion !== null && expectedVersion !== undefined &&
+            (!Number.isSafeInteger(expectedVersion) || Number(expectedVersion) < 0)) {
+          throw new Error(
+            "lease_request.expected_version must be a non-negative safe integer or null",
+          );
+        }
+        return {
+          idempotency_key: normalizeIdempotencyKey(request.idempotency_key),
+          expected_version: expectedVersion === undefined ? null : expectedVersion as number | null,
+          ttl_seconds: normalizeTtl(request.ttl_seconds),
+        };
+      })();
     const result = await executeCoordinationTodoClaim(store, {
       goal_id: goalId,
       todo_id: requireAuthorityStoreId(input.todo_id, "todo id"),
@@ -572,6 +594,7 @@ export async function claimLocalCoordinationTodo(
         : requireAuthorityStoreId(input.role, "role"),
       registered_agents: registeredAgents,
       operation_id: requireAuthorityStoreId(input.operation_id, "operation id"),
+      lease_request: leaseRequest,
       dry_run: input.dry_run,
       now: claimObservedAt(input.observed_at),
     });

--- a/loopx/control_plane/coordination/todo_claim.ts
+++ b/loopx/control_plane/coordination/todo_claim.ts
@@ -11,7 +11,23 @@ import {
   prepareCoordinationProjectionCommit,
   indexCoordinationProjection,
   validateCoordinationTodoReadModel,
+  type CoordinationProjectionMutation,
 } from "./coordination_projection.ts";
+import {
+  evaluateTaskLeaseAcquireDecision,
+  leaseEpoch,
+  leaseInteger,
+  leaseIsActive,
+  normalizeAgent,
+  normalizeIdempotencyKey,
+  normalizeTtl,
+  normalizeWriteScopes,
+  ownerRejection,
+  TASK_LEASE_SCHEMA_VERSION,
+  utcIsoformat,
+  type LeaseRecord,
+  type TodoFact,
+} from "../work_items/task_lease_acquire.ts";
 
 export const COORDINATION_TODO_CLAIM_RESULT_SCHEMA =
   "loopx_coordination_todo_claim_result_v0";
@@ -28,8 +44,15 @@ export interface CoordinationTodoClaimInput {
   readonly expected_role: string | null;
   readonly registered_agents: readonly string[];
   readonly operation_id: string;
+  readonly lease_request?: CoordinationTodoClaimLeaseRequest | null;
   readonly dry_run: boolean;
   readonly now: Date;
+}
+
+export interface CoordinationTodoClaimLeaseRequest {
+  readonly idempotency_key: string;
+  readonly expected_version: number | null;
+  readonly ttl_seconds: number;
 }
 
 export type CoordinationTodoClaimResult = JsonObject & {
@@ -210,7 +233,61 @@ export function evaluateCoordinationTodoClaimDecision(
   };
 }
 
-function leaseIsActiveForOwner(lease: JsonObject | undefined, owner: string, now: Date): boolean {
+function normalizeLeaseRequest(value: unknown): CoordinationTodoClaimLeaseRequest | null {
+  if (value === undefined || value === null) return null;
+  const request = canonicalAuthorityObject(value, "lease_request");
+  const expectedVersion = request.expected_version;
+  if (expectedVersion !== null && expectedVersion !== undefined &&
+      (!Number.isSafeInteger(expectedVersion) || Number(expectedVersion) < 0)) {
+    throw new AuthorityStoreProtocolError(
+      "lease_request.expected_version must be a non-negative safe integer or null",
+    );
+  }
+  return {
+    idempotency_key: normalizeIdempotencyKey(request.idempotency_key),
+    expected_version: expectedVersion === undefined ? null : expectedVersion as number | null,
+    ttl_seconds: normalizeTtl(request.ttl_seconds),
+  };
+}
+
+function todoLeaseFact(todo: JsonObject): TodoFact {
+  const requiredWriteScopes = todo.required_write_scopes ?? [];
+  if (!Array.isArray(requiredWriteScopes) ||
+      requiredWriteScopes.some((scope) => typeof scope !== "string")) {
+    throw new AuthorityStoreProtocolError(
+      "todo.required_write_scopes must be an array of strings",
+    );
+  }
+  const writeScopes = normalizeWriteScopes(requiredWriteScopes);
+  if (writeScopes.length !== requiredWriteScopes.length) {
+    throw new AuthorityStoreProtocolError(
+      "todo.required_write_scopes contains an invalid or duplicate scope",
+    );
+  }
+  return {
+    todo_id: String(todo.todo_id),
+    status: typeof todo.status === "string" ? todo.status : "",
+    claimed_by: normalizeAgent(todo.claimed_by),
+    excluded_agents: normalizeExcludedAgents(todo.excluded_agents),
+    role: typeof todo.role === "string" ? todo.role : undefined,
+    task_class: typeof todo.task_class === "string" ? todo.task_class : null,
+    bound_agent: normalizeAgent(todo.bound_agent),
+    blocks_agent: normalizeAgent(todo.blocks_agent),
+  };
+}
+
+function leaseDecisionInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new AuthorityStoreProtocolError(`${label} must be a non-negative safe integer`);
+  }
+  return Number(value);
+}
+
+function activeLeaseForOwner(
+  lease: JsonObject | undefined,
+  owner: string,
+  now: Date,
+): boolean {
   if (lease === undefined || lease.status !== "active" ||
       typeof lease.owner !== "string" || typeof lease.expires_at !== "string") return false;
   let leaseOwner: string;
@@ -246,6 +323,7 @@ export async function executeCoordinationTodoClaim(
       actor_agent_id: rawInput.actor_agent_id === null
         ? null : normalizeTodoAgent(rawInput.actor_agent_id, "actor_agent_id"),
       registered_agents: normalizeRegisteredTodoAgents(rawInput.registered_agents),
+      lease_request: normalizeLeaseRequest(rawInput.lease_request),
     };
     if (typeof input.dry_run !== "boolean") {
       throw new AuthorityStoreProtocolError("dry_run must be a boolean");
@@ -259,6 +337,7 @@ export async function executeCoordinationTodoClaim(
       error instanceof Error ? error.message : "invalid Todo claim",
     );
   }
+  const leaseRequest = input.lease_request ?? null;
 
   // Intent identity excludes observation time and current authorization facts.
   // A receipt proves historical acceptance, never a renewed/current lease.
@@ -269,6 +348,7 @@ export async function executeCoordinationTodoClaim(
     actor_agent_id: input.actor_agent_id,
     expected_role: input.expected_role,
     dry_run: input.dry_run,
+    ...(leaseRequest === null ? {} : {lease_request: leaseRequest}),
   });
   const replay = (
     receipt: AuthorityStoreReceiptResult,
@@ -295,6 +375,13 @@ export async function executeCoordinationTodoClaim(
           typeof result.handoff_mode !== "string" ||
           result.mutation_authority === null || typeof result.mutation_authority !== "object") {
         throw new AuthorityStoreProtocolError("original claim result is invalid");
+      }
+      if (leaseRequest !== null) {
+        const lease = canonicalAuthorityObject(result.lease, "original claim lease");
+        if (lease.todo_id !== input.todo_id || lease.owner !== input.claimed_by ||
+            lease.idempotency_key !== leaseRequest.idempotency_key) {
+          throw new AuthorityStoreProtocolError("original claim lease identity is invalid");
+        }
       }
     } catch (error) {
       return failure("invalid_coordination_todo_claim_receipt",
@@ -361,12 +448,128 @@ export async function executeCoordinationTodoClaim(
   if (!["legacy", "soft_claim", "hard_lease"].includes(handoffMode)) {
     return failure("invalid_handoff_mode", "canonical projection has an invalid handoff mode");
   }
-  if (handoffMode === "hard_lease" &&
-      !leaseIsActiveForOwner(projection.leases.get(input.todo_id), authority.owner, input.now)) {
+  if (leaseRequest !== null && handoffMode !== "hard_lease") {
     return failure(
-      "handoff_mode_requires_lease",
-      "hard_lease Todo claim requires an active canonical lease held by the claiming agent",
-      { todo_id: input.todo_id, actor_agent_id: authority.owner },
+      "claim_lease_requires_hard_lease",
+      "atomic Todo claim and lease acquire requires handoff_mode=hard_lease",
+      { todo_id: input.todo_id, handoff_mode: handoffMode },
+    );
+  }
+
+  let lease: JsonObject | null = null;
+  let leaseChanged = false;
+  let leaseIdempotent = false;
+  try {
+    const currentLease = projection.leases.get(input.todo_id);
+    if (handoffMode === "hard_lease" && leaseRequest !== null) {
+      const todoFact = todoLeaseFact(todo);
+      const currentActive = currentLease !== undefined && leaseIsActive(currentLease, input.now);
+      const currentEffective = currentLease !== undefined && currentActive && ownerRejection(
+        todoFact,
+        normalizeAgent(currentLease.owner),
+        input.registered_agents,
+      ) === null;
+      const otherLeases = projection.lease_todo_ids.flatMap((todoId) => {
+        if (todoId === input.todo_id) return [];
+        const candidate = projection.leases.get(todoId)!;
+        const active = leaseIsActive(candidate, input.now);
+        const otherTodo = projection.todos.get(todoId);
+        return [{
+          todo_id: todoId,
+          active,
+          effective: active && otherTodo !== undefined && ownerRejection(
+            todoLeaseFact(otherTodo),
+            normalizeAgent(candidate.owner),
+            input.registered_agents,
+          ) === null,
+          write_scopes: normalizeWriteScopes(candidate.write_scopes),
+        }];
+      });
+      const writeScopes = normalizeWriteScopes(todo.required_write_scopes ?? []);
+      const decision = evaluateTaskLeaseAcquireDecision({
+        handoff_mode: handoffMode,
+        registered_agents: [...input.registered_agents],
+        todo: todoFact,
+        lease: currentLease === undefined ? null : {
+          present: true,
+          active: currentActive,
+          effective: currentEffective,
+          status: typeof currentLease.status === "string" ? currentLease.status : null,
+          owner: normalizeAgent(currentLease.owner),
+          idempotency_key: typeof currentLease.idempotency_key === "string"
+            ? currentLease.idempotency_key : null,
+          version: leaseInteger(currentLease, "version") ?? 0,
+          lease_epoch: leaseEpoch(currentLease),
+          write_scopes: normalizeWriteScopes(currentLease.write_scopes),
+          acquire_ttl_seconds: leaseInteger(currentLease, "acquire_ttl_seconds"),
+        },
+        other_leases: otherLeases,
+        command: {
+          owner: authority.owner,
+          idempotency_key: leaseRequest.idempotency_key,
+          ttl_seconds: leaseRequest.ttl_seconds,
+          write_scopes: writeScopes,
+          expected_version: leaseRequest.expected_version,
+        },
+      });
+      if (decision.outcome === "no_change") {
+        if (currentLease === undefined) {
+          throw new AuthorityStoreProtocolError(
+            "lease acquire replay is missing its canonical lease",
+          );
+        }
+        lease = currentLease;
+        leaseIdempotent = true;
+      } else if (decision.outcome === "apply") {
+        if (decision.next_lease === null) {
+          throw new AuthorityStoreProtocolError("lease acquire apply is missing next_lease");
+        }
+        const acquiredAt = utcIsoformat(input.now);
+        lease = {
+          schema_version: TASK_LEASE_SCHEMA_VERSION,
+          goal_id: input.goal_id,
+          todo_id: input.todo_id,
+          owner: authority.owner,
+          idempotency_key: leaseRequest.idempotency_key,
+          write_scopes: writeScopes,
+          acquire_ttl_seconds: leaseRequest.ttl_seconds,
+          version: leaseDecisionInteger(decision.next_lease.version, "next_lease.version"),
+          lease_epoch: leaseDecisionInteger(
+            decision.next_lease.lease_epoch,
+            "next_lease.lease_epoch",
+          ),
+          acquired_at: acquiredAt,
+          updated_at: acquiredAt,
+          expires_at: utcIsoformat(
+            new Date(input.now.valueOf() + leaseRequest.ttl_seconds * 1_000),
+          ),
+          status: "active",
+        } satisfies LeaseRecord;
+        leaseChanged = true;
+      } else {
+        return failure(
+          decision.code,
+          `canonical task lease acquire rejected the Todo claim: ${decision.code}`,
+          {
+            todo_id: input.todo_id,
+            actor_agent_id: authority.owner,
+            lease_decision: decision,
+          },
+        );
+      }
+    } else if (handoffMode === "hard_lease" &&
+        !activeLeaseForOwner(currentLease, authority.owner, input.now)) {
+      return failure(
+        "handoff_mode_requires_lease",
+        "hard_lease Todo claim requires an active canonical lease held by the claiming agent",
+        { todo_id: input.todo_id, actor_agent_id: authority.owner },
+      );
+    }
+  } catch (error) {
+    return failure(
+      "invalid_coordination_task_lease",
+      error instanceof Error ? error.message : "invalid canonical task lease",
+      {todo_id: input.todo_id},
     );
   }
 
@@ -375,7 +578,8 @@ export async function executeCoordinationTodoClaim(
     "Todo claim mutation authority",
   );
   const updatedAt = input.now.toISOString().replace(/\.\d{3}Z$/u, "Z");
-  const changed = todo.claimed_by !== authority.owner;
+  const todoChanged = todo.claimed_by !== authority.owner;
+  const changed = todoChanged || leaseChanged;
   const result = {
     todo_id: input.todo_id,
     claimed_by: authority.owner,
@@ -383,6 +587,12 @@ export async function executeCoordinationTodoClaim(
     handoff_mode: handoffMode,
     ...(changed ? {updated_at: updatedAt} : {}),
     mutation_authority: mutationAuthority,
+    ...(leaseRequest === null ? {} : {
+      todo_changed: todoChanged,
+      lease_changed: leaseChanged,
+      lease_idempotent: leaseIdempotent,
+      lease,
+    }),
   };
 
   if (input.dry_run) {
@@ -398,13 +608,21 @@ export async function executeCoordinationTodoClaim(
 
   // A successful no-op still consumes its operation identity. Commit only its
   // receipt under the observed head's CAS; never fabricate a Todo mutation.
-  const commit: AuthorityStoreCommit = changed ? prepareCoordinationProjectionCommit({
+  const mutations: CoordinationProjectionMutation[] = [
+    ...(leaseChanged && lease !== null
+      ? [{kind: "lease_upsert" as const, lease}]
+      : []),
+    ...(todoChanged
+      ? [{ kind: "todo_upsert" as const, todo: {...todo,
+        claimed_by: authority.owner, updated_at: updatedAt} }]
+      : []),
+  ];
+  const commit: AuthorityStoreCommit = mutations.length > 0 ? prepareCoordinationProjectionCommit({
     goal_id: input.goal_id,
     operation_id: input.operation_id,
     expected_provider_revision: head.provider_revision,
     projection: head.head,
-    mutations: [{ kind: "todo_upsert", todo: {...todo,
-      claimed_by: authority.owner, updated_at: updatedAt} }],
+    mutations,
   }) : {
     operation_id: input.operation_id,
     expected_provider_revision: head.provider_revision,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1088,6 +1088,8 @@ def update_goal_todo(
     clear_claim: bool = False,
     claim_only: bool = False,
     claim_operation_id: str | None = None,
+    task_lease_idempotency_key: str | None = None,
+    task_lease_expected_version: int | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -1113,6 +1115,14 @@ def update_goal_todo(
             raise ValueError("claim_operation_id is supported only by todo claim")
         if not promoted_claim:
             raise ValueError("--claim-operation-id requires promoted canonical authority; no legacy write attempted")
+    if task_lease_expected_version is not None and task_lease_idempotency_key is None:
+        raise ValueError(
+            "--task-lease-expected-version requires --task-lease-idempotency-key"
+        )
+    if task_lease_idempotency_key is not None and not promoted_claim:
+        raise ValueError(
+            "--task-lease-idempotency-key on todo claim requires promoted canonical authority; no legacy write attempted"
+        )
     if promoted_claim:
         unsupported_claim_values = (
             text, status, note, evidence, reason, task_class, action_kind,
@@ -1146,6 +1156,8 @@ def update_goal_todo(
             actor_agent_id=agent_id,
             dry_run=dry_run,
             operation_id=claim_operation_id,
+            task_lease_idempotency_key=task_lease_idempotency_key,
+            task_lease_expected_version=task_lease_expected_version,
         )
         if canonical_claim is not None:
             return canonical_claim

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -41,6 +41,85 @@ def _todo_read_model(todo_count: int) -> dict[str, object]:
     }
 
 
+def _promote_local_projection(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    projection: dict[str, object],
+    operation_suffix: str,
+) -> str:
+    canonical_bytes = json.dumps(
+        projection,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    projection_sha256 = hashlib.sha256(canonical_bytes).hexdigest()
+    source_version = f"state:{operation_suffix}:1"
+
+    bootstrap = effect_runtime_result(
+        "coordination.runtime_shadow.bootstrap",
+        {
+            "schema_version": "loopx_coordination_runtime_shadow_bootstrap_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": goal_id,
+            "operation_id": f"bootstrap:{goal_id}:{operation_suffix}",
+            "source_version": f"state:{operation_suffix}:0",
+            "projection": projection,
+        },
+    )
+    assert bootstrap["status"] == "applied"
+    mirrored = effect_runtime_result(
+        "coordination.runtime_shadow.commit",
+        {
+            "schema_version": "loopx_coordination_runtime_shadow_commit_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": goal_id,
+            "operation_id": f"todo:{goal_id}:{operation_suffix}:qualify",
+            "event_kind": "todo_update",
+            "source_version": source_version,
+            "projection": projection,
+        },
+    )
+    assert mirrored["status"] == "applied"
+    provider_revision = str(mirrored["provider_revision"])
+    fence = {
+        "schema_version": "loopx_legacy_coordination_writer_fence_v0",
+        "state": "engaged",
+        "goal_id": goal_id,
+        "fence_id": f"legacy-writer-fence:{goal_id}:{operation_suffix}",
+        "source_version": source_version,
+        "source_projection_sha256": projection_sha256,
+        "expected_shadow_provider_revision": provider_revision,
+    }
+    engaged = effect_runtime_result(
+        "coordination.local_authority.legacy_writer_fence.engage",
+        {
+            "schema_version": "loopx_legacy_coordination_writer_fence_engage_request_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": goal_id,
+            "fence": fence,
+        },
+    )
+    assert engaged["status"] == "applied"
+    promoted = effect_runtime_result(
+        "coordination.local_authority.promote",
+        {
+            "schema_version": "loopx_local_coordination_promotion_request_v0",
+            "runtime_root": str(runtime_root),
+            "goal_id": goal_id,
+            "operation_id": f"promote:{goal_id}:{operation_suffix}",
+            "expected_shadow_provider_revision": provider_revision,
+            "expected_shadow_projection_sha256": projection_sha256,
+            "minimum_operations": 1,
+            "required_event_kinds": ["todo_update"],
+            "writer_fence": fence,
+        },
+    )
+    assert promoted["status"] == "applied"
+    return provider_revision
+
+
 def test_absent_fence_preserves_legacy_path_without_starting_typescript(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -130,6 +209,8 @@ def test_promoted_claim_adapter_invokes_typescript_without_markdown_fallback(
         claimed_by="agent-a",
         actor_agent_id="agent-a",
         dry_run=False,
+        task_lease_idempotency_key="turn:claim-and-acquire",
+        task_lease_expected_version=0,
     )
 
     assert result is not None and result["changed"] is True
@@ -139,6 +220,11 @@ def test_promoted_claim_adapter_invokes_typescript_without_markdown_fallback(
         "todo-claim:goal-a:todo_a:"
     )
     assert isinstance(calls[0][1]["observed_at"], str)
+    assert calls[0][1]["lease_request"] == {
+        "idempotency_key": "turn:claim-and-acquire",
+        "expected_version": 0,
+        "ttl_seconds": None,
+    }
 
 
 def test_promoted_add_invokes_native_create_without_markdown_state(
@@ -313,6 +399,131 @@ def test_todo_list_uses_provider_after_cutover_even_when_markdown_disagrees(
     assert result["authority_read"]["legacy_fallback_used"] is False
 
 
+def test_promoted_hard_lease_claim_cli_atomically_acquires_ownership(
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    state_file = project / ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text("# Goal\n", encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": "goal-a",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md",
+                        "coordination": {
+                            "registered_agents": ["agent-a", "agent-b"]
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    todo = {
+        "schema_version": "todo_item_v0",
+        "index": 1,
+        "done": False,
+        "text": "Claim and acquire one canonical ownership transaction",
+        "todo_id": "todo_atomic_claim",
+        "role": "agent",
+        "status": "open",
+        "archive_state": "active",
+        "source_section": TODO_SECTION_HEADINGS["agent"],
+        "required_write_scopes": ["loopx/control_plane/**"],
+    }
+    projection = build_todo_runtime_shadow_projection(
+        goal_id="goal-a",
+        todos=[todo],
+    )
+    projection["handoff_mode"] = "hard_lease"
+    _promote_local_projection(
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        projection=projection,
+        operation_suffix="atomic-claim",
+    )
+    state_file.unlink()
+
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--format",
+        "json",
+        "--registry",
+        str(registry_path),
+        "todo",
+        "claim",
+        "--goal-id",
+        "goal-a",
+        "--todo-id",
+        "todo_atomic_claim",
+        "--claimed-by",
+        "agent-a",
+        "--agent-id",
+        "agent-a",
+        "--claim-operation-id",
+        "atomic-cli-claim",
+        "--task-lease-idempotency-key",
+        "turn:atomic-cli-claim",
+        "--task-lease-expected-version",
+        "0",
+    ]
+    before = list_goal_todos(registry_path=registry_path, goal_id="goal-a")
+    preview = json.loads(
+        subprocess.run(
+            [*command, "--dry-run"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        ).stdout
+    )
+    assert preview["status"] == "planned"
+    assert preview["todo_changed"] is True
+    assert preview["lease_changed"] is True
+    assert list_goal_todos(registry_path=registry_path, goal_id="goal-a") == before
+
+    applied = json.loads(
+        subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        ).stdout
+    )
+    assert applied["status"] == "applied"
+    assert applied["todo_changed"] is True
+    assert applied["lease_changed"] is True
+    assert applied["lease"]["owner"] == "agent-a"
+    assert applied["lease"]["idempotency_key"] == "turn:atomic-cli-claim"
+    assert applied["lease"]["write_scopes"] == ["loopx/control_plane/**"]
+    replay = json.loads(
+        subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        ).stdout
+    )
+    assert replay["status"] == "replayed"
+    assert replay["original_receipt"] == applied["original_receipt"]
+    after = list_goal_todos(registry_path=registry_path, goal_id="goal-a")
+    assert after["todos"][0]["claimed_by"] == "agent-a"
+    assert not state_file.exists()
+
+
 def test_real_shadow_projection_promotes_complete_complex_todo_semantics(
     tmp_path: Path,
 ) -> None:
@@ -412,74 +623,12 @@ def test_real_shadow_projection_promotes_complete_complex_todo_semantics(
         goal_id="goal-a",
         todos=[complex_todo, successor, claimable],
     )
-    canonical_bytes = json.dumps(
-        projection,
-        ensure_ascii=False,
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
-    projection_sha256 = hashlib.sha256(canonical_bytes).hexdigest()
-
-    bootstrap = effect_runtime_result(
-        "coordination.runtime_shadow.bootstrap",
-        {
-            "schema_version": "loopx_coordination_runtime_shadow_bootstrap_v0",
-            "runtime_root": str(runtime_root),
-            "goal_id": "goal-a",
-            "operation_id": "bootstrap:goal-a:complex",
-            "source_version": "state:complex:0",
-            "projection": projection,
-        },
+    _promote_local_projection(
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        projection=projection,
+        operation_suffix="complex",
     )
-    assert bootstrap["status"] == "applied"
-    mirrored = effect_runtime_result(
-        "coordination.runtime_shadow.commit",
-        {
-            "schema_version": "loopx_coordination_runtime_shadow_commit_v0",
-            "runtime_root": str(runtime_root),
-            "goal_id": "goal-a",
-            "operation_id": "todo:goal-a:complex:qualify",
-            "event_kind": "todo_update",
-            "source_version": "state:complex:1",
-            "projection": projection,
-        },
-    )
-    assert mirrored["status"] == "applied"
-    provider_revision = str(mirrored["provider_revision"])
-    fence = {
-        "schema_version": "loopx_legacy_coordination_writer_fence_v0",
-        "state": "engaged",
-        "goal_id": "goal-a",
-        "fence_id": "legacy-writer-fence:goal-a:complex",
-        "source_version": "state:complex:1",
-        "source_projection_sha256": projection_sha256,
-        "expected_shadow_provider_revision": provider_revision,
-    }
-    engaged = effect_runtime_result(
-        "coordination.local_authority.legacy_writer_fence.engage",
-        {
-            "schema_version": "loopx_legacy_coordination_writer_fence_engage_request_v0",
-            "runtime_root": str(runtime_root),
-            "goal_id": "goal-a",
-            "fence": fence,
-        },
-    )
-    assert engaged["status"] == "applied"
-    promoted = effect_runtime_result(
-        "coordination.local_authority.promote",
-        {
-            "schema_version": "loopx_local_coordination_promotion_request_v0",
-            "runtime_root": str(runtime_root),
-            "goal_id": "goal-a",
-            "operation_id": "promote:goal-a:complex",
-            "expected_shadow_provider_revision": provider_revision,
-            "expected_shadow_projection_sha256": projection_sha256,
-            "minimum_operations": 1,
-            "required_event_kinds": ["todo_update"],
-            "writer_fence": fence,
-        },
-    )
-    assert promoted["status"] == "applied"
 
     state_file.unlink()
     result = list_goal_todos(registry_path=registry_path, goal_id="goal-a")

--- a/tests/control_plane_ts/authority_store_conformance.ts
+++ b/tests/control_plane_ts/authority_store_conformance.ts
@@ -39,6 +39,7 @@ function todoClaimProjection(goalId: string, native: boolean): Record<string, un
     archive_state: "active",
     source_section: "Agent Todo",
     note: "preserve complete canonical record",
+    required_write_scopes: ["loopx/control_plane/**"],
   }];
   if (native) {
     todos[0]!.schema_version = TODO_DOMAIN_ITEM_SCHEMA;
@@ -435,6 +436,132 @@ export function registerAuthorityStoreConformance(
         assert.equal((await editCoordinationTodo(store, {...request, ...invalid})).status, "failed");
       }
       assert.deepEqual(await store.loadAuthority(), afterRace);
+    });
+    test(`${providerName} conformance: Todo claim atomically acquires canonical ownership (${native ? "native" : "v0"})`, async (t) => {
+      const {store} = await factory(t);
+      const goalId = "goal-atomic-ownership";
+      const projection = {
+        ...todoClaimProjection(goalId, native),
+        handoff_mode: "hard_lease",
+      };
+      assert.equal((await store.commitAuthority({
+        expected_provider_revision: null,
+        operation_id: "seed-atomic-ownership",
+        events: [],
+        receipts: [],
+        next_projection: projection,
+      })).status, "applied");
+      const request = {
+        goal_id: goalId,
+        todo_id: "todo-claim",
+        claimed_by: "agent-a",
+        actor_agent_id: "agent-a",
+        expected_role: "agent",
+        registered_agents: ["agent-a", "agent-b"],
+        operation_id: "claim-and-acquire",
+        lease_request: {
+          idempotency_key: "turn:atomic-ownership",
+          expected_version: 0,
+          ttl_seconds: 2_700,
+        },
+        dry_run: false,
+        now: new Date("2026-09-05T04:30:00Z"),
+      };
+      const preview = await executeCoordinationTodoClaim(store, {...request, dry_run: true});
+      assert.equal(preview.status, "planned");
+      assert.equal(preview.todo_changed, true);
+      assert.equal(preview.lease_changed, true);
+      assert.equal((await store.readReceipt(request.operation_id)).status, "missing");
+
+      const applied = await executeCoordinationTodoClaim(store, request);
+      assert.equal(applied.status, "applied", JSON.stringify(applied));
+      assert.equal(applied.todo_changed, true);
+      assert.equal(applied.lease_changed, true);
+      const loaded = await store.loadAuthority();
+      assert.equal(loaded.status, "loaded");
+      if (loaded.status !== "loaded") return;
+      const claimedTodo = (loaded.head.todos as Record<string, unknown>[])[0]!;
+      const lease = (loaded.head.leases as Record<string, unknown>[])[0]!;
+      assert.equal(claimedTodo.claimed_by, "agent-a");
+      assert.equal(lease.owner, "agent-a");
+      assert.equal(lease.idempotency_key, "turn:atomic-ownership");
+      assert.deepEqual(lease.write_scopes, ["loopx/control_plane/**"]);
+      assert.equal((await executeCoordinationTodoClaim(store, request)).status, "replayed");
+
+      const idempotent = await executeCoordinationTodoClaim(store, {
+        ...request,
+        operation_id: "claim-and-acquire-idempotent",
+        lease_request: {...request.lease_request, expected_version: 1},
+      });
+      assert.equal(idempotent.status, "no_change", JSON.stringify(idempotent));
+      assert.equal(idempotent.todo_changed, false);
+      assert.equal(idempotent.lease_changed, false);
+      assert.equal(idempotent.lease_idempotent, true);
+      const afterIdempotent = await store.loadAuthority();
+      assert.equal(afterIdempotent.status, "loaded");
+      if (afterIdempotent.status !== "loaded") return;
+      assert.deepEqual(afterIdempotent.head, loaded.head);
+      assert.equal((await store.readReceipt("claim-and-acquire-idempotent")).status, "found");
+    });
+    test(`${providerName} conformance: competing ownership transactions cannot split claim and lease (${native ? "native" : "v0"})`, async (t) => {
+      const {store, contender} = await factory(t);
+      const goalId = "goal-competing-ownership";
+      const projection = {
+        ...todoClaimProjection(goalId, native),
+        handoff_mode: "hard_lease",
+      };
+      assert.equal((await store.commitAuthority({
+        expected_provider_revision: null,
+        operation_id: "seed-competing-ownership",
+        events: [],
+        receipts: [],
+        next_projection: projection,
+      })).status, "applied");
+      const request = (owner: "agent-a" | "agent-b") => ({
+        goal_id: goalId,
+        todo_id: "todo-claim",
+        claimed_by: owner,
+        actor_agent_id: owner,
+        expected_role: "agent",
+        registered_agents: ["agent-a", "agent-b"],
+        operation_id: `claim-and-acquire:${owner}`,
+        lease_request: {
+          idempotency_key: `turn:competing-ownership:${owner}`,
+          expected_version: 0,
+          ttl_seconds: 2_700,
+        },
+        dry_run: false,
+        now: new Date("2026-09-05T04:30:00Z"),
+      });
+
+      const results = await Promise.all([
+        executeCoordinationTodoClaim(store, request("agent-a")),
+        executeCoordinationTodoClaim(contender, request("agent-b")),
+      ]);
+      assert.deepEqual(
+        results.map((result) => result.status).sort(),
+        ["applied", "conflict"],
+      );
+      const winnerIndex = results.findIndex((result) => result.status === "applied");
+      assert.notEqual(winnerIndex, -1);
+      const winner = winnerIndex === 0 ? "agent-a" : "agent-b";
+      const loser = winner === "agent-a" ? "agent-b" : "agent-a";
+      const loaded = await store.loadAuthority();
+      assert.equal(loaded.status, "loaded");
+      if (loaded.status !== "loaded") return;
+      const claimedTodo = (loaded.head.todos as Record<string, unknown>[])[0]!;
+      const leases = loaded.head.leases as Record<string, unknown>[];
+      assert.equal(claimedTodo.claimed_by, winner);
+      assert.equal(leases.length, 1);
+      assert.equal(leases[0]!.owner, winner);
+      assert.equal(leases[0]!.idempotency_key, `turn:competing-ownership:${winner}`);
+      assert.equal((await store.readReceipt(`claim-and-acquire:${winner}`)).status, "found");
+      assert.equal((await store.readReceipt(`claim-and-acquire:${loser}`)).status, "missing");
+      assert.equal((await executeCoordinationTodoClaim(store, request(winner))).status, "replayed");
+      const rejected = await executeCoordinationTodoClaim(store, request(loser));
+      assert.equal(rejected.status, "failed");
+      assert.equal(rejected.reason_code, "claim_owner_mismatch");
+      assert.deepEqual(await store.loadAuthority(), loaded);
     });
     for (const fault of ["lease_replaced", "lost_response"] as const) {
       test(`${providerName} conformance: hard-lease claim ${fault} (${native ? "native" : "v0"})`, async (t) => {

--- a/tests/control_plane_ts/local_authority_runtime.test.ts
+++ b/tests/control_plane_ts/local_authority_runtime.test.ts
@@ -871,6 +871,84 @@ test("provider-first Todo claim validates authority and hard-lease ownership", a
   assert.equal((unchanged.todo as Record<string, unknown>).claimed_by, undefined);
 });
 
+test("provider-first Todo claim atomically acquires its canonical hard lease", async () => {
+  const root = await mkdtemp(join(tmpdir(), "loopx-local-authority-claim-lease-"));
+  const store = new FileAuthorityStore(join(root, "authority", "file-v0"), "goal-a");
+  assert.equal((await store.commitAuthority({
+    expected_provider_revision: null,
+    operation_id: "promote:claim-with-lease",
+    events: [{ schema_version: "promotion_v0" }],
+    next_projection: withTodoReadModel({
+      goal_id: "goal-a",
+      handoff_mode: "hard_lease",
+      todos: [todoRecord({ required_write_scopes: ["loopx/control_plane/**"] })],
+      leases: [],
+    }),
+    receipts: [],
+  })).status, "applied");
+  const request = {
+    schema_version: LOCAL_COORDINATION_TODO_CLAIM_REQUEST_SCHEMA,
+    runtime_root: root,
+    goal_id: "goal-a",
+    todo_id: "todo_a",
+    role: "agent",
+    claimed_by: "agent-a",
+    actor_agent_id: "agent-a",
+    registered_agents: ["agent-a", "agent-b"],
+    operation_id: "todo-claim:goal-a:todo_a:with-lease",
+    observed_at: "2026-09-05T04:30:00Z",
+    dry_run: false,
+    lease_request: {
+      idempotency_key: "turn:claim-with-lease",
+      expected_version: 0,
+      ttl_seconds: 2_700,
+    },
+  };
+
+  const preview = await claimLocalCoordinationTodo({...request, dry_run: true});
+  assert.equal(preview.status, "planned");
+  assert.equal(preview.todo_changed, true);
+  assert.equal(preview.lease_changed, true);
+  const before = await store.loadAuthority();
+  assert.equal(before.status, "loaded");
+  if (before.status !== "loaded") return;
+  assert.deepEqual(before.head.leases, []);
+  assert.equal((await store.readReceipt(request.operation_id)).status, "missing");
+
+  const applied = await claimLocalCoordinationTodo(request);
+  assert.equal(applied.status, "applied", JSON.stringify(applied));
+  assert.equal(applied.todo_changed, true);
+  assert.equal(applied.lease_changed, true);
+  assert.equal(applied.lease_idempotent, false);
+  const after = await store.loadAuthority();
+  assert.equal(after.status, "loaded");
+  if (after.status !== "loaded") return;
+  assert.equal((after.head.todos as Record<string, unknown>[])[0]?.claimed_by, "agent-a");
+  assert.deepEqual(after.head.leases, [applied.lease]);
+  const lease = applied.lease as Record<string, unknown>;
+  assert.equal(lease.schema_version, "task_lease_v0");
+  assert.equal(lease.owner, "agent-a");
+  assert.equal(lease.idempotency_key, "turn:claim-with-lease");
+  assert.deepEqual(lease.write_scopes, ["loopx/control_plane/**"]);
+  assert.equal(lease.version, 1);
+  assert.equal(lease.lease_epoch, 1);
+
+  const replay = await claimLocalCoordinationTodo({
+    ...request,
+    observed_at: "2026-09-05T06:00:00Z",
+  });
+  assert.equal(replay.status, "replayed");
+  assert.deepEqual(replay.original_receipt, applied.original_receipt);
+  const retiredGeneration = await claimLocalCoordinationTodo({
+    ...request,
+    operation_id: "todo-claim:goal-a:todo_a:fresh-after-expiry",
+    observed_at: "2026-09-05T06:00:00Z",
+    lease_request: {...request.lease_request, expected_version: 1},
+  });
+  assert.equal(retiredGeneration.reason_code, "idempotency_key_reuse");
+  assert.deepEqual(await store.loadAuthority(), after);
+});
+
 test("local canonical runtime never falls back when provider state is missing", async () => {
   const root = await mkdtemp(join(tmpdir(), "loopx-local-authority-missing-"));
   const result = await readLocalCoordinationTodo({

--- a/tests/test_cli_argument_diagnostics.py
+++ b/tests/test_cli_argument_diagnostics.py
@@ -566,7 +566,8 @@ def test_quota_action_selection_requires_turn_identity() -> None:
                 "Continue the work.",
             ],
             "todo claim only accepts --todo-id, --claimed-by, --agent-id, optional --role, "
-            "--claim-operation-id, --project, --state-file, and --dry-run; unsupported: "
+            "--claim-operation-id, --task-lease-idempotency-key, "
+            "--task-lease-expected-version, --project, --state-file, and --dry-run; unsupported: "
             "--decision-outcome, --next-agent-todo",
         ),
     ],


### PR DESCRIPTION
## Summary

- extend promoted `hard_lease` Todo claim with an optional typed lease request;
- derive write scopes from the canonical Todo and commit lease, claim, and receipt under one provider CAS;
- preserve the existing claim contract when lease options are omitted and fail closed before authority promotion;
- document the bounded TypeScript-first migration order for shared authority.

## Why

The next shared-authority stages should not migrate a split Python claim plus lease workflow under provider pressure. This moves one already-shipped ownership transaction into the existing TypeScript authority boundary without introducing a second ownership API or provider-specific decision path.

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` — 641 passed, 1 intentional skip
- `npm run test:postgresql-authority-store` — 30 passed against a disposable isolated PostgreSQL server, 0 skipped
- focused Python tests — 107 passed
- changed-path Ruff and scoped mypy passed
- docs-governance and repository-hygiene smokes passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18, no holds
- strict change-quality receipt `cqr_a6900a2677a0ff16500c`

## Compatibility and scope

The no-lease claim request identity and historical compatibility path remain unchanged. File, NoKV, and PostgreSQL conformance prove that competing owners cannot split the claim from its lease. No provider promotion, production action, credential, private state, or generated evidence is included.

This PR is intentionally left open for independent review.
