### PR TITLE
fix(state): reject boolean append sequences

### DIFF
--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -506,12 +506,8 @@ def normalize_state_event(event: dict[str, Any], *, append_sequence: int | None 
 
     sequence = append_sequence if append_sequence is not None else event.get("append_sequence")
     if sequence is not None:
-        if isinstance(sequence, bool):
+        if isinstance(sequence, bool) or not isinstance(sequence, int):
             raise StateEventError("append_sequence must be an integer")
-        try:
-            sequence = int(sequence)
-        except (TypeError, ValueError) as exc:
-            raise StateEventError("append_sequence must be an integer") from exc
         if sequence < 1:
             raise StateEventError("append_sequence must be positive")
 

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -506,6 +506,8 @@ def normalize_state_event(event: dict[str, Any], *, append_sequence: int | None 
 
     sequence = append_sequence if append_sequence is not None else event.get("append_sequence")
     if sequence is not None:
+        if isinstance(sequence, bool):
+            raise StateEventError("append_sequence must be an integer")
         try:
             sequence = int(sequence)
         except (TypeError, ValueError) as exc:

--- a/tests/test_event_sourced_state_store.py
+++ b/tests/test_event_sourced_state_store.py
@@ -1,8 +1,12 @@
+import json
 from pathlib import Path
+
+import pytest
 
 from loopx.event_sourced_state import (
     TODO_ADDED,
     AppendOnlyStateEventStore,
+    StateEventError,
     make_state_event,
 )
 
@@ -25,3 +29,20 @@ def test_load_observes_events_appended_by_another_store(tmp_path: Path) -> None:
     )
 
     assert reader.load() == [appended]
+
+
+def test_load_rejects_boolean_append_sequence(tmp_path: Path) -> None:
+    event_log = tmp_path / "events.jsonl"
+    event = make_state_event(
+        event_id="evt-bool-sequence",
+        goal_id="goal-a",
+        event_type=TODO_ADDED,
+        refs={"todo_id": "todo_bool_sequence"},
+        payload={"role": "agent", "title": "Reject corrupt sequence."},
+        recorded_at="2026-09-07T00:00:00Z",
+    )
+    event["append_sequence"] = True
+    event_log.write_text(json.dumps(event) + "\n", encoding="utf-8")
+
+    with pytest.raises(StateEventError, match="append_sequence must be an integer"):
+        AppendOnlyStateEventStore(event_log).load()

--- a/tests/test_event_sourced_state_store.py
+++ b/tests/test_event_sourced_state_store.py
@@ -28,10 +28,12 @@ def test_load_observes_events_appended_by_another_store(tmp_path: Path) -> None:
         )
     )
 
+    assert appended["append_sequence"] == 1
     assert reader.load() == [appended]
 
 
-def test_load_rejects_boolean_append_sequence(tmp_path: Path) -> None:
+@pytest.mark.parametrize("sequence", [True, False, 1.5, "2"])
+def test_load_rejects_non_integer_append_sequence(tmp_path: Path, sequence: object) -> None:
     event_log = tmp_path / "events.jsonl"
     event = make_state_event(
         event_id="evt-bool-sequence",
@@ -41,7 +43,7 @@ def test_load_rejects_boolean_append_sequence(tmp_path: Path) -> None:
         payload={"role": "agent", "title": "Reject corrupt sequence."},
         recorded_at="2026-09-07T00:00:00Z",
     )
-    event["append_sequence"] = True
+    event["append_sequence"] = sequence
     event_log.write_text(json.dumps(event) + "\n", encoding="utf-8")
 
     with pytest.raises(StateEventError, match="append_sequence must be an integer"):


### PR DESCRIPTION
## Summary

- reject boolean `append_sequence` values at the shared state-event normalization boundary
- keep corrupt JSONL authority data from being silently coerced from `true` to sequence `1`
- add a real file-backed regression test

## Root cause

Python `bool` is a subclass of `int`, and `int(True)` returns `1`. The event decoder used `int(sequence)` as validation, so a persisted JSON boolean bypassed the documented integer contract and entered state projection as a valid sequence.

## Validation

- red phase: the new regression failed because no `StateEventError` was raised
- focused event-store test: 2 passed
- related event-store/Todo/shared-goal suite: 307 passed
- changed-file Ruff, Python compile, and `git diff --check` passed
- `loopx canary premerge --from-git-diff`: 4/4 checks passed, 0 manual holds