### PR TITLE
fix(dsh): declare canonical plugin repository metadata

### DIFF
--- a/packages/dsh-loopx-plugin/package.json
+++ b/packages/dsh-loopx-plugin/package.json
@@ -111,6 +111,11 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/huangruiteng/loopx.git",
+    "directory": "packages/dsh-loopx-plugin"
+  },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The DSH plugin manifest does not identify its canonical monorepo source, so fixed-source Catalog review reports a repository-identity mismatch. Add the standard npm `repository` object with the `packages/dsh-loopx-plugin` directory.

This is the smallest independent fix from the request in AI-Scarlett/DSH-Store#494. It changes only contributor/package metadata; plugin version, lifecycle scripts, dependency ranges, host/client implementation, Bundle Patch and first-run readiness behavior are unchanged. No broader refactor is needed for this metadata boundary.

Validation: parsed the manifest, verified the only semantic addition is `repository`, and ran `git diff --check`. Runtime/build tests were not run for this metadata-only change. No Store approval or new DSH compatibility is claimed.

Remaining review: the current Patch modifies the official `webserver` and `web-runtime` rows to await `loopxBootstrap`. This has a documented readiness purpose, so removing those rows simply to clear a catalog gate would change behavior. That boundary needs a separate design decision; the Store source-size and capability findings also remain distinct from this identity correction.
