### PR TITLE
fix(pr-review): require canonical state and producer evidence

### DIFF
--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -691,6 +691,7 @@ def main() -> int:
         "problem_context",
         "architecture_flow",
         "repository_reuse",
+        "observable_semantics",
         "changed_line_classification",
         "scope_fit",
         "symbol_map",
@@ -758,6 +759,7 @@ def main() -> int:
     assert execution["completion_gate"]["stale_head_verdict_allowed"] is False
     assert execution["completion_gate"]["blocking_evidence_verdicts"] == {
         "repository_reuse": ["unjustified_duplication", "not_yet_proven"],
+        "observable_semantics": ["unintended_drift", "not_yet_proven"],
         "change_proportionality": ["disproportionate", "not_yet_proven"],
         "default_off_isolation": ["not_isolated", "not_yet_proven"],
         "authority_semantics": ["misleading", "not_yet_proven"],

--- a/loopx/capabilities/pr_review_queue/README.md
+++ b/loopx/capabilities/pr_review_queue/README.md
@@ -185,7 +185,15 @@ typed evidence groups before a verdict:
   ownership. Prefer the nearest existing owner; justify independent boundaries
   with evidence, not green CI or conflict-free coexistence. For alternative
   views of one resource, validate consumer switching and concurrent updates
-  where relevant. Repeat the comparison after base integration or head changes;
+  where relevant. Before accepting introduced or newly enforced state, classify
+  it as an authoritative fact, irreducible intent, derived projection or
+  diagnostic hint. Trace whether existing canonical state can derive the
+  outcome before adding another declaration to maintain. Require the actual
+  producer, triggering workflow, authoring discovery and update/retirement
+  owner; a generic JSON writer plus a hand-filled fixture proves transport,
+  not an ordinary workflow. Intent such as consent or an alternative relation
+  cannot be invented from unrelated records. Repeat the comparison after base
+  integration or head changes;
 - caller-observable semantic parity for every behavior-bearing change, whether
   or not its title says refactor or migration. Inventory legacy caller branches,
   then run the same synthetic fixture through the public entrypoint and affected
@@ -196,7 +204,13 @@ typed evidence groups before a verdict:
   case must make the real path fail on the historical defect or a deliberate
   dropped-field/detail or stronger-precondition mutation, then pass at the fixed
   head. New-rule provider conformance and prose-only claims do not establish
-  before/after compatibility;
+  before/after compatibility. When state/projections drive behavior, vary only
+  redundant annotations, display order/pagination and unrelated-item count
+  beyond display caps, holding authoritative facts fixed. Admission must not
+  change merely because a record falls off a diagnostic page. Check completed,
+  superseded and archived references against the actual acceptance/lifecycle
+  contract; source incompleteness is not proven absence. Do not confuse a real
+  intent or priority change with a presentation-only counterfactual;
 - exact changed-line classification across production, tests/fixtures, docs,
   generated output, and mechanical moves;
 - a 2-5 item exact-head symbol map for code-changing PRs, including caller,
@@ -245,8 +259,10 @@ are `reused`, `separation_justified`, `no_existing_candidate`,
 `unjustified_duplication`, or `not_yet_proven`. A negative search must name its
 scope and limitations; an empty candidate list is not proof of absence.
 Unjustified duplication or missing evidence requires a request-changes
-conclusion. Similar-looking code with distinct invariants or compatibility
-needs may legitimately remain separate. Ordinary docs retain their existing
+conclusion, including missing state derivation, producer/trigger or completeness
+proof in `state_model_assessment`. The same existing gate applies; there is no
+second semantic classifier. Similar-looking code with distinct invariants or
+compatibility needs may legitimately remain separate. Ordinary docs retain their existing
 review path; smoke-only changes retain `durable_smoke_value` coverage review.
 This is a reviewer-executed contract projected by the packet, not an automatic
 repository search or a semantic validator of published prose. Tests establish

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -76,7 +76,7 @@ def build_review_template(item: Mapping[str, Any]) -> dict[str, Any]:
             _section(
                 "改动思路",
                 "300-500字",
-                "Use `architecture_flow`, `repository_reuse`, and `walkthroughs`: entry point, authoritative state, decision boundary, positive path, existing implementation comparison, and ownership trade-off.",
+                "Use `architecture_flow`, `repository_reuse`, and `walkthroughs`: entry point, authoritative state, decision boundary, positive path, existing implementation comparison, and ownership trade-off. For introduced or newly enforced state, explain derivation versus irreducible intent and the real producer/trigger, not just its serializer.",
             ),
             _section(
                 "具体改动",
@@ -147,13 +147,46 @@ def build_review_execution_contract() -> dict[str, Any]:
                 "fields": [
                     "searched_revisions", "queries_and_paths", "existing_candidates",
                     "semantic_comparison", "reuse_or_separation_reason",
-                    "validation_evidence", "verdict",
+                    "state_model_assessment", "validation_evidence", "verdict",
                 ],
                 "comparison_dimensions": [
                     "resource_and_caller", "data_scope_and_filters",
                     "ordering_and_pagination", "authority_and_sanitization",
                     "state_retry_and_failure_owner",
                 ],
+                "state_model_assessment": {
+                    "required_when": "introduced_or_newly_enforced_state",
+                    "classification_values": [
+                        "authoritative_fact", "irreducible_intent",
+                        "derived_projection", "diagnostic_hint",
+                    ],
+                    "item_fields": [
+                        "field_or_relation", "classification", "existing_canonical_sources",
+                        "derivation_or_irreducibility_evidence", "producer_and_trigger",
+                        "authoring_discovery_path", "update_retire_and_replay_owner",
+                        "missing_stale_or_conflicting_value_behavior", "source_completeness",
+                        "counterfactual_validation", "decision",
+                    ],
+                    "rule": (
+                        "Before accepting each added or newly enforced declaration, flag, "
+                        "relation or journal field, classify it and trace existing canonical "
+                        "facts/relations that could derive the required outcome. Prefer a "
+                        "projection over a second manually synchronized state. Identify the "
+                        "real producer, triggering workflow, authoring discovery path and "
+                        "update/retirement/replay owner. A generic JSON writer, schema "
+                        "acceptance, reader call site or hand-filled fixture proves transport, "
+                        "not that an ordinary agent/user will author the fact when needed. "
+                        "Do not invent intent: a system cannot infer an alternative, consent "
+                        "or commitment from unrelated records; genuinely irreducible intent "
+                        "needs an explicit scoped authoring contract. Trace any diagnostic "
+                        "slice back to its completeness boundary: absence from a bounded "
+                        "view is not proof of absence in canonical state. Record no applicable "
+                        "state with a reason, not a fabricated producer. Unjustified duplicate "
+                        "state makes repository_reuse unjustified_duplication; missing "
+                        "derivation, producer or completeness proof makes it not_yet_proven. "
+                        "These are reviewer evidence, not automatic semantic detection."
+                    ),
+                },
                 "rule": (
                     "Before judging the proposed architecture, search the base and "
                     "exact-head repository by caller outcome, resource, routes and "
@@ -197,9 +230,32 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "normalization_rules",
                     "intentional_deltas",
                     "regression_sensitivity",
+                    "state_projection_counterfactuals",
                     "unverified_dimensions",
                     "verdict",
                 ],
+                "state_projection_counterfactuals": {
+                    "required_when": "state_or_projection_drives_behavior",
+                    "cases": [
+                        "same_canonical_state_without_redundant_annotation",
+                        "unrelated_items_beyond_display_limit",
+                        "equivalent_pagination_or_display_order",
+                        "completed_superseded_or_archived_reference",
+                        "incomplete_source_is_not_proven_absence",
+                    ],
+                    "rule": (
+                        "Run applicable counterfactuals through the real public caller, "
+                        "using comparison_rows and execution_receipts. Hold authoritative "
+                        "facts fixed when removing redundant annotations or changing only "
+                        "display order, pagination or unrelated-item count beyond a cap; "
+                        "these must not change admission or obligations. Derive the oracle "
+                        "from an independent invariant, not the new helper. Do not remove "
+                        "genuine user intent or change semantic priority and demand parity. "
+                        "For reference lifecycle changes assert the documented new outcome; "
+                        "done is not automatically proof of goal acceptance. Explain cases "
+                        "that do not apply; an untested applicable case is not_yet_proven."
+                    ),
+                },
                 "comparison_dimensions": [
                     "accepted_inputs_and_defaults",
                     "eligibility_and_rejection_precedence",
@@ -302,7 +358,9 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "verify a shipped behavior and at least one active production "
                     "call site or automatic installation/loading path in the reviewed "
                     "branch. For instructions, verify the audience and activation "
-                    "scope reached by that path. Test-only coverage of an unused "
+                    "scope reached by that path. A consumer or serializer alone does not "
+                    "prove the producer/trigger in repository_reuse.state_model_assessment. "
+                    "Test-only coverage of an unused "
                     "module or uninstalled instruction is not a shipped behavior; "
                     "name the gap and treat it as blocking unless an explicit, owner-accepted "
                     "coverage-only boundary is recorded."
@@ -668,7 +726,9 @@ def build_review_execution_contract() -> dict[str, Any]:
             "open_pr_unresolved_reuse": (
                 "REQUEST_CHANGES when repository_reuse is unjustified_duplication "
                 "or not_yet_proven, including missing/unverified search evidence; "
-                "request reuse, an evidence-backed separation, or further investigation"
+                "request reuse, an evidence-backed separation, or further investigation; "
+                "this includes unproved state derivation, producer/trigger and "
+                "projection completeness, even when the new reader is typed and tested"
             ),
             "open_pr_unresolved_proportionality": (
                 "REQUEST_CHANGES when change_proportionality is disproportionate "

--- a/tests/capabilities/test_pr_review_contract.py
+++ b/tests/capabilities/test_pr_review_contract.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
+from loopx.cli import main as cli_main
 from loopx.capabilities.pr_review_queue import (
     build_agent_response_contract,
     build_review_plan,
@@ -343,6 +347,77 @@ def test_reuse_evidence_compares_semantics_beyond_the_diff() -> None:
     assert "coexistence" in reuse["rule"]
     assert "not an automatic similarity detector" in reuse["rule"]
     assert "repository_reuse" in contract["verdict_policy"]["open_pr_unresolved_reuse"]
+
+
+def test_reuse_requires_state_derivation_and_real_authoring_evidence() -> None:
+    """A typed reader plus a generic JSON writer is not a product producer."""
+    contract = build_agent_response_contract()["review_execution_contract"]
+    reuse = next(
+        row for row in contract["evidence_requirements"]
+        if row["evidence_id"] == "repository_reuse"
+    )
+    assert "state_model_assessment" in reuse["fields"]
+    assessment = reuse["state_model_assessment"]
+    assert assessment["classification_values"] == [
+        "authoritative_fact", "irreducible_intent", "derived_projection", "diagnostic_hint"
+    ]
+    assert {
+        "field_or_relation", "classification", "existing_canonical_sources",
+        "derivation_or_irreducibility_evidence", "producer_and_trigger",
+        "authoring_discovery_path", "update_retire_and_replay_owner",
+        "missing_stale_or_conflicting_value_behavior", "source_completeness",
+        "counterfactual_validation", "decision",
+    } <= set(assessment["item_fields"])
+    assert "generic JSON" in assessment["rule"]
+    assert "cannot infer" in assessment["rule"]
+    assert "not_yet_proven" in assessment["rule"]
+    # This extends the existing reuse gate, rather than creating an independent
+    # automatic classifier that treats every user-authored intent as redundant.
+    assert contract["completion_gate"]["blocking_evidence_verdicts"]["repository_reuse"] == [
+        "unjustified_duplication", "not_yet_proven"
+    ]
+
+
+def test_public_cli_delivers_state_review_without_claiming_it_was_performed(capsys) -> None:
+    fixture = Path(__file__).resolve().parents[2] / "examples/fixtures/pr-review.public.json"
+    assert cli_main(["--format", "json", "pr-review", "--fixture", str(fixture)]) == 0
+    packet = json.loads(capsys.readouterr().out)
+    contract = packet["agent_response_contract"]["review_execution_contract"]
+    requirements = {row["evidence_id"]: row for row in contract["evidence_requirements"]}
+    assert requirements["repository_reuse"]["state_model_assessment"]["required_when"] == (
+        "introduced_or_newly_enforced_state"
+    )
+    assert requirements["observable_semantics"]["state_projection_counterfactuals"]["cases"]
+    assert packet["pull_requests"]
+    reviewed_code = False
+    for item in packet["pull_requests"]:
+        evidence = item["review_plan"]["result_template"]["evidence"]
+        if "repository_reuse" in item["review_plan"]["required_evidence_ids"]:
+            reviewed_code = True
+            assert evidence["repository_reuse"] == {"status": "unverified"}
+            assert evidence["observable_semantics"] == {"status": "unverified"}
+    assert reviewed_code
+
+
+def test_semantic_review_requires_compaction_and_annotation_counterfactuals() -> None:
+    contract = build_agent_response_contract()["review_execution_contract"]
+    parity = next(
+        row for row in contract["evidence_requirements"]
+        if row["evidence_id"] == "observable_semantics"
+    )
+    assert "state_projection_counterfactuals" in parity["fields"]
+    cases = parity["state_projection_counterfactuals"]
+    assert cases["required_when"] == "state_or_projection_drives_behavior"
+    assert {
+        "same_canonical_state_without_redundant_annotation",
+        "unrelated_items_beyond_display_limit",
+        "equivalent_pagination_or_display_order",
+        "completed_superseded_or_archived_reference",
+        "incomplete_source_is_not_proven_absence",
+    } <= set(cases["cases"])
+    assert "independent invariant" in cases["rule"]
+    assert "user intent" in cases["rule"]
+    assert "real public caller" in cases["rule"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Strengthen the existing `pull-request-review` execution contract after the architectural review of #4049 exposed a gap: a typed consumer and generic JSON writer do not prove that a new declaration is necessary or normally authored.

- Extend `repository_reuse` with conditional state-model evidence: canonical derivability versus irreducible intent; actual producer, trigger, discovery and maintenance; source completeness and stale/missing behavior.
- Extend `observable_semantics` with real-caller counterfactuals for redundant annotations, display caps/pagination and reference lifecycle. Preserve genuine user intent and semantic priority; do not infer alternatives or consent from unrelated records.
- Reuse the existing unresolved-reuse / semantic-drift Request Changes rules. No new review gate, automatic semantic classifier, authorization, or agent-maintained product state.
- Document the operational requirements, test public CLI delivery with initially unverified evidence, and repair two stale smoke expectations that omitted the already-existing observable-semantics contract.

## Validation

- 58 focused contract, capability queue and GitHub scan tests passed, including the real public CLI with a synthetic fixture.
- New contract assertions failed before the change and passed after it.
- Public `pr-review` command smoke passed; Ruff and diff hygiene passed.
- Standard risk-based `canary premerge --from-git-diff` passed: 16 selected checks (7 catalog, 8 risk-profile, 1 public-boundary), plus diff hygiene and changed-Python compilation; zero failures.
- Baseline inspection independently confirmed the smoke's missing observable-semantics requirement; production evidence IDs and blocking verdict categories are unchanged.

These tests prove delivery/applicability of the review contract, not guaranteed model adherence. No live-model evaluation, live Goal mutation, provider migration or deployment was performed.

## Scope and ownership

Nearest owner: the built-in `pull-request-review` capability's existing packet contract, consumed by `loopx pr-review`. No provider or extension changes. The bounded future-facing pass strengthens the existing reuse/parity boundaries instead of adding another skill checklist or review framework. Ordinary docs-only applicability and initial unverified review results remain unchanged. The change intentionally asks reviewers for stronger evidence before a verdict; it does not automatically execute a review or enforce semantic judgments in the runtime.

One cohesive signed commit includes product contract, durable documentation and focused validation. Private state, incident traces and local probe artifacts are excluded. This PR does not change or resolve #4049's implementation.
