### PR TITLE
fix(configure-goal): validate numeric value types

### DIFF
--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import shlex
 import shutil
 from collections.abc import Mapping
@@ -171,25 +172,25 @@ def _now_iso() -> str:
 def _positive_number(value: float | None, *, field: str) -> float | None:
     if value is None:
         return None
-    if value <= 0:
-        raise ValueError(f"{field} must be greater than 0")
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{field} must be a finite number greater than 0")
     return float(value)
 
 
 def _non_negative_number(value: float | None, *, field: str) -> float | None:
     if value is None:
         return None
-    if value < 0:
-        raise ValueError(f"{field} must be greater than or equal to 0")
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(value) or value < 0:
+        raise ValueError(f"{field} must be a finite number greater than or equal to 0")
     return float(value)
 
 
 def _non_negative_int(value: int | None, *, field: str) -> int | None:
     if value is None:
         return None
-    if value < 0:
-        raise ValueError(f"{field} must be greater than or equal to 0")
-    return int(value)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer")
+    return value
 
 
 def _clean_domains(values: list[str] | None) -> list[str] | None:

--- a/tests/control_plane/test_quota_paused_precedence.py
+++ b/tests/control_plane/test_quota_paused_precedence.py
@@ -331,3 +331,33 @@ def test_configure_goal_rejects_negative_compute(tmp_path: Path) -> None:
             quota_compute=-0.1,
             execute=False,
         )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("quota_compute", True),
+        ("quota_compute", float("nan")),
+        ("quota_window_hours", float("inf")),
+        ("max_children", True),
+        ("max_children", 1.5),
+    ],
+)
+def test_configure_goal_rejects_invalid_numeric_values(
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps({"goals": [{"id": GOAL_ID, "repo": str(tmp_path)}]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=field):
+        configure_goal(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            execute=False,
+            **{field: value},
+        )


### PR DESCRIPTION
## Summary

- reject booleans and non-finite values for quota numeric settings
- reject booleans and fractional values for max_children
- preserve zero as the supported quota pause value

## Root cause

The shared configure-goal validators checked only numeric ranges before coercion. Because Python bool is an int subclass, true became 1 or 1.0; NaN and infinity bypassed one-sided comparisons; fractional max_children values were truncated by int(...).

## Regression evidence

Before the fix, the focused parameterized regression failed 5/5 twice: four invalid inputs were silently accepted and infinity escaped later as OverflowError. After the fix it passes 5/5.

## Validation

- 16 passed: focused quota/configure-goal tests
- 80 passed, 1 deselected: related configure-goal/control-plane tests
- Ruff check passed
- Python compileall passed
- npm audit --audit-level=high: 0 vulnerabilities
- loopx canary premerge --from-git-diff: passed, 6/6 selected canaries

The deselected existing test writes under the host ~/.codex/loopx directory, which the sandbox denies. The full pytest suite was not run.

## Scope

Sibling sweep: configure-goal's three shared numeric validators are fixed. Other numeric helpers either already reject booleans/fractional integers and bound values, or belong to separate capability contracts. One decision-context timeout helper still needs its own finite-value regression and is intentionally not mixed into this PR.

Future-facing pass: no refactor added; the existing shared validators remain the narrow owning boundary.