### PR TITLE
Fix Todo-less periodic report hook identity

### DIFF
--- a/docs/reference/protocols/periodic-report-v0.md
+++ b/docs/reference/protocols/periodic-report-v0.md
@@ -345,8 +345,10 @@ The optional automatic path uses the provider-neutral TypeScript
 `periodic_report.runtime_trigger` only when the Goal's local control-plane
 configuration explicitly enables a periodic-report profile. Core dispatches
 only after the primary `refresh-state` durable writeback and exact settlement
-readback have succeeded with complete Goal, Agent, Todo, Turn, and effect
-identity. The best-effort rollout-event log is not dispatch authority.
+readback have succeeded with complete Goal, Agent, Turn, and effect identity.
+Todo-bound settlements carry a non-empty Todo id; Todo-less autonomous replans
+carry an explicit `null` Todo id rather than inventing a Todo identity. The
+best-effort rollout-event log is not dispatch authority.
 
 The hook input contains only the committed receipt identity, stable state
 revision, and derived `periodic_report_stage_completion_receipt_v0`. Its result
@@ -358,7 +360,9 @@ or result-contract failure persists a `retryable_failure` receipt with a stable
 dispatch reference and monotonic attempt count; exact replay may atomically
 advance that receipt to `intent_recorded` or `not_applicable`. Conflicts and
 optional hook failures remain isolated and cannot roll back the primary
-writeback or alter quota-spend eligibility.
+writeback or alter quota-spend eligibility. A Python-to-TypeScript runtime
+failure additionally projects a bounded typed phase, error kind, and diagnostic
+code; it never includes raw provider or private state.
 
 Recorded trigger intent means neither report generation nor publication. A
 later governed executor must evaluate the intent. Composition, rendering, and

--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -177,7 +177,7 @@ composition boundary:
 ```
 
 After a committed `refresh-state` writeback with complete
-Goal/Agent/Todo/Turn/effect identity, core dispatches the TypeScript-validated
+Goal/Agent/Turn/effect identity, core dispatches the TypeScript-validated
 `post_writeback` hook outside the primary transaction. The capability receives
 only a bounded stage-completion projection and its public-safe progress
 snapshot, both captured at the writeback boundary. It may propose one
@@ -185,9 +185,15 @@ idempotent `periodic_report.trigger_evaluation` intent. Core checkpoints that
 proposal in a replay-safe sidecar. A transient failure is durably recorded as
 `retryable_failure`; the next exact replay advances its attempt and may replace
 it with `intent_recorded` or `not_applicable`, while terminal replay returns the
-original receipt without invoking the provider again. Disabled profiles,
-incomplete settlement identity, ordinary
-Todo completion, and generic replan produce no provider invocation or intent.
+original receipt without invoking the provider again. Todo-bound settlements
+carry a non-empty Todo id, while Todo-less autonomous replans carry an explicit
+`null` Todo id. Disabled profiles, incomplete settlement identity, ordinary
+Todo completion, and generic replan produce no trigger intent.
+
+If the Python bridge cannot complete the TypeScript hook transaction, the
+isolated failure includes only a typed runtime phase, error kind, and diagnostic
+code. It does not expose raw provider output or private state, and it does not
+change the committed primary writeback.
 
 The intent is not a report and grants no generation, publication, connector,
 network, credential, or sink authority. A separate governed executor may

--- a/loopx/cli_commands/post_writeback.py
+++ b/loopx/cli_commands/post_writeback.py
@@ -62,7 +62,11 @@ def dispatch_committed_cli_post_writeback_hooks(
                 "identity": {
                     "goal_id": goal_id,
                     "agent_id": str(identity.get("agent_id") or ""),
-                    "todo_id": str(identity.get("todo_id") or ""),
+                    "todo_id": (
+                        str(identity["todo_id"])
+                        if identity.get("todo_id")
+                        else None
+                    ),
                     "turn_instance_id": str(
                         identity.get("turn_instance_id") or ""
                     ),

--- a/loopx/control_plane/capability_hooks.py
+++ b/loopx/control_plane/capability_hooks.py
@@ -16,7 +16,12 @@ from ..file_lock import (
     LockAcquireTimeoutError,
     exclusive_file_lock,
 )
-from .effect_runtime import EffectRuntimeRejected, effect_runtime_result
+from .effect_runtime import (
+    EffectRuntimeRejected,
+    EffectRuntimeRemoteError,
+    EffectRuntimeStartupError,
+    effect_runtime_result,
+)
 from .coordination.coordination_state_contract_generated import (
     CAPABILITY_HOOK_INTERACTION_RESULT_SCHEMA,
     CAPABILITY_HOOK_POST_WRITEBACK_INPUT_SCHEMA,
@@ -301,8 +306,9 @@ def _post_writeback_failure_dispatch(
     *,
     error_code: str,
     invoked_count: int = 0,
+    runtime_failure: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
-    return {
+    dispatch: dict[str, Any] = {
         "schema_version": POST_WRITEBACK_HOOK_DISPATCH_SCHEMA_VERSION,
         "phase": "post_writeback",
         "registered_count": len(registrations),
@@ -317,6 +323,34 @@ def _post_writeback_failure_dispatch(
         ],
         "primary_writeback_preserved": True,
         "external_writes_performed": False,
+    }
+    if runtime_failure is not None:
+        dispatch["runtime_failure"] = dict(runtime_failure)
+    return dispatch
+
+
+def _post_writeback_runtime_failure(
+    error: BaseException,
+    *,
+    phase: str,
+) -> dict[str, str]:
+    if isinstance(error, EffectRuntimeRemoteError):
+        error_kind = error.error_kind
+        diagnostic_code = error.diagnostic_code
+    elif isinstance(error, EffectRuntimeStartupError):
+        error_kind = "startup_failed"
+        diagnostic_code = error.diagnostic_code
+    elif isinstance(error, OSError):
+        error_kind = "local_io_failed"
+        diagnostic_code = "runtime_transport_io_failed"
+    else:
+        error_kind = "local_contract_invalid"
+        diagnostic_code = "runtime_result_shape_invalid"
+    return {
+        "schema_version": "loopx_post_writeback_runtime_failure_v0",
+        "phase": phase,
+        "error_kind": error_kind,
+        "diagnostic_code": diagnostic_code,
     }
 
 
@@ -636,6 +670,7 @@ def dispatch_post_writeback_hooks(
             error_code="registration_or_input_rejected",
         )
     invoked_count = 0
+    runtime_phase = "preflight"
     try:
         source_packet = dict(source) if source is not None else None
         legacy_hook_input = dict(hook_input) if hook_input is not None else None
@@ -701,6 +736,7 @@ def dispatch_post_writeback_hooks(
             outcomes=sizing_outcomes,
         )
 
+        runtime_phase = "provider"
         compatibility_timeout = (
             LOCK_POLICIES[LockAcquisitionPolicy.MUTATION].timeout_seconds
             if lease_timeout_seconds is None
@@ -714,7 +750,7 @@ def dispatch_post_writeback_hooks(
                     str(raw_plan.get("hook_id") or ""),
                     str(raw_plan.get("capability_id") or ""),
                 )
-                registration = providers.get(key)
+                provider_registration = providers.get(key)
                 unavailable_status = (
                     _enter_legacy_post_writeback_guard(
                         legacy_writer_guards,
@@ -729,7 +765,7 @@ def dispatch_post_writeback_hooks(
                 )
                 outcome, invoked = _post_writeback_provider_outcome(
                     raw_plan,
-                    registration=registration,
+                    registration=provider_registration,
                     unavailable_status=unavailable_status,
                 )
                 invoked_count += int(invoked)
@@ -739,6 +775,7 @@ def dispatch_post_writeback_hooks(
                 transaction_id=transaction_id,
                 outcomes=outcomes,
             )
+            runtime_phase = "finalize"
             finalized = effect_runtime_result(
                 "capability_hook.post_writeback.transaction",
                 _post_writeback_finalize_params(
@@ -752,11 +789,15 @@ def dispatch_post_writeback_hooks(
             ):
                 raise ValueError("post-writeback transaction result is invalid")
             return dict(finalized["dispatch"])
-    except (EffectRuntimeRejected, OSError, RuntimeError, TypeError, ValueError):
+    except (EffectRuntimeRejected, OSError, RuntimeError, TypeError, ValueError) as exc:
         return _post_writeback_failure_dispatch(
             ordered_registrations,
             error_code="runtime_result_invalid",
             invoked_count=invoked_count,
+            runtime_failure=_post_writeback_runtime_failure(
+                exc,
+                phase=runtime_phase,
+            ),
         )
 
 

--- a/loopx/control_plane/capability_hooks.ts
+++ b/loopx/control_plane/capability_hooks.ts
@@ -690,6 +690,12 @@ export function validatePostWritebackHookInput(input: {
   const identity = requiredObject(hookInput.identity, "post-writeback identity");
   requireExactFields(identity, POST_WRITEBACK_IDENTITY_FIELDS, "post-writeback identity");
   for (const field of POST_WRITEBACK_IDENTITY_FIELDS) {
+    if (field === "todo_id") {
+      if (identity[field] !== null) {
+        requiredString(identity[field], `post-writeback identity ${field}`);
+      }
+      continue;
+    }
     requiredString(identity[field], `post-writeback identity ${field}`);
   }
   requiredString(hookInput.state_version, "post-writeback state_version");

--- a/loopx/control_plane/post_writeback_hook_transaction.ts
+++ b/loopx/control_plane/post_writeback_hook_transaction.ts
@@ -72,7 +72,7 @@ interface PostWritebackSource extends JsonObject {
   event_kind: string;
   status: string;
   durable: boolean;
-  identity: JsonObject & { goal_id: string };
+  identity: JsonObject & { goal_id: string; todo_id: string | null };
   state_version: string;
   committed_at: string;
   projection: JsonObject;
@@ -265,6 +265,14 @@ function pythonStrippedString(value: unknown, label: string): string {
   return stripped;
 }
 
+function optionalPythonStrippedString(
+  value: unknown,
+  label: string,
+): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  return pythonStrippedString(value, label);
+}
+
 function boundedTransactionResult(result: JsonObject): JsonObject {
   if (
     new TextEncoder().encode(JSON.stringify(result)).byteLength >
@@ -369,10 +377,16 @@ function decodeSource(value: unknown): PostWritebackSource {
     ["goal_id", "agent_id", "todo_id", "turn_instance_id", "effect_id"],
     "source.identity",
   );
-  const normalizedIdentity: JsonObject & { goal_id: string } = {
+  const normalizedIdentity: JsonObject & {
+    goal_id: string;
+    todo_id: string | null;
+  } = {
     goal_id: pythonStrippedString(identity.goal_id, "source.identity.goal_id"),
     agent_id: pythonStrippedString(identity.agent_id, "source.identity.agent_id"),
-    todo_id: pythonStrippedString(identity.todo_id, "source.identity.todo_id"),
+    todo_id: optionalPythonStrippedString(
+      identity.todo_id,
+      "source.identity.todo_id",
+    ),
     turn_instance_id: pythonStrippedString(
       identity.turn_instance_id,
       "source.identity.turn_instance_id",

--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -260,6 +260,37 @@ def test_post_writeback_dispatch_returns_one_effect_free_intent() -> None:
     assert dispatch["external_writes_performed"] is False
 
 
+def test_post_writeback_dispatch_accepts_todoless_replan_identity() -> None:
+    source = _source()
+    identity = source["identity"]
+    assert isinstance(identity, dict)
+    identity["todo_id"] = None
+
+    dispatch = dispatch_post_writeback_hooks([_hook()], source=source)
+
+    assert dispatch["invoked_count"] == 1
+    assert dispatch["intent_count"] == 1
+    assert dispatch["failures"] == []
+
+
+def test_post_writeback_runtime_failure_identifies_rejected_preflight() -> None:
+    source = _source()
+    identity = source["identity"]
+    assert isinstance(identity, dict)
+    identity["todo_id"] = 7
+
+    dispatch = dispatch_post_writeback_hooks([_hook()], source=source)
+
+    assert dispatch["invoked_count"] == 0
+    assert dispatch["failures"][0]["error_code"] == "runtime_result_invalid"
+    assert dispatch["runtime_failure"] == {
+        "schema_version": "loopx_post_writeback_runtime_failure_v0",
+        "phase": "preflight",
+        "error_kind": "request_rejected",
+        "diagnostic_code": "invalid_request",
+    }
+
+
 def test_post_writeback_legacy_lock_uses_the_admitted_goal_path(tmp_path: Path) -> None:
     hook_input = _input()
     identity = hook_input["identity"]

--- a/tests/control_plane/test_quota_settlement_cli.py
+++ b/tests/control_plane/test_quota_settlement_cli.py
@@ -2439,6 +2439,18 @@ def test_todoless_autonomous_replan_settles_quota_refresh_spend_chain(
 ) -> None:
     project, runtime, registry_path = _write_fixture(tmp_path)
     _configure_autonomous_replan_fixture(project, runtime, registry_path)
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["goals"][0]["control_plane"] = {
+        "periodic_report": {
+            "enabled": True,
+            "profile_preset": "weekly",
+            "route_ref": "project-room",
+        }
+    }
+    registry_path.write_text(
+        json.dumps(registry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
     turn_instance_id = "turn-autonomous-replan-settlement-1"
 
     guard_rc, guard = _run_cli(
@@ -2512,6 +2524,9 @@ def test_todoless_autonomous_replan_settles_quota_refresh_spend_chain(
     assert [
         receipt["step_kind"] for receipt in refresh["settlement_result"]["receipts"]
     ] == ["validation", "durable_writeback"]
+    assert refresh["post_writeback_hooks"]["invoked_count"] == 1
+    assert refresh["post_writeback_hooks"]["intent_count"] == 0
+    assert refresh["post_writeback_hooks"]["failures"] == []
 
     spend_args = _projected_cli_args(
         spend_command,

--- a/tests/control_plane_ts/capability_hooks.test.ts
+++ b/tests/control_plane_ts/capability_hooks.test.ts
@@ -176,9 +176,17 @@ test("post-writeback hook binds intent to the exact durable receipt", () => {
   );
 });
 
-test("post-writeback hook requires the complete settlement identity", () => {
+test("post-writeback hook accepts Todo-less identity but rejects an empty Todo id", () => {
+  const todoLess = postWritebackInput();
+  (todoLess.identity as Record<string, unknown>).todo_id = null;
+  const admitted = validatePostWritebackHookInput({
+    registration: postWritebackRegistration(),
+    hook_input: todoLess,
+  });
+  assert.equal((admitted.identity as Record<string, unknown>).todo_id, null);
+
   const incomplete = postWritebackInput();
-  (incomplete.identity as Record<string, unknown>).todo_id = null;
+  (incomplete.identity as Record<string, unknown>).todo_id = "";
   assert.throws(
     () => validatePostWritebackHookInput({
       registration: postWritebackRegistration(),

--- a/tests/control_plane_ts/post_writeback_hook_transaction.test.ts
+++ b/tests/control_plane_ts/post_writeback_hook_transaction.test.ts
@@ -267,6 +267,25 @@ test("source and dispatch identities replay the retired Python canonical bytes",
   );
 });
 
+test("todoless autonomous replan source preserves an explicit null Todo identity", async () => {
+  const value = source();
+  const identity = value.identity as Record<string, unknown>;
+  identity.todo_id = null;
+
+  const preflight = await evaluatePostWritebackHookTransaction(
+    request(null, { source: value }),
+  );
+  const plan = (preflight.provider_plan as Record<string, unknown>[])[0];
+  const hookInput = plan.hook_input as Record<string, unknown>;
+  const admittedIdentity = hookInput.identity as Record<string, unknown>;
+
+  assert.equal(admittedIdentity.todo_id, null);
+  assert.equal(admittedIdentity.goal_id, "goal-1");
+  assert.equal(admittedIdentity.agent_id, "agent-1");
+  assert.equal(admittedIdentity.turn_instance_id, "turn-1");
+  assert.equal(admittedIdentity.effect_id, "effect-1");
+});
+
 test("legacy hook input is exact-validated and preserves its durable event identity", async () => {
   const preflight = await evaluatePostWritebackHookTransaction(
     request(null, {


### PR DESCRIPTION
## Summary

- preserve Todo-less autonomous replan identity as an explicit `null` across the Python-to-TypeScript post-writeback hook boundary
- keep the TypeScript hook transaction as the semantic authority and avoid synthetic Todo identities or a second trigger path
- project bounded typed runtime diagnostics (`phase`, `error_kind`, `diagnostic_code`) without exposing raw provider output
- cover direct hook dispatch, full CLI settlement, boundary validation, and exact canonical identity behavior

## Root cause

The CLI adapter serialized an absent Todo id as an empty string, while the TypeScript transaction required a non-empty Todo id. A valid Todo-less autonomous replan therefore failed during hook preflight before any provider invocation and surfaced only as `runtime_result_invalid`.

## Validation

- `npm run test:control-plane` — 642 passed, 1 skipped
- `npm run typecheck:control-plane`
- focused Python suites — 54 passed
- focused Ruff and mypy
- `python examples/docs-governance-smoke.py`
- `loopx check` on all changed paths — public/private scan clean
- `loopx canary premerge --from-git-diff --goal-id loopx-meta` — 18/18 selected checks passed, no manual holds
- change-quality receipt: `cqr_9be4bfd9cdc3bdb4f48e`

No PostgreSQL authority-store behavior is changed; the affected production boundary is the post-writeback capability-hook transaction.

## Future-facing refactor pass

Applied at the owning boundary: the nullable Todo identity is now explicit in the typed transaction and shared hook validator. No broader abstraction was added because the existing transaction and sidecar receipt already own the lifecycle and replay semantics.
