### PR TITLE
docs: align current status with LoopX 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,16 +718,16 @@ traces, credentials, private logs, or operator artifacts.
 
 ## Current Status
 
-The v0.4.x line is a usable local control plane for long-running agent work and
-is entering broader adoption. It is not a full agent platform, an agent runtime,
-or an autonomous production controller.
+LoopX 1.0 is a usable local control plane for long-running agent work and is
+entering broader adoption. It is not a full agent platform, an agent runtime, or
+an autonomous production controller.
 
 Today LoopX ships a durable state kernel for goals, typed todos and decision
 scopes, peer claims and leases, evidence and writeback, quota-aware scheduling,
 and cross-turn continuation. Guided start, recurring heartbeat, isolated Codex
 CLI turns, evidence-backed Issue-Fix admission, optional Explore and auto
-research paths, public validation canaries, and a read-first multi-project
-dashboard build on that shared control state.
+research paths, public validation canaries, and the multi-project Personal
+Workspace all build on that shared control state.
 
 Support levels remain explicit. The state and CLI contracts are the stable
 center; several host integrations and advanced paths are optional, default-off,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -644,14 +644,14 @@ raw benchmark task/log/trajectory/verifier output、credentials、token、私有
 
 ## 当前状态
 
-`0.4.x` 已经是一套可用的长程 Agent 本地控制面，正在进入更广泛的采用阶段。
+LoopX 1.0 已经是一套可用的长程 Agent 本地控制面，正在进入更广泛的采用阶段。
 LoopX 不是完整 agent platform，不是 agent runtime，也不是自治生产控制器。
 
 目前 LoopX 已交付围绕 goal、typed todo / decision scope、平级 claim / lease、
 evidence / writeback、quota-aware scheduling 和跨轮 continuation 的 durable state
 kernel。在这套共享控制状态之上，已经提供 guided start、recurring heartbeat、
 隔离 Codex CLI Turn、evidence-backed Issue-Fix admission、可选 Explore / auto
-research 路径、公开 validation canary，以及 read-first 多项目 dashboard。
+research 路径、公开 validation canary，以及多项目 Personal Workspace。
 
 不同表面的支持等级仍需明确区分：state 与 CLI contract 是稳定核心；部分 host
 integration 和进阶路径仍是 optional、default-off 或 experimental。LoopX 不会自行


### PR DESCRIPTION
## Summary

- update the bilingual Current Status sections from the stale `0.4.x` line to LoopX 1.0
- replace the old read-first dashboard description with the shipped multi-project Personal Workspace

This only corrects the status sections near the end of each README. It does not change either README's first viewport or add new product claims.

## Validation

- `python3 examples/repository-hygiene-smoke.py`: passed
- `python3 examples/docs-governance-smoke.py`: passed
- `loopx canary premerge --from-git-diff`: 13 selected, 13 passed, 0 failures, 0 manual holds
- public/private boundary scan: clean for both README files
- `git diff --check`: passed
