### PR TITLE
ci: parallelize Stage 2C without reducing correctness coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -176,9 +176,14 @@ jobs:
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-  stage2c-correctness-e2e:
+  stage2c-suite:
+    name: stage2c (${{ matrix.suite }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [e2e, mutants, installed]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -216,29 +221,48 @@ jobs:
           # Remove the generated source copy before pytest's normal discovery.
           python -c "import shutil; shutil.rmtree('build')"
       - name: Qualify real CLI, mixed writers, process death, and recovery
+        if: matrix.suite == 'e2e'
         env:
           LOOPX_SHADOW_COMPARISON_OUTPUT: .local/stage2c-observables
-        run: python -m pytest -q -m stage2c_e2e --junitxml=stage2c-e2e.xml
+        # Keep each module's shared workspace and ordered parity rows on one worker.
+        run: python -m pytest -q -n 2 --dist loadfile -m stage2c_e2e --durations=20 --junitxml=stage2c-e2e.xml
       - name: Reject deliberate correctness regressions
+        if: matrix.suite == 'mutants'
         run: python examples/shared-goal-authority-e2e/mutants.py --output .local/stage2c-mutants
       - name: Build independently installed distributions
+        if: matrix.suite == 'installed'
         run: python -m build --no-isolation
       - name: Qualify wheel outside the repository
+        if: matrix.suite == 'installed'
         run: python examples/shared-goal-authority-e2e/installed.py --artifact dist/*.whl --report-json installed-wheel.json
       - name: Qualify sdist outside the repository
+        if: matrix.suite == 'installed'
         run: python examples/shared-goal-authority-e2e/installed.py --artifact dist/*.tar.gz --report-json installed-sdist.json
       - name: Retain bounded acceptance evidence
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: stage2c-correctness-evidence
+          name: stage2c-correctness-evidence-${{ matrix.suite }}
           include-hidden-files: true
+          if-no-files-found: error
           path: |
             stage2c-e2e.xml
             .local/stage2c-observables/
             installed-wheel.json
             installed-sdist.json
             .local/stage2c-mutants/
+
+  stage2c-correctness-e2e:
+    # Preserve the public check name and reject failed, cancelled or skipped lanes.
+    if: always()
+    needs: [stage2c-suite]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every Stage 2C lane
+        env:
+          STAGE2C_RESULT: ${{ needs.stage2c-suite.result }}
+        run: test "$STAGE2C_RESULT" = success
 
   windows-powershell:
     runs-on: windows-latest

--- a/examples/shared-goal-authority-e2e/correctness.md
+++ b/examples/shared-goal-authority-e2e/correctness.md
@@ -246,7 +246,7 @@ separately without skip or relaxation flags:
 ```bash
 python -m pip install -e '.[test]' 'build==1.6.0'
 npm ci --ignore-scripts
-python -m pytest -q -m stage2c_e2e --junitxml=stage2c-e2e.xml
+python -m pytest -q -n 2 --dist loadfile -m stage2c_e2e --durations=20 --junitxml=stage2c-e2e.xml
 python examples/shared-goal-authority-e2e/mutants.py --output .local/stage2c-mutants
 python -m build
 python examples/shared-goal-authority-e2e/installed.py --artifact dist/*.whl --report-json .local/installed-wheel.json
@@ -261,11 +261,20 @@ python examples/control_plane/cli-output-budget-regression-smoke.py
 loopx --format json canary premerge --from-git-diff
 ```
 
-The Linux/Python 3.11 CI job uses the exact dependency versions and hashes in
+The Linux/Python 3.11 CI lanes use the exact dependency versions and hashes in
 `tests/requirements-stage2c-linux-py311.txt`, including pytest 9.1.1. It builds
 the checked-out source wheel, verifies its hash during installation, and removes
 its generated build tree before normal pytest discovery. The workflow records
 the complete installation sequence and retains normal source discovery.
+
+E2E, deliberate mutants, and independently installed wheel/sdist qualification
+run in separate jobs; the stable `stage2c-correctness-e2e` check requires all three
+to succeed. No path-based skipping or reduced case selection is used. E2E uses
+two file-grouped workers so a module's shared workspaces and ordered parity rows
+stay together. Each lane has a distinct evidence artifact. Mutants remain serial
+inside their isolated source copy: parallel edits to that copy would invalidate
+the control/mutant comparison. Single-row fence probes initialize only the
+workspace they use, without removing any baseline or mutant assertion.
 
 The full TS suite's PostgreSQL conformance requires `LOOPX_TEST_POSTGRES_URL`
 pointing to a disposable test database. Source smoke success does not replace

--- a/tests/control_plane/test_shadow_fence_caller_parity_e2e.py
+++ b/tests/control_plane/test_shadow_fence_caller_parity_e2e.py
@@ -8,6 +8,7 @@ Nothing is mocked; the fence is engaged by the real TypeScript owner.
 """
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
 import json
 from pathlib import Path
 import shutil
@@ -198,11 +199,17 @@ def load_rows() -> list[dict]:
 
 
 @pytest.fixture(scope="module")
-def workspaces(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Workspace]:
+def workspaces(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Callable[[str], Workspace]]:
     built: dict[str, Workspace] = {}
-    for key, build in WORKSPACES.items():
-        built[key] = build(tmp_path_factory.mktemp(key))
-    yield built
+
+    def get(key: str) -> Workspace:
+        # Single-row mutation probes need only this row's workspace. Keep reuse
+        # and ordered mutations within a module, never across worker processes.
+        if key not in built:
+            built[key] = WORKSPACES[key](tmp_path_factory.mktemp(key))
+        return built[key]
+
+    yield get
     for ws in built.values():
         shutil.rmtree(ws.w.path, ignore_errors=True)
 
@@ -214,10 +221,10 @@ def observe_row(ws: Workspace, row: dict) -> dict:
 
 
 @pytest.mark.parametrize("row", load_rows(), ids=[row["id"] for row in load_rows()])
-def test_fence_caller_parity(workspaces: dict[str, Workspace], row: dict) -> None:
+def test_fence_caller_parity(workspaces: Callable[[str], Workspace], row: dict) -> None:
     if row["id"] == "fixture-missing":
         pytest.fail(f"parity fixture is missing: {FIXTURE}")
-    observed = observe_row(workspaces[row["workspace"]], row)
+    observed = observe_row(workspaces(row["workspace"]), row)
     assert observed["exit"] == row["exit"], observed
     if row.get("match") == "subset":
         assert {key: observed["envelope"].get(key) for key in row["expect"]} == row["expect"], observed

--- a/tests/test_python_ci_workflow.py
+++ b/tests/test_python_ci_workflow.py
@@ -16,6 +16,74 @@ WORKFLOW = (
 ).read_text(encoding="utf-8")
 
 
+@pytest.mark.parametrize("result", ["success", "failure", "cancelled", "skipped", ""])
+def test_stage2c_gate_requires_all_lanes(result: str) -> None:
+    gate = WORKFLOW.split("  stage2c-correctness-e2e:", 1)[1].split("  windows-powershell:", 1)[0]
+    assert "if: always()" in gate
+    assert "needs: [stage2c-suite]" in gate
+    assert "STAGE2C_RESULT: ${{ needs.stage2c-suite.result }}" in gate
+    script = gate.split("run: ", 1)[1].strip()
+    actual = subprocess.run(
+        ["bash", "-e", "-c", script],
+        env={**os.environ, "STAGE2C_RESULT": result}, check=False,
+    )
+    assert (actual.returncode == 0) == (result == "success")
+    suite = WORKFLOW.split("  stage2c-suite:", 1)[1].split("  stage2c-correctness-e2e:", 1)[0]
+    assert "fail-fast: false" in suite
+    assert "suite: [e2e, mutants, installed]" in suite
+    assert "    if:" not in suite.split("    steps:", 1)[0]
+    steps = {step.splitlines()[0]: step for step in suite.split("      - name: ")[1:]}
+    for name, lane in [
+        ("Qualify real CLI, mixed writers, process death, and recovery", "e2e"),
+        ("Reject deliberate correctness regressions", "mutants"),
+        ("Build independently installed distributions", "installed"),
+        ("Qualify wheel outside the repository", "installed"),
+        ("Qualify sdist outside the repository", "installed"),
+    ]:
+        assert f"if: matrix.suite == '{lane}'" in steps[name]
+    assert "--case" not in steps["Reject deliberate correctness regressions"]
+    artifact = steps["Retain bounded acceptance evidence"]
+    assert "if: always()" in artifact
+    assert "name: stage2c-correctness-evidence-${{ matrix.suite }}" in artifact
+    assert "if-no-files-found: error" in artifact
+
+
+def test_stage2c_workers_preserve_module_state_and_execute_every_row(tmp_path: Path) -> None:
+    step = WORKFLOW.split("name: Qualify real CLI, mixed writers, process death, and recovery", 1)[1]
+    command = step.split("run: ", 1)[1].splitlines()[0]
+    args = shlex.split(command)
+    args[0] = sys.executable
+    # Actual workflow command against two modules with order-sensitive shared state.
+    # Per-test distribution would break the module fixture's accumulated state.
+    for name in ("first", "second"):
+        (tmp_path / f"test_{name}.py").write_text(
+            "import os\nfrom pathlib import Path\nimport pytest\n"
+            "pytestmark = pytest.mark.stage2c_e2e\n"
+            "@pytest.fixture(scope='module')\ndef state():\n    return []\n"
+            "@pytest.mark.parametrize('row', range(4))\n"
+            "def test_order(state, row):\n"
+            "    assert state == list(range(row))\n    state.append(row)\n"
+            f"    with Path('{name}.visits').open('a') as stream:\n"
+            "        stream.write(f'{os.getpid()}:{row}\\n')\n",
+            encoding="utf-8",
+        )
+    (tmp_path / "pytest.ini").write_text("[pytest]\nmarkers = stage2c_e2e\n")
+    env = {key: value for key, value in os.environ.items()
+           if not key.startswith(("PYTEST", "COVERAGE", "COV_CORE"))}
+    actual = subprocess.run(args, cwd=tmp_path, env=env, capture_output=True,
+                            text=True, timeout=60, check=False)
+    assert actual.returncode == 0, actual.stdout + actual.stderr
+    cases = ET.parse(tmp_path / "stage2c-e2e.xml").findall(".//testcase")
+    assert len(cases) == 8
+    workers = set()
+    for name in ("first", "second"):
+        rows = [line.split(":") for line in (tmp_path / f"{name}.visits").read_text().splitlines()]
+        assert [row for _, row in rows] == ["0", "1", "2", "3"]
+        assert len({pid for pid, _ in rows}) == 1
+        workers.add(rows[0][0])
+    assert len(workers) == 2
+
+
 @pytest.mark.parametrize("checks", ["success", "failure", "cancelled", "skipped"])
 @pytest.mark.parametrize("shards", ["success", "failure", "cancelled", "skipped"])
 def test_required_pytest_check_rejects_incomplete_upstream_jobs(


### PR DESCRIPTION
## Summary

Reduce Stage 2C wall time without removing coverage or weakening correctness oracles.

- Run real E2E, deliberate mutants, and independently installed distributions in three isolated CI lanes. Preserve `stage2c-correctness-e2e` as an always-run aggregate that rejects failure, cancellation, and skipped lanes.
- Use two `loadfile` E2E workers, retaining each module's shared workspace and row ordering. Keep all marked tests, unfiltered mutant cases, wheel and sdist checks.
- Lazily initialize fence-parity workspaces so single-row mutant controls do not build unrelated goals. Preserve reuse, cleanup, and every assertion.
- Give evidence artifacts distinct lane names and fail on missing output; keep mutants serial within their isolated mutable source copy.

## Why this scope

The previous successful run spent 9m08s on E2E and then 5m15s on mutants, out of 15m34s total. Dependency setup was not the dominant cost. This changes CI scheduling and fixture preparation only, not production authority, test selection, fault injection, timeout semantics, or packaging qualification. No new dependency or sharding framework. File grouping is intentional: distributing individual rows could invalidate stateful parity fixtures.

## Validation

- 23 workflow tests passed, including executing the actual aggregate shell for success/failure/cancelled/skipped/missing status, and the actual two-worker pytest command against order-sensitive module fixtures.
- Changed-test lint and diff hygiene passed.
- Hosted Linux/Python 3.11 exact-head validation passed: **213 E2E tests**, **37/37 mutants killed by assertions after green controls**, and independent wheel/sdist qualification. Compared downloaded baseline/head artifacts: identical test multiset, mutant case set, and all **59 observable evidence filenames** retained.
- Deliberately replacing `loadfile` with per-test `load` makes the new order-sensitive worker test fail; the safety test does not merely assert flag spelling.
- Local wheel/sdist qualification also passed (five checks each). Public boundary scan clean for all four changed files. No production authority/backend logic changed.

## Measured wall time

| Stage 2C | Before | After |
| --- | --- | --- |
| End-to-end wait, including aggregate | 15m34s | **6m37s** |
| E2E job | part of the serial job | 6m29s |
| Mutant job | part of the serial job | 5m44s |
| Installed distributions job | part of the serial job | 1m25s |

About **57% lower Stage 2C latency** in these two successful hosted runs, not a universal timing guarantee. The normal Python shards remain independent and may now dominate total workflow time. No claim that total CI finishes in 6m37s.

New run: https://github.com/huangruiteng/loopx/actions/runs/34141450202

Baseline timing: https://github.com/huangruiteng/loopx/actions/runs/34135927703/job/101786881924

No local logs, installed state, credentials, or generated artifacts are included.
