### PR TITLE
feat(benchmark): preserve traceable case observations

### DIFF
--- a/loopx/capabilities/benchmark_toolkit/README.md
+++ b/loopx/capabilities/benchmark_toolkit/README.md
@@ -1049,6 +1049,49 @@ solver-trajectory slice, even when no case became terminal. This readback is for
 campaign supervision and insight discovery only; it must not expose hidden
 evaluator evidence to the solving arm.
 
+When that readback produces a useful case-level runtime finding before terminal
+scoring, preserve it as a private provisional observation rather than waiting for
+the final grader or overstating it as a scored insight:
+
+```json
+{
+  "schema_version": "benchmark_case_observation_v0",
+  "case": {
+    "benchmark_id": "<public-id>",
+    "case_id": "<public-id>",
+    "arm": "<baseline-or-treatment>"
+  },
+  "run_status": "running",
+  "runtime_outcome": "<ok-error-in_progress-or-unknown>",
+  "duration_ms": null,
+  "evidence_refs": [
+    {
+      "kind": "trace",
+      "trace_id": "<opaque-id-or-null>",
+      "span_id": "<opaque-id-or-null>",
+      "env": "<environment-token-or-null>",
+      "artifact_ref": "<private-pointer-or-null>"
+    }
+  ],
+  "hypothesis": "<provisional-causal-explanation>",
+  "confidence": "medium",
+  "promotion_state": "pending_terminal_score_review"
+}
+```
+
+`trace_id`, `span_id`, and `env` are provider-neutral optional traceability fields.
+Provider-specific session identifiers belong in private provider extensions, not in
+this common contract. Raw evidence references can still disclose sensitive runtime
+topology, so the artifact stays in private benchmark storage. The public experiment
+board records only a compact classification or private artifact handle; it never
+copies trace IDs, spans, URLs, paths, or provider-specific session identifiers.
+
+The provisional observation must not invent a score or treat request success,
+progress, or runtime status as case quality. Once the run is terminal and scoring
+is complete, the analyst re-reads the complete authorized evidence and writes a
+separate `benchmark_case_insight_v0`; it does not relabel the provisional artifact
+as final.
+
 This is a provider obligation, not an effect performed by the reducer: the
 runtime-observation command only returns a typed classification and recommended
 transition. The provider remains responsible for the monitor cycle, trajectory
@@ -1092,6 +1135,15 @@ Record the result in this compact shape:
     "hidden_tests",
     "grader_or_verifier",
     "failure_and_score_details"
+  ],
+  "evidence_refs": [
+    {
+      "kind": "<trace-log-artifact-report-or-other>",
+      "trace_id": "<opaque-id-or-null>",
+      "span_id": "<opaque-id-or-null>",
+      "env": "<environment-token-or-null>",
+      "artifact_ref": "<private-pointer-or-null>"
+    }
   ],
   "insight": {
     "approach_summary": "<what-the-solver-tried>",

--- a/loopx/capabilities/benchmark_toolkit/catalog_entry.py
+++ b/loopx/capabilities/benchmark_toolkit/catalog_entry.py
@@ -746,6 +746,51 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "raw_log_error_count_alone",
             ],
         },
+        "active_case_observation": {
+            "status": "provisional_only",
+            "purpose": (
+                "Preserve traceable runtime evidence while a case or campaign is "
+                "still active without presenting it as an official scored insight."
+            ),
+            "artifact_template": {
+                "schema_version": "benchmark_case_observation_v0",
+                "case": {
+                    "benchmark_id": "<public-id>",
+                    "case_id": "<public-id>",
+                    "arm": "<baseline-or-treatment>",
+                },
+                "run_status": "<planned-running-or-terminal>",
+                "runtime_outcome": "<ok-error-in_progress-or-unknown>",
+                "duration_ms": "<non-negative-integer-or-null>",
+                "evidence_refs": [
+                    {
+                        "kind": "<trace-log-artifact-report-or-other>",
+                        "trace_id": "<opaque-id-or-null>",
+                        "span_id": "<opaque-id-or-null>",
+                        "env": "<environment-token-or-null>",
+                        "artifact_ref": "<private-pointer-or-null>",
+                    }
+                ],
+                "hypothesis": "<provisional-causal-explanation>",
+                "confidence": "<high-medium-or-low>",
+                "promotion_state": "pending_terminal_score_review",
+            },
+            "score_boundary": (
+                "A provisional observation must not invent an official score or "
+                "treat request success, progress, or runtime status as case quality."
+            ),
+            "promotion_rule": (
+                "After terminal scoring, re-read the complete authorized evidence "
+                "and write a separate benchmark_case_insight_v0; do not relabel the "
+                "provisional artifact as final."
+            ),
+            "privacy_boundary": (
+                "Keep raw evidence references in private benchmark storage. The "
+                "public experiment board may expose only a compact classification "
+                "or private artifact handle, never trace IDs, spans, URLs, paths, "
+                "or provider-specific session identifiers."
+            ),
+        },
         "hint": (
             "After the solver has stopped and scoring is complete, read the task, "
             "real trajectory, final patch or workspace, hidden tests, grader or "
@@ -814,6 +859,15 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
                 "hidden_tests",
                 "grader_or_verifier",
                 "failure_and_score_details",
+            ],
+            "evidence_refs": [
+                {
+                    "kind": "<trace-log-artifact-report-or-other>",
+                    "trace_id": "<opaque-id-or-null>",
+                    "span_id": "<opaque-id-or-null>",
+                    "env": "<environment-token-or-null>",
+                    "artifact_ref": "<private-pointer-or-null>",
+                }
             ],
             "insight": {
                 "approach_summary": "<what-the-solver-tried>",
@@ -938,6 +992,11 @@ BENCHMARK_TOOLKIT_CATALOG_ENTRY: dict[str, Any] = {
         {
             "schema_version": "run_permission_policy_v0",
             "module": "loopx.capabilities.benchmark_toolkit.run_permissions",
+            "doc": "loopx/capabilities/benchmark_toolkit/README.md",
+        },
+        {
+            "schema_version": "benchmark_case_observation_v0",
+            "module": "loopx.capabilities.benchmark_toolkit.catalog_entry",
             "doc": "loopx/capabilities/benchmark_toolkit/README.md",
         },
         {

--- a/tests/capabilities/test_benchmark_toolkit.py
+++ b/tests/capabilities/test_benchmark_toolkit.py
@@ -221,6 +221,38 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
     assert "must not read hidden evaluator evidence" in active_monitor
     assert "send findings back" in active_monitor
     assert "only after" in analysis["role_boundary"]["post_run_analyst"]
+
+    observation = analysis["active_case_observation"]
+    assert observation["status"] == "provisional_only"
+    assert observation["artifact_template"] == {
+        "schema_version": "benchmark_case_observation_v0",
+        "case": {
+            "benchmark_id": "<public-id>",
+            "case_id": "<public-id>",
+            "arm": "<baseline-or-treatment>",
+        },
+        "run_status": "<planned-running-or-terminal>",
+        "runtime_outcome": "<ok-error-in_progress-or-unknown>",
+        "duration_ms": "<non-negative-integer-or-null>",
+        "evidence_refs": [
+            {
+                "kind": "<trace-log-artifact-report-or-other>",
+                "trace_id": "<opaque-id-or-null>",
+                "span_id": "<opaque-id-or-null>",
+                "env": "<environment-token-or-null>",
+                "artifact_ref": "<private-pointer-or-null>",
+            }
+        ],
+        "hypothesis": "<provisional-causal-explanation>",
+        "confidence": "<high-medium-or-low>",
+        "promotion_state": "pending_terminal_score_review",
+    }
+    assert "must not invent an official score" in observation["score_boundary"]
+    assert "write a separate benchmark_case_insight_v0" in observation[
+        "promotion_rule"
+    ]
+    assert "never trace IDs" in observation["privacy_boundary"]
+
     artifact = analysis["artifact_template"]
     assert artifact["schema_version"] == "benchmark_case_insight_v0"
     assert artifact["evidence_reviewed"] == [
@@ -230,6 +262,15 @@ def test_catalog_exposes_post_run_case_insight_monitor_contract() -> None:
         "hidden_tests",
         "grader_or_verifier",
         "failure_and_score_details",
+    ]
+    assert artifact["evidence_refs"] == [
+        {
+            "kind": "<trace-log-artifact-report-or-other>",
+            "trace_id": "<opaque-id-or-null>",
+            "span_id": "<opaque-id-or-null>",
+            "env": "<environment-token-or-null>",
+            "artifact_ref": "<private-pointer-or-null>",
+        }
     ]
     assert set(artifact["insight"]) == {
         "approach_summary",


### PR DESCRIPTION
## Summary
- add a provider-neutral benchmark_case_observation_v0 template for active-run findings
- add optional trace_id, span_id, env, and private artifact references to runtime observations and final case insights
- keep raw references private and expose only compact classifications or handles on the public experiment board
- require a separate post-terminal insight instead of relabeling provisional evidence

## Validation
- 137 focused benchmark toolkit tests passed
- 104 catalog contract tests passed with the configured Python runtime
- Python compile and git diff checks passed
- standard LoopX premerge canary: 18 checks passed, public-boundary scan clean

## Boundary
No private traces, session identifiers, internal URLs, local paths, credentials, or benchmark content are included. The premerge gate retains its benchmark-sensitive manual-review hold, so this PR is intentionally not self-merged.