### PR TITLE
fix(desktop): surface runtime bootstrap failures on the boot page

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -106,12 +106,47 @@ Older backup directories are retained for manual recovery and can consume disk.
 
 The embedded Recovery & updates section includes selectable, copyable diagnostics
 with the App version, last failure category, installer exit code when available,
-and runtime identity availability/match results. The last failure survives a
-subsequent update check within the same App process. Copying never includes raw
-installer output, environment variables, local paths, or Goal content. Installation
-failures, missing/corrupt bundles, and runtime mismatch show distinct recovery
-instructions. A terminal `loopx doctor` checks the terminal-selected runtime;
-it does not prove that Desktop selected the same installation or matching revision.
+runtime identity availability/match results, and (v2) coarse environment facts:
+OS version, architecture, whether the runtime executable resolved, and whether a
+`python3` in the installer's bounded search path reported a version. The last
+failure survives a subsequent update check within the same App process. Copying
+never includes raw installer output, environment variables, local paths, or Goal
+content. Installation failures, missing/corrupt bundles, and runtime mismatch
+show distinct recovery instructions. A terminal `loopx doctor` checks the
+terminal-selected runtime; it does not prove that Desktop selected the same
+installation or matching revision.
+
+When the update snapshot stays in a terminal phase, the boot screen itself stops
+presenting an endless loading state: after several poll rounds the main status
+line switches to the error projection of the current snapshot code and points at
+the Recovery & updates panel. It returns to the loading shape as soon as the
+snapshot leaves the terminal phase (for example while an explicit repair runs).
+
+## Known Issues
+
+### Fresh Mac without a usable Python stays on the boot screen
+
+On a new macOS machine with no developer environment, the App's automatic
+runtime installation can fail with `runtime_install_exit_2`: the installer
+requires a usable Python 3.11+ (`python3` reachable through the bounded search
+path that covers standard Homebrew locations), and a bare macOS does not ship
+one. The automatic install budget (three attempts) exhausts itself, and before
+this fix the failure was only visible inside the collapsed Recovery & updates
+panel, so the window read as a permanent loading state.
+
+Self-service:
+
+1. Check the boot screen error code or Recovery & updates → Diagnostics
+   (`error_code: runtime_install_exit_2`, `environment.python3_found` /
+   `python3_version` confirm the missing interpreter).
+2. Install Python 3.11+ — for example `brew install python@3.12` — or install
+   the Xcode Command Line Tools.
+3. Press **Repair this version** (or reopen the App); the live supervisor
+   reconnects the same window without a second App restart.
+
+`loopx doctor` run on another machine (for example the Linux host that also
+serves your terminal runtime) checks that host's installation. It cannot
+diagnose this Mac App's local bootstrap; only the App's own diagnostics do.
 
 The updater accepts only fixed official HTTPS channels, not browser-provided
 commands, paths or download URLs. Its signing private key is confined to the

--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -139,8 +139,9 @@ Self-service:
 1. Check the boot screen error code or Recovery & updates → Diagnostics
    (`error_code: runtime_install_exit_2`, `environment.python3_found` /
    `python3_version` confirm the missing interpreter).
-2. Install Python 3.11+ — for example `brew install python@3.12` — or install
-   the Xcode Command Line Tools.
+2. Install Python 3.11+ — for example `brew install python@3.12` or via
+   official python.org installer (note that macOS Command Line Tools provides
+   Python 3.9, which does not satisfy the Python 3.11+ requirement).
 3. Press **Repair this version** (or reopen the App); the live supervisor
    reconnects the same window without a second App restart.
 

--- a/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/lib.rs
@@ -21,6 +21,25 @@ fn maintenance_origin(url: &Url) -> String {
     url.origin().ascii_serialization()
 }
 
+// Supervisor failures are either stable machine codes emitted by the
+// maintenance state machine (runtime_setup_required, runtime_install_exit_2,
+// ...) or human-readable service diagnostics. Only a stable code is safe to
+// echo verbatim into the boot surface, where it names the recovery panel's
+// actionable diagnostics instead of a misleading fixed message.
+fn boot_failure_message(error: &str) -> String {
+    let is_stable_code = !error.is_empty()
+        && error.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+        });
+    if is_stable_code {
+        format!(
+            "本地服务暂时无法启动，请检查安装或端口占用。（错误码 {error}，详见恢复与更新面板）"
+        )
+    } else {
+        "本地服务暂时无法启动，请检查安装或端口占用。".to_string()
+    }
+}
+
 fn show_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.show();
@@ -121,7 +140,7 @@ pub fn run() {
                             }
                         }
                         Err(error) => {
-                            let message = "本地服务暂时无法启动，请检查安装或端口占用。";
+                            let message = boot_failure_message(&error);
                             eprintln!("LoopX service error: {error}");
                             if let Some(window) = handle.get_webview_window("main") {
                                 if let Ok(encoded) = serde_json::to_string(&message) {
@@ -203,5 +222,32 @@ mod tests {
         assert!(style.contains("--warning: #f5a623"));
         assert!(script.contains("desktop_update_status"));
         assert!(script.contains("window.loopxBootRetrying"));
+        // The boot surface must derive its error projection from the polled
+        // snapshot itself and name the known fresh-Mac installer failure.
+        assert!(script.contains("runtime_install_exit_2"));
+        assert!(script.contains("desktop_recovery_diagnostics_v2"));
+    }
+
+    #[test]
+    fn boot_failure_message_appends_stable_codes_only() {
+        use super::boot_failure_message;
+        assert_eq!(
+            boot_failure_message("runtime_install_exit_2"),
+            "本地服务暂时无法启动，请检查安装或端口占用。（错误码 runtime_install_exit_2，详见恢复与更新面板）"
+        );
+        assert_eq!(
+            boot_failure_message("runtime_setup_required"),
+            "本地服务暂时无法启动，请检查安装或端口占用。（错误码 runtime_setup_required，详见恢复与更新面板）"
+        );
+        // Human-readable service diagnostics and empty errors keep the fixed
+        // message; free-form text is never echoed into the boot surface.
+        assert_eq!(
+            boot_failure_message("port 8766 is occupied by a service that is not LoopX status"),
+            "本地服务暂时无法启动，请检查安装或端口占用。"
+        );
+        assert_eq!(
+            boot_failure_message(""),
+            "本地服务暂时无法启动，请检查安装或端口占用。"
+        );
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -20,6 +20,7 @@ pub struct Maintenance {
     last_failure: Mutex<Value>,
     runtime_retry: Mutex<RuntimeRetry>,
     install_journal_discarded: AtomicBool,
+    environment_cache: Mutex<Option<(Instant, Value)>>,
 }
 
 #[derive(Default)]
@@ -170,11 +171,68 @@ fn check_error(error: tauri_plugin_updater::Error) -> &'static str {
         _ => "update_check_failed",
     }
 }
+// Environment telemetry for the recovery diagnostics: coarse, non-PII facts
+// that separate "fresh Mac without a usable Python" from OS-specific defects.
+// No paths, environment variables or process output beyond the probed version.
+const ENVIRONMENT_TTL: Duration = Duration::from_secs(30);
+
+fn compose_environment(
+    os_version: Option<String>,
+    arch: &str,
+    runtime_executable_found: bool,
+    python3: (bool, Option<String>),
+) -> Value {
+    json!({
+        "os_version": os_version,
+        "arch": arch,
+        "runtime_executable_found": runtime_executable_found,
+        "python3_found": python3.0,
+        "python3_version": python3.1,
+    })
+}
+
+fn environment_is_fresh(cached: &Option<(Instant, Value)>, now: Instant) -> bool {
+    cached
+        .as_ref()
+        .is_some_and(|(probed_at, _)| now.duration_since(*probed_at) < ENVIRONMENT_TTL)
+}
+
+fn detect_environment() -> Value {
+    let os_version = (cfg!(target_os = "macos"))
+        .then(|| {
+            let mut probe = std::process::Command::new("sw_vers");
+            probe.arg("-productVersion");
+            crate::services::timed_output(probe)
+                .filter(|output| output.status.success())
+                .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+                .filter(|version| !version.is_empty())
+        })
+        .flatten();
+    let runtime_executable_found =
+        std::path::Path::new(&crate::services::loopx_executable()).is_file();
+    compose_environment(
+        os_version,
+        std::env::consts::ARCH,
+        runtime_executable_found,
+        crate::services::python3_environment(),
+    )
+}
+
 #[tauri::command]
 pub fn desktop_update_status(app: AppHandle, state: State<'_, Maintenance>) -> Value {
     let snapshot = state.snapshot.lock().unwrap().clone();
     let last_failure = state.last_failure.lock().unwrap().clone();
-    json!({"state": snapshot, "last_failure": last_failure, "app_version": app.package_info().version.to_string(), "runtime": bundled_runtime::identity(&app).ok(), "rollback_available": crate::update_backup::available(&app)})
+    // Probing spawns bounded sub-processes; the boot page polls every second,
+    // so serve the cached block and refresh at most every ENVIRONMENT_TTL.
+    let environment = {
+        let now = Instant::now();
+        let mut cache = state.environment_cache.lock().unwrap();
+        if !environment_is_fresh(&cache, now) {
+            *cache = Some((now, detect_environment()));
+        }
+        cache.as_ref().expect("refreshed above").1.clone()
+    };
+    json!({"state": snapshot, "last_failure": last_failure, "app_version": app.package_info().version.to_string(), "runtime": bundled_runtime::identity(&app).ok(), "rollback_available": crate::update_backup::available(&app), "environment": environment})
 }
 #[tauri::command]
 pub async fn desktop_update(
@@ -696,6 +754,57 @@ mod tests {
         let state = Maintenance::default();
         state.publish("downloading", json!({"received":12,"total":24}));
         assert_eq!(state.snapshot.lock().unwrap()["details"]["received"], 12);
+    }
+
+    #[test]
+    fn environment_telemetry_is_coarse_and_non_identifying() {
+        let environment = compose_environment(
+            Some("26.5".to_string()),
+            "aarch64",
+            false,
+            (true, Some("3.9.6".to_string())),
+        );
+        assert_eq!(environment["os_version"], "26.5");
+        assert_eq!(environment["arch"], "aarch64");
+        assert_eq!(environment["runtime_executable_found"], false);
+        assert_eq!(environment["python3_found"], true);
+        assert_eq!(environment["python3_version"], "3.9.6");
+        // The fresh-Mac signature: no Homebrew/CLT python3 answers a version
+        // probe, and the runtime executable has never been installed.
+        let fresh = compose_environment(None, "aarch64", false, (false, None));
+        assert_eq!(fresh["os_version"], Value::Null);
+        assert_eq!(fresh["python3_found"], false);
+        assert_eq!(fresh["python3_version"], Value::Null);
+        // The block carries exactly the five diagnostic keys — no paths,
+        // environment variables or free-form output can join it.
+        let keys: Vec<&str> = environment
+            .as_object()
+            .expect("environment object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            keys,
+            [
+                "arch",
+                "os_version",
+                "python3_found",
+                "python3_version",
+                "runtime_executable_found"
+            ]
+        );
+    }
+
+    #[test]
+    fn environment_cache_serves_within_ttl_and_refreshes_after_it() {
+        let now = Instant::now();
+        let cached = Some((now, json!({"os_version":"26.5"})));
+        assert!(environment_is_fresh(&cached, now + Duration::from_secs(29)));
+        assert!(!environment_is_fresh(
+            &cached,
+            now + Duration::from_secs(30)
+        ));
+        assert!(!environment_is_fresh(&None, now));
     }
 
     #[test]

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -595,6 +595,72 @@ fn runtime_search_path(
     env::join_paths(paths).unwrap_or_else(|_| inherited.unwrap_or_default())
 }
 
+/// Resolve `python3` inside the same bounded tool search the installer and
+/// owned services use, and ask it for its version. Returns
+/// (found, version): `found` is filesystem-level resolution only, so a
+/// Command Line Tools stub that never finishes still reports found with no
+/// version — exactly the state `install-local.sh` rejects. The version probe
+/// is bounded so the status polling path cannot hang on it.
+pub(crate) fn python3_environment() -> (bool, Option<String>) {
+    let search_path = runtime_search_path(env::var_os("HOME"), env::var_os("PATH"));
+    let resolved = resolve_executable_path("python3", Some(search_path.as_os_str()));
+    let found = resolved.is_some();
+    let version = resolved.and_then(|python| {
+        let mut probe = Command::new(python);
+        probe.arg("--version");
+        timed_output(probe)
+            .filter(|output| output.status.success())
+            .and_then(|output| parse_python_version(&output))
+    });
+    (found, version)
+}
+
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+
+pub(crate) fn timed_output(mut command: Command) -> Option<std::process::Output> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(command.output());
+    });
+    receiver
+        .recv_timeout(VERSION_PROBE_TIMEOUT)
+        .ok()
+        .and_then(|result| result.ok())
+}
+
+// `python3 --version` prints `Python 3.11.9`; accept the version on either
+// stream (some wrappers print to stderr) and keep only a strict
+// major.minor.patch prefix so odd output never enters diagnostics.
+fn parse_python_version(output: &std::process::Output) -> Option<String> {
+    let text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_python_banner(&text)
+}
+
+fn parse_python_banner(text: &str) -> Option<String> {
+    let version = text.trim().strip_prefix("Python ")?;
+    let mut digits_or_dots = String::new();
+    for character in version.chars() {
+        if character.is_ascii_digit() || character == '.' {
+            digits_or_dots.push(character);
+        } else {
+            break;
+        }
+    }
+    let parts: Vec<&str> = digits_or_dots.split('.').collect();
+    if parts.len() != 3 || parts.iter().any(|part| part.is_empty()) {
+        return None;
+    }
+    Some(digits_or_dots)
+}
+
 fn resolve_executable_path(executable: &str, search_path: Option<&OsStr>) -> Option<PathBuf> {
     let requested = PathBuf::from(executable);
     if requested.components().count() > 1 {
@@ -849,6 +915,34 @@ mod tests {
             ),
             Probe::Stale
         );
+    }
+
+    #[test]
+    fn python_version_parsing_accepts_strict_triplets_only() {
+        assert_eq!(
+            parse_python_banner("Python 3.13.5\n"),
+            Some("3.13.5".to_string())
+        );
+        // Some wrappers and old interpreters print the banner to stderr; the
+        // Output-level wrapper reads both streams through this parser.
+        assert_eq!(
+            parse_python_banner("Python 3.9.6\n"),
+            Some("3.9.6".to_string())
+        );
+        // A trailing pre-release tag is truncated to its release triplet.
+        assert_eq!(
+            parse_python_banner("Python 3.11.0b4\n"),
+            Some("3.11.0".to_string())
+        );
+        // Stub chatter, missing prefixes and partial triplets never enter
+        // diagnostics as a version.
+        assert_eq!(
+            parse_python_banner("xcode-select: note: install requested"),
+            None
+        );
+        assert_eq!(parse_python_banner("Python 3"), None);
+        assert_eq!(parse_python_banner("Python 3.11"), None);
+        assert_eq!(parse_python_banner(""), None);
     }
 
     #[test]

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -629,9 +629,9 @@ pub(crate) fn timed_output_with_timeout(
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let mut child = command.spawn().ok()?;
-    let mut stdout_pipe = child.stdout.take();
-    let mut stderr_pipe = child.stderr.take();
+    let mut child = command.group_spawn().ok()?;
+    let mut stdout_pipe = child.inner().stdout.take();
+    let mut stderr_pipe = child.inner().stderr.take();
 
     let stdout_reader = thread::spawn(move || {
         let mut buf = Vec::new();
@@ -652,34 +652,48 @@ pub(crate) fn timed_output_with_timeout(
     let started = Instant::now();
     let poll_interval = Duration::from_millis(20);
 
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break Some(status),
-            Ok(None) => {
-                if started.elapsed() >= timeout {
+    let mut child_status: Option<std::process::ExitStatus> = None;
+
+    loop {
+        if child_status.is_none() {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    child_status = Some(status);
+                }
+                Ok(None) => {}
+                Err(_) => {
                     let _ = child.kill();
                     let _ = child.wait();
-                    break None;
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    return None;
                 }
-                let remaining = timeout.saturating_sub(started.elapsed());
-                thread::sleep(poll_interval.min(remaining));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                break None;
             }
         }
-    };
 
-    let stdout = stdout_reader.join().unwrap_or_default();
-    let stderr = stderr_reader.join().unwrap_or_default();
+        if let Some(status) = child_status {
+            if stdout_reader.is_finished() && stderr_reader.is_finished() {
+                let stdout = stdout_reader.join().unwrap_or_default();
+                let stderr = stderr_reader.join().unwrap_or_default();
+                return Some(std::process::Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
+            }
+        }
 
-    status.map(|status| std::process::Output {
-        status,
-        stdout,
-        stderr,
-    })
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return None;
+        }
+
+        let remaining = timeout.saturating_sub(started.elapsed());
+        thread::sleep(poll_interval.min(remaining));
+    }
 }
 
 // `python3 --version` prints `Python 3.11.9`; accept the version on either
@@ -1148,6 +1162,52 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(4),
             "command completed in reasonable time without blocking (took {elapsed:?})"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn timed_output_descendant_inheriting_pipes_terminates_near_deadline() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = temp_dir.path().join("descendant.pid");
+        let mut cmd = Command::new("sh");
+        // Direct child `sh` exits immediately after launching background descendant `sleep 30`.
+        // The background descendant inherits the stdout/stderr pipe handles without exec.
+        cmd.args([
+            "-c",
+            &format!("(sleep 30 & echo $! > \"{}\")", pid_path.display()),
+        ]);
+
+        let start = Instant::now();
+        let output = timed_output_with_timeout(cmd, Duration::from_millis(300));
+        let elapsed = start.elapsed();
+
+        assert!(output.is_none(), "timed_output must return None on timeout");
+        assert!(
+            elapsed >= Duration::from_millis(250) && elapsed < Duration::from_secs(2),
+            "timed_output must bound execution to around timeout (took {elapsed:?})"
+        );
+
+        let pid_str = fs::read_to_string(&pid_path).expect("read pidfile");
+        let pid: u32 = pid_str.trim().parse().expect("parse pid");
+
+        let mut descendant_alive = true;
+        for _ in 0..20 {
+            let check_status = Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .stderr(Stdio::null())
+                .status()
+                .expect("kill -0");
+            if !check_status.success() {
+                descendant_alive = false;
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+
+        assert!(
+            !descendant_alive,
+            "descendant process {pid} inheriting pipes must be terminated, but kill -0 succeeded"
         );
     }
 }

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -617,19 +617,69 @@ pub(crate) fn python3_environment() -> (bool, Option<String>) {
 
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 
-pub(crate) fn timed_output(mut command: Command) -> Option<std::process::Output> {
+pub(crate) fn timed_output(command: Command) -> Option<std::process::Output> {
+    timed_output_with_timeout(command, VERSION_PROBE_TIMEOUT)
+}
+
+pub(crate) fn timed_output_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+) -> Option<std::process::Output> {
     command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    let (sender, receiver) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = sender.send(command.output());
+    let mut child = command.spawn().ok()?;
+    let mut stdout_pipe = child.stdout.take();
+    let mut stderr_pipe = child.stderr.take();
+
+    let stdout_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(ref mut stream) = stdout_pipe {
+            let _ = stream.read_to_end(&mut buf);
+        }
+        buf
     });
-    receiver
-        .recv_timeout(VERSION_PROBE_TIMEOUT)
-        .ok()
-        .and_then(|result| result.ok())
+
+    let stderr_reader = thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(ref mut stream) = stderr_pipe {
+            let _ = stream.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let started = Instant::now();
+    let poll_interval = Duration::from_millis(20);
+
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {
+                if started.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                let remaining = timeout.saturating_sub(started.elapsed());
+                thread::sleep(poll_interval.min(remaining));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+        }
+    };
+
+    let stdout = stdout_reader.join().unwrap_or_default();
+    let stderr = stderr_reader.join().unwrap_or_default();
+
+    status.map(|status| std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
 }
 
 // `python3 --version` prints `Python 3.11.9`; accept the version on either
@@ -996,6 +1046,108 @@ mod tests {
                 "release_id": "path-release",
                 "source_revision": "path-revision",
             }))
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn timed_output_terminates_and_reaps_child_process_on_timeout() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = temp_dir.path().join("helper.pid");
+        let mut cmd = Command::new("sh");
+        cmd.args([
+            "-c",
+            &format!("echo $$ > \"{}\" && exec sleep 30", pid_path.display()),
+        ]);
+
+        let start = Instant::now();
+        let output = timed_output_with_timeout(cmd, Duration::from_millis(500));
+        let elapsed = start.elapsed();
+
+        assert!(output.is_none(), "timed_output must return None on timeout");
+        assert!(
+            elapsed >= Duration::from_millis(450) && elapsed < Duration::from_secs(5),
+            "timed_output must bound execution to around timeout (took {elapsed:?})"
+        );
+
+        let pid_str = fs::read_to_string(&pid_path).expect("read pidfile");
+        let pid: u32 = pid_str.trim().parse().expect("parse pid");
+
+        let check_status = Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stderr(Stdio::null())
+            .status()
+            .expect("kill -0");
+        assert!(
+            !check_status.success(),
+            "child process {pid} must be terminated and reaped, but kill -0 succeeded"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn timed_output_consecutive_refreshes_do_not_accumulate_workers() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let mut pids = Vec::new();
+
+        for i in 0..3 {
+            let pid_path = temp_dir.path().join(format!("helper_{i}.pid"));
+            let mut cmd = Command::new("sh");
+            cmd.args([
+                "-c",
+                &format!("echo $$ > \"{}\" && exec sleep 30", pid_path.display()),
+            ]);
+
+            let start = Instant::now();
+            let output = timed_output_with_timeout(cmd, Duration::from_millis(300));
+            let elapsed = start.elapsed();
+
+            assert!(
+                output.is_none(),
+                "probe iteration {i} must return None on timeout"
+            );
+            assert!(
+                elapsed >= Duration::from_millis(250) && elapsed < Duration::from_secs(3),
+                "probe iteration {i} must finish near timeout (took {elapsed:?})"
+            );
+
+            let pid_str = fs::read_to_string(&pid_path).expect("read pidfile");
+            let pid: u32 = pid_str.trim().parse().expect("parse pid");
+            pids.push(pid);
+        }
+
+        for pid in pids {
+            let check_status = Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .stderr(Stdio::null())
+                .status()
+                .expect("kill -0");
+            assert!(
+                !check_status.success(),
+                "accumulated worker candidate {pid} was not terminated/reaped"
+            );
+        }
+    }
+
+    #[test]
+    fn timed_output_large_output_does_not_deadlock() {
+        let mut cmd = Command::new("python3");
+        cmd.args(["-c", "import sys; sys.stdout.write('X' * 262144)"]);
+
+        let start = Instant::now();
+        let output = timed_output_with_timeout(cmd, Duration::from_secs(5));
+        let elapsed = start.elapsed();
+
+        assert!(
+            output.is_some(),
+            "timed_output must not deadlock on large output buffer"
+        );
+        let out = output.unwrap();
+        assert!(out.status.success(), "command must succeed");
+        assert_eq!(out.stdout.len(), 262144);
+        assert!(
+            elapsed < Duration::from_secs(4),
+            "command completed in reasonable time without blocking (took {elapsed:?})"
         );
     }
 }

--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -58,6 +58,18 @@ const errors = {
   app_install_incomplete: "App 安装中断，且无法确认当前版本是否完整，请勿直接重启。请在恢复与更新面板还原上一版本（或重新安装）后再试。",
   backup_failed: "无法备份当前版本，更新已停止。请检查磁盘空间后重试。",
 };
+function codeText(code, phase) {
+  if (typeof code === "string" && /^runtime_install_exit_(\d+|signal)$/.test(code)) {
+    // Exit 2 from install-local.sh is its "no usable Python 3.11+" gate; the
+    // same exit can technically be a usage error, so the wording stays
+    // probabilistic and points at the repair action.
+    if (code === "runtime_install_exit_2") {
+      return "安装程序退出（2）：本机多半缺少可用的 Python 3.11+。安装 Python 后点击「修复当前版本」。";
+    }
+    return `安装程序退出（${code.slice("runtime_install_exit_".length)}）。请复制诊断信息反馈；修复没有完成。`;
+  }
+  return Object.hasOwn(errors, code) ? errors[code] : labels[phase] || "";
+}
 function render(state) {
   if (!state?.phase) return;
   if (state.phase === "available" && state.details?.channel !== channel.value) state = {phase:"idle"};
@@ -68,24 +80,37 @@ function render(state) {
   channel.disabled = working || state.phase === "restart_required";
   nextAction = state.phase === "available" ? "apply" : state.phase === "restart_required" ? "restart" : "check";
   update.textContent = nextAction === "apply" ? "更新并准备重启 / Install update" : nextAction === "restart" ? "重启完成更新 / Restart" : "检查更新 / Check for updates";
-  const code = state.details?.code;
-  updateStatus.textContent = typeof code === "string" && /^runtime_install_exit_(\d+|signal)$/.test(code)
-    ? `安装程序退出（${code.slice("runtime_install_exit_".length)}）。请复制诊断信息反馈；修复没有完成。`
-    : Object.hasOwn(errors, code) ? errors[code] : labels[state.phase] || "";
+  updateStatus.textContent = codeText(state.details?.code, state.phase);
 }
 const diagnostics = document.querySelector("#diagnostics");
 function safeCode(code) {
   return typeof code === "string" && (Object.hasOwn(errors, code) || /^runtime_install_exit_(\d+|signal)$/.test(code) || ["service_start_failed", "update_failed"].includes(code)) ? code : "unknown";
 }
+// v2 adds the non-PII environment block surfaced by desktop_update_status.
+// Fields the backend has not sent yet stay null so old payloads still render.
+function safeEnvironment(result) {
+  const environment = result.environment;
+  if (!environment || typeof environment !== "object") return null;
+  const text = (value) => typeof value === "string" && value ? value : null;
+  const flag = (value) => typeof value === "boolean" ? value : null;
+  return {
+    os_version: text(environment.os_version),
+    arch: text(environment.arch),
+    runtime_executable_found: flag(environment.runtime_executable_found),
+    python3_found: flag(environment.python3_found),
+    python3_version: text(environment.python3_version),
+  };
+}
 function renderDiagnostics(result) {
   const failure = result.last_failure ?? result.state;
   const text = JSON.stringify({
-    schema_version: "desktop_recovery_diagnostics_v1",
+    schema_version: "desktop_recovery_diagnostics_v2",
     failure_phase: ["error", "runtime_required", "service_error"].includes(failure?.phase) ? failure.phase : null,
     app_version: /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(result.app_version) ? result.app_version : "unknown",
     error_code: safeCode(failure?.details?.code),
     installed_identity_available: typeof failure?.details?.installed_identity_available === "boolean" ? failure.details.installed_identity_available : null,
     revision_matches: typeof failure?.details?.revision_matches === "boolean" ? failure.details.revision_matches : null,
+    environment: safeEnvironment(result),
   }, null, 2);
   if (diagnostics.value !== text) diagnostics.value = text;
 }
@@ -110,6 +135,15 @@ async function run(action) {
 update.onclick = () => run(nextAction);
 repair.onclick = () => run("repair");
 rollback.onclick = () => run("rollback");
+// The main status line keeps its loading shape while the supervisor retries.
+// A snapshot that stays in a terminal phase for several polls is the only
+// front-end-derived error projection: the page pulls it from
+// desktop_update_status itself, so it does not depend on the native eval()
+// calls racing this script's definition.
+const TERMINAL_PHASES = ["error", "runtime_required"];
+const ERROR_ESCALATION_ROUNDS = 5;
+let terminalRounds = 0;
+let escalated = false;
 async function refresh() {
   if (!window.__TAURI__) { renderDiagnostics({state:{phase:"error",details:{code:"desktop_status_unavailable"}}}); return; }
   try {
@@ -121,7 +155,24 @@ async function refresh() {
     rollback.hidden = !result.rollback_available;
     renderDiagnostics(result);
     render(result.state);
+    escalateFromSnapshot(result.state);
   } catch { renderDiagnostics({state:{phase:"error",details:{code:"desktop_status_unavailable"}}}); }
+}
+function escalateFromSnapshot(state) {
+  const terminal = TERMINAL_PHASES.includes(state?.phase);
+  terminalRounds = terminal ? terminalRounds + 1 : 0;
+  if (terminal && terminalRounds >= ERROR_ESCALATION_ROUNDS) escalated = true;
+  if (!escalated) return;
+  if (terminal) {
+    panel.dataset.state = "error";
+    panel.setAttribute("aria-busy", "false");
+    status.textContent = `${codeText(state?.details?.code, state?.phase)} 详见下方「恢复与更新」面板，可复制诊断信息反馈。`;
+  } else {
+    escalated = false;
+    panel.dataset.state = "loading";
+    panel.setAttribute("aria-busy", "true");
+    status.textContent = "正在重新连接本地控制面";
+  }
 }
 void refresh();
 setInterval(refresh,1000);

--- a/examples/desktop-update-browser-smoke.mjs
+++ b/examples/desktop-update-browser-smoke.mjs
@@ -31,10 +31,11 @@ try {
   let failUpdate = false;
   let checkFailure = null;
   let statusFailure = false;
+  let environmentTelemetry = null;
   await page.exposeFunction("nativeInvoke", async (command, args) => {
     if (command === "desktop_update_status") {
       if (statusFailure) throw new Error("Command desktop_update_status not allowed by ACL");
-      return { state: nativeState, app_version: "0.5.4", rollback_available: true };
+      return { state: nativeState, app_version: "0.5.4", rollback_available: true, environment: environmentTelemetry };
     }
     calls.push({ command, args });
     if (checkFailure && args.action === "check") return { phase: "error", details: { code: checkFailure } };
@@ -196,7 +197,41 @@ try {
     assert.equal(await page.locator(selector).isEnabled(), true, `${selector} remains usable after service failure`);
   }
   await page.screenshot({ path: resolve(output, "startup-recovery.png") });
-  console.log("desktop-update-browser-smoke: passed (confirmation, failure redaction, mobile, missing assets + reload, startup motion states, startup recovery)");
+
+  // A snapshot stuck in a terminal phase must turn the main status line into
+  // its error projection (fresh Mac without Python 3.11+: installer exit 2),
+  // not the pre-fix permanent loading shape. The projection is derived by the
+  // page from desktop_update_status itself.
+  environmentTelemetry = { os_version: "26.5", arch: "aarch64", runtime_executable_found: false, python3_found: false, python3_version: null };
+  nativeState = { phase: "error", details: { code: "runtime_install_exit_2" } };
+  await page.reload();
+  assert.equal(await startupPanel.getAttribute("data-state"), "loading");
+  await page.waitForTimeout(2500);
+  assert.equal(await startupPanel.getAttribute("data-state"), "loading", "escalation waits for several terminal poll rounds");
+  await page.waitForFunction(() => document.querySelector("main").dataset.state === "error");
+  assert.equal(await startupPanel.getAttribute("aria-busy"), "false");
+  const bootHeadline = await page.locator("#status").innerText();
+  assert.ok(bootHeadline.includes("安装程序退出（2）"), bootHeadline);
+  assert.ok(bootHeadline.includes("Python 3.11+"), bootHeadline);
+  assert.ok(bootHeadline.includes("恢复与更新"), bootHeadline);
+  assert.equal(await startupDots.isVisible(), false);
+  await page.getByText("恢复与更新 / Recovery & updates").click();
+  assert.ok((await page.locator("#update-status").innerText()).includes("本机多半缺少可用的 Python 3.11+"));
+  const bootDiagnostics = JSON.parse(await page.locator("#diagnostics").inputValue());
+  assert.equal(bootDiagnostics.schema_version, "desktop_recovery_diagnostics_v2");
+  assert.equal(bootDiagnostics.error_code, "runtime_install_exit_2");
+  assert.deepEqual(bootDiagnostics.environment, environmentTelemetry);
+  await page.screenshot({ path: resolve(output, "startup-runtime-install-error.png") });
+
+  // A transient repair phase clears the escalation while it runs, and a
+  // terminal snapshot re-escalates with the matching runtime_required copy.
+  nativeState = { phase: "installing_runtime", details: {} };
+  await page.waitForFunction(() => document.querySelector("main").dataset.state === "loading");
+  assert.equal(await startupPanel.getAttribute("aria-busy"), "true");
+  nativeState = { phase: "runtime_required", details: { code: "runtime_setup_required" } };
+  await page.waitForFunction(() => document.querySelector("main").dataset.state === "error" && document.querySelector("#status").innerText.includes("请修复当前版本，成功后重启"));
+  environmentTelemetry = null;
+  console.log("desktop-update-browser-smoke: passed (confirmation, failure redaction, mobile, missing assets + reload, startup motion states, startup recovery, startup error escalation)");
 } finally {
   await browser.close();
   await new Promise((done) => server.close(done));


### PR DESCRIPTION
## Summary

- The boot page now escalates its main status line to an error state after five consecutive terminal snapshots (~5s): the page reads `desktop_update_status` itself, so the escalation does not depend on eval timing, and a phase leaving the terminal set (e.g. a repair in progress) restores the loading presentation automatically. `runtime_install_exit_2` gets a dedicated message pointing at the Python 3.11+ requirement and the Repair button.
- `desktop_update_status` reports a non-PII `environment` block (os_version, arch, runtime_executable_found, python3_found, python3_version) using the installer bounded search path with a 1s-timeout probe and a 30s TTL cache so the 1s status poll never hot-loops the probe; the diagnostics schema moves v1 to v2 with all v1 fields preserved.
- The supervisor error branch appends the stable machine code (matching ^[a-z0-9_]+$) to its message instead of echoing natural-language service text, and the control-plane README gains a Known Issues section for the fresh-Mac exit-2 shape (symptom, three self-service steps, and why the pi-host doctor cannot see it).

## Issue Or Task

Closes #4012 (diagnostics and error-surfacing slice; the hardware-independent root cause — a fresh machine without system Python 3.11+ exhausting the install retries — is documented rather than worked around).

## Validation

- [x] Real-bundle smoke (Chromium driving the actual static boot bundle through refresh, render, and renderDiagnostics): with the source change stashed, the new assertion times out after 30s — reproducing the issue symptom exactly; restored, the full scenario passes including the escalation, the 5-round guard counter-example, transient de-escalation, and re-escalation
- [x] cargo test --locked 58 passed (5 new injection-style unit tests: boot_failure_message code shapes, environment key set, cache behavior)
- [x] cargo fmt --check and cargo clippy --all-targets --locked -D warnings clean (run before committing)
- [x] pytest tests/desktop 12 passed; personal-workspace contract smoke passed

## Type of Change

- [x] Bug fix

## LoopX Area

- [x] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- Target base branch: main
- Direction tracker or promotion unit: follows #4014 diagnostics / #4021 install-failure boundary

## State Classification (#4057 contract)

- snapshot phase/code: authoritative fact (read-only from the existing state machine)
- boot main status line: derived projection (five consecutive terminal snapshots; de-escalates when the phase leaves the terminal set)
- environment block: diagnostic hint (30s-cached, poll-triggered; retires once an embedded interpreter lands)
- README known-issue: irreducible intent (fresh Macs need system Python 3.11+ until an interpreter ships)

## Producer Evidence

The smoke drives the real static bundle rather than a hand-filled fixture; the Rust additions are injection-style unit tests over the pure combinators; canonical provenance references #4014 diagnostics v1 and the #4021 install-failure boundary.

## Boundary Checklist

- [x] No .loopx/, credentials, private traces, raw sessions, or local machine paths committed
- [x] No duplicated maintainer-owned benchmark work; #4041 progress-animation area untouched
- [x] Change scoped to the issue #4012 diagnostics slice
- [x] Every commit includes a DCO Signed-off-by trailer (git commit -s)
