### PR TITLE
fix: show safe checkpoint recovery on first refresh

### DIFF
--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -762,9 +762,18 @@ For an accountable, Turn-bound refresh, a successful writeback and a satisfied
 vision checkpoint are separate facts. `ok=true` does not imply that an omitted
 vision decision was supplied. Inspect `vision_checkpoint.satisfied`.
 
-If the checkpoint is `missing_required`, retry the original refresh command
-with the **same** Goal, Agent, Todo/obligation, Turn, and delivery fields, adding
-only one vision decision:
+If the checkpoint is `missing_required`, submit a checkpoint-only refresh with
+the **same** Goal, Agent, Todo/obligation, Turn, and delivery fields. Preserve
+its runtime target, scope, and isolation options such as `--no-global-sync`
+and `--suppress-external-sinks`. Remove previously executed state-mutation
+options, even when their values are unchanged: `--next-action`,
+`--autonomous-replan-recorded`, `--repair-delta-kind`, `--usage-json`, and
+`--usage-codex-session`. Remove any dependent options that would become invalid
+without them. Repeating mutations is rejected as
+`checkpoint_supplement_must_not_repeat_mutations`; do not simply append vision
+arguments to an original command that contains these options.
+
+Add only one vision decision:
 
 - `--vision-unchanged-reason 'Existing scope and acceptance still apply.'` when
   a persisted vision genuinely remains applicable;

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -764,9 +764,16 @@ vision decision was supplied. Inspect `vision_checkpoint.satisfied`.
 
 If the checkpoint is `missing_required`, submit a checkpoint-only refresh with
 the **same** Goal, Agent, Todo/obligation, Turn, and delivery fields. Preserve
-its runtime target, scope, and isolation options such as `--no-global-sync`
-and `--suppress-external-sinks`. Remove previously executed state-mutation
-options, even when their values are unchanged: `--next-action`,
+the original working directory and explicit target (`--registry`, `--runtime-root`,
+`--project`, `--state-file`), scope (`--progress-scope`, `--agent-lane`), and
+isolation (`--no-global-sync`, `--suppress-external-sinks`) options, with their
+original values and presence. Both first-writeback and replay Markdown list
+the preserve/remove/add rules; do not add isolation flags absent from the
+original command or silently change the delivery target. These instructions
+preserve the original boundary when followed; they do not persist an authority
+ceiling that rejects callers who manually remove flags.
+
+Remove previously executed state-mutation options, even when their values are unchanged: `--next-action`,
 `--autonomous-replan-recorded`, `--repair-delta-kind`, `--usage-json`, and
 `--usage-codex-session`. Remove any dependent options that would become invalid
 without them. Repeating mutations is rejected as

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -37,6 +37,74 @@ QUOTA_SETTLEMENT_READBACK_RESULT_SCHEMA = (
 SEMANTIC_REPLAN_GUARD_SCHEMA = "semantic_replan_guard_v0"
 
 
+def _checkpoint_instructions(checkpoint: Mapping[str, Any]) -> str:
+    lines = [
+        "Submit a checkpoint-only refresh with the same Goal, Agent, Todo/obligation, "
+        "Turn, and delivery fields, from the original working directory.",
+        "- Preserve: Keep original values and presence for target, scope, and isolation "
+        "options: `--registry`, `--runtime-root`, `--project`, `--state-file`, "
+        "`--progress-scope`, `--agent-lane`, `--available-capability`, "
+        "`--no-global-sync`, `--suppress-external-sinks`; identity and delivery options: "
+        "`--goal-id`, `--agent-id`, `--todo-id`, `--replan-obligation-id`, "
+        "`--turn-instance-id`, `--completion-todo-id`, `--completion-turn-key`, "
+        "`--classification`, `--recommended-action`, `--delivery-batch-scale`, "
+        "`--delivery-outcome`, `--delivery-boundary`, `--delivery-workspace-path`, "
+        "`--progress-result-class`, `--progress-surface-id`, `--progress-hypothesis-id`, "
+        "`--progress-probe-kind`, `--progress-blocker-id`, `--progress-coverage-scope-id`, "
+        "`--progress-evidence-id`, `--progress-coverage-complete`. Do not add options absent "
+        "from the original command or change its delivery target.",
+        "- Remove: Remove previously executed state-mutation options, even when their "
+        "values are unchanged: `--next-action`, `--autonomous-replan-recorded`, "
+        "`--repair-delta-kind`, `--usage-json`, `--usage-codex-session`. "
+        "Remove dependent options that become invalid without them.",
+        "- Add: Add only one valid vision decision: a valid `--agent-vision-json` packet "
+        "or inline `--vision-*` patch containing your authored vision content.",
+    ]
+    if checkpoint.get("missing_baseline") is True:
+        lines.append(
+            "No persisted vision baseline is available; an unchanged reason cannot "
+            "satisfy this checkpoint."
+        )
+    else:
+        lines[-1] += (
+            " Alternatively use `--vision-unchanged-reason` only if a persisted vision "
+            "exists and its scope and acceptance still apply."
+        )
+    lines.append(
+        "Do not repeat implementation, manufacture a successor, or begin another "
+        "Turn solely to repair this checkpoint. Keep the ordinary one-spend "
+        "settlement order. Recovery remains subject to existing validation and "
+        "does not certify acceptance or bypass replan, identity, or terminal gates."
+    )
+    return "\n".join(lines)
+
+
+def render_first_refresh_checkpoint_hint(payload: dict[str, Any]) -> list[str]:
+    """Explain the first committed missing checkpoint without changing admission."""
+    recovery = payload.get("refresh_recovery")
+    identity = payload.get("settlement_identity")
+    checkpoint = payload.get("vision_checkpoint")
+    if (
+        payload.get("ok") is True
+        and payload.get("appended") is True
+        and payload.get("dry_run") is False
+        and isinstance(recovery, dict)
+        and recovery.get("decision") == "append"
+        and recovery.get("reason") == "first_writeback"
+        and isinstance(identity, dict)
+        and identity
+        and isinstance(checkpoint, dict)
+        and checkpoint.get("required") is True
+        and checkpoint.get("satisfied") is False
+        and checkpoint.get("decision") == "missing_required"
+    ):
+        return [
+            "The writeback succeeded, but the required vision checkpoint is still unsatisfied.",
+            _checkpoint_instructions(checkpoint),
+        ]
+    return []
+
+
 def render_refresh_recovery_markdown(payload: dict[str, Any]) -> str | None:
     """Present an admitted recovery result without deriving settlement policy."""
     recovery = payload.get("refresh_recovery") or {}
@@ -58,17 +126,7 @@ def render_refresh_recovery_markdown(payload: dict[str, Any]) -> str | None:
     if payload.get("error"):
         lines.append(str(payload["error"]))
     elif checkpoint.get("satisfied") is False:
-        lines.append(
-            "Submit a checkpoint-only refresh with the same Goal, Agent, Todo/obligation, "
-            "Turn, and delivery fields. Remove previously executed state-mutation options, "
-            "even when their values are unchanged: --next-action, --autonomous-replan-recorded, "
-            "--repair-delta-kind, --usage-json, and --usage-codex-session. "
-            "Add only one valid vision decision: a valid --agent-vision-json packet or "
-            "inline --vision-* patch, or --vision-unchanged-reason only if a persisted "
-            "vision exists and its scope and acceptance still apply. Do not repeat work "
-            "or begin a new Turn solely to repair this checkpoint. Recovery remains "
-            "subject to existing validation."
-        )
+        lines.append(_checkpoint_instructions(checkpoint))
     return "\n".join(lines)
 
 

--- a/loopx/control_plane/quota/settlement.py
+++ b/loopx/control_plane/quota/settlement.py
@@ -59,7 +59,15 @@ def render_refresh_recovery_markdown(payload: dict[str, Any]) -> str | None:
         lines.append(str(payload["error"]))
     elif checkpoint.get("satisfied") is False:
         lines.append(
-            "Retry the same refresh command and Turn with --vision-unchanged-reason if an existing vision still applies, or --agent-vision-json for a valid vision patch. Do not repeat work or begin a new Turn for this checkpoint."
+            "Submit a checkpoint-only refresh with the same Goal, Agent, Todo/obligation, "
+            "Turn, and delivery fields. Remove previously executed state-mutation options, "
+            "even when their values are unchanged: --next-action, --autonomous-replan-recorded, "
+            "--repair-delta-kind, --usage-json, and --usage-codex-session. "
+            "Add only one valid vision decision: a valid --agent-vision-json packet or "
+            "inline --vision-* patch, or --vision-unchanged-reason only if a persisted "
+            "vision exists and its scope and acceptance still apply. Do not repeat work "
+            "or begin a new Turn solely to repair this checkpoint. Recovery remains "
+            "subject to existing validation."
         )
     return "\n".join(lines)
 

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -26,6 +26,7 @@ from .control_plane.agents.workspace_guard import (
 from .control_plane.quota.settlement import (
     SettlementIdentity,
     read_heartbeat_settlement,
+    render_first_refresh_checkpoint_hint,
     render_refresh_recovery_markdown,
     settlement_result_payload,
 )
@@ -681,47 +682,7 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
                 "- vision_checkpoint_required_resolution: "
                 f"{','.join(str(item) for item in required_resolution)}"
             )
-        recovery = payload.get("refresh_recovery")
-        identity = payload.get("settlement_identity")
-        if (
-            payload.get("ok") is True
-            and payload.get("appended") is True
-            and payload.get("dry_run") is False
-            and isinstance(recovery, dict)
-            and recovery.get("decision") == "append"
-            and recovery.get("reason") == "first_writeback"
-            and isinstance(identity, dict)
-            and identity
-            and vision_checkpoint.get("required") is True
-            and vision_checkpoint.get("satisfied") is False
-            and vision_checkpoint.get("decision") == "missing_required"
-        ):
-            lines.append(
-                "The writeback succeeded, but the required vision checkpoint is still "
-                "unsatisfied. Submit a checkpoint-only refresh with the same Goal, Agent, "
-                "Todo/obligation, Turn, and delivery fields. Remove previously executed "
-                "state-mutation options, even when their values are unchanged: "
-                "--next-action, --autonomous-replan-recorded, --repair-delta-kind, "
-                "--usage-json, and --usage-codex-session. Add only one valid vision decision."
-            )
-            if vision_checkpoint.get("missing_baseline") is True:
-                lines.append(
-                    "No persisted vision baseline is available. Supply a valid "
-                    "--agent-vision-json packet or inline --vision-* patch; "
-                    "an unchanged reason cannot satisfy this checkpoint."
-                )
-            else:
-                lines.append(
-                    "Supply a valid --agent-vision-json packet or inline --vision-* patch. "
-                    "Use --vision-unchanged-reason only if a persisted vision exists "
-                    "and its scope and acceptance still apply."
-                )
-            lines.append(
-                "Do not repeat implementation, manufacture a successor, or begin another "
-                "Turn solely to repair this checkpoint. Keep the ordinary one-spend "
-                "settlement order. Recovery remains subject to existing validation and "
-                "does not certify acceptance or bypass replan, identity, or terminal gates."
-            )
+        lines.extend(render_first_refresh_checkpoint_hint(payload))
 
     projection_gap = (
         payload.get("state_projection_gap")

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -681,6 +681,47 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
                 "- vision_checkpoint_required_resolution: "
                 f"{','.join(str(item) for item in required_resolution)}"
             )
+        recovery = payload.get("refresh_recovery")
+        identity = payload.get("settlement_identity")
+        if (
+            payload.get("ok") is True
+            and payload.get("appended") is True
+            and payload.get("dry_run") is False
+            and isinstance(recovery, dict)
+            and recovery.get("decision") == "append"
+            and recovery.get("reason") == "first_writeback"
+            and isinstance(identity, dict)
+            and identity
+            and vision_checkpoint.get("required") is True
+            and vision_checkpoint.get("satisfied") is False
+            and vision_checkpoint.get("decision") == "missing_required"
+        ):
+            lines.append(
+                "The writeback succeeded, but the required vision checkpoint is still "
+                "unsatisfied. Submit a checkpoint-only refresh with the same Goal, Agent, "
+                "Todo/obligation, Turn, and delivery fields. Remove previously executed "
+                "state-mutation options, even when their values are unchanged: "
+                "--next-action, --autonomous-replan-recorded, --repair-delta-kind, "
+                "--usage-json, and --usage-codex-session. Add only one valid vision decision."
+            )
+            if vision_checkpoint.get("missing_baseline") is True:
+                lines.append(
+                    "No persisted vision baseline is available. Supply a valid "
+                    "--agent-vision-json packet or inline --vision-* patch; "
+                    "an unchanged reason cannot satisfy this checkpoint."
+                )
+            else:
+                lines.append(
+                    "Supply a valid --agent-vision-json packet or inline --vision-* patch. "
+                    "Use --vision-unchanged-reason only if a persisted vision exists "
+                    "and its scope and acceptance still apply."
+                )
+            lines.append(
+                "Do not repeat implementation, manufacture a successor, or begin another "
+                "Turn solely to repair this checkpoint. Keep the ordinary one-spend "
+                "settlement order. Recovery remains subject to existing validation and "
+                "does not certify acceptance or bypass replan, identity, or terminal gates."
+            )
 
     projection_gap = (
         payload.get("state_projection_gap")

--- a/tests/control_plane/test_refresh_checkpoint_isolation.py
+++ b/tests/control_plane/test_refresh_checkpoint_isolation.py
@@ -1,0 +1,235 @@
+"""Follow real CLI recovery instructions through configured delivery gates."""
+
+import json
+import re
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import pytest
+
+from loopx import cli
+from loopx.capabilities.explore.result_log import (
+    append_explore_result_event,
+    build_explore_node_event,
+    explore_result_log_path,
+)
+from loopx.control_plane.runtime import runtime_projection_route
+from loopx.extensions.lark import goal_channel_contracts, goal_channel_runtime
+from loopx.extensions.lark.presentation import explore_results
+from loopx.extensions.runtime import install_extension
+from loopx.global_registry import sync_project_registry_to_global
+from loopx.state_refresh import render_state_refresh_markdown
+from tests.control_plane.test_refresh_checkpoint_recovery import first_refresh as first_refresh
+from tests.control_plane.test_quota_settlement_cli import (
+    AGENT_ID, GOAL_ID, REPO_ROOT, TODO_ID, TURN_ID,
+    _append_blocking_user_gate, _spend_run_count, _write_fixture,
+)
+from tests.extensions.test_lark_goal_channel import _write_binding
+
+
+def _recovery_argv(stdout, original, vision):
+    """Interpret only printed rules; never infer omitted options from product code."""
+    sections = {}
+    for name in ("Preserve", "Remove", "Add"):
+        line, = [line for line in stdout.splitlines() if line.startswith(f"- {name}:")]
+        sections[name] = re.findall(r"`(--[a-z*-]+)`", line)
+    result = []
+    index = 0
+    while index < len(original):
+        option = original[index]
+        end = index + 1
+        while end < len(original) and not original[end].startswith("--"):
+            end += 1
+        if option == "refresh-state":
+            result.append(option)
+        elif any(fnmatchcase(option, pattern) for pattern in sections["Remove"]):
+            pass
+        else:
+            assert any(fnmatchcase(option, pattern) for pattern in sections["Preserve"]), (
+                f"recovery instruction missing for {option}"
+            )
+            result.extend(original[index:end])
+        index = end
+    for option in vision:
+        if option.startswith("--"):
+            assert any(fnmatchcase(option, pattern) for pattern in sections["Add"])
+    return [*result, *vision]
+
+
+def _snapshot(root):
+    return {
+        str(path.relative_to(root)): (path.read_bytes(), path.stat().st_mtime_ns)
+        for path in root.rglob("*") if path.is_file()
+    }
+
+
+def _configure_sinks(registry, runtime):
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    payload["goals"][0]["explore_graph"] = {"enabled": True}
+    registry.write_text(json.dumps(payload), encoding="utf-8")
+    installed = install_extension(
+        REPO_ROOT / "loopx/extensions/lark/extension.toml",
+        state_file=runtime / "extensions/state.json", execute=True,
+    )
+    assert installed["doctor"]["verified"]
+    append_explore_result_event(
+        explore_result_log_path(runtime, GOAL_ID),
+        build_explore_node_event(
+            goal_id=GOAL_ID, node_id="fix_pr_lane", title="Fix validation",
+        ),
+    )
+    explore_results.write_lark_explore_local_config(
+        registry.parent / "lark-explore.json",
+        {"board": {"base_token": "PUBLIC_FIXTURE_BASE", "identity": "user",
+                   "tables": {"nodes": "tblN", "edges": "tblE", "findings": "tblF"}}},
+    )
+    binding_path = registry.parent / "goal-channel.json"
+    _write_binding(binding_path, registry.parent / "lark-kanban.json")
+    bindings = goal_channel_contracts.read_goal_channel_binding(binding_path)
+    binding = next(iter(bindings["bindings"].values()))
+    binding["goal_id"] = GOAL_ID
+    binding["automation"] = {"human_gate_auto_notify_enabled": True}
+    bindings["bindings"] = {GOAL_ID: binding}
+    # Configuration is fixture input; exercise production reads and activation below.
+    binding_path.write_text(json.dumps(bindings), encoding="utf-8")
+    marker = goal_channel_contracts.human_gate_auto_notify_marker_path(binding_path, GOAL_ID)
+    marker.write_text(json.dumps({
+        "schema_version": goal_channel_contracts.HUMAN_GATE_AUTO_NOTIFY_MARKER_SCHEMA_VERSION,
+        "enabled": True,
+    }), encoding="utf-8")
+
+
+@pytest.mark.parametrize("hint_source", ["first", "replay"])
+@pytest.mark.parametrize("baseline", [False, True])
+@pytest.mark.parametrize("isolated", [True, False], ids=["isolated", "send-control"])
+def test_stdout_driven_recovery_preserves_boundaries(
+    tmp_path, monkeypatch, capsys, hint_source, baseline, isolated,
+):
+    project, runtime, registry = _write_fixture(tmp_path)
+    shared = tmp_path / "shared-runtime"
+    monkeypatch.setenv("LOOPX_RUNTIME_ROOT", str(shared))
+    monkeypatch.setenv("PYTHONPATH", str(REPO_ROOT))
+    monkeypatch.setattr(runtime_projection_route, "DEFAULT_RUNTIME_ROOT", shared)
+    monkeypatch.chdir(project)
+    prefix = ["--registry", str(registry), "--runtime-root", str(runtime)]
+
+    def run(argv, output="json"):
+        rc = cli.main(["--format", output, *argv])
+        stdout = capsys.readouterr().out
+        assert rc == 0, stdout
+        return json.loads(stdout) if output == "json" else stdout
+
+    if baseline:
+        run([*prefix, "refresh-state", "--goal-id", GOAL_ID, "--agent-id", AGENT_ID,
+             "--vision-summary", "Validate the scoped change.",
+             "--vision-acceptance", "Focused validation passes.",
+             "--no-global-sync", "--suppress-external-sinks"])
+    binding = ["--goal-id", GOAL_ID, "--agent-id", AGENT_ID,
+               "--todo-id", TODO_ID, "--turn-instance-id", TURN_ID]
+    guard = run([*prefix, "quota", "should-run", "--codex-app", *binding,
+                 "--scan-path", str(project)])
+    assert guard["decision"] == "run", guard
+    _append_blocking_user_gate(project)
+    _configure_sinks(registry, runtime)
+    sync = sync_project_registry_to_global(
+        registry_path=registry, runtime_root_override=str(shared), goal_id=GOAL_ID,
+    )
+    assert sync["ok"], sync
+    shared_before = _snapshot(shared)
+    graph_calls, channel_calls = [], []
+
+    def send_rows(config, **kwargs):
+        assert kwargs["execute"] is True
+        assert kwargs["projection"]["nodes"]
+        graph_calls.append(config)
+        return {"ok": True, "readback": {"verified": True}}
+
+    monkeypatch.setattr(explore_results, "sync_explore_results_to_lark", send_rows)
+    def send_notification(**kwargs):
+        # The real lifecycle must select an actionable gate before the adapter sends.
+        quota = kwargs["quota_packet"]
+        assert quota["state"] == "operator_gate" and quota["notify_user_on_gate"] is True, quota
+        assert kwargs["execute"] is True
+        channel_calls.append(kwargs["goal_id"])
+        return {"ok": True, "status": "sent_verified", "external_write_performed": True,
+                "readback_verified": True}
+
+    monkeypatch.setattr(goal_channel_runtime, "notify_lark_goal_channel_gate", send_notification)
+    state_path = project / f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    original = [
+        *prefix, "refresh-state", *binding,
+        "--project", str(project), "--state-file", str(state_path),
+        "--progress-scope", "goal",
+        "--classification", "validated_change", "--delivery-batch-scale", "implementation",
+        "--delivery-outcome", "outcome_progress", "--delivery-boundary", "semantic_closeout",
+        "--next-action", "Verify the scoped delivery evidence.",
+    ]
+    original += ["--no-global-sync", "--suppress-external-sinks"]
+    first_stdout = run(original, "markdown")
+    assert "writeback succeeded" in first_stdout
+    index = runtime / "goals" / GOAL_ID / "runs/index.jsonl"
+    first = json.loads(index.read_text(encoding="utf-8").splitlines()[-1])
+    assert first["vision_checkpoint"]["decision"] == "missing_required"
+    original_record = Path(first["json_path"]).read_bytes()
+    original_state = state_path.read_bytes()
+    assert b"Verify the scoped delivery evidence." in original_state
+    stdout = first_stdout if hint_source == "first" else run(original, "markdown")
+    if hint_source == "replay":
+        assert "- recovery: `replay`" in stdout
+    vision = (
+        ["--vision-unchanged-reason", "The accepted scope and evidence remain applicable."]
+        if baseline else ["--vision-summary", "Validate the scoped change.",
+                          "--vision-acceptance", "Focused validation passes."]
+    )
+    recovery = _recovery_argv(stdout, original, vision)
+    # Independent oracle: recovery retains every fixture argument except this mutation.
+    position = original.index("--next-action")
+    assert recovery == original[:position] + original[position + 2:] + vision
+    if isolated:
+        for omitted in ("--no-global-sync", "--suppress-external-sinks", "--next-action"):
+            damaged = stdout.replace(f"`{omitted}`", "", 1)
+            with pytest.raises(AssertionError, match="recovery instruction missing"):
+                _recovery_argv(damaged, original, vision)
+    assert graph_calls == [] and channel_calls == []
+    assert _snapshot(shared) == shared_before
+    if not isolated:
+        # Independent control: explicitly widen this call after following the hint.
+        recovery = [arg for arg in recovery if arg not in {
+            "--no-global-sync", "--suppress-external-sinks",
+        }]
+    repaired = run(recovery)
+    assert repaired["appended"] is True
+    assert repaired["vision_checkpoint"]["satisfied"] is True
+    assert repaired["settlement_identity"] == first["settlement_identity"]
+    assert repaired["progress_scope"] == "goal"
+    after = index.read_bytes()
+    replay = run(recovery)
+    assert replay["idempotent_replay"] is True and replay["appended"] is False
+    assert index.read_bytes() == after
+    assert Path(first["json_path"]).read_bytes() == original_record
+    assert state_path.read_bytes() == original_state
+    assert _spend_run_count(runtime) == 0
+    assert repaired["explore_graph_sync"]["applicable"] is True
+    assert repaired["explore_graph_sync"]["extension_activation"]["doctor_verified"] is True
+    assert explore_result_log_path(runtime, GOAL_ID).exists()
+    if isolated:
+        assert _snapshot(shared) == shared_before
+        assert not (runtime / "registry.global.json").exists()
+        assert graph_calls == [] and channel_calls == []
+        assert repaired["goal_channel_gate_sync"]["status"] == "external_sink_suppressed"
+    else:
+        assert _snapshot(shared) != shared_before
+        assert graph_calls and channel_calls, (graph_calls, channel_calls)
+
+
+@pytest.mark.parametrize("hint_source", ["first", "replay"])
+def test_hint_preserves_lane_and_repeated_options_without_adding_isolation(first_refresh, hint_source):
+    if hint_source == "replay":
+        first_refresh["refresh_recovery"] = {"decision": "replay", "reason": "original_writeback_preserved"}
+    original = [
+        "--registry", "registry with spaces.json", "refresh-state", "--goal-id", GOAL_ID,
+        "--agent-id", AGENT_ID, "--progress-scope", "agent_lane", "--agent-lane", "validation",
+        "--available-capability", "filesystem_read", "--available-capability", "shell",
+    ]
+    vision = ["--vision-last-patch", "Validation evidence checked."]
+    assert _recovery_argv(render_state_refresh_markdown(first_refresh), original, vision) == original + vision

--- a/tests/control_plane/test_refresh_checkpoint_recovery.py
+++ b/tests/control_plane/test_refresh_checkpoint_recovery.py
@@ -1,6 +1,11 @@
 """Real CLI recovery: missing checkpoint must not require another work Turn."""
 
+from copy import deepcopy
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -8,6 +13,7 @@ from loopx.state_refresh import render_state_refresh_markdown
 
 from tests.control_plane.test_quota_settlement_cli import (
     AGENT_ID,
+    REPO_ROOT,
     GOAL_ID,
     TODO_ID,
     TURN_ID,
@@ -17,15 +23,106 @@ from tests.control_plane.test_quota_settlement_cli import (
 )
 
 
-def test_replay_markdown_exposes_saved_checkpoint_and_recovery():
-    rendered = render_state_refresh_markdown({
-        "ok": True,
-        "refresh_recovery": {"decision": "replay", "reason": "original_writeback_preserved"},
+def _assert_checkpoint_instructions(rendered: str) -> None:
+    assert "same Goal, Agent, Todo/obligation, Turn, and delivery fields" in rendered
+    assert "Remove previously executed state-mutation options" in rendered
+    for option in (
+        "--next-action", "--autonomous-replan-recorded", "--repair-delta-kind",
+        "--usage-json", "--usage-codex-session",
+    ):
+        assert option in rendered
+    assert "even when their values are unchanged" in rendered
+    assert "only one valid vision decision" in rendered
+
+
+@pytest.fixture
+def first_refresh():
+    return {
+        "ok": True, "appended": True, "dry_run": False,
+        "refresh_recovery": {"decision": "append", "reason": "first_writeback"},
+        "settlement_identity": {"turn_instance_id": TURN_ID},
+        "vision_checkpoint": {
+            "required": True, "satisfied": False, "decision": "missing_required",
+            "required_resolution": ["write_vision_patch"],
+        },
+        "state_projection_gap": {"recommended_action": "Inspect the remaining scope."},
+    }
+
+
+@pytest.mark.parametrize("missing_baseline", [True, False, None])
+def test_first_markdown_explains_checkpoint_without_mutating_payload(
+    first_refresh, missing_baseline,
+):
+    if missing_baseline is not None:
+        first_refresh["vision_checkpoint"]["missing_baseline"] = missing_baseline
+    before = deepcopy(first_refresh)
+    rendered = render_state_refresh_markdown(first_refresh)
+    _assert_checkpoint_instructions(rendered)
+    assert "writeback succeeded" in rendered
+    assert "required vision checkpoint is still unsatisfied" in rendered
+    assert "one-spend settlement order" in rendered
+    assert "does not certify acceptance or bypass replan, identity, or terminal gates" in rendered
+    if missing_baseline is True:
+        assert "No persisted vision baseline is available" in rendered
+        assert "--vision-unchanged-reason" not in rendered
+    else:
+        assert "No persisted vision baseline is available" not in rendered
+        assert "only if a persisted vision exists and its scope and acceptance still apply" in rendered
+    assert rendered.index("vision_checkpoint_required_resolution") < rendered.index("writeback succeeded")
+    assert rendered.index("writeback succeeded") < rendered.index("state_projection_gap")
+    assert render_state_refresh_markdown(first_refresh) == rendered
+    assert first_refresh == before
+
+
+@pytest.mark.parametrize("field,value", [
+    ("ok", False), ("ok", 1), ("appended", False), ("appended", 1),
+    ("dry_run", True), ("dry_run", 0), ("dry_run", None),
+    ("settlement_identity", None), ("settlement_identity", {}),
+    ("settlement_identity", "invalid"), ("refresh_recovery", None),
+    ("vision_checkpoint", None), ("vision_checkpoint", "invalid"),
+    ("refresh_recovery.reason", "other"), ("refresh_recovery.reason", None),
+    ("refresh_recovery.decision", "supplement_checkpoint"),
+    ("vision_checkpoint.required", False), ("vision_checkpoint.required", 1),
+    ("vision_checkpoint.satisfied", True), ("vision_checkpoint.satisfied", 0),
+    ("vision_checkpoint.decision", "not_required"),
+])
+def test_first_markdown_hint_requires_first_committed_missing_checkpoint(
+    first_refresh, field, value,
+):
+    # Stay within the existing renderer's supported input domain.
+    keys = field.split(".")
+    target = first_refresh if len(keys) == 1 else first_refresh[keys[0]]
+    if value is None:
+        target.pop(keys[-1])
+    else:
+        target[keys[-1]] = value
+    rendered = render_state_refresh_markdown(first_refresh)
+    assert "Submit a checkpoint-only refresh" not in rendered
+    assert "state_projection_gap" in rendered
+
+
+@pytest.mark.parametrize("decision", ["replay", "repair_receipt", "reject"])
+def test_recovery_markdown_preserves_routing_and_error_precedence(decision):
+    payload = {
+        "ok": decision != "reject",
+        "refresh_recovery": {"decision": decision, "reason": "original_writeback_preserved"},
         "vision_checkpoint": {"decision": "missing_required", "satisfied": False},
-    })
+    }
+    if decision == "reject":
+        payload["error"] = "committed_writeback_payload_conflict"
+    rendered = render_state_refresh_markdown(payload)
     assert "missing_required" in rendered
-    assert "same refresh command and Turn" in rendered
+    assert "original writeback preserved" in rendered
+    assert "writeback succeeded" not in rendered
     assert "None" not in rendered
+    if decision == "reject":
+        assert payload["error"] in rendered
+        assert "Submit a checkpoint-only refresh" not in rendered
+    else:
+        _assert_checkpoint_instructions(rendered)
+        assert "only if a persisted vision exists and its scope and acceptance still apply" in rendered
+    payload["vision_checkpoint"].update(decision="patched", satisfied=True)
+    assert "Submit a checkpoint-only refresh" not in render_state_refresh_markdown(payload)
 
 
 @pytest.mark.parametrize("decision", ["unchanged", "patch"])
@@ -84,10 +181,36 @@ def test_same_turn_checkpoint_supplement_is_idempotent(tmp_path: Path, decision:
         "--no-global-sync",
         "--suppress-external-sinks",
     )
-    rc, first = _run_cli(registry, runtime, *args, cwd=project)
-    assert rc == 0, first
+    mutation = ("--next-action", "Verify the scoped delivery evidence.") if decision == "patch" else ()
+    if mutation:
+        args += ("--progress-scope", "goal")
+        # Capture the actual first Markdown stdout, not a JSON-then-replay result.
+        result = subprocess.run(
+            [sys.executable, "-m", "loopx.cli", "--registry", str(registry),
+             "--runtime-root", str(runtime), "--format", "markdown", *args, *mutation],
+            cwd=project, capture_output=True, text=True, check=False,
+            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        )
+        assert result.returncode == 0, (result.stdout, result.stderr)
+        _assert_checkpoint_instructions(result.stdout)
+        assert "writeback succeeded" in result.stdout
+        rows = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+        first = json.loads(rows.read_text(encoding="utf-8").splitlines()[-1])
+    else:
+        rc, first = _run_cli(registry, runtime, *args, cwd=project)
+        assert rc == 0, first
+        assert first["ok"] is True and first["appended"] is True
+        assert first["dry_run"] is False
+        _assert_checkpoint_instructions(render_state_refresh_markdown(first))
+    assert first["refresh_recovery"]["decision"] == "append"
+    assert first["refresh_recovery"]["reason"] == "first_writeback"
+    assert first["settlement_identity"]["turn_instance_id"] == TURN_ID
     assert first["vision_checkpoint"]["decision"] == "missing_required"
     original_bytes = Path(first["json_path"]).read_bytes()
+    state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    original_state = state_path.read_bytes()
+    if mutation:
+        assert mutation[1] in original_state.decode("utf-8")
     supplement = (
         (
             "--vision-unchanged-reason",
@@ -98,6 +221,14 @@ def test_same_turn_checkpoint_supplement_is_idempotent(tmp_path: Path, decision:
     )
     index = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
     before_preview = index.read_bytes()
+    if mutation:
+        rc, rejected = _run_cli(registry, runtime, *args, *mutation, *supplement, cwd=project)
+        assert rc == 1, rejected
+        assert rejected["refresh_recovery"]["reason"] == "checkpoint_supplement_must_not_repeat_mutations"
+        assert index.read_bytes() == before_preview
+        assert Path(first["json_path"]).read_bytes() == original_bytes
+        assert state_path.read_bytes() == original_state
+        assert _spend_run_count(runtime) == 0
     rc, preview = _run_cli(
         registry, runtime, *args, *supplement, "--dry-run", cwd=tmp_path
     )
@@ -119,11 +250,14 @@ def test_same_turn_checkpoint_supplement_is_idempotent(tmp_path: Path, decision:
     assert repaired["settlement_identity"] == first["settlement_identity"]
     assert repaired["delivery_workspace"] == first["delivery_workspace"]
     assert Path(first["json_path"]).read_bytes() == original_bytes
+    assert state_path.read_bytes() == original_state
+    after_supplement = index.read_bytes()
     rc, replay = _run_cli(registry, runtime, *args, *supplement, cwd=tmp_path)
     assert rc == 0, replay
     assert replay["appended"] is False
     assert replay["idempotent_replay"] is True
     assert replay["vision_checkpoint"]["satisfied"] is True
+    assert index.read_bytes() == after_supplement
     rc, conflict = _run_cli(
         registry,
         runtime,


### PR DESCRIPTION
## Summary

When a Turn-bound `refresh-state` commits without a required vision checkpoint, show the same-Turn recovery instructions immediately. Both first-writeback and replay hints now explicitly preserve the original target, scope, settlement identity, delivery fields, and isolation flags; remove already executed mutations; and require one authored, valid vision decision.

The shared renderer lives in the existing quota/settlement module. First-writeback eligibility, error precedence, typed recovery admission, JSON/state schemas, and one-spend settlement remain unchanged. This bounded refactor removes the new maintenance burden from `state_refresh.py` without raising ratchet limits.

Following the instructions preserves the original isolation boundary. Persisted authority ceilings and rejection of callers who manually remove flags are outside this PR.

## Issue Or Task

- Related issue: none; bounded first-refresh recovery guidance and P1/P2 review fixes.
- Contributor task ID: not assigned.
- Target base branch: `main`.

## Validation

- [x] Linux Python 3.11 / Node 22.6: **71 tests passed**, covering checkpoint recovery/isolation, maintainability ratchet, and adjacent CLI/Goal Channel lifecycle behavior.
- [x] Actual CLI stdout drives recovery argv for first/replay × present/absent baseline. Tests check unchanged identity/original writes, no repeated mutation or spend, and unchanged global/shared files.
- [x] Configured, activated Explore and Goal Channel sinks use no-network adapters after the authorization gates. Isolation yields zero sends; deliberately removing flags on an independent recovery call reaches both adapters and writes the shared projection.
- [x] Removing either isolation instruction or the executed mutation's removal instruction makes the output-driven test fail. Absent isolation flags remain absent; lane and repeated capability arguments are preserved.
- [x] Linux CLI output-budget and base/head differential smoke passed against the original PR source snapshot.
- [x] Ruff, mypy (21 source files), TypeScript typecheck, and `git diff --check` passed.
- [x] Linux TypeScript control-plane tests: **689 passed, 1 skipped**. The opt-in PostgreSQL integration test had no configured server; this PR does not change the authority backend.
- [x] Required remote `pytest` aggregate and `merge-gate` passed at `5c29b888060f3cdfb7feb20f4ce31e3bb427cee2`: [CI run](https://github.com/huangruiteng/loopx/actions/runs/34187768968). Both test shards, checks, Stage2C, Windows, builds, and DCO are green.

Local Windows symlink-dependent checks could not complete; the corresponding checks above were run successfully in an isolated Linux snapshot. No active project state or real external delivery was used. Required remote CI has passed; maintainer re-review remains pending. No self-merge is requested.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary
- [ ] Capability or extension
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- Direction tracker or promotion unit: not applicable; existing state-refresh/settlement contract.

## Boundary Checklist

- [x] No credentials, active Goal state, private incident notes, raw sessions, internal links, or machine-specific paths are committed.
- [x] The change remains scoped to P1/P2; broader historical permission and target-migration work is deferred.
- [x] Every commit includes the contributor's DCO `Signed-off-by` trailer.

