### PR TITLE
fix(chat): accept nested Goal workspaces

### DIFF
--- a/examples/loopx-chat-actions-smoke.py
+++ b/examples/loopx-chat-actions-smoke.py
@@ -1082,6 +1082,22 @@ def assert_zero_goal_workspace_selection(root: Path) -> None:
     assert source_goal["id"] == ""
     assert source_goal["adapter"]["kind"] == "generic_project_goal_v0"
 
+    monorepo = root / "monorepo"
+    (monorepo / ".git").mkdir(parents=True)
+    nested_project = monorepo / "zoolander"
+    nested_project.mkdir()
+    nested_service = ChatActionService(
+        store=ChatActionStore(root / "nested-action-store"),
+        registry_path=registry_path,
+        workspace_roots=[nested_project],
+    )
+    nested_selected, nested_source_goal = nested_service._project_for_goal_create({
+        "normalized_parameters": {"workspace_ref": "current"},
+        "context": {"kind": "manager", "goal_id": None},
+    })
+    assert nested_selected == nested_project.resolve()
+    assert nested_source_goal["repo"] == str(nested_project.resolve())
+
     second = root / "second-empty-workspace"
     (second / ".git").mkdir(parents=True)
     multi = ChatActionService(

--- a/loopx/chat_actions.py
+++ b/loopx/chat_actions.py
@@ -81,6 +81,12 @@ def _digest(payload: Any) -> str:
     return hashlib.sha256(stable.encode("utf-8")).hexdigest()
 
 
+def _is_git_workspace(path: Path) -> bool:
+    return path.is_dir() and any(
+        (candidate / ".git").exists() for candidate in (path, *path.parents)
+    )
+
+
 def _normalize_cadence(value: Any) -> str:
     candidate = str(value or "").strip().lower().replace("-", "_")
     aliases = {
@@ -712,7 +718,7 @@ class ChatActionService(
         if source_goal is None and workspace_ref == "current":
             workspace_candidates = [
                 root for root in self.workspace_roots
-                if root.is_dir() and (root / ".git").exists()
+                if _is_git_workspace(root)
             ]
             if len(workspace_candidates) == 1:
                 return workspace_candidates[0], {
@@ -736,7 +742,7 @@ class ChatActionService(
         elif source_goal is None and workspace_ref.startswith("workspace-"):
             workspace_candidates = [
                 root for root in self.workspace_roots
-                if root.is_dir() and (root / ".git").exists()
+                if _is_git_workspace(root)
             ]
             selected = next(
                 (
@@ -763,7 +769,7 @@ class ChatActionService(
                 for index, root in enumerate(
                     (
                         root for root in self.workspace_roots
-                        if root.is_dir() and (root / ".git").exists()
+                        if _is_git_workspace(root)
                     ),
                     start=1,
                 )


### PR DESCRIPTION
## Summary

- recognize an explicitly configured scan path as a Git workspace when it is nested inside a checkout
- preserve the exact configured subdirectory as the Goal repo boundary
- cover nested monorepo project selection in the Chat action smoke

## Validation

- `python3.11 examples/loopx-chat-actions-smoke.py`
- isolated production Chat HTTP preview returned `preview_ready`; diagnostic proposal was cancelled
- `ruff check loopx/chat_actions.py`
- `loopx check --scan-path loopx/chat_actions.py --scan-path examples/loopx-chat-actions-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 120`

## Risk and scope

Changed surface: Goal-create workspace qualification only. Existing direct Git roots and multi-workspace selection retain their behavior. No permissions, write scope, or apply semantics change.

Future-facing pass: applied a bounded private predicate so all three workspace-candidate paths share one Git-membership rule; broader workspace discovery changes were unnecessary.