### PR TITLE
fix(reward-memory): surface destination match in the guidance receipt

### DIFF
--- a/loopx/capabilities/reward_memory/outbound.py
+++ b/loopx/capabilities/reward_memory/outbound.py
@@ -104,6 +104,10 @@ def outbound_guidance_hook(
             .get("destinations", {})
             .get(destination_digest, {})
         )
+        # A configured-but-mismatched digest silently degrades to no required
+        # refs; surface the match so configuration drift stays observable in
+        # the receipt instead of masquerading as a satisfied check.
+        destination_configured = bool(destination)
         required_refs = destination.get("required_candidate_refs", [])
         queries = []
         # Required records have their own bounded lookup and are checked after
@@ -204,6 +208,7 @@ def outbound_guidance_hook(
             "grants_new_action_authority": False,
             "required_guidance_complete": not missing_required,
             "missing_required_candidate_refs": missing_required,
+            "destination_configured": destination_configured,
             "application": result.get("application"),
             "applications": [r.get("application") for r in results],
             "telemetry": telemetry,

--- a/tests/capabilities/test_outbound_guidance.py
+++ b/tests/capabilities/test_outbound_guidance.py
@@ -305,6 +305,31 @@ def test_agent_id_normalization_preserves_valid_scope(tmp_path, monkeypatch):
         assert hook("sha256:intent")["status"] == "applied"
 
 
+def test_destination_match_is_observable_when_digest_drifts(tmp_path, monkeypatch):
+    config, provider = configure(tmp_path, monkeypatch)
+    chat = "oc_example_group"
+    digest = hashlib.sha256(chat.encode()).hexdigest()
+    config["surfaces"][outbound.SURFACE]["destinations"] = {
+        digest: {
+            "query_label": "Example Team",
+            "required_candidate_refs": ["candidate:rule"],
+        }
+    }
+    hook = outbound.outbound_guidance_hook(
+        registry_path=tmp_path / "registry.json", goal_id="goal", agent_id="pilot"
+    )
+    # The bound chat resolves its configured destination.
+    matched = hook.for_destination(chat)("intent")
+    assert matched["destination_configured"] is True
+    # A digest that matches no configured destination (for example, the
+    # display name was hashed instead of the chat id) must not masquerade as
+    # a satisfied required-read check.
+    drifted = hook.for_destination("oc_other_group")("intent")
+    assert drifted["destination_configured"] is False
+    assert drifted["required_guidance_complete"] is True
+    assert drifted["missing_required_candidate_refs"] == []
+
+
 def test_destination_and_purpose_queries_merge_without_private_id(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

A destination digest that matches no configured destination degrades to an empty destination record: `required_candidate_refs` silently vanish and the receipt reports `required_guidance_complete: true` for a check that never ran. The most natural way to land in this state is hashing the group display name instead of the exact chat id — exactly the mistake OUTBOUND.md spends a paragraph warning about — and it currently produces zero signal anywhere in the receipt or telemetry: the owner believes required reads are enforced while every message takes the unguarded path.

This change adds `destination_configured: bool` to the guidance result, so a match (or drift) is observable directly from the receipt: configured-and-matched destinations report `true`; an unbound or unmatched digest reports `false` next to the (vacuously) complete required check, making the mismatch visible.

## Issue

Found during a post-merge audit of #4018 (destination recall and required guidance checks), together with #4030 which fixes the opposite direction (configured refs that can never match). No open issue yet — happy to file one if preferred.

## Validation

- New regression test: a configured destination reports `destination_configured: true`; binding a chat whose digest matches no configured destination reports `false` while `required_guidance_complete` stays `true` — pinning the previously invisible drift (red when the field is hardcoded `true`, green with the real match).
- `pytest tests/capabilities/test_outbound_guidance.py tests/extensions/ tests/capabilities/test_reward_memory_feedback_hint.py`: 715 passed.
- `ruff check` / `ruff format` clean.

## Type

- [x] fix

## Area

- [x] capabilities

## Direction

- [x] follow-up (post-merge audit of #4018)

## Boundary

One observability field on the guidance result and one regression test. The recall path, required-read enforcement, and review semantics are untouched.
