### PR TITLE
fix(dsh): derive unambiguous local session identities

### DIFF
--- a/docs/integrations/deepseek-harness-connector.md
+++ b/docs/integrations/deepseek-harness-connector.md
@@ -94,6 +94,17 @@ SDK home by default. Override it with `--dsh-home <path>`; the historical
 Session persistence itself is owned by the selected dsh composition and is not
 implied by the home-directory name.
 
+The headless adapter derives its local session id from a versioned digest of
+`[goal_id, agent_id, todo_id]`, preserving component positions so delimiters
+inside an id cannot alias another lineage. The same lineage produces the same
+id on retries; when all three components are absent, the existing Turn-key
+fallback is retained. These opaque ids stay out of public LoopX state.
+
+Upgrading from the former hyphen-joined naming scheme selects a new session id
+for a populated lineage. The adapter does not fall back to the ambiguous old
+name, rename sessions, or delete existing session files. Any persistence or
+resume behavior for the newly selected id remains owned by the dsh composition.
+
 ## Run One Governed Turn In Process (`--host dsh`)
 
 The built-in host runs the same adapter inside the CLI process:

--- a/loopx/dsh_goal_mode/turn_host_adapter.py
+++ b/loopx/dsh_goal_mode/turn_host_adapter.py
@@ -531,19 +531,23 @@ class DshHostConfig:
 def _derive_session_id(request: Mapping[str, Any], turn_key: str) -> str:
     # Keep the opaque dsh session keyed by the same (goal, agent, todo) lineage
     # LoopX already uses for the Turn transaction. The exact value is a local
-    # adapter concern and must not enter public LoopX state.
+    # adapter concern and must not enter public LoopX state. Encode every
+    # component position before hashing: delimiter-joined ids can collide when
+    # an id itself contains the delimiter.
     envelope = _mapping(request.get("turn_envelope"))
     action = _mapping(envelope.get("action"))
     selected_todo = _mapping(action.get("selected_todo"))
-    return "-".join(
-        str(value)
-        for value in (
-            envelope.get("goal_id"),
-            envelope.get("agent_id"),
-            selected_todo.get("todo_id"),
-        )
-        if value
-    ) or f"dsh-{turn_key.removeprefix('sha256:')[:24]}"
+    lineage = [
+        envelope.get("goal_id"),
+        envelope.get("agent_id"),
+        selected_todo.get("todo_id"),
+    ]
+    # Keep the legacy truthiness boundary: empty or non-string false-like
+    # values are not lineage identities, while their positions stay encoded.
+    lineage = [value if value else None for value in lineage]
+    if any(lineage):
+        return "dsh-lineage-v1-" + _canonical_hash(lineage).removeprefix("sha256:")
+    return f"dsh-{turn_key.removeprefix('sha256:')[:24]}"
 
 
 def _execute_turn_host_request(

--- a/tests/test_dsh_goal_mode.py
+++ b/tests/test_dsh_goal_mode.py
@@ -28,16 +28,19 @@ TURN_KEY = "sha256:" + "0" * 64
 def _signed_request(
     *,
     primary_action: str = "Do the signed thing.",
+    goal_id: str = "g",
+    agent_id: str = "a",
+    todo_id: str | None = None,
 ) -> dict:
     request = {
         "schema_version": dsh_goal_mode.LOOPX_TURN_HOST_REQUEST_SCHEMA,
         "turn_key": TURN_KEY,
         "route": "primary_delivery",
-        "session": {"goal_id": "g", "agent_id": "a"},
+        "session": {"goal_id": goal_id, "agent_id": agent_id},
         "turn_envelope": {
             "schema_version": "loopx_turn_envelope_v0",
-            "goal_id": "g",
-            "agent_id": "a",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
             "action": {
                 "recommended_action": "legacy action must not win",
                 "primary_action": primary_action,
@@ -68,6 +71,8 @@ def _signed_request(
             "completed_phases": list(dsh_goal_mode.COMPLETED_PHASES),
         },
     }
+    if todo_id is not None:
+        request["turn_envelope"]["action"]["selected_todo"] = {"todo_id": todo_id}
     signature = turn_envelope_action_signature_document(
         request["turn_envelope"]
     )
@@ -86,6 +91,91 @@ def _signed_request(
         }
     )
     return request
+
+
+def _lineage_request(
+    *, goal_id: object = None, agent_id: object = None, todo_id: object = None
+) -> dict:
+    envelope: dict[str, object] = {"action": {}}
+    if goal_id is not None:
+        envelope["goal_id"] = goal_id
+    if agent_id is not None:
+        envelope["agent_id"] = agent_id
+    if todo_id is not None:
+        envelope["action"] = {"selected_todo": {"todo_id": todo_id}}
+    return {"turn_envelope": envelope}
+
+
+def test_dsh_session_id_uses_a_versioned_lineage_digest() -> None:
+    # Hyphen-delimited fields are ambiguous: both inputs produced
+    # "goal-a-worker-todo_b-todo_abc" under the historical naming scheme.
+    first = _lineage_request(
+        goal_id="goal-a", agent_id="worker", todo_id="todo_b-todo_abc"
+    )
+    second = _lineage_request(
+        goal_id="goal-a-worker", agent_id="todo_b", todo_id="todo_abc"
+    )
+
+    first_id = turn_host_adapter._derive_session_id(first, TURN_KEY)
+    second_id = turn_host_adapter._derive_session_id(second, TURN_KEY)
+    expected = "dsh-lineage-v1-" + sha256(
+        json.dumps(
+            ["goal-a", "worker", "todo_b-todo_abc"],
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert first_id.startswith("dsh-lineage-v1-")
+    assert second_id.startswith("dsh-lineage-v1-")
+    assert first_id == expected
+    assert first_id != second_id
+    assert first_id == turn_host_adapter._derive_session_id(first, TURN_KEY)
+
+
+def test_dsh_session_id_preserves_missing_lineage_component_positions() -> None:
+    missing_agent = _lineage_request(goal_id="goal", todo_id="todo")
+    missing_todo = _lineage_request(goal_id="goal", agent_id="todo")
+
+    assert turn_host_adapter._derive_session_id(
+        missing_agent, TURN_KEY
+    ) != turn_host_adapter._derive_session_id(missing_todo, TURN_KEY)
+    assert turn_host_adapter._derive_session_id(
+        _lineage_request(), TURN_KEY
+    ) == "dsh-" + "0" * 24
+    assert turn_host_adapter._derive_session_id(
+        _lineage_request(goal_id=False, agent_id=0, todo_id=""), TURN_KEY
+    ) == "dsh-" + "0" * 24
+
+
+def test_dsh_host_passes_lineage_session_id_to_the_runner(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    requests = [
+        _signed_request(
+            goal_id="goal-a", agent_id="worker", todo_id="todo_b-todo_abc"
+        ),
+        _signed_request(
+            goal_id="goal-a-worker", agent_id="todo_b", todo_id="todo_abc"
+        ),
+        _signed_request(
+            goal_id="goal-a", agent_id="worker", todo_id="todo_b-todo_abc"
+        ),
+    ]
+    session_ids: list[str] = []
+
+    def run_fake_dsh_turn(**kwargs: object) -> str:
+        session_ids.append(str(kwargs["session_id"]))
+        return '{"result_kind":"wait"}'
+
+    monkeypatch.setattr(turn_host_adapter, "run_dsh_turn", run_fake_dsh_turn)
+    config = turn_host_adapter.DshHostConfig(workspace=tmp_path)
+    for request in requests:
+        turn_host_adapter.run_dsh_host(request, config=config)
+
+    assert session_ids[0] != session_ids[1]
+    assert session_ids[0] == session_ids[2]
 
 
 def test_dsh_goal_mode_is_a_first_class_subpackage() -> None:


### PR DESCRIPTION
## Summary

The headless DSH adapter joins Goal, Agent and Todo ids with hyphens, so distinct valid lineages can select the same local session. For example, `(goal-a, worker, todo_b-todo_abc)` and `(goal-a-worker, todo_b, todo_abc)` both formerly produced `goal-a-worker-todo_b-todo_abc`.

Derive the session id from a fixed-position canonical JSON tuple and the existing SHA-256 helper, with a `dsh-lineage-v1-` prefix. Missing/falsy components normalize to null instead of being dropped from the tuple; completely absent lineage retains the existing Turn-key fallback. Identical lineage remains stable across retries. Session ids remain local to the adapter/DSH runner and do not become LoopX state or authority.

Compatibility: populated lineages select new session ids after upgrade. There is no fallback to ambiguous old names, and no existing session files are renamed or deleted. Session persistence remains owned by the selected DSH composition; this change adds no cross-process resume guarantee. The connector documentation records this behavior.

## Validation

- The old implementation fails the collision and missing-position regressions; final DSH module suite: **53 passed**.
- Signed `run_dsh_host` requests prove that both legal collision tuples reach the external runner with distinct ids and retries retain the same id.
- Adapter smoke: **11 checks passed**; generic CLI and built-in host Turn e2e smokes passed, including independent validation, writeback, quota accounting, retry exhaustion and idempotent replay.
- Real `deepseek-harness-sdk==0.1.2a3` and bundled runtime: both generic CLI and built-in host e2e passed using a local mock SSE endpoint, without a real model call or user session.
- Ruff, module mypy, diff and public-boundary checks passed. Mypy excludes the external SDK's missing `py.typed` marker; local module strict checking remains enabled. Restricted-worker Effect runtime startup failures were resolved by rerunning the same tests with the required local runtime permissions.
- Independent subagent review found no blockers. Existing canonical hashing was reused; no new dependency, store or general identity framework.

## Type of Change

- [x] Bug fix
- [x] Breaking change (local session naming; old files retained)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- Target base branch: `main`

## Boundary Checklist

- [x] Only adapter code, focused synthetic tests and connector documentation are included.
- [x] No credentials, private sessions, local evidence, internal links or machine paths are committed.
- [x] Every commit has a DCO sign-off.
