### PR TITLE
Recover Todo Markdown projection from canonical authority journal

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2338,10 +2338,14 @@ write that cannot preserve the contract.
   lineage; it does not create the former second local-shadow candidate. Before
   promotion, add sustained mixed-writer parity runs, event-only Todo coverage,
   and the selected provider profile's recovery/capacity evidence.
-- The provider-neutral authority binding, compatibility projection outbox,
-  and conformance rows for file, NoKV, and PostgreSQL. This does not require all
-  providers to promote together; each profile must pass the same contract
-  before it is eligible.
+- Completion of the compatibility projection outbox and conformance rows for
+  file, NoKV, and PostgreSQL. The first provider-first slice now reuses the
+  committed authority journal as the durable intent for native Todo create,
+  claim, and narrow update, then renders native active/archive records into
+  machine-owned Markdown regions with idempotent replay. Remaining native Todo
+  mutations, lease-file projection, backlog/status readback, and provider-
+  neutral authority binding still need the same contract. Providers do not
+  promote together; each profile must pass it before it is eligible.
 - Retention, fast path, and measured capacity for the selected first-promotion
   profile; the reference executor's removal and status flips (question 13).
 - Post-promotion rollback: the shipped rollback quarantines a pre-promotion

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -1855,9 +1855,12 @@ integrity chain、确定性 scan 与 recovery readback。物理 profile 可以�
   提交到既有 `coordination.runtime_shadow` file-v0 lineage，不再创建第二套 local-shadow
   candidate。晋升前仍需补持续 mixed-writer parity、event-only Todo 覆盖和所选 provider
   profile 的 recovery/capacity 证据。
-- provider-neutral authority binding、兼容投影 outbox，以及 file、NoKV、PostgreSQL
-  的 conformance row。三个 provider 不必同时晋升，但每个 profile 都必须先通过同一
-  合同才具备资格。
+- 补齐兼容投影 outbox 与 file、NoKV、PostgreSQL 的 conformance row。首个
+  provider-first 切片已把 committed authority journal 复用为 native Todo create、
+  claim 和窄 update 的持久 intent，再以幂等 replay 把 native active/archive record
+  渲染到机器所有的 Markdown region。其余 native Todo mutation、lease-file 投影、
+  backlog/status 回读和 provider-neutral authority binding 仍需落实同一合同。三个
+  provider 不必同时晋升，但每个 profile 都必须先通过该合同才具备资格。
 - 首个晋升 profile 的 retention、fast path 与实测 capacity；参考执行器的删除与
   status flip（问题 13）。
 - 晋升后的 rollback：已交付的 rollback 隔离的是晋升前 lineage。首次权威写

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -177,7 +177,7 @@ records for that role. The marker is lineage evidence, not a write API.
 The command proves that the rendered records came from the exact provider head
 observed at read time. It does not claim that the revision remains the current
 head after that read; a later canonical mutation makes the Markdown projection
-stale and requires another explicit projection. Consumers must always read the
+stale until the journal-backed delivery replays. Consumers must always read the
 provider, never the Markdown marker, when they need current authority state.
 
 Rollback is intentionally asymmetric. Before promotion, the existing shadow
@@ -188,14 +188,22 @@ Todo sections, but must not promote stale Markdown back to canonical truth.
 
 ## Migration Path
 
-The explicit projector currently accepts only complete legacy v0 records for
-the two active Todo sections. Native `TodoDomainRecord` manifests and archived
-records remain fail-closed inputs; this command must not invent missing
-Markdown provenance or claim native/archive export qualification. A later
-adapter slice must prove native domain parity, legacy ordering preservation,
-and archive ownership before expanding that boundary. It is a manual
-read-time projection, not the transaction-bound projection outbox needed for
-automatic synchronization.
+The projector accepts complete legacy records and native `TodoDomainRecord`
+manifests. Native records receive display-only section/index provenance; that
+provenance never enters the canonical record. Archived records render only
+inside an existing machine-owned `Completed Work Archive` region and retain
+their original `role`. Unknown canonical fields, missing sections, and unsafe
+region ownership continue to fail closed.
+
+For promoted provider-first Todo create, claim, and narrow text/note update,
+the committed authority journal is the transaction-bound projection outbox:
+the canonical mutation, complete head, cursor, revision, and receipt land in
+one provider transaction. After that commit, the Python compatibility adapter
+renders the latest head under the Markdown lock and durably reads it back. A
+missing target or renderer/write failure leaves typed `pending` delivery
+evidence without reversing or hiding the canonical commit. A later successful
+mutation or `todo project-markdown --execute` replays the current head
+idempotently. This is projection recovery, not a second authority path.
 
 1. Emit this projection from active-state Markdown.
 2. Add parity smokes comparing it with existing status todo summaries.
@@ -203,7 +211,10 @@ automatic synchronization.
    the same projection fields.
 4. Promote one complete provider-backed mutation at a time behind the durable
    writer fence; keep the default Markdown mode unchanged.
-5. Regenerate only machine-owned sections from one exact canonical provider
-   revision, preserving human narrative and validating parse/render parity.
-6. Promote a provider projection only after rollback and idempotency checks are
+5. Regenerate only machine-owned active/archive sections from one exact
+   canonical provider revision, preserving human narrative and validating
+   parse/render parity.
+6. Extend the same journal-backed delivery contract to each remaining native
+   Todo mutation before claiming full promotion coverage.
+7. Promote a provider projection only after rollback and idempotency checks are
    in place.

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
-import stat
-import tempfile
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -20,19 +17,15 @@ from ..control_plane.coordination.runtime_shadow import (
     load_task_lease_runtime_shadow_records,
     resolve_coordination_runtime_shadow_config,
 )
-from ..control_plane.coordination.local_authority import (
-    read_canonical_todos_if_promoted,
-)
 from ..control_plane.quota.settlement import (
     QuotaSettlementReadback,
     read_heartbeat_settlement,
     settlement_result_payload,
 )
 from ..control_plane.todos.markdown import render_todo_markdown
-from ..control_plane.todos.machine_section_projection import (
-    render_canonical_todo_sections,
+from ..control_plane.todos.provider_projection import (
+    project_current_canonical_todos,
 )
-from ..file_lock import exclusive_file_lock
 from ..history import load_index, load_registry
 from ..paths import resolve_runtime_root
 from ..registry import find_registry_goal, registry_goals
@@ -50,7 +43,6 @@ from ..todos import (
     complete_goal_todo,
     list_goal_todos,
     resolve_todo_state,
-    resolve_todo_state_path,
     supersede_goal_todo,
     update_goal_todo,
 )
@@ -84,43 +76,6 @@ from ..control_plane.agents.capability_gate import (
 from ..control_plane.turn_driver.journal_store import (
     turn_journal_observed_capabilities,
 )
-
-
-def _fsync_parent_directory(path: Path) -> None:
-    if os.name != "posix":  # pragma: no cover - Windows has no directory fsync
-        return
-    descriptor = os.open(path.parent, os.O_RDONLY)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-
-
-def _atomic_write_text(path: Path, text: str) -> None:
-    """Durably replace a projection without changing the state-file mode."""
-
-    original_mode = stat.S_IMODE(path.stat().st_mode)
-    descriptor, temporary = tempfile.mkstemp(
-        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
-    )
-    temporary_path = Path(temporary)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
-            os.chmod(temporary_path, original_mode)
-            handle.write(text)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary_path, path)
-        _fsync_parent_directory(path)
-    finally:
-        temporary_path.unlink(missing_ok=True)
-
-
-def _read_text_exact(path: Path) -> str:
-    """Decode UTF-8 while preserving every source newline sequence."""
-
-    with path.open("r", encoding="utf-8", newline="") as handle:
-        return handle.read()
 
 
 PrintPayload = Callable[
@@ -379,57 +334,20 @@ def handle_todo_command(
         elif args.todo_command == "project-markdown":
             validate_todo_project_markdown_options(args)
             registry = load_registry(registry_path)
-            authority_read = read_canonical_todos_if_promoted(
+            projection = project_current_canonical_todos(
+                registry_path=registry_path,
                 runtime_root=resolve_runtime_root(registry, runtime_root_arg),
                 goal_id=args.goal_id,
-            )
-            if not isinstance(authority_read, dict):
-                raise ValueError(
-                    "todo project-markdown requires promoted canonical authority; "
-                    "legacy Markdown mode is unchanged"
-                )
-            if authority_read.get("provider_revision") != args.provider_revision:
-                raise ValueError(
-                    "todo project-markdown provider revision does not match the "
-                    "canonical read head"
-                )
-            _resolved_project, state_path = resolve_todo_state_path(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
+                expected_provider_revision=args.provider_revision,
+                execute=bool(args.execute),
+                registry_data=registry,
                 **_todo_path_args(args),
             )
-            with exclusive_file_lock(
-                state_path,
-                operation="project_canonical_todo_sections",
-            ):
-                source = _read_text_exact(state_path)
-                projection = render_canonical_todo_sections(
-                    source,
-                    authority_read["todos"],
-                    provider_revision=args.provider_revision,
-                )
-                if args.execute and projection.changed:
-                    _atomic_write_text(state_path, projection.markdown)
-                    if _read_text_exact(state_path) != projection.markdown:
-                        raise RuntimeError("Todo Markdown projection readback mismatch")
             payload = {
                 "ok": True,
                 "dry_run": not bool(args.execute),
                 "command": "project-markdown",
-                "goal_id": args.goal_id,
-                "state_file": str(state_path),
-                "source_authority": authority_read.get("source_authority"),
-                "provider_revision": projection.provider_revision,
-                "todo_count": projection.todo_count,
-                "changed": projection.changed,
-                "executed": bool(args.execute),
-                "source_sha256": projection.source_sha256,
-                "rendered_sha256": projection.rendered_sha256,
-                "narrative_sha256": projection.narrative_sha256,
-                "section_record_sha256": projection.section_record_sha256,
-                "parse_render_parity": True,
-                "narrative_preserved": True,
-                "legacy_fallback_used": False,
+                **projection,
             }
         elif args.todo_command == "add":
             validate_todo_add_options(args)

--- a/loopx/control_plane/coordination/local_authority.py
+++ b/loopx/control_plane/coordination/local_authority.py
@@ -74,6 +74,8 @@ def claim_canonical_todo_if_promoted(
     operation_id: str | None = None,
     task_lease_idempotency_key: str | None = None,
     task_lease_expected_version: int | None = None,
+    project: Path | None = None,
+    state_file: Path | None = None,
 ) -> dict[str, Any] | None:
     """Route a post-cutover claim to the TypeScript transaction owner."""
 
@@ -125,7 +127,9 @@ def claim_canonical_todo_if_promoted(
             code=str(payload.get("reason_code") or "local_authority_todo_claim_failed"),
             payload=payload,
         )
-    return {
+    from ..todos.provider_projection import settle_canonical_todo_projection
+
+    return settle_canonical_todo_projection({
         "ok": True,
         "dry_run": dry_run,
         "goal_id": goal_id,
@@ -133,7 +137,8 @@ def claim_canonical_todo_if_promoted(
         "section": "Agent Todo",
         "todo_id": todo_id,
         **payload,
-    }
+    }, registry_path=registry_path, runtime_root=runtime_root, goal_id=goal_id,
+        project=project, state_file=state_file)
 
 
 def read_canonical_todos_if_promoted(

--- a/loopx/control_plane/coordination/todo_claim.ts
+++ b/loopx/control_plane/coordination/todo_claim.ts
@@ -395,6 +395,8 @@ export async function executeCoordinationTodoClaim(
       provider_revision: receipt.provider_revision,
       cursor: receipt.cursor,
       original_receipt: original,
+      projection_delivery: result.changed === false ? "not_required" : "pending",
+      projection_source: "committed_authority_journal",
     };
   };
   const existing = replay(await store.readReceipt(input.operation_id), "replayed");

--- a/loopx/control_plane/coordination/todo_create.ts
+++ b/loopx/control_plane/coordination/todo_create.ts
@@ -77,6 +77,8 @@ function replayCreate(
     provider_revision: receipt.provider_revision,
     cursor: receipt.cursor,
     original_receipt: original,
+    projection_delivery: "pending",
+    projection_source: "committed_authority_journal",
   };
 }
 

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -743,6 +743,11 @@ def normalize_todo_status(value: Any) -> str | None:
     return None
 
 
+def normalize_todo_role(value: Any) -> str | None:
+    candidate = str(value or "").strip().lower()
+    return candidate if candidate in {"user", "agent"} else None
+
+
 def todo_done_for_status(status: Any) -> bool:
     return normalize_todo_status(status) in TODO_TERMINAL_STATUS_VALUES
 
@@ -874,6 +879,11 @@ _TODO_METADATA_FIELD_SCHEMA = (
         invalid_message=(
             "todo status must be one of: " + ", ".join(sorted(TODO_STATUS_VALUES))
         ),
+    ),
+    _TodoMetadataField(
+        "role",
+        normalize_todo_role,
+        invalid_message="todo role must be one of: agent, user",
     ),
     _TodoMetadataField(
         "task_class",
@@ -1229,6 +1239,7 @@ def format_todo_metadata_line(
     *,
     todo_id: str | None = None,
     status: str | None = None,
+    role: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
     task_domain: str | None = None,

--- a/loopx/control_plane/todos/machine_region.py
+++ b/loopx/control_plane/todos/machine_region.py
@@ -23,6 +23,7 @@ _ROLE_HEADINGS = {
     "agent todo": "agent",
     "codex todo": "agent",
     "project agent todo": "agent",
+    "completed work archive": "archive",
 }
 
 
@@ -37,7 +38,7 @@ class TodoRegion:
 
 
 def todo_region_marker(role: str, edge: str) -> str:
-    if role not in {"user", "agent"} or edge not in {"begin", "end"}:
+    if role not in {"user", "agent", "archive"} or edge not in {"begin", "end"}:
         raise ValueError("invalid Todo region marker")
     return f"{TODO_REGION_PREFIX}role={role} {edge} -->"
 

--- a/loopx/control_plane/todos/machine_section_projection.py
+++ b/loopx/control_plane/todos/machine_section_projection.py
@@ -18,9 +18,18 @@ from typing import Any
 from ..coordination.coordination_state_contract import (
     TODO_CANONICAL_READ_RECORD_FIELDS,
     TODO_CANONICAL_REQUIRED_READ_FIELDS,
+    TODO_DOMAIN_ITEM_SCHEMA_VERSION,
+    TODO_DOMAIN_RECORD_FIELDS,
+    TODO_DOMAIN_REQUIRED_FIELDS,
+    TODO_ITEM_SCHEMA_VERSION,
     canonical_record_fields,
 )
-from .active_state_editing import TODO_SECTION_HEADINGS
+from .active_state_editing import (
+    COMPLETED_WORK_ARCHIVE_HEADING,
+    TODO_SECTION_HEADINGS,
+    archive_section_bounds,
+    todo_blocks,
+)
 from .machine_region import find_todo_regions, todo_region_marker
 from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
@@ -36,7 +45,7 @@ from .todo_summary import canonical_todo_read_record
 TODO_SECTION_PROJECTION_SCHEMA_VERSION = "loopx_todo_section_projection_v0"
 _MARKER_PATTERN = re.compile(
     r"(?m)^<!-- loopx:todo-section-projection-v0 "
-    r"role=(?P<role>user|agent) "
+    r"role=(?P<role>user|agent|archive) "
     r"provider_revision=(?P<revision>[A-Za-z0-9_.:-]+) "
     r"records_sha256=(?P<digest>[a-f0-9]{64}) -->\r?$"
 )
@@ -77,10 +86,19 @@ def _canonical_records(records: Sequence[Mapping[str, object]]) -> list[dict[str
     canonical: list[dict[str, object]] = []
     seen: set[str] = set()
     for index, value in enumerate(records):
+        native = value.get("schema_version") == TODO_DOMAIN_ITEM_SCHEMA_VERSION
         record = canonical_record_fields(
             value,
-            fields=TODO_CANONICAL_READ_RECORD_FIELDS,
-            required_fields=TODO_CANONICAL_REQUIRED_READ_FIELDS,
+            fields=(
+                TODO_DOMAIN_RECORD_FIELDS
+                if native
+                else TODO_CANONICAL_READ_RECORD_FIELDS
+            ),
+            required_fields=(
+                TODO_DOMAIN_REQUIRED_FIELDS
+                if native
+                else TODO_CANONICAL_REQUIRED_READ_FIELDS
+            ),
             label=f"canonical Todo projection record {index}",
             reject_unknown=True,
         )
@@ -90,11 +108,23 @@ def _canonical_records(records: Sequence[Mapping[str, object]]) -> list[dict[str
         seen.add(todo_id)
         if record.get("role") not in TODO_SECTION_HEADINGS:
             raise TodoSectionProjectionError(f"Todo {todo_id!r} has invalid role")
-        if record.get("archive_state") != "active":
+        if record.get("archive_state") not in {"active", "archive"}:
             raise TodoSectionProjectionError(
-                f"Todo {todo_id!r} is not part of an active Markdown Todo section"
+                f"Todo {todo_id!r} has an unsupported archive state"
             )
-        canonical_todo_read_record(record, reject_unknown=True)
+        canonical_todo_read_record(
+            {
+                **record,
+                "schema_version": TODO_ITEM_SCHEMA_VERSION,
+                "source_section": (
+                    COMPLETED_WORK_ARCHIVE_HEADING
+                    if record.get("archive_state") == "archive"
+                    else TODO_SECTION_HEADINGS[str(record["role"])]
+                ),
+                "index": record.get("index", index + 1),
+            },
+            reject_unknown=True,
+        )
         canonical.append(record)
     return canonical
 
@@ -134,7 +164,11 @@ def _narrative_segments(markdown: str) -> list[str]:
     return parts
 
 
-def _render_record(record: Mapping[str, object]) -> list[str]:
+def _render_record(
+    record: Mapping[str, object],
+    *,
+    include_role: bool = False,
+) -> list[str]:
     status = normalize_todo_status(record.get("status")) or TODO_STATUS_OPEN
     text = " ".join(str(record.get("text") or "").strip().split())
     if not text:
@@ -146,6 +180,8 @@ def _render_record(record: Mapping[str, object]) -> list[str]:
         for field in TODO_METADATA_FIELDS
         if field in record and record[field] is not None
     }
+    if not include_role:
+        metadata_values.pop("role", None)
     metadata = format_todo_metadata_line(**metadata_values)
     return [
         f"- [{todo_marker_for_status(status)}] {text}",
@@ -161,15 +197,20 @@ def _render_section(
     newline: str,
 ) -> tuple[str, str]:
     digest = _sha256_text(_canonical_json(records))
+    heading = (
+        COMPLETED_WORK_ARCHIVE_HEADING
+        if role == "archive"
+        else TODO_SECTION_HEADINGS[role]
+    )
     lines = [
-        f"## {TODO_SECTION_HEADINGS[role]}",
+        f"## {heading}",
         todo_region_marker(role, "begin"),
         f"<!-- loopx:todo-section-projection-v0 role={role} "
         f"provider_revision={provider_revision} records_sha256={digest} -->",
         "",
     ]
     for record in records:
-        lines.extend(_render_record(record))
+        lines.extend(_render_record(record, include_role=role == "archive"))
     lines.append(todo_region_marker(role, "end"))
     lines.append("")
     return newline.join(lines), digest
@@ -198,6 +239,56 @@ def _parsed_active_records(markdown: str) -> list[dict[str, Any]]:
             if isinstance(item, dict) and item.get("archive_state") == "active":
                 records.append(canonical_todo_read_record(item, reject_unknown=False))
     return records
+
+
+def _parsed_archive_records(markdown: str) -> list[dict[str, Any]]:
+    lines = markdown.splitlines()
+    bounds = archive_section_bounds(lines)
+    if bounds is None:
+        return []
+    records: list[dict[str, Any]] = []
+    for item in todo_blocks(
+        lines,
+        bounds[0],
+        bounds[1],
+        source_section=COMPLETED_WORK_ARCHIVE_HEADING,
+    ):
+        if item.get("role") not in TODO_SECTION_HEADINGS:
+            raise TodoSectionProjectionError(
+                f"archived Todo {item.get('todo_id')!r} omits its source role"
+            )
+        records.append(
+            canonical_todo_read_record(
+                {
+                    **item,
+                    "schema_version": TODO_ITEM_SCHEMA_VERSION,
+                    "archive_state": "archive",
+                    "source_section": COMPLETED_WORK_ARCHIVE_HEADING,
+                },
+                reject_unknown=False,
+            )
+        )
+    return records
+
+
+def _projection_record(
+    record: Mapping[str, object],
+    *,
+    display_index: int,
+) -> dict[str, object]:
+    return dict(canonical_todo_read_record(
+        {
+            **record,
+            "schema_version": TODO_ITEM_SCHEMA_VERSION,
+            "source_section": (
+                COMPLETED_WORK_ARCHIVE_HEADING
+                if record.get("archive_state") == "archive"
+                else TODO_SECTION_HEADINGS[str(record["role"])]
+            ),
+            "index": record.get("index", display_index),
+        },
+        reject_unknown=True,
+    ))
 
 
 _DERIVED_READ_MODEL_FIELDS = {
@@ -238,26 +329,26 @@ def render_canonical_todo_sections(
         raise TodoSectionProjectionError(
             "active Markdown omits required Todo sections: " + ", ".join(missing_roles)
         )
-    lossy_fields = sorted(
-        {
-            field
-            for record in canonical
-            for field in _DERIVED_READ_MODEL_FIELDS
-            if field in record and record[field] not in (None, False, "", [], {})
-        }
-    )
-    if lossy_fields:
-        raise TodoSectionProjectionError(
-            "canonical Todo fields are not representable in Markdown: "
-            + ", ".join(lossy_fields)
-        )
     by_role = {
         role: sorted(
-            [record for record in canonical if record.get("role") == role],
+            [
+                record
+                for record in canonical
+                if record.get("role") == role
+                and record.get("archive_state") == "active"
+            ],
             key=_record_sort_key,
         )
         for role in TODO_SECTION_HEADINGS
     }
+    archived = sorted(
+        [record for record in canonical if record.get("archive_state") == "archive"],
+        key=_record_sort_key,
+    )
+    if archived and "archive" not in source_spans:
+        raise TodoSectionProjectionError(
+            "active Markdown omits required Completed Work Archive section"
+        )
     newline = "\r\n" if "\r\n" in markdown else "\n"
     rendered_sections: dict[str, str] = {}
     section_digests: dict[str, str] = {}
@@ -265,6 +356,13 @@ def render_canonical_todo_sections(
         rendered_sections[role], section_digests[role] = _render_section(
             role=role,
             records=by_role[role],
+            provider_revision=provider_revision,
+            newline=newline,
+        )
+    if "archive" in source_spans:
+        rendered_sections["archive"], section_digests["archive"] = _render_section(
+            role="archive",
+            records=archived,
             provider_revision=provider_revision,
             newline=newline,
         )
@@ -278,11 +376,20 @@ def render_canonical_todo_sections(
     if before_narrative != after_narrative:
         raise TodoSectionProjectionError("render changed Markdown outside Todo sections")
 
-    expected = _parity_records(
-        [*by_role["user"], *by_role["agent"]]
-    )
+    expected_records = [
+        _projection_record(record, display_index=index)
+        for records_for_section in (by_role["user"], by_role["agent"], archived)
+        for index, record in enumerate(records_for_section, 1)
+    ]
+    expected = _parity_records(expected_records)
     # Validate the generated payload, independently of unrelated document text.
-    actual = _parity_records(_parsed_active_records("\n".join(rendered_sections.values())))
+    rendered_payload = "\n".join(rendered_sections.values())
+    actual = _parity_records(
+        [
+            *_parsed_active_records(rendered_payload),
+            *_parsed_archive_records(rendered_payload),
+        ]
+    )
     if _canonical_json(actual) != _canonical_json(expected):
         raise TodoSectionProjectionError("Todo section parse/render parity mismatch")
     second = _replace_existing_sections(rendered, rendered_sections=rendered_sections)

--- a/loopx/control_plane/todos/provider_compatibility_edit.py
+++ b/loopx/control_plane/todos/provider_compatibility_edit.py
@@ -21,12 +21,14 @@ from ..effect_runtime import effect_runtime_result
 from .active_state_editing import find_todo_block, set_todo_text
 from .contract import format_todo_metadata_line, metadata_line_for_todo_block
 from .line_update import upsert_todo_metadata
+from .provider_projection import settle_canonical_todo_projection
 
 
 def edit_canonical_todo_if_promoted(
     *, registry_path: Path, runtime_root: Path, goal_id: str, todo_id: str,
     actor_agent_id: str | None, role: str | None, text: str | None,
     note: str | None, dry_run: bool,
+    project: Path | None = None, state_file: Path | None = None,
 ) -> dict[str, Any] | None:
     canonical = read_canonical_todos_if_promoted(runtime_root=runtime_root, goal_id=goal_id)
     if canonical is None:
@@ -74,5 +76,9 @@ def edit_canonical_todo_if_promoted(
             code=str(payload.get("reason_code") or payload.get("conflict_kind")
                      or "compatibility_edit_failed"), payload=payload,
         )
-    return {"ok": True, "goal_id": goal_id, "todo_id": todo_id,
-            "role": todo["role"], "dry_run": dry_run, **result}
+    return settle_canonical_todo_projection(
+        {"ok": True, "goal_id": goal_id, "todo_id": todo_id,
+         "role": todo["role"], "dry_run": dry_run, **result},
+        registry_path=registry_path, runtime_root=runtime_root, goal_id=goal_id,
+        project=project, state_file=state_file,
+    )

--- a/loopx/control_plane/todos/provider_create.py
+++ b/loopx/control_plane/todos/provider_create.py
@@ -19,12 +19,14 @@ from .contract import (
     normalize_todo_task_class,
     todo_done_for_status,
 )
+from .provider_projection import settle_canonical_todo_projection
 
 
 def create_canonical_todo_if_promoted(
     *, registry_path: Path, runtime_root: Path, goal_id: str, role: str,
     text: str, status: str, actor_agent_id: str | None,
     claimed_by: str | None, metadata: dict[str, Any], dry_run: bool,
+    project: Path | None = None, state_file: Path | None = None,
 ) -> dict[str, Any] | None:
     canonical = read_canonical_todos_if_promoted(
         runtime_root=runtime_root, goal_id=goal_id
@@ -80,7 +82,7 @@ def create_canonical_todo_if_promoted(
             code=str(payload.get("reason_code") or payload.get("conflict_kind")
                      or "todo_create_failed"), payload=payload,
         )
-    return {
+    return settle_canonical_todo_projection({
         "ok": True,
         "goal_id": goal_id,
         "role": role,
@@ -90,4 +92,5 @@ def create_canonical_todo_if_promoted(
         "added": result.get("status") not in {"replayed", "no_change"},
         "already_exists": result.get("status") in {"replayed", "no_change"},
         **result,
-    }
+    }, registry_path=registry_path, runtime_root=runtime_root, goal_id=goal_id,
+        project=project, state_file=state_file)

--- a/loopx/control_plane/todos/provider_projection.py
+++ b/loopx/control_plane/todos/provider_projection.py
@@ -1,0 +1,213 @@
+"""Recoverable Markdown delivery for provider-owned Todo state.
+
+The canonical authority journal is the transaction-bound projection outbox:
+each committed mutation already retains the complete canonical head and its
+provider revision.  This adapter drains that durable intent into the legacy
+Markdown compatibility view.  Delivery failure never rolls back or obscures
+the canonical commit; a later mutation or explicit projection can replay the
+current head idempotently.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ...file_lock import exclusive_file_lock
+from ...history import load_registry
+from ...state_refresh import resolve_goal_state
+from ..coordination.local_authority import (
+    LocalCoordinationAuthorityUnavailable,
+    read_canonical_todos_if_promoted,
+)
+from .machine_section_projection import (
+    TodoSectionProjectionError,
+    render_canonical_todo_sections,
+)
+
+
+TODO_PROJECTION_DELIVERY_SCHEMA = "loopx_todo_projection_delivery_v0"
+
+
+def _read_text_exact(path: Path) -> str:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        return handle.read()
+
+
+def _fsync_parent_directory(path: Path) -> None:
+    if os.name != "posix":  # pragma: no cover - Windows has no directory fsync
+        return
+    descriptor = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Durably replace a compatibility projection without changing its mode."""
+
+    original_mode = stat.S_IMODE(path.stat().st_mode)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+    )
+    temporary_path = Path(temporary)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            os.chmod(temporary_path, original_mode)
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        _fsync_parent_directory(path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def project_current_canonical_todos(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    expected_provider_revision: str | None = None,
+    project: Path | None = None,
+    state_file: Path | None = None,
+    execute: bool = True,
+    registry_data: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Render one exact canonical head into machine-owned Markdown regions."""
+
+    registry = dict(registry_data) if registry_data is not None else load_registry(registry_path)
+    goal, resolved_project, state_path = resolve_goal_state(
+        registry=registry,
+        goal_id=goal_id,
+        project_override=project,
+        state_file_override=state_file,
+    )
+    if goal is None:
+        raise ValueError(f"goal {goal_id!r} is not present in the registry")
+    if not state_path.exists():
+        raise ValueError("Todo Markdown projection target does not exist")
+
+    with exclusive_file_lock(state_path, operation="project_canonical_todo_sections"):
+        authority_read = read_canonical_todos_if_promoted(
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+        )
+        if not isinstance(authority_read, dict):
+            raise ValueError(
+                "Todo Markdown projection requires promoted canonical authority"
+            )
+        provider_revision = authority_read.get("provider_revision")
+        if not isinstance(provider_revision, str) or not provider_revision:
+            raise ValueError("canonical Todo authority omitted provider revision")
+        if (
+            expected_provider_revision is not None
+            and provider_revision != expected_provider_revision
+        ):
+            raise ValueError(
+                "Todo Markdown projection provider revision does not match the "
+                "canonical read head"
+            )
+        source = _read_text_exact(state_path)
+        projection = render_canonical_todo_sections(
+            source,
+            authority_read["todos"],
+            provider_revision=provider_revision,
+        )
+        if execute and projection.changed:
+            _atomic_write_text(state_path, projection.markdown)
+            if _read_text_exact(state_path) != projection.markdown:
+                raise RuntimeError("Todo Markdown projection readback mismatch")
+
+    return {
+        "schema_version": TODO_PROJECTION_DELIVERY_SCHEMA,
+        "status": (
+            "delivered" if execute and projection.changed else
+            "current" if execute else
+            "planned"
+        ),
+        "source": "committed_authority_journal",
+        "goal_id": goal_id,
+        "state_file": str(state_path),
+        "project": str(resolved_project) if resolved_project else None,
+        "source_authority": authority_read.get("source_authority"),
+        "provider_revision": projection.provider_revision,
+        "todo_count": projection.todo_count,
+        "changed": projection.changed,
+        "executed": execute,
+        "source_sha256": projection.source_sha256,
+        "rendered_sha256": projection.rendered_sha256,
+        "narrative_sha256": projection.narrative_sha256,
+        "section_record_sha256": projection.section_record_sha256,
+        "parse_render_parity": True,
+        "narrative_preserved": True,
+        "legacy_fallback_used": False,
+    }
+
+
+def settle_canonical_todo_projection(
+    payload: dict[str, Any],
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    project: Path | None = None,
+    state_file: Path | None = None,
+) -> dict[str, Any]:
+    """Drain the committed provider head, preserving a successful mutation."""
+
+    if payload.get("dry_run") is True or payload.get("status") == "planned":
+        payload["projection_delivery"] = "not_required"
+        payload["projection_outbox"] = {
+            "schema_version": TODO_PROJECTION_DELIVERY_SCHEMA,
+            "status": "not_required",
+            "source": "committed_authority_journal",
+        }
+        return payload
+    trigger_revision = payload.get("provider_revision")
+    trigger_cursor = payload.get("cursor")
+    try:
+        delivery = project_current_canonical_todos(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            project=project,
+            state_file=state_file,
+            execute=True,
+        )
+    except Exception as error:  # noqa: BLE001 - canonical commit already landed
+        if isinstance(error, LocalCoordinationAuthorityUnavailable):
+            reason_code = "todo_projection_authority_unavailable"
+        elif isinstance(error, TodoSectionProjectionError):
+            reason_code = "todo_projection_render_rejected"
+        elif isinstance(error, OSError):
+            reason_code = "todo_projection_write_unavailable"
+        else:
+            reason_code = "todo_projection_target_unavailable"
+        delivery = {
+            "schema_version": TODO_PROJECTION_DELIVERY_SCHEMA,
+            "status": "pending",
+            "source": "committed_authority_journal",
+            "reason_code": reason_code,
+            "error_class": error.__class__.__name__,
+            "retryable": True,
+        }
+    if isinstance(trigger_revision, str) and trigger_revision:
+        delivery["trigger_provider_revision"] = trigger_revision
+    if isinstance(trigger_cursor, str) and trigger_cursor:
+        delivery["trigger_cursor"] = trigger_cursor
+    payload["projection_delivery"] = delivery["status"]
+    payload["projection_outbox"] = delivery
+    return payload
+
+
+__all__ = [
+    "TODO_PROJECTION_DELIVERY_SCHEMA",
+    "project_current_canonical_todos",
+    "settle_canonical_todo_projection",
+]

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -890,6 +890,8 @@ def add_goal_todo(
             "note": note,
             "updated_at": updated_at,
         },
+        project=project,
+        state_file=state_file,
         dry_run=dry_run,
     )
     if canonical_create is not None:
@@ -1158,6 +1160,8 @@ def update_goal_todo(
             operation_id=claim_operation_id,
             task_lease_idempotency_key=task_lease_idempotency_key,
             task_lease_expected_version=task_lease_expected_version,
+            project=project,
+            state_file=state_file,
         )
         if canonical_claim is not None:
             return canonical_claim
@@ -1179,6 +1183,7 @@ def update_goal_todo(
             registry_path=registry_path, runtime_root=shadow_runtime_root,
             goal_id=goal_id, todo_id=normalize_todo_id(todo_id) or todo_id,
             actor_agent_id=agent_id, role=role, text=text, note=note, dry_run=dry_run,
+            project=project, state_file=state_file,
         )
         if canonical_edit is not None:
             return canonical_edit

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -17,8 +17,13 @@ from loopx.control_plane.coordination.local_authority import (
 from loopx.control_plane.coordination.runtime_shadow import (
     build_todo_runtime_shadow_projection,
 )
+from loopx.control_plane.coordination.coordination_state_contract import (
+    TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION,
+    TODO_DOMAIN_RECORD_FIELDS,
+)
 from loopx.control_plane.effect_runtime import effect_runtime_result
 from loopx.control_plane.todos.active_state_editing import TODO_SECTION_HEADINGS
+from loopx.control_plane.todos import provider_projection
 from loopx.control_plane.coordination.legacy_writer_fence import (
     legacy_coordination_writer_fence_path,
 )
@@ -315,6 +320,98 @@ def test_promoted_add_delegates_semantic_duplicate_to_typescript(
     assert result["already_exists"] is True
     assert result["todo_id"] == "todo_existing"
     assert calls[0][0] == "coordination.local_authority.todo_create"
+
+
+def test_promoted_native_create_recovers_markdown_after_delivery_crash(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    state_file = project / ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    source = """# Goal
+
+Human context.
+
+## User Todo / Owner Review Reading Queue
+
+## Agent Todo
+
+## Completed Work Archive
+
+## Next Action
+
+Continue.
+"""
+    state_file.write_text(source, encoding="utf-8")
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(json.dumps({
+        "schema_version": 1,
+        "common_runtime_root": str(runtime_root),
+        "goals": [{
+            "id": "goal-a", "status": "active", "repo": str(project),
+            "state_file": ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md",
+            "coordination": {"registered_agents": ["agent-a", "agent-b"]},
+        }],
+    }), encoding="utf-8")
+    projection = build_todo_runtime_shadow_projection(goal_id="goal-a", todos=[])
+    projection["todo_read_model"] = {
+        **projection["todo_read_model"],
+        "schema_version": TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION,
+        "contract_fields": list(TODO_DOMAIN_RECORD_FIELDS),
+    }
+    _promote_local_projection(
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+        projection=projection,
+        operation_suffix="native-projection-recovery",
+    )
+
+    real_write = provider_projection._atomic_write_text
+
+    def crash(*_args: object, **_kwargs: object) -> None:
+        raise OSError("injected projection crash")
+
+    monkeypatch.setattr(provider_projection, "_atomic_write_text", crash)
+    applied = add_goal_todo(
+        registry_path=registry_path,
+        goal_id="goal-a",
+        role="agent",
+        text="Recover the native compatibility projection",
+        task_class="advancement_task",
+        action_kind="implement",
+        claimed_by="agent-a",
+        agent_id="agent-a",
+    )
+
+    assert applied["status"] == "applied"
+    assert applied["projection_delivery"] == "pending"
+    canonical = read_canonical_todos_if_promoted(
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+    )
+    assert canonical is not None
+    assert canonical["todos"][0]["schema_version"] == "todo_domain_record_v0"
+    assert state_file.read_text(encoding="utf-8") == source
+
+    monkeypatch.setattr(provider_projection, "_atomic_write_text", real_write)
+    replay = add_goal_todo(
+        registry_path=registry_path,
+        goal_id="goal-a",
+        role="agent",
+        text="Recover the native compatibility projection",
+        task_class="advancement_task",
+        action_kind="implement",
+        claimed_by="agent-a",
+        agent_id="agent-a",
+    )
+    assert replay["status"] == "no_change"
+    assert replay["projection_delivery"] == "delivered"
+    rendered = state_file.read_text(encoding="utf-8")
+    assert "Recover the native compatibility projection" in rendered
+    assert "Human context." in rendered
+    assert "Continue." in rendered
 
 
 def test_engaged_fence_never_falls_back_when_provider_is_missing(

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -17,6 +17,7 @@ from loopx.control_plane.todos.machine_section_projection import (
 )
 from loopx.cli import build_parser
 from loopx.cli_commands import todo as todo_command
+from loopx.control_plane.todos import provider_projection
 from loopx.control_plane.coordination.local_authority import read_canonical_todos_if_promoted
 from loopx.control_plane.coordination.runtime_shadow import build_todo_runtime_shadow_projection
 from loopx.control_plane.effect_runtime import effect_runtime_result
@@ -131,18 +132,26 @@ def test_projection_rejects_missing_role_section() -> None:
         )
 
 
-def test_projection_does_not_invent_native_markdown_provenance() -> None:
+def test_projection_assigns_display_only_provenance_to_native_records() -> None:
     records = _records()
     for record in records:
         record["schema_version"] = "todo_domain_record_v0"
         del record["source_section"]
         del record["index"]
-    with pytest.raises(ValueError, match="omits required fields: source_section"):
-        render_canonical_todo_sections(SOURCE, records, provider_revision="rev-native")
+    projected = render_canonical_todo_sections(
+        SOURCE,
+        records,
+        provider_revision="rev-native",
+    )
+    assert projected.changed is True
+    assert projected.todo_count == 2
+    assert {item["revision"] for item in inspect_todo_section_projection(
+        projected.markdown
+    )["sections"]} == {"rev-native"}
     assert all("source_section" not in record and "index" not in record for record in records)
 
 
-def test_projection_rejects_unknown_or_derived_field_loss() -> None:
+def test_projection_rejects_unknown_fields_but_allows_known_read_model_fields() -> None:
     unknown = deepcopy(_records())
     unknown[0]["future_field"] = "must-not-disappear"
     with pytest.raises(ValueError, match="unversioned fields: future_field"):
@@ -150,8 +159,76 @@ def test_projection_rejects_unknown_or_derived_field_loss() -> None:
 
     derived = deepcopy(_records())
     derived[0]["resume_ready"] = True
-    with pytest.raises(TodoSectionProjectionError, match="resume_ready"):
-        render_canonical_todo_sections(SOURCE, derived, provider_revision="rev-1")
+    projected = render_canonical_todo_sections(
+        SOURCE,
+        derived,
+        provider_revision="rev-1",
+    )
+    assert projected.changed is True
+    assert "resume_ready" not in projected.markdown
+
+
+def test_projection_renders_native_archive_with_role_and_replays() -> None:
+    source = SOURCE + "\n## Completed Work Archive\n\n- [x] stale archive\n"
+    records = _records()
+    for record in records:
+        record["schema_version"] = "todo_domain_record_v0"
+        record.pop("source_section")
+        record.pop("index")
+    records.append(
+        {
+            "schema_version": "todo_domain_record_v0",
+            "todo_id": "todo_archived",
+            "role": "agent",
+            "status": "done",
+            "done": True,
+            "text": "Completed provider-owned work.",
+            "archive_state": "archive",
+            "task_class": "advancement_task",
+            "created_by": "codex-worker",
+            "last_actor_agent_id": "codex-worker",
+        }
+    )
+
+    projected = render_canonical_todo_sections(
+        source,
+        records,
+        provider_revision="rev-archive",
+    )
+
+    assert "stale archive" not in projected.markdown
+    assert "Completed provider-owned work." in projected.markdown
+    assert "role=agent" in projected.markdown
+    markers = inspect_todo_section_projection(projected.markdown)
+    assert {item["role"] for item in markers["sections"]} == {
+        "user",
+        "agent",
+        "archive",
+    }
+    replay = render_canonical_todo_sections(
+        projected.markdown,
+        records,
+        provider_revision="rev-archive",
+    )
+    assert replay.changed is False
+
+
+def test_projection_requires_archive_region_for_archived_records() -> None:
+    archived = {
+        "schema_version": "todo_domain_record_v0",
+        "todo_id": "todo_archived",
+        "role": "agent",
+        "status": "done",
+        "done": True,
+        "text": "Completed provider-owned work.",
+        "archive_state": "archive",
+    }
+    with pytest.raises(TodoSectionProjectionError, match="Completed Work Archive"):
+        render_canonical_todo_sections(
+            SOURCE,
+            [archived],
+            provider_revision="rev-archive",
+        )
 
 
 def test_projection_rejects_duplicate_sections_and_unsafe_revision() -> None:
@@ -180,14 +257,14 @@ def test_project_markdown_cli_requires_promoted_exact_revision(
             lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
         )
         monkeypatch.setattr(
-            todo_command,
+            provider_projection,
             "read_canonical_todos_if_promoted",
             lambda **_kwargs: payload,
         )
         monkeypatch.setattr(
-            todo_command,
-            "resolve_todo_state_path",
-            lambda **_kwargs: (tmp_path, state_path),
+            provider_projection,
+            "resolve_goal_state",
+            lambda **_kwargs: (object(), tmp_path, state_path),
         )
         result = todo_command.handle_todo_command(
             parser.parse_args(
@@ -252,7 +329,7 @@ def test_project_markdown_cli_uses_raw_provider_records(
         lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
     )
     monkeypatch.setattr(
-        todo_command,
+        provider_projection,
         "read_canonical_todos_if_promoted",
         lambda **_kwargs: {
             "todos": raw_records,
@@ -266,9 +343,9 @@ def test_project_markdown_cli_uses_raw_provider_records(
         lambda **_kwargs: pytest.fail("projection must not consume the enriched list view"),
     )
     monkeypatch.setattr(
-        todo_command,
-        "resolve_todo_state_path",
-        lambda **_kwargs: (tmp_path, state_path),
+        provider_projection,
+        "resolve_goal_state",
+        lambda **_kwargs: (object(), tmp_path, state_path),
     )
     captured: dict[str, object] = {}
 
@@ -303,7 +380,7 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     original_mode = stat.S_IMODE(state_path.stat().st_mode)
     parent_syncs: list[object] = []
     monkeypatch.setattr(
-        todo_command,
+        provider_projection,
         "_fsync_parent_directory",
         lambda path: parent_syncs.append(path),
     )
@@ -313,7 +390,7 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
         lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
     )
     monkeypatch.setattr(
-        todo_command,
+        provider_projection,
         "read_canonical_todos_if_promoted",
         lambda **_kwargs: {
             "todos": _records(),
@@ -322,18 +399,18 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
         },
     )
     monkeypatch.setattr(
-        todo_command,
-        "resolve_todo_state_path",
-        lambda **_kwargs: (tmp_path, state_path),
+        provider_projection,
+        "resolve_goal_state",
+        lambda **_kwargs: (object(), tmp_path, state_path),
     )
     replacements: list[tuple[object, object]] = []
-    real_replace = todo_command.os.replace
+    real_replace = provider_projection.os.replace
 
     def record_replace(source, target) -> None:
         replacements.append((source, target))
         real_replace(source, target)
 
-    monkeypatch.setattr(todo_command.os, "replace", record_replace)
+    monkeypatch.setattr(provider_projection.os, "replace", record_replace)
 
     result = todo_command.handle_todo_command(
         build_parser().parse_args(
@@ -368,7 +445,7 @@ def test_atomic_projection_failure_preserves_original(monkeypatch, tmp_path, ope
     state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
     state_path.write_bytes(b"original\r\n")
     opened = []
-    real_fdopen = todo_command.os.fdopen
+    real_fdopen = provider_projection.os.fdopen
 
     def capture_handle(*args, **kwargs):
         handle = real_fdopen(*args, **kwargs)
@@ -378,10 +455,10 @@ def test_atomic_projection_failure_preserves_original(monkeypatch, tmp_path, ope
     def fail(*_args, **_kwargs):
         raise OSError("injected pre-publication failure")
 
-    monkeypatch.setattr(todo_command.os, "fdopen", capture_handle)
-    monkeypatch.setattr(todo_command.os, operation, fail)
+    monkeypatch.setattr(provider_projection.os, "fdopen", capture_handle)
+    monkeypatch.setattr(provider_projection.os, operation, fail)
     with pytest.raises(OSError, match="injected pre-publication failure"):
-        todo_command._atomic_write_text(state_path, "replacement\n")
+        provider_projection._atomic_write_text(state_path, "replacement\n")
     assert state_path.read_bytes() == b"original\r\n"
     assert opened and all(handle.closed for handle in opened)
     assert list(tmp_path.iterdir()) == [state_path]
@@ -408,7 +485,7 @@ def test_project_markdown_cli_preserves_narrative_boundaries(
         lambda _path: {"common_runtime_root": str(tmp_path / "runtime")},
     )
     monkeypatch.setattr(
-        todo_command,
+        provider_projection,
         "read_canonical_todos_if_promoted",
         lambda **_kwargs: {
             "todos": _records(),
@@ -417,9 +494,9 @@ def test_project_markdown_cli_preserves_narrative_boundaries(
         },
     )
     monkeypatch.setattr(
-        todo_command,
-        "resolve_todo_state_path",
-        lambda **_kwargs: (tmp_path, state_path),
+        provider_projection,
+        "resolve_goal_state",
+        lambda **_kwargs: (object(), tmp_path, state_path),
     )
 
     captured: dict[str, object] = {}

--- a/tests/control_plane/test_todo_provider_projection.py
+++ b/tests/control_plane/test_todo_provider_projection.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.todos import provider_projection
+
+
+SOURCE = """# Goal
+
+Human-owned introduction.
+
+## User Todo / Owner Review Reading Queue
+
+## Agent Todo
+
+## Completed Work Archive
+
+## Next Action
+
+Keep working.
+"""
+
+
+def _registry(tmp_path: Path) -> tuple[Path, Path, Path]:
+    runtime_root = tmp_path / "runtime"
+    project = tmp_path / "project"
+    state_file = project / ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(SOURCE, encoding="utf-8")
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({
+        "schema_version": 1,
+        "common_runtime_root": str(runtime_root),
+        "goals": [{
+            "id": "goal-a", "status": "active", "repo": str(project),
+            "state_file": ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md",
+        }],
+    }), encoding="utf-8")
+    return registry, runtime_root, state_file
+
+
+def _authority_read() -> dict[str, object]:
+    return {
+        "status": "loaded",
+        "source_authority": "file_v0",
+        "provider_revision": "file:7:abc",
+        "todos": [
+            {
+                "schema_version": "todo_domain_record_v0",
+                "todo_id": "todo_active",
+                "role": "agent",
+                "status": "open",
+                "done": False,
+                "text": "Render native provider work.",
+                "archive_state": "active",
+                "task_class": "advancement_task",
+            },
+            {
+                "schema_version": "todo_domain_record_v0",
+                "todo_id": "todo_archive",
+                "role": "user",
+                "status": "done",
+                "done": True,
+                "text": "Preserve archived source ownership.",
+                "archive_state": "archive",
+                "task_class": "user_action",
+            },
+        ],
+    }
+
+
+def test_project_current_canonical_todos_is_durable_and_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry, runtime_root, state_file = _registry(tmp_path)
+    monkeypatch.setattr(
+        provider_projection,
+        "read_canonical_todos_if_promoted",
+        lambda **_kwargs: _authority_read(),
+    )
+
+    delivered = provider_projection.project_current_canonical_todos(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+    )
+    rendered = state_file.read_text(encoding="utf-8")
+
+    assert delivered["status"] == "delivered"
+    assert delivered["source"] == "committed_authority_journal"
+    assert "Render native provider work." in rendered
+    assert "Preserve archived source ownership." in rendered
+    assert "role=user" in rendered
+    assert "Human-owned introduction." in rendered
+    assert "Keep working." in rendered
+
+    replay = provider_projection.project_current_canonical_todos(
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+    )
+    assert replay["status"] == "current"
+    assert replay["changed"] is False
+    assert state_file.read_text(encoding="utf-8") == rendered
+
+
+def test_settlement_preserves_commit_and_replays_after_projection_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry, runtime_root, state_file = _registry(tmp_path)
+    monkeypatch.setattr(
+        provider_projection,
+        "read_canonical_todos_if_promoted",
+        lambda **_kwargs: _authority_read(),
+    )
+    real_write = provider_projection._atomic_write_text
+    monkeypatch.setattr(
+        provider_projection,
+        "_atomic_write_text",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("crash")),
+    )
+
+    committed = provider_projection.settle_canonical_todo_projection(
+        {"status": "applied", "changed": True},
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+    )
+
+    assert committed["status"] == "applied"
+    assert committed["changed"] is True
+    assert committed["projection_delivery"] == "pending"
+    assert committed["projection_outbox"] == {
+        "schema_version": "loopx_todo_projection_delivery_v0",
+        "status": "pending",
+        "source": "committed_authority_journal",
+        "reason_code": "todo_projection_write_unavailable",
+        "error_class": "OSError",
+        "retryable": True,
+    }
+    assert state_file.read_text(encoding="utf-8") == SOURCE
+
+    monkeypatch.setattr(provider_projection, "_atomic_write_text", real_write)
+    replay = provider_projection.settle_canonical_todo_projection(
+        {"status": "replayed", "changed": False},
+        registry_path=registry,
+        runtime_root=runtime_root,
+        goal_id="goal-a",
+    )
+    assert replay["projection_delivery"] == "delivered"
+    assert "Render native provider work." in state_file.read_text(encoding="utf-8")
+
+
+def test_explicit_projection_fences_requested_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    registry, runtime_root, state_file = _registry(tmp_path)
+    monkeypatch.setattr(
+        provider_projection,
+        "read_canonical_todos_if_promoted",
+        lambda **_kwargs: _authority_read(),
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        provider_projection.project_current_canonical_todos(
+            registry_path=registry,
+            runtime_root=runtime_root,
+            goal_id="goal-a",
+            expected_provider_revision="file:6:stale",
+        )
+
+    assert state_file.read_text(encoding="utf-8") == SOURCE

--- a/tests/control_plane_ts/authority_store_conformance.ts
+++ b/tests/control_plane_ts/authority_store_conformance.ts
@@ -270,7 +270,11 @@ export function registerAuthorityStoreConformance(
       const replayRequest = first.status === "applied" ? request : {...request,
         operation_id: "create-todo-contender", todo: {...todo, text: "Competing create"}};
       assert.equal(applied.todo_id, todo.todo_id);
-      assert.equal((await executeCoordinationTodoCreate(store, replayRequest)).status, "replayed");
+      assert.equal(applied.projection_delivery, "pending");
+      assert.equal(applied.projection_source, "committed_authority_journal");
+      const replayedCreate = await executeCoordinationTodoCreate(store, replayRequest);
+      assert.equal(replayedCreate.status, "replayed");
+      assert.equal(replayedCreate.projection_delivery, "pending");
       assert.equal((await executeCoordinationTodoCreate(store, {...replayRequest,
         todo: {...replayRequest.todo, note: "different intent"}})).status, "failed");
       assert.equal((await executeCoordinationTodoCreate(store, {...replayRequest,
@@ -741,6 +745,8 @@ export function registerAuthorityStoreConformance(
       };
       const claimed = await executeCoordinationTodoClaim(store, request);
       assert.equal(claimed.status, "applied", JSON.stringify(claimed));
+      assert.equal(claimed.projection_delivery, "pending");
+      assert.equal(claimed.projection_source, "committed_authority_journal");
 
       const loaded = await store.loadAuthority();
       assert.equal(loaded.status, "loaded");


### PR DESCRIPTION
## Summary

- reuse the committed authority journal as the durable outbox for the Markdown Todo compatibility projection
- render native active and archived Todo records idempotently while preserving human-authored narrative
- report typed pending delivery after commit-before-render failures and repair the projection on replay
- keep explicit `todo project-markdown` and provider-first create, claim, and narrow update on one projection owner
- update the shared-authority RFC and structured-projection protocol in English and Chinese

## Validation

- focused Python projection/authority suites: 83 passed
- `npm run test:control-plane`: 641 passed, 1 environment-gated PostgreSQL row skipped, 0 failed
- isolated PostgreSQL 16 integration: 30 passed, 0 skipped
- TypeScript control-plane typecheck: passed
- scoped mypy and Ruff: passed
- `loopx check` public/private scan: 0 errors
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 selected checks passed, 0 manual holds
- exact-scope change-quality receipt: `cqr_cd5fbd7e36a515005b2d`

## Scope and hold

This is the first provider-first projection-recovery slice: create, claim, and narrow compatibility update are covered. Native completion/supersede/archive routing and projection backlog inspection remain follow-up work. The adjacent future-facing pass consolidated one projection owner and strengthened typed result fields; it deliberately did not add a second state machine or speculative provider abstraction. Runtime behavior is held for independent review; no self-merge.