### PR TITLE
fix(status-api): reject non-boolean control flags

### DIFF
--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -114,6 +114,19 @@ def parse_goal_activation_filter(query: dict[str, list[str]]) -> str | None:
     return values[0] if values else None
 
 
+def _json_boolean(body: dict[str, Any], field: str, *, default: bool = False) -> bool:
+    if field not in body:
+        return default
+    value = body[field]
+    if type(value) is not bool:
+        raise ValueError(f"{field} must be a JSON boolean")
+    return value
+
+
+def _optional_json_boolean(body: dict[str, Any], field: str) -> bool | None:
+    return _json_boolean(body, field) if field in body else None
+
+
 def is_loopback_host(host: str) -> bool:
     hostname = host.strip().lower()
     return hostname in {"127.0.0.1", "localhost", "::1", "[::1]"}
@@ -299,7 +312,11 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             run_generated_at=run_generated_at,
             reward=reward,
             dry_run=True,
-            write_active_state_summary=bool(body.get("write_active_state_summary")) if append else False,
+            write_active_state_summary=(
+                _json_boolean(body, "write_active_state_summary", default=True)
+                if append
+                else False
+            ),
         )
 
     def _handle_reward_dry_run(self) -> None:
@@ -375,7 +392,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
                 run_generated_at=run_generated_at,
                 reward=reward,
                 dry_run=False,
-                write_active_state_summary=bool(body.get("write_active_state_summary", True)),
+                write_active_state_summary=_json_boolean(
+                    body, "write_active_state_summary", default=True
+                ),
             )
         except Exception as exc:  # noqa: BLE001 - preserve validation diagnostics for the local UI.
             self._send_json(
@@ -449,20 +468,22 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "goal_id": goal_id,
             "quota_compute": body.get("quota_compute"),
             "quota_window_hours": body.get("quota_window_hours"),
-            "self_repair_enabled": body.get("self_repair_enabled"),
-            "self_repair_health": body.get("self_repair_health"),
-            "self_repair_waiting_projection": body.get("self_repair_waiting_projection"),
+            "self_repair_enabled": _optional_json_boolean(body, "self_repair_enabled"),
+            "self_repair_health": _optional_json_boolean(body, "self_repair_health"),
+            "self_repair_waiting_projection": _optional_json_boolean(
+                body, "self_repair_waiting_projection"
+            ),
             "multi_subagent_feature": body.get("multi_subagent_feature"),
             "orchestration_mode": body.get("orchestration_mode"),
-            "spawn_allowed": body.get("spawn_allowed"),
+            "spawn_allowed": _optional_json_boolean(body, "spawn_allowed"),
             "max_children": body.get("max_children"),
             "allowed_domains": [str(item) for item in allowed_domains] if allowed_domains is not None else None,
-            "clear_allowed_domains": bool(body.get("clear_allowed_domains", False)),
+            "clear_allowed_domains": _json_boolean(body, "clear_allowed_domains"),
             "registered_agents": [str(item) for item in registered_agents] if registered_agents is not None else None,
-            "clear_registered_agents": bool(body.get("clear_registered_agents", False)),
+            "clear_registered_agents": _json_boolean(body, "clear_registered_agents"),
             "peer_task_coordinator": body.get("peer_task_coordinator"),
-            "clear_peer_task_coordinator": bool(
-                body.get("clear_peer_task_coordinator", False)
+            "clear_peer_task_coordinator": _json_boolean(
+                body, "clear_peer_task_coordinator"
             ),
             "agent_profiles": agent_profiles,
             "clear_agent_profiles": (
@@ -489,10 +510,10 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
                 if supervised_agents is not None
                 else None
             ),
-            "clear_supervisor": bool(body.get("clear_supervisor", False)),
+            "clear_supervisor": _json_boolean(body, "clear_supervisor"),
             "write_scope": [str(item) for item in write_scope] if write_scope is not None else None,
-            "replace_write_scope": bool(body.get("replace_write_scope", False)),
-            "clear_write_scope": bool(body.get("clear_write_scope", False)),
+            "replace_write_scope": _json_boolean(body, "replace_write_scope"),
+            "clear_write_scope": _json_boolean(body, "clear_write_scope"),
             "boundary_authority_scopes": (
                 [str(item) for item in boundary_authority_scopes]
                 if boundary_authority_scopes is not None
@@ -502,7 +523,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "boundary_authority_decision_id": body.get("boundary_authority_decision_id"),
             "boundary_authority_recorded_at": body.get("boundary_authority_recorded_at"),
             "boundary_authority_expires_at": body.get("boundary_authority_expires_at"),
-            "clear_boundary_authority": bool(body.get("clear_boundary_authority", False)),
+            "clear_boundary_authority": _json_boolean(body, "clear_boundary_authority"),
         }
 
     def _configure_goal_payload(self, body: dict[str, Any], *, apply: bool, execute: bool) -> dict[str, Any]:

--- a/tests/test_status_server_fast_path.py
+++ b/tests/test_status_server_fast_path.py
@@ -22,7 +22,7 @@ from loopx.status_server import (
 
 
 @contextmanager
-def _status_server(tmp_path: Path) -> Iterator[str]:
+def _status_server(tmp_path: Path, *, reward_write_enabled: bool = False) -> Iterator[str]:
     registry = tmp_path / "registry.json"
     registry.write_text(json.dumps({"goals": []}) + "\n", encoding="utf-8")
     server = StatusHTTPServer(("127.0.0.1", 0), StatusRequestHandler)
@@ -33,7 +33,7 @@ def _status_server(tmp_path: Path) -> Iterator[str]:
     server.status_path = DEFAULT_STATUS_PATH
     server.reward_dry_run_path = DEFAULT_REWARD_DRY_RUN_PATH
     server.reward_append_path = DEFAULT_REWARD_APPEND_PATH
-    server.reward_write_enabled = False
+    server.reward_write_enabled = reward_write_enabled
     server.configure_goal_dry_run_path = DEFAULT_CONFIGURE_GOAL_DRY_RUN_PATH
     server.configure_goal_apply_path = DEFAULT_CONFIGURE_GOAL_APPLY_PATH
     server.control_plane_write_enabled = False
@@ -153,3 +153,98 @@ def test_status_endpoint_rejects_mixed_blank_goal_activation_scope(
     assert raised.value.code == 400
     payload = json.loads(raised.value.read().decode("utf-8"))
     assert payload["error"] == "goal_activation must be active or stopped"
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "clear_allowed_domains",
+        "clear_registered_agents",
+        "clear_peer_task_coordinator",
+        "self_repair_enabled",
+        "self_repair_health",
+        "self_repair_waiting_projection",
+        "spawn_allowed",
+        "clear_supervisor",
+        "replace_write_scope",
+        "clear_write_scope",
+        "clear_boundary_authority",
+    ],
+)
+def test_configure_goal_rejects_string_boolean_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field: str,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_configure_goal(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {
+            "dry_run": True,
+            "execute": False,
+            "written": False,
+            "changed": False,
+            "goal_id": "goal-a",
+            "changed_fields": [],
+            "before": {},
+            "after": {},
+        }
+
+    monkeypatch.setattr(
+        "loopx.status_server.configure_goal_with_global_sync",
+        fake_configure_goal,
+    )
+    with _status_server(tmp_path) as base_url:
+        request = urllib.request.Request(
+            f"{base_url}{DEFAULT_CONFIGURE_GOAL_DRY_RUN_PATH}",
+            data=json.dumps({"goal_id": "goal-a", field: "false"}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(request, timeout=5)
+
+    assert raised.value.code == 400
+    payload = json.loads(raised.value.read().decode("utf-8"))
+    assert payload["error"] == f"{field} must be a JSON boolean"
+    assert calls == []
+
+
+def test_reward_append_rejects_string_boolean_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "loopx.status_server.append_human_reward",
+        lambda **kwargs: calls.append(kwargs) or {"goal_id": "goal-a"},
+    )
+
+    with _status_server(tmp_path, reward_write_enabled=True) as base_url:
+        request = urllib.request.Request(
+            f"{base_url}{DEFAULT_REWARD_APPEND_PATH}",
+            data=json.dumps(
+                {
+                    "goal_id": "goal-a",
+                    "run_generated_at": "2026-09-07T00:00:00Z",
+                    "decision": "ship",
+                    "reward": "positive",
+                    "reason_summary": "verified",
+                    "preview_id": "preview",
+                    "write_active_state_summary": "false",
+                }
+            ).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Origin": "http://127.0.0.1",
+            },
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(request, timeout=5)
+
+    assert raised.value.code == 400
+    payload = json.loads(raised.value.read().decode("utf-8"))
+    assert payload["error"] == "write_active_state_summary must be a JSON boolean"
+    assert calls == []


### PR DESCRIPTION
## Summary

- reject non-boolean JSON values for configure-goal control flags
- apply the same validation to reward append write_active_state_summary
- keep dry-run and apply defaults aligned

## Root cause

Python bool(...) coercion treated non-empty JSON strings such as false-in-quotes as true, so malformed HTTP payloads could trigger clear or replace operations.

## Validation

- 18 passed: tests/test_status_server_fast_path.py
- 58 passed, 1 deselected: related status/configuration/control-plane tests
- Ruff check passed
- Python compileall passed
- npm audit --audit-level=high: 0 vulnerabilities
- loopx canary premerge --from-git-diff: passed, 4/4 selected canaries

The full pytest suite was sampled for 120 seconds to 7% without failures; it was not completed. One unrelated test requiring writes under the host ~/.codex/loopx directory was excluded from the related run because the sandbox denied that path.

## Scope

Future-facing pass: no companion refactor needed; the existing status-server parsing boundary is the narrow owner for this validation.