### PR TITLE
fix(chat): honor serve defaults in action service

### DIFF
--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -1477,10 +1477,10 @@ def serve_chat(
     )
     server.action_service = ChatActionService(
         store=server.action_store,
-        registry_path=registry_path,
+        registry_path=resolved_registry_path,
         chat_store=server.chat_store,
         runtime_controller=server.runtime_controller,
-        workspace_roots=scan_roots,
+        workspace_roots=resolved_scan_roots,
     )
     server.lark_goal_topic_runtime = LarkGoalTopicRuntimeService(
         snapshot_provider=lambda: build_lark_goal_topic_runtime_snapshot(

--- a/tests/test_chat_startup_isolation.py
+++ b/tests/test_chat_startup_isolation.py
@@ -18,11 +18,16 @@ def test_real_chat_entrypoint_serves_while_binding_discovery_is_blocked(
     entered = threading.Event()
     release = threading.Event()
     servers: list[chat.ChatHTTPServer] = []
-    registry = tmp_path / "registry.json"
+    home = tmp_path / "home"
+    registry = home / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True)
     registry.write_text(json.dumps({"goals": []}))
     assets = tmp_path / "web"
     assets.mkdir()
     (assets / "index.html").write_text("<html>workspace fixture</html>")
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda _cls: home))
+    monkeypatch.chdir(tmp_path)
 
     class Server(chat.ChatHTTPServer):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -48,9 +53,7 @@ def test_real_chat_entrypoint_serves_while_binding_discovery_is_blocked(
     worker = threading.Thread(
         target=chat.serve_chat,
         kwargs={
-            "registry_path": registry,
             "runtime_root_override": tmp_path / "runtime",
-            "scan_roots": [],
             "port": 0,
             "assets_dir": assets,
             "codex_bin": "nonexistent-loopx-test-codex",
@@ -61,6 +64,8 @@ def test_real_chat_entrypoint_serves_while_binding_discovery_is_blocked(
     worker.start()
     try:
         assert entered.wait(5)
+        assert servers[0].action_service.registry_path == registry.resolve()
+        assert servers[0].action_service.workspace_roots == (tmp_path.resolve(),)
         base = f"http://127.0.0.1:{servers[0].server_port}"
         for route in ("/healthz", "/api/chat/capabilities"):
             with urlopen(base + route, timeout=2) as response:


### PR DESCRIPTION
## Summary

- pass `serve_chat()`'s resolved default registry path into `ChatActionService`
- pass its resolved default workspace roots into the service as well
- exercise the real startup entrypoint without explicit registry or scan-root arguments

## Why

`serve_chat()` advertises optional `registry_path` and `scan_roots`, resolves both values, and uses those defaults elsewhere in startup. The action service was still receiving the unresolved `None` values, so direct callers relying on the public defaults could fail during service construction.

## Validation

- `pytest -q` over the Chat/API/Goal-activation set: **106 passed**
- `ruff check tests/test_chat_startup_isolation.py`
- `python3 examples/loopx-chat-actions-smoke.py`
- `loopx check` public-boundary scan on both changed files: **clean**
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff`: **passed**

A broader dashboard suite has one unrelated launcher assertion failure; the exact test reproduces unchanged on latest `origin/main`.
