### PR TITLE
fix(periodic-report): diagnose invalid goal overrides

### DIFF
--- a/loopx/capabilities/periodic_report/README.md
+++ b/loopx/capabilities/periodic_report/README.md
@@ -113,6 +113,11 @@ validated stage boundaries. The selected extension, runtime capability,
 configured route, sender identity, and exact readback must still pass their
 own fail-closed gates.
 
+An explicit Goal override is authoritative and must be complete; LoopX never
+fills its missing fields from machine defaults. `plan-goal-delivery` reports an
+invalid override with a typed field list, its configuration source, and the
+choice to complete or clear the override. This diagnostic path is read-only.
+
 The capability is intentionally effect-free. It first evaluates scheduled or
 material progress facts into a deterministic trigger receipt, then composes a
 run with stable run and sink idempotency, typed source snapshots, artifact and

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -6,7 +6,7 @@ import os
 import sys
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from ...extensions.runtime import (
     execute_extension_runtime_binding,
@@ -46,10 +46,16 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
-ProviderCommandRegistrar = Callable[
-    [argparse._SubParsersAction, AddFormat],
-    None,
-]
+
+
+class ProviderCommandRegistrar(Protocol):
+    def __call__(
+        self,
+        subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+        add_subcommand_format: AddFormat,
+    ) -> None: ...
+
+
 ProviderCommandHandler = Callable[..., int | None]
 
 
@@ -310,6 +316,31 @@ def _archive_openviking(
 
 def render_periodic_report_markdown(payload: dict[str, object]) -> str:
     if not payload.get("ok"):
+        if payload.get("schema_version") == SUBSCRIPTION_ERROR_SCHEMA:
+            invalid_fields = payload.get("invalid_fields")
+            normalized_invalid_fields = (
+                [str(field) for field in invalid_fields]
+                if isinstance(invalid_fields, list)
+                else []
+            )
+            rendered_invalid_fields = ", ".join(
+                f"`{field}`" for field in normalized_invalid_fields
+            )
+            return "\n".join(
+                [
+                    "# Periodic Report Configuration Error",
+                    "",
+                    f"- error: {payload.get('error')}",
+                    f"- configuration_source: `{payload.get('configuration_source')}`",
+                    f"- invalid_fields: {rendered_invalid_fields}",
+                    f"- mutation_performed: `{payload.get('mutation_performed')}`",
+                    "",
+                    "## Remediation",
+                    "",
+                    str(payload.get("remediation") or ""),
+                    "",
+                ]
+            )
         return f"# Periodic Report Error\n\n- error: {payload.get('error')}\n"
     if payload.get("schema_version") == "periodic_report_activation_v0":
         profile = payload.get("profile")

--- a/loopx/capabilities/periodic_report/cli.py
+++ b/loopx/capabilities/periodic_report/cli.py
@@ -14,6 +14,8 @@ from ...extensions.runtime import (
 from ...rollout_event_log import iter_rollout_events
 from .core import build_periodic_report_run
 from .machine_defaults import (
+    SUBSCRIPTION_ERROR_SCHEMA,
+    PeriodicReportSubscriptionConfigurationError,
     build_goal_periodic_report_delivery_plan,
 )
 from .machine_store import (
@@ -542,6 +544,19 @@ def handle_periodic_report_command(
         else:
             request = _load_json_object(args.request_json)
             payload = build_periodic_report_run(request)
+    except PeriodicReportSubscriptionConfigurationError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": SUBSCRIPTION_ERROR_SCHEMA,
+            "command": args.periodic_report_command,
+            "error_kind": "subscription_configuration_invalid",
+            "goal_id": exc.goal_id,
+            "configuration_source": exc.configuration_source,
+            "invalid_fields": list(exc.invalid_fields),
+            "error": str(exc),
+            "remediation": exc.remediation,
+            "mutation_performed": False,
+        }
     except Exception as exc:
         payload = {
             "ok": False,

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -26,9 +26,31 @@ DELIVERY_IDENTITY_SCHEMA = "periodic_report_goal_delivery_identity_v0"
 DELIVERY_AUTHORITY_SCHEMA = "periodic_report_delivery_authority_v0"
 DELIVERY_PLAN_REQUEST_SCHEMA = "periodic_report_goal_delivery_plan_request_v0"
 DELIVERY_PLAN_SCHEMA = "periodic_report_goal_delivery_plan_v0"
+SUBSCRIPTION_ERROR_SCHEMA = "periodic_report_subscription_error_v0"
 
 _INHERITANCE_MODE = "live_machine_default"
 _REVISION_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class PeriodicReportSubscriptionConfigurationError(ValueError):
+    """Expose bounded diagnosis for one invalid effective Goal subscription."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        goal_id: str,
+        configuration_source: str,
+        invalid_fields: tuple[str, ...],
+    ) -> None:
+        super().__init__(message)
+        self.goal_id = goal_id
+        self.configuration_source = configuration_source
+        self.invalid_fields = invalid_fields
+        self.remediation = (
+            "Provide a complete explicit periodic_report override, or clear the "
+            "override to restore live machine-default inheritance."
+        )
 
 
 def _mapping(value: object, label: str) -> dict[str, Any]:
@@ -259,6 +281,29 @@ def _normalized_goal_subscription(
     return subscription
 
 
+def _invalid_goal_subscription_fields(config: Mapping[str, Any]) -> tuple[str, ...]:
+    """Identify invalid typed fields without interpreting exception prose."""
+
+    invalid: list[str] = []
+    enabled = config.get("enabled")
+    if not isinstance(enabled, bool):
+        invalid.append("enabled")
+    try:
+        timezone_name = _text(
+            config.get("timezone", "UTC"), "goal periodic_report.timezone"
+        )
+        ZoneInfo(timezone_name)
+    except (TypeError, ValueError, ZoneInfoNotFoundError):
+        invalid.append("timezone")
+    if enabled is True:
+        for field in ("profile_preset", "route_ref"):
+            try:
+                _text(config.get(field), f"goal periodic_report.{field}")
+            except (TypeError, ValueError):
+                invalid.append(field)
+    return tuple(invalid or ["configuration"])
+
+
 def resolve_goal_periodic_report_subscription(
     goal: Mapping[str, Any],
     machine_defaults: Mapping[str, Any] | None = None,
@@ -285,12 +330,25 @@ def resolve_goal_periodic_report_subscription(
     configuration = resolution["configuration"]
     if not isinstance(configuration, Mapping):  # pragma: no cover - kernel contract
         raise TypeError("resolved periodic report configuration must be an object")
-    return _normalized_goal_subscription(
-        goal_id=goal_id,
-        config=configuration,
-        source=("not_configured" if source == "capability_default" else source),
-        source_revision=(source_revision if source == "machine_default" else None),
+    normalized_source = (
+        "not_configured" if source == "capability_default" else source
     )
+    try:
+        return _normalized_goal_subscription(
+            goal_id=goal_id,
+            config=configuration,
+            source=normalized_source,
+            source_revision=(source_revision if source == "machine_default" else None),
+        )
+    except (TypeError, ValueError) as exc:
+        if source != "goal_override":
+            raise
+        raise PeriodicReportSubscriptionConfigurationError(
+            str(exc),
+            goal_id=goal_id,
+            configuration_source=source,
+            invalid_fields=_invalid_goal_subscription_fields(configuration),
+        ) from exc
 
 
 def normalize_periodic_report_delivery_authority(raw: object) -> dict[str, Any]:
@@ -491,6 +549,8 @@ __all__ = [
     "GOAL_SUBSCRIPTION_SCHEMA",
     "MACHINE_DEFAULTS_SCHEMA",
     "PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA",
+    "SUBSCRIPTION_ERROR_SCHEMA",
+    "PeriodicReportSubscriptionConfigurationError",
     "build_goal_periodic_report_delivery_identity",
     "build_periodic_report_delivery_authority",
     "build_goal_periodic_report_delivery_plan",

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -12,6 +12,7 @@ from loopx.capabilities.machine_configuration.store import (
     configure_machine_configuration,
 )
 from loopx.capabilities.periodic_report.machine_defaults import (
+    PeriodicReportSubscriptionConfigurationError,
     build_goal_periodic_report_delivery_identity,
     build_goal_periodic_report_delivery_plan,
     normalize_loopx_machine_defaults,
@@ -116,9 +117,21 @@ def test_goal_override_beats_machine_default() -> None:
 def test_runtime_goal_subscription_does_not_fall_back_to_machine_defaults() -> None:
     goal = _goal("research")
     goal["control_plane"] = {"periodic_report": {"enabled": True}}
+    original_goal = json.loads(json.dumps(goal))
+    defaults = _defaults()
+    original_defaults = json.loads(json.dumps(defaults))
 
-    with pytest.raises(ValueError, match="profile_preset"):
-        resolve_goal_periodic_report_subscription(goal, _defaults())
+    with pytest.raises(
+        PeriodicReportSubscriptionConfigurationError,
+        match="profile_preset",
+    ) as caught:
+        resolve_goal_periodic_report_subscription(goal, defaults)
+
+    assert caught.value.goal_id == "research"
+    assert caught.value.configuration_source == "goal_override"
+    assert caught.value.invalid_fields == ("profile_preset", "route_ref")
+    assert goal == original_goal
+    assert defaults == original_defaults
 
 
 def test_unconfigured_goal_is_not_subscribed_at_runtime() -> None:
@@ -488,3 +501,79 @@ def test_goal_delivery_plan_cli_fails_closed_on_invalid_machine_store(
     assert payload["ok"] is False
     assert payload["command"] == "plan-goal-delivery"
     assert "route_ref is required" in payload["error"]
+
+
+def test_goal_delivery_plan_cli_diagnoses_incomplete_explicit_override_read_only(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text('{"goals": []}', encoding="utf-8")
+    runtime_root = tmp_path / "runtime"
+    _apply_defaults(runtime_root, _defaults())
+    request_path = tmp_path / "request.json"
+    goal = _goal("research")
+    goal["control_plane"] = {
+        "periodic_report": {
+            "enabled": True,
+            "profile_preset": "weekly-progress",
+        }
+    }
+    request_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "periodic_report_goal_delivery_plan_request_v0",
+                "goal": goal,
+                "period_window": {
+                    "start_at": "2026-08-24T00:00:00+08:00",
+                    "end_at": "2026-08-31T00:00:00+08:00",
+                },
+                "reporting_agent_id": "agent-b",
+                "eligible_agent_ids": ["agent-b"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store_path = runtime_root / "machine" / "configuration.json"
+    before = {
+        "registry": registry_path.read_bytes(),
+        "request": request_path.read_bytes(),
+        "machine_configuration": store_path.read_bytes(),
+    }
+
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "periodic-report",
+                "plan-goal-delivery",
+                "--request-json",
+                str(request_path),
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == {
+        "ok": False,
+        "schema_version": "periodic_report_subscription_error_v0",
+        "command": "plan-goal-delivery",
+        "error_kind": "subscription_configuration_invalid",
+        "goal_id": "research",
+        "configuration_source": "goal_override",
+        "invalid_fields": ["route_ref"],
+        "error": "goal periodic_report.route_ref is required",
+        "remediation": (
+            "Provide a complete explicit periodic_report override, or clear the "
+            "override to restore live machine-default inheritance."
+        ),
+        "mutation_performed": False,
+    }
+    assert registry_path.read_bytes() == before["registry"]
+    assert request_path.read_bytes() == before["request"]
+    assert store_path.read_bytes() == before["machine_configuration"]

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -574,6 +574,33 @@ def test_goal_delivery_plan_cli_diagnoses_incomplete_explicit_override_read_only
         ),
         "mutation_performed": False,
     }
+    assert (
+        main(
+            [
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "markdown",
+                "periodic-report",
+                "plan-goal-delivery",
+                "--request-json",
+                str(request_path),
+            ]
+        )
+        == 1
+    )
+    assert capsys.readouterr().out == (
+        "# Periodic Report Configuration Error\n\n"
+        "- error: goal periodic_report.route_ref is required\n"
+        "- configuration_source: `goal_override`\n"
+        "- invalid_fields: `route_ref`\n"
+        "- mutation_performed: `False`\n\n"
+        "## Remediation\n\n"
+        "Provide a complete explicit periodic_report override, or clear the "
+        "override to restore live machine-default inheritance.\n\n"
+    )
     assert registry_path.read_bytes() == before["registry"]
     assert request_path.read_bytes() == before["request"]
     assert store_path.read_bytes() == before["machine_configuration"]


### PR DESCRIPTION
## Summary

- preserve explicit Goal overrides as authoritative and fail closed when incomplete
- return a typed, field-level recovery diagnostic from `plan-goal-delivery`
- prove the diagnostic path does not mutate the request, registry, or machine configuration

## Validation

- 204 periodic-report capability tests passed
- Ruff passed on changed Python files
- configured mypy scope passed
- public/private boundary scan passed
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 14/14 passed
- change-quality receipt: `cqr_11e15def6e8675953208`

## Review

Independent review requested; this PR is not self-merged.