### PR TITLE
release: prepare LoopX 1.0.1

### DIFF
--- a/docs/book/chapters/00-reading-guide.md
+++ b/docs/book/chapters/00-reading-guide.md
@@ -103,7 +103,7 @@ lifecycle 选择，不是所有贡献的默认终点。
 
 ## 版本基线
 
-当前内容以 LoopX GitHub release `v1.0.0` 为发布锚点；本地命令示例已按 `loopx 1.0.0` 的
+当前内容以 LoopX GitHub release `v1.0.1` 为发布锚点；本地命令示例已按 `loopx 1.0.1` 的
 公开 CLI 与协议表面复核。该版本要求 Python 3.11+ 与 Node.js 22.6+；后者运行由 LoopX 自动管理、
 空闲后退出的 TypeScript Effect runtime，用户不需要手工维护 daemon。
 

--- a/docs/book/en/chapters/00-reading-guide.md
+++ b/docs/book/en/chapters/00-reading-guide.md
@@ -114,8 +114,8 @@ Do not bypass a newer permission or lifecycle check just to make an older exampl
 
 ## Version baseline
 
-The current release anchor is LoopX GitHub release `v1.0.0`. Local command examples were checked against
-the public `loopx 1.0.0` CLI and protocol surface. This release requires Python 3.11+ and Node.js 22.6+.
+The current release anchor is LoopX GitHub release `v1.0.1`. Local command examples were checked against
+the public `loopx 1.0.1` CLI and protocol surface. This release requires Python 3.11+ and Node.js 22.6+.
 LoopX starts and reuses its managed, idle-exiting TypeScript Effect runtime automatically; users do not
 operate that runtime as a manual daemon.
 

--- a/docs/book/en/index.md
+++ b/docs/book/en/index.md
@@ -79,7 +79,7 @@ versioned or optional functionality, not the default shape of every contribution
 - Source format: Markdown
 - Site generator: MkDocs Material
 - Hosting: GitHub Pages
-- LoopX release anchor: `v1.0.0`
+- LoopX release anchor: `v1.0.1`
 - Runtime prerequisites: Python 3.11+ and Node.js 22.6+
 
 The official public protocols remain authoritative for protocol facts. Commands that change across

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -70,7 +70,7 @@ Extension 只是可独立版本化和交付的一种路径。
 - 正文格式：Markdown；
 - 站点生成器：MkDocs Material；
 - 在线发布：GitHub Pages；
-- LoopX 发布锚点：`v1.0.0`；
+- LoopX 发布锚点：`v1.0.1`；
 - 运行时前提：Python 3.11+ 与 Node.js 22.6+。
 
 协议解释以 LoopX 官方公开合同为事实源。易变化的命令仍以对应发布物、官方文档和当前

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 1.0.0" "User Commands"
+.TH LOOPX 1 "" "LoopX 1.0.1" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "1.0.0"
+version = "1.0.1"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Prepare the exact LoopX v1.0.1 release candidate by synchronizing the canonical Python package version, package metadata, generated manpage version, and bilingual book release anchors.

The runtime diff is intentionally empty beyond the version constant. The release notes separately disclose the removal of the experimental benchmark execution bridge and include bilingual activation, validation, rollback, authority, and versioned documentation guidance for every optional capability changed since v1.0.0.

## Validation

- release version contract smoke: passed
- release artifact workflow smoke: passed
- release readiness documentation smoke: passed for seven optional/material surfaces
- bilingual book publication smoke: passed
- CLI help/manpage consistency smoke: passed
- exact-release qualification contract smoke: passed
- license metadata pytest: 4 passed
- configured Ruff scope: passed
- configured mypy scope: passed
- public/private boundary scan: passed
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --goal-id loopx-meta`: 10/10 passed, no manual holds
- change-quality receipt: `cqr_480cc2d1fe2783f28d14` (`valid`)

The exact-release commit gate, actual-default Doubao portfolio, full-public fleet, install/upgrade/host checks, and release-body remote readback remain release-time gates and will be reported before publication.

## Future-facing pass

No adjacent refactor was added. The existing canonical version sources and renderers are already the narrow owning boundary; adding release plumbing here would increase scope without changing shipped behavior.
