### PR TITLE
feat: make completed-Todo Goal review cadence configurable

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -52,6 +52,56 @@ depending on the executor:
 - a shared controller loop can use the same number as a weighted selection
   ratio between eligible goals.
 
+## Completed-Todo Review Cadence
+
+`execution_profile.replan_after_completed_todos` is a Goal-level integer
+hyperparameter, default **5** in both standard and fine-grained Turn modes.
+Set it to 2 or 3 for earlier review. Supported values are 1–5: the current
+agent projection retains five recent completions, so larger values are rejected.
+Restoring 5 removes the override and preserves the existing default behavior.
+
+```bash
+# Preview, apply, and read back the Goal setting.
+loopx configure-goal --goal-id example --execution-replan-after-todos 3
+loopx configure-goal --goal-id example --execution-replan-after-todos 3 --execute
+loopx configure-goal --goal-id example
+
+# Restore the default cadence.
+loopx configure-goal --goal-id example --execution-replan-after-todos 5 --execute
+```
+
+The Dashboard's Goal configuration catalog exposes **Goal review cadence** as
+an integer field through the existing preview/apply flow. This is a setting of
+the built-in goal control plane, with no provider or plugin installation.
+
+The count includes completed advancement Todos claimed by the same Agent, with
+valid completion timestamps, after the latest qualifying outcome checkpoint.
+Open Todos, other Agents' work, and protocol steps do not count. A checkpoint
+must satisfy the existing material-outcome and acceptance-evidence rules;
+a generic refresh or an unqualified replan ACK does not reset the window.
+A closed Agent vision is excluded by the existing terminal-state rule.
+
+At the threshold, the next `quota should-run --goal-id example --agent-id agent-a`
+evaluation contributes a `vision_outcome_checkpoint_required` acceptance gap
+with `completed_todo_count` and `completed_todo_threshold`, through the existing
+replan obligation path. This is a machine-evaluated review obligation, subject
+to existing lane arbitration. The review can retain the current path with
+`continue` or `no_change`, or choose `replan`; reaching the threshold does not
+require changing a correct plan. No permission or quota boundary changes, and
+no external data is published by this setting.
+
+This counter does not interrupt the host or schedule a continuation turn.
+For review during a long turn, the executor must write completion state as
+work finishes and re-enter quota before starting the next Todo. Completing all
+Todos in one batch at closeout or never re-entering quota can defer review until
+after implementation. Lowering the threshold alone cannot repair that gap.
+
+Other cadences are independent: the standard profile's two-small-delivery
+streak suggests widening work; fine mode's five-small-delivery streak suggests
+direction review. Neither is this completed-Todo counter. The periodic review
+window of 20 material run records and long-open-Todo-chain triggers also retain
+their existing thresholds.
+
 ## Minimal Contract
 
 The compact status shape can start with a small object:

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -102,6 +102,28 @@ direction review. Neither is this completed-Todo counter. The periodic review
 window of 20 material run records and long-open-Todo-chain triggers also retain
 their existing thresholds.
 
+### Governed Turn Execution
+
+`loopx turn plan` / `loopx turn run-once` is a separate execution surface from
+fine-grained planning. A new Turn reads live quota, and successful material
+execution goes through result validation, durable writeback, quota settlement,
+and a fresh scheduler/quota readback. Its host result must declare an unchanged
+path with a reason or a material replan with a bounded vision/path packet.
+This path declaration is checked at each material Turn boundary; it is not an
+automatic change of plan or independent proof of complete Goal acceptance.
+
+The completed-Todo hyperparameter applies to the shared quota frontier and
+write-time replan gate used by Turn execution. It does not change the per-Turn
+result contract or count partial-progress Turns as completed Todos.
+
+The separate [Turn Loop Controller](reference/protocols/turn-loop-controller-v0.md)
+can request replan when a caller-provided budget for continued progress on one
+Todo is exhausted. That budget has no default, and the `turn` CLI does not
+invoke this controller or maintain that counter. `run-once` executes one Turn;
+an outer caller still owns repeated execution. A completed-Todo threshold, a
+per-Turn path declaration, and a same-Todo continuation budget are different
+controls.
+
 ## Minimal Contract
 
 The compact status shape can start with a small object:

--- a/docs/reference/protocols/turn-loop-controller-v0.md
+++ b/docs/reference/protocols/turn-loop-controller-v0.md
@@ -11,6 +11,13 @@ a model, sleep, write state, or spend quota. Scheduler process management,
 host-specific wake adapters, and operator presentation are later slices in the
 Turn Loop Controller plan.
 
+The controller is an exported transition API, not a loop implicitly started by
+`loopx turn run-once`. The CLI does not currently call `decide_loop_disposition`
+or persist a `BoundedTurnBudget`. Both `max_turns` and `completed_turns` must be
+supplied by an integrating caller; there is no CLI or product default of three
+Turns. The budget applies to continued `validated_progress` on the same Todo,
+not a chain of completed Todos and not fine-grained planning mode.
+
 ## Inputs
 
 | Input | Shape | Notes |

--- a/loopx/capabilities/configuration_ui.py
+++ b/loopx/capabilities/configuration_ui.py
@@ -58,6 +58,24 @@ def capability_configuration_editor(
     """Return the provider-neutral editor contract consumed by every UI scope."""
 
     definitions: dict[str, dict[str, Any]] = {
+        "todo_replan_cadence": {
+            "supported_scopes": ["goal"],
+            "writable_scopes": ["goal"],
+            "fields": [
+                _field(
+                    "completed_todos",
+                    "Completed Todos between Goal reviews",
+                    "number",
+                    minimum=1,
+                    maximum=5,
+                    required=True,
+                    description=(
+                        "Default 5 in both turn modes. Use 2 or 3 for earlier review; "
+                        "5 restores the default. Counts this Agent's advancement work."
+                    ),
+                ),
+            ],
+        },
         "periodic_report": {
             "supported_scopes": ["machine", "goal"],
             "writable_scopes": ["machine", "goal"],

--- a/loopx/chat_goal_configuration_api.py
+++ b/loopx/chat_goal_configuration_api.py
@@ -5,12 +5,6 @@ from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import parse_qs, urlparse
 
-from .configuration_transaction import (
-    build_configuration_update_plan,
-    configuration_payload_revision,
-    goal_capability_configuration_revision,
-    require_expected_configuration_plan_revision,
-)
 from .capabilities.configuration_ui import (
     build_capability_configuration_catalog,
 )
@@ -18,9 +12,17 @@ from .capabilities.machine_configuration.builtins import (
     build_builtin_machine_configuration_registry,
 )
 from .capabilities.machine_configuration.store import inspect_machine_configuration
+from .configuration_transaction import (
+    build_configuration_update_plan,
+    configuration_payload_revision,
+    goal_capability_configuration_revision,
+    require_expected_configuration_plan_revision,
+)
 from .configure_goal import configure_goal
 from .control_plane.goals.configure_goal_service import configure_goal_with_global_sync
-
+from .control_plane.goals.goal_vision_policy import (
+    normalize_completed_todo_replan_threshold,
+)
 
 CHAT_GOAL_CONFIGURATION_PATH = "/api/chat/goal-configuration"
 CHAT_GOAL_CONFIGURATION_PREVIEW_PATH = f"{CHAT_GOAL_CONFIGURATION_PATH}/preview"
@@ -112,6 +114,7 @@ def _goal_capability_options(
         raise ValueError(f"Goal capability cannot be cleared: {capability_id}")
     config = dict(configuration)
     allowed: dict[str, set[str]] = {
+        "todo_replan_cadence": {"completed_todos"},
         "multi_subagent": {"enabled", "max_children", "allowed_domains"},
         "peer_task_coordination": {"coordinator_agent_id"},
         "explore_graph": {"enabled"},
@@ -131,6 +134,12 @@ def _goal_capability_options(
 
     if capability_id == "multi_subagent":
         return _multi_subagent_options(config)
+    if capability_id == "todo_replan_cadence":
+        return {
+            "execution_replan_after_todos": normalize_completed_todo_replan_threshold(
+                config.get("completed_todos")
+            ),
+        }
     if capability_id == "periodic_report":
         return {"periodic_report_configuration": config}
     if capability_id == "peer_task_coordination":

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -455,6 +455,7 @@ def handle_registry_admin_command(
                 quota_compute=args.quota_compute,
                 quota_window_hours=args.quota_window_hours,
                 execution_turn_granularity=args.execution_turn_granularity,
+                execution_replan_after_todos=args.execution_replan_after_todos,
                 self_repair_enabled=args.self_repair_enabled,
                 self_repair_health=args.self_repair_health,
                 self_repair_waiting_projection=args.self_repair_waiting_projection,

--- a/loopx/cli_commands/registry_admin_configure.py
+++ b/loopx/cli_commands/registry_admin_configure.py
@@ -30,8 +30,18 @@ def register_configure_goal_command(subparsers: argparse._SubParsersAction) -> N
         "--execution-turn-granularity",
         choices=TURN_GRANULARITY_CHOICES,
         help=(
-            "Set sticky goal turn granularity. fine runs one small checkpoint Todo "
-            "per turn and replans from fresh evidence before its successor."
+            "Set sticky goal turn granularity. fine plans small checkpoints within "
+            "a coherent work slice; completed-Todo review cadence defaults to 5 in both modes."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--execution-replan-after-todos",
+        type=int,
+        choices=range(1, 6),
+        help=(
+            "Require goal review after this many same-agent advancement Todo completions "
+            "without a covering outcome checkpoint. Default 5; use 2 or 3 for earlier "
+            "review, or 5 to restore the default. Applies to standard and fine modes."
         ),
     )
     configure_goal_parser.add_argument(

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from .capabilities.configuration_ui import build_capability_configuration_catalog
+from .control_plane.goals.goal_vision_policy import completed_todo_replan_threshold
 
 DEFAULT_MULTI_SUBAGENT_MAX_CHILDREN = 2
 
@@ -125,6 +126,49 @@ def build_goal_configuration_catalog(
             ),
         },
         "features": [
+            {
+                "feature_id": "todo_replan_cadence",
+                "display_name": "Goal review cadence",
+                "availability": "supported_opt_in",
+                "default": {"completed_todos": 5},
+                "current": {
+                    "completed_todos": completed_todo_replan_threshold(
+                        settings.get("execution_profile")
+                    ),
+                },
+                "consider_when": "A short Todo chain needs earlier review against the Goal.",
+                "effect": (
+                    "Requires review after 1–5 same-agent advancement Todo completions "
+                    "without a covering outcome checkpoint; default 5 in standard and fine modes."
+                ),
+                "does_not": [
+                    "create host continuation turns or interrupt running work",
+                    "count open Todos, protocol steps, or another Agent's completions",
+                    "bypass quota, permissions, or outcome evidence requirements",
+                ],
+                "commands": {
+                    "preview_enable": _configure_command(
+                        goal_id, "--execution-replan-after-todos", "3"
+                    ),
+                    "apply_enable": _configure_command(
+                        goal_id, "--execution-replan-after-todos", "3", execute=True
+                    ),
+                    "preview_disable": _configure_command(
+                        goal_id, "--execution-replan-after-todos", "5"
+                    ),
+                    "apply_disable": _configure_command(
+                        goal_id, "--execution-replan-after-todos", "5", execute=True
+                    ),
+                    "verify": [inspect_command],
+                },
+                "documentation": {
+                    "path": "docs/quota-allocation.md#completed-todo-review-cadence",
+                    "url": (
+                        "https://github.com/huangruiteng/loopx/blob/main/"
+                        "docs/quota-allocation.md#completed-todo-review-cadence"
+                    ),
+                },
+            },
             {
                 "feature_id": "local_authority_shadow",
                 "display_name": "Local post-commit authority observation",

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -11,7 +11,6 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .agent_registry import normalize_registered_agents
-from .capabilities.periodic_report import goal_configuration as periodic_report_config
 from .boundary_authority import (
     build_checkpointed_boundary_authority_entry,
     checkpointed_boundary_authority_summary,
@@ -20,7 +19,11 @@ from .capabilities.change_quality.policy import (
     CHANGE_QUALITY_POLICY_SCHEMA_VERSION,
     change_quality_goal_policy_summary,
 )
-from .configuration_catalog import DEFAULT_MULTI_SUBAGENT_MAX_CHILDREN, build_goal_configuration_catalog
+from .capabilities.periodic_report import goal_configuration as periodic_report_config
+from .configuration_catalog import (
+    DEFAULT_MULTI_SUBAGENT_MAX_CHILDREN,
+    build_goal_configuration_catalog,
+)
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .control_plane.agents.legacy_migration import (
     completed_peer_agent_runtime_migration,
@@ -49,8 +52,7 @@ from .control_plane.todos.mutation_authority import (
 )
 from .execution_profile import (
     compact_execution_profile,
-    execution_profile_with_turn_granularity,
-    normalize_turn_granularity,
+    configure_execution_profile,
 )
 from .explore_graph import compact_explore_graph_policy
 from .orchestration import (
@@ -421,6 +423,7 @@ def configure_goal(
     quota_compute: float | None = None,
     quota_window_hours: float | None = None,
     execution_turn_granularity: str | None = None,
+    execution_replan_after_todos: int | None = None,
     self_repair_enabled: bool | None = None,
     self_repair_health: bool | None = None,
     self_repair_waiting_projection: bool | None = None,
@@ -479,10 +482,6 @@ def configure_goal(
 ) -> dict[str, Any]:
     if not registry_path.exists():
         raise FileNotFoundError(f"registry file does not exist: {registry_path}")
-    if execution_turn_granularity is not None:
-        execution_turn_granularity = normalize_turn_granularity(
-            execution_turn_granularity
-        )
     if clear_allowed_domains and allowed_domains:
         raise ValueError(
             "--clear-allowed-domains cannot be combined with --allowed-domain"
@@ -765,10 +764,11 @@ def configure_goal(
 
     before_goal = deepcopy(goal)
     before = _settings_summary(before_goal)
-    if execution_turn_granularity is not None:
-        goal["execution_profile"] = execution_profile_with_turn_granularity(
+    if execution_turn_granularity is not None or execution_replan_after_todos is not None:
+        goal["execution_profile"] = configure_execution_profile(
             goal.get("execution_profile"),
-            execution_turn_granularity,
+            turn_granularity=execution_turn_granularity,
+            replan_after_completed_todos=execution_replan_after_todos,
         )
     legacy_hierarchy_before = legacy_agent_hierarchy_present(before_goal)
     expected_migration_id = peer_agent_runtime_migration_id(goal_id, before_goal)

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -34,7 +34,7 @@ from ...work_items.autonomous_replan_obligation import (
 )
 from ...work_items.progress_observation import build_replan_context
 from ..goal_vision_policy import (
-    COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
+    completed_todo_replan_threshold,
     goal_vision_repeats_advancement_until_closed,
 )
 from ..goal_vision_state import (
@@ -1565,7 +1565,9 @@ def build_goal_frontier_projection_context_from_status(
             latest_vision_checkpoint,
             agent_todo_summary=agent_todo_summary,
             agent_id=agent_id,
-            completed_todo_threshold=COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
+            completed_todo_threshold=completed_todo_replan_threshold(
+                project_asset.get("execution_profile")
+            ),
         )
     )
     if _terminal_no_followup_resolves_vision_checkpoint(

--- a/loopx/control_plane/goals/goal_frontier/__init__.py
+++ b/loopx/control_plane/goals/goal_frontier/__init__.py
@@ -1566,7 +1566,7 @@ def build_goal_frontier_projection_context_from_status(
             agent_todo_summary=agent_todo_summary,
             agent_id=agent_id,
             completed_todo_threshold=completed_todo_replan_threshold(
-                project_asset.get("execution_profile")
+                (project_asset or {}).get("execution_profile")
             ),
         )
     )

--- a/loopx/control_plane/goals/goal_vision_policy.py
+++ b/loopx/control_plane/goals/goal_vision_policy.py
@@ -18,6 +18,20 @@ GOAL_VISION_ADVANCEMENT_POLICY_CHOICES = tuple(
 COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD = 5
 
 
+def normalize_completed_todo_replan_threshold(value: Any) -> int:
+    # The durable agent projection retains five completions. Larger thresholds
+    # would be unreachable without widening that evidence window.
+    if type(value) is not int or not 1 <= value <= COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD:
+        raise ValueError("replan_after_completed_todos must be an integer from 1 to 5")
+    return value
+
+
+def completed_todo_replan_threshold(profile: Any) -> int:
+    if not isinstance(profile, dict) or "replan_after_completed_todos" not in profile:
+        return COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD
+    return normalize_completed_todo_replan_threshold(profile["replan_after_completed_todos"])
+
+
 def normalize_goal_vision_advancement_policy(value: Any) -> str:
     candidate = str(value or "").strip().lower().replace("-", "_")
     try:

--- a/loopx/control_plane/work_items/semantic_replan_writeback.py
+++ b/loopx/control_plane/work_items/semantic_replan_writeback.py
@@ -266,7 +266,7 @@ def qualify_replan_writeback(
                 else {}
             )
         },
-        project_asset=None,
+        project_asset={"execution_profile": (registry_goal or {}).get("execution_profile")},
         user_todo_summary=user_todos,
         agent_todo_summary=agent_todos,
         agent_todo_source_items=agent_todo_source_items,

--- a/loopx/execution_profile.py
+++ b/loopx/execution_profile.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from .control_plane.goals.goal_vision_policy import (
+    COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD,
+    completed_todo_replan_threshold,
+    normalize_completed_todo_replan_threshold,
+)
 from .control_plane.work_items.delivery_outcome import DeliveryOutcome
-
 
 DEFAULT_EXECUTION_PROFILE: dict[str, Any] = {
     "cadence": "bounded_progress_segment",
@@ -150,6 +154,10 @@ def compact_execution_profile(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return profile
 
+    threshold = completed_todo_replan_threshold(value)
+    if threshold != COMPLETED_TODO_CHAIN_REPLAN_THRESHOLD:
+        profile["replan_after_completed_todos"] = threshold
+
     if "turn_granularity" in value:
         turn_granularity = normalize_turn_granularity(value.get("turn_granularity"))
         if turn_granularity == TURN_GRANULARITY_FINE:
@@ -188,6 +196,22 @@ def compact_execution_profile(value: Any) -> dict[str, Any]:
     if execution_profile_is_fine_grained(profile):
         _apply_fine_grained_contract(profile)
     return profile
+
+
+def configure_execution_profile(
+    profile: Any,
+    *,
+    turn_granularity: str | None = None,
+    replan_after_completed_todos: int | None = None,
+) -> dict[str, Any]:
+    normalized = compact_execution_profile(profile)
+    if turn_granularity is not None:
+        normalized = execution_profile_with_turn_granularity(normalized, turn_granularity)
+    if replan_after_completed_todos is not None:
+        normalized["replan_after_completed_todos"] = normalize_completed_todo_replan_threshold(
+            replan_after_completed_todos
+        )
+    return compact_execution_profile(normalized)
 
 
 def normalize_turn_granularity(value: Any) -> str:
@@ -283,4 +307,8 @@ def execution_profile_summary(profile: dict[str, Any] | None) -> str:
         f"small_streak_threshold={policy.get('small_scale_streak_threshold')}"
         f"{floor_suffix}"
         f"{turn_suffix}"
+        + (
+            f" replan_after_completed_todos={normalized['replan_after_completed_todos']}"
+            if "replan_after_completed_todos" in normalized else ""
+        )
     )

--- a/tests/control_plane/test_fine_grained_turn_mode.py
+++ b/tests/control_plane/test_fine_grained_turn_mode.py
@@ -6,6 +6,8 @@ import subprocess
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from loopx.bootstrap_command_pack import build_start_goal_guided_packet
 from loopx.cli_commands.start_goal import _resolve_start_goal_input
 from loopx.configure_goal import configure_goal
@@ -324,7 +326,9 @@ def test_heartbeat_cli_reads_sticky_fine_mode_from_registry(tmp_path: Path) -> N
     assert FINE_GRAINED_TURN_RULE in payload["task_body"]
 
 
-def _fine_frontier_context_after_completions(completion_count: int) -> dict:
+def _fine_frontier_context_after_completions(
+    completion_count: int, *, execution_profile: dict | None = None
+) -> dict:
     successor_id = "todo_checkpoint_successor"
     completed = [
         quota_todo_item(
@@ -351,7 +355,10 @@ def _fine_frontier_context_after_completions(completion_count: int) -> dict:
         recommended_action="Continue the current evidence direction.",
         agent_todos=summary,
         project_asset_extra={
-            "execution_profile": build_execution_profile(turn_granularity="fine")
+            "execution_profile": (
+                execution_profile if execution_profile is not None
+                else build_execution_profile(turn_granularity="fine")
+            )
         },
         latest_runs=[
             {
@@ -435,3 +442,23 @@ def test_configure_goal_persists_and_can_revert_fine_mode(tmp_path: Path) -> Non
     assert "planning_granularity" not in persisted["execution_profile"]
     assert "turn_work_budget" not in persisted["execution_profile"]
     assert "checkpoint_accounting" not in persisted["execution_profile"]
+
+
+@pytest.mark.parametrize("mode", ["standard", "fine"])
+@pytest.mark.parametrize("threshold", [1, 2, 3, 4, 5])
+def test_configured_completion_cadence_reaches_the_active_frontier(mode, threshold):
+    profile = build_execution_profile(turn_granularity=mode)
+    profile["replan_after_completed_todos"] = threshold
+    before = _fine_frontier_context_after_completions(
+        threshold - 1, execution_profile=compact_execution_profile(profile)
+    )
+    assert before["acceptance_gaps"] == []
+    assert before["replan_obligation"] is None
+    due = _fine_frontier_context_after_completions(
+        threshold, execution_profile=compact_execution_profile(profile)
+    )
+    gap = due["acceptance_gaps"][0]
+    assert gap["source"] == "recent_completed_advancement_todo"
+    assert gap["completed_todo_threshold"] == threshold
+    assert gap["required_path_outcomes"] == ["continue", "no_change", "replan"]
+    assert due["replan_obligation"]["required"] is True

--- a/tests/control_plane/test_refresh_state_replan_gate.py
+++ b/tests/control_plane/test_refresh_state_replan_gate.py
@@ -29,8 +29,8 @@ OTHER_AGENT_ID = "codex-replan-gate-other-agent"
 STATE_TEXT = "# Active Goal State\n"
 
 
-def _completed_advancement_chain_state() -> str:
-    """Five completed slices with explicit lineage and no succession warning.
+def _completed_advancement_chain_state(count: int = 5) -> str:
+    """Completed slices with explicit lineage and no succession warning.
 
     The final non-advancement anchor keeps this fixture focused on the outcome
     checkpoint rule instead of the independent completed-without-successor
@@ -38,10 +38,10 @@ def _completed_advancement_chain_state() -> str:
     """
 
     lines = ["## Agent Todo", ""]
-    for index in range(5):
+    for index in range(count):
         successor_id = (
             f"todo_completed_slice_{index + 1}"
-            if index < 4
+            if index < count - 1
             else "todo_completed_outcome_anchor"
         )
         lines.extend(
@@ -1342,3 +1342,25 @@ def test_matching_non_successor_ack_clears_rotated_vision_obligation(
     )
 
     assert remaining is None
+
+
+@pytest.mark.parametrize("threshold", [2, 3])
+def test_writeback_uses_configured_completion_cadence(threshold: int) -> None:
+    state = _completed_advancement_chain_state(threshold)
+    arguments = {
+        "newest_first_runs": [], "state_text": state,
+        "agent_id": AGENT_ID, "goal_id": GOAL_ID,
+    }
+    default_obligation, _ = qualify_replan_writeback(**arguments)
+    assert default_obligation is None
+    goal = {"execution_profile": {"replan_after_completed_todos": threshold}}
+    obligation, _ = qualify_replan_writeback(**arguments, registry_goal=goal)
+    assert obligation is not None
+    assert any(
+        trigger.get("kind") == "vision_outcome_checkpoint_required"
+        and trigger.get("completed_todo_count") == threshold
+        and trigger.get("completed_todo_threshold") == threshold
+        for trigger in obligation["triggers"]
+    )
+    with pytest.raises(ReplanWritebackRejected):
+        enforce_open_replan_writeback(**arguments, registry_goal=goal)

--- a/tests/control_plane/test_todo_replan_cadence.py
+++ b/tests/control_plane/test_todo_replan_cadence.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from loopx.chat_goal_configuration_api import _goal_capability_options
+from loopx.configure_goal import configure_goal
+from loopx.control_plane.goals.goal_frontier.outcome_continuity import (
+    acceptance_gaps_from_todo_completion_checkpoint,
+)
+from loopx.execution_profile import (
+    build_execution_profile,
+    compact_execution_profile,
+    execution_profile_with_turn_granularity,
+)
+
+
+@pytest.mark.parametrize("invalid", [0, -1, 6, True, 2.5, "3", None])
+def test_invalid_cadence_is_rejected_at_profile_and_dashboard_boundaries(invalid):
+    with pytest.raises(ValueError, match="integer from 1 to 5"):
+        compact_execution_profile({"replan_after_completed_todos": invalid})
+    with pytest.raises(ValueError, match="integer from 1 to 5"):
+        _goal_capability_options("todo_replan_cadence", {"completed_todos": invalid})
+
+
+def test_cadence_configuration_previews_persists_and_restores_default(tmp_path):
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({"goals": [{"id": "example", "status": "active"}]}))
+    original = registry.read_bytes()
+    options = _goal_capability_options("todo_replan_cadence", {"completed_todos": 3})
+    preview = configure_goal(registry_path=registry, goal_id="example", **options)
+    assert registry.read_bytes() == original
+    assert preview["changed_fields"] == ["execution_profile"]
+    configure_goal(registry_path=registry, goal_id="example", execute=True, **options)
+    persisted = json.loads(registry.read_text())["goals"][0]["execution_profile"]
+    assert persisted["replan_after_completed_todos"] == 3
+    for mode in ["fine", "standard"]:
+        persisted = execution_profile_with_turn_granularity(persisted, mode)
+        assert persisted["replan_after_completed_todos"] == 3
+    readback = configure_goal(registry_path=registry, goal_id="example")
+    catalog = readback["configuration_catalog"]["capability_catalog"]
+    feature = next(
+        c
+        for c in catalog["capabilities"]
+        if c["capability_id"] == "todo_replan_cadence"
+    )
+    assert feature["current"] == {"completed_todos": 3}
+    editor = feature["configuration_editor"]
+    assert editor["writable_scopes"] == ["goal"]
+    assert editor["fields"][0]["input_kind"] == "number"
+    assert editor["fields"][0]["minimum"] == 1
+    assert editor["fields"][0]["maximum"] == 5
+    configure_goal(
+        registry_path=registry,
+        goal_id="example",
+        execute=True,
+        execution_replan_after_todos=5,
+    )
+    assert (
+        json.loads(registry.read_text())["goals"][0]["execution_profile"]
+        == build_execution_profile()
+    )
+
+
+def test_cli_cadence_roundtrip_syncs_to_an_isolated_runtime(tmp_path):
+    root = Path(__file__).resolve().parents[2]
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({"goals": [{"id": "example", "status": "active"}]}))
+    result = subprocess.run(
+        [
+            str(root / "scripts/loopx"),
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "--runtime-root",
+            str(tmp_path / "runtime"),
+            "configure-goal",
+            "--goal-id",
+            "example",
+            "--execution-replan-after-todos",
+            "2",
+            "--execute",
+        ],
+        cwd=root,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(result.stdout)["changed_fields"] == ["execution_profile"]
+    assert (
+        json.loads(registry.read_text())["goals"][0]["execution_profile"][
+            "replan_after_completed_todos"
+        ]
+        == 2
+    )
+
+
+@pytest.mark.parametrize("threshold", [2, 3])
+def test_earlier_review_still_requires_scoped_completions_and_qualified_checkpoint(
+    threshold,
+):
+    items = [
+        {
+            "todo_id": f"work-{i}",
+            "claimed_by": "agent-a",
+            "completed_at": f"2026-01-01T00:0{i}:00Z",
+        }
+        for i in range(1, threshold + 1)
+    ]
+    kwargs = {
+        "agent_todo_summary": {"recent_completed_advancement_items": items},
+        "agent_id": "agent-a",
+        "completed_todo_threshold": threshold,
+    }
+    vision = {"state": "active", "vision_patch": {}}
+    assert acceptance_gaps_from_todo_completion_checkpoint(vision, None, **kwargs)
+    # Another Agent's work cannot bring this Agent across the threshold.
+    items[-1]["claimed_by"] = "agent-b"
+    assert acceptance_gaps_from_todo_completion_checkpoint(vision, None, **kwargs) == []
+    items[-1]["claimed_by"] = "agent-a"
+    # A no-op/satisfied receipt without material outcome evidence cannot reset it.
+    checkpoint = {
+        "generated_at": "2026-01-01T00:10:00Z",
+        "satisfied": True,
+        "triggers": [],
+    }
+    assert acceptance_gaps_from_todo_completion_checkpoint(vision, checkpoint, **kwargs)
+    checkpoint["triggers"] = [
+        {"kind": "material_delivery_outcome", "delivery_outcome": "outcome_progress"}
+    ]
+    # Material progress alone still lacks a claim, fresh path decision, and evidence.
+    assert acceptance_gaps_from_todo_completion_checkpoint(vision, checkpoint, **kwargs)
+    vision["generated_at"] = checkpoint["generated_at"]
+    vision["vision_patch"] = {
+        "acceptance_summary": "The required output remains valid."
+    }
+    vision["path_delta"] = {
+        "outcome": "continue",
+        "evidence_refs": ["artifact:acceptance-check"],
+    }
+    checkpoint["decision"] = "patched"
+    assert (
+        acceptance_gaps_from_todo_completion_checkpoint(vision, checkpoint, **kwargs)
+        == []
+    )
+    # Only completions after the covering checkpoint enter the next window.
+    checkpoint["generated_at"] = "2026-01-01T00:01:00Z"
+    vision["generated_at"] = checkpoint["generated_at"]
+    assert (
+        acceptance_gaps_from_todo_completion_checkpoint(vision, checkpoint, **kwargs)
+        == []
+    )
+    items.append(
+        {
+            "todo_id": "next-work",
+            "claimed_by": "agent-a",
+            "completed_at": "2026-01-01T00:09:00Z",
+        }
+    )
+    assert acceptance_gaps_from_todo_completion_checkpoint(vision, checkpoint, **kwargs)
+
+
+@pytest.mark.parametrize("threshold", [2, 3, 5])
+@pytest.mark.parametrize("paused", [False, True])
+def test_quota_uses_cadence_without_bypassing_a_goal_pause(threshold, paused):
+    from loopx.control_plane.scheduler.execution_context import (
+        scheduler_execution_context_for_runtime_profile,
+    )
+    from loopx.control_plane.testing.quota_fixtures import (
+        quota_status_payload,
+        quota_todo_item,
+    )
+    from loopx.quota import build_quota_should_run
+
+    completed = [
+        quota_todo_item(
+            todo_id=f"todo_work_{i}",
+            title="Validated work",
+            status="done",
+            claimed_by="agent-a",
+            completed_at=f"2026-01-01T00:0{i}:00Z",
+            successor_todo_ids=["todo_next"],
+        )
+        for i in range(1, 4)
+    ]
+    status = quota_status_payload(
+        goal_id="example",
+        status="active",
+        recommended_action="Continue the goal.",
+        claim_scope_agent_id="agent-a",
+        coordination={"agent_model": "peer_v1", "registered_agents": ["agent-a"]},
+        agent_todo_items=[
+            *completed,
+            quota_todo_item(todo_id="todo_next", title="Next work", claimed_by="agent-a"),
+        ],
+        project_asset_extra={
+            "execution_profile": {"replan_after_completed_todos": threshold},
+            **({"quota": {"compute": 0}} if paused else {}),
+        },
+    )
+    result = build_quota_should_run(
+        status,
+        goal_id="example",
+        agent_id="agent-a",
+        scheduler_execution_context=scheduler_execution_context_for_runtime_profile(
+            "codex_app_heartbeat"
+        ),
+    )
+    if paused:
+        assert result["should_run"] is False
+        assert result["normal_delivery_allowed"] is False
+    else:
+        gaps = result["goal_frontier_projection"]["acceptance_gaps"]
+        completed_gaps = [
+            g for g in gaps if g.get("source") == "recent_completed_advancement_todo"
+        ]
+        assert bool(completed_gaps) is (threshold <= 3)
+        if completed_gaps:
+            assert completed_gaps[0]["completed_todo_threshold"] == threshold
+            assert result["goal_frontier_projection"]["replan_required"] is True


### PR DESCRIPTION
## Summary

A Goal with a short Todo chain can finish its work before reaching the fixed five-completion review threshold. Add the Goal hyperparameter `execution_profile.replan_after_completed_todos`, configurable with `--execution-replan-after-todos` and the Dashboard's existing numeric configuration editor and preview/apply API.

The default remains 5 in standard and fine modes. Values 1–5 are accepted; 2 or 3 request earlier review, and 5 removes the override. Larger values are rejected because the current Agent projection retains five completions. The active quota/frontier and write-time replan paths use the same setting while preserving scoped completion counting, qualifying outcome checkpoints, and lane/permission arbitration. Callers without a project asset retain the default. The setting requires completion writeback and subsequent quota evaluation; it does not schedule host continuations.

Governed `loopx turn run-once` already enforces a path declaration at each material Turn boundary and owns validation/writeback/settlement. This hyperparameter controls completed-Todo counting, not the separate same-Todo continuation budget. The exported `BoundedTurnBudget` controller has no default and is not invoked by the Turn CLI.

Execution-profile updates stay with the existing profile owner. Also correct stale fine-mode CLI help and document activation, readback, rollback, and observation requirements.

## Issue Or Task

Maintainer-requested configurable Goal review cadence. No separate issue.

## Validation

- [x] 273 focused pytest cases (including governed Turn executor/controller/CLI and writeback tests): cadence boundaries in both modes, persistence/rollback, isolated CLI synchronization, checkpoint evidence/reset, Agent scoping, quota pause, existing frontier/vision parity, and Goal/machine configuration APIs.
- [x] `loopx canary premerge --from-git-diff`: 18 selected checks passed, plus changed-Python compilation and diff checks. Covers routing, scheduler authority, heartbeat quota, replan rules, CLI payload budgets, maintainability, and public boundaries.
- [x] Dashboard personal-workspace contract test passed.
- [x] Ruff comparison against the base: no new findings; eleven existing findings in touched modules remain.

Execution-profile handling remains in its existing owner without growing the Goal configurator. Regression coverage proves that refresh/writeback can omit project assets, uses the configured 2/3 threshold, and rejects maintenance while review is due. No canary skips or manual holds. Browser rendering and live Goal execution were not exercised; the existing form renderer and backend configuration contract are covered without changing frontend components.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [x] Public docs or presentation surface (README, protocols, dashboard)

## Technical Direction

- [x] Core control-plane hardening
- Target base branch: `main`
- Direction tracker or promotion unit: existing Goal control plane / execution profile

## Boundary Checklist

- [x] Public code, generic fixtures, and reference documentation only; no credentials, private evidence, internal links, or local machine paths.
- [x] No benchmark runner/scoring changes or new jobs.
- [x] One configurable cadence; existing default and other cadence triggers are preserved.
- [x] Every commit includes a DCO sign-off.
