### PR TITLE
docs: record LoopX 1.0.1 release readiness

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -1,6 +1,6 @@
 # Release Readiness
 
-Status: v0.x maintainer contract.
+Status: stable maintainer contract.
 
 LoopX can move quickly without making every merged PR feel like a product
 release. This note defines the small mental model maintainers should use before
@@ -133,7 +133,7 @@ option is read-only and accepted only by `update check`.
 
 ## Named Version Contract
 
-LoopX v0.x releases are tagged and built from GitHub. The release workflow
+LoopX releases are tagged and built from GitHub. The release workflow
 publishes artifacts to GitHub Releases and, when its Trusted Publisher gate
 passes, PyPI; each stable promotion still needs one package version name. The
 version source is `loopx.__version__`, mirrored by `pyproject.toml`; the
@@ -542,6 +542,14 @@ path, and canary route rather than as a user-facing release baseline.
   promoted claim retry identity from #3987); multi-agent Goal Channels ship
   with per-agent connection resolution (#3969); and reward-memory recall
   guides outbound messages behind a digest-bound review loop (#3968).
+- `v1.0.1` on 2026-09-08 06:51 +08:00: post-1.0 reliability release at the
+  matching `v1.0.1` tag (`7f2a020b`). Goal Channels gain resumable multi-Agent
+  onboarding and Agent-authorized typed report requests; Desktop recovery gains
+  bounded diagnostics and verified signed updates; Todo ownership, projection
+  recovery, and Stage 2C management use stronger typed transaction boundaries;
+  and frozen bundles install the same version-bound workflow skills as package
+  distributions. The exact-tag Python, PyPI, macOS, Windows, signed-update,
+  public-smoke, and live-model gates passed before `stable` fast-forwarded.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -370,7 +370,7 @@ def main() -> None:
 
     doc = compact(read(DOC))
     for required in [
-        "Status: v0.x maintainer contract.",
+        "Status: stable maintainer contract.",
         "## Supported Install And Update Paths",
         "loopx update check",
         "loopx update plan",
@@ -384,7 +384,7 @@ def main() -> None:
         "canary_only_untrusted_checkout",
         "explicit_override",
         "## Named Version Contract",
-        "LoopX v0.x releases are tagged and built from GitHub",
+        "LoopX releases are tagged and built from GitHub",
         "when its Trusted Publisher gate passes, PyPI",
         "The version source is `loopx.__version__`, mirrored by `pyproject.toml`",
         "examples/release/release-version-contract-smoke.py",


### PR DESCRIPTION
## Summary

- record the completed v1.0.1 tag, release workflows, PyPI publication, and `stable` promotion in the canonical public release timeline;
- replace the obsolete `v0.x` maintainer-contract wording with stable-release wording;
- keep the durable release-readiness smoke aligned with the canonical document.

The published release is [LoopX v1.0.1](https://github.com/huangruiteng/loopx/releases/tag/v1.0.1), targeting exact candidate `7f2a020b18d1b5bb00da4044403ae72ddce2d743`. This PR is a post-release documentation receipt only; it changes no runtime, package, update, permission, or release behavior.

## Validation

- `python examples/release/release-readiness-doc-smoke.py`
- `python examples/release/release-version-contract-smoke.py`
- Ruff on the changed smoke
- scoped mypy on the changed smoke
- public/private boundary scan over both changed paths
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 selected checks passed, zero failures, zero manual holds
- change-quality receipt `cqr_6c8d1db1fdf35693523f`, exact committed fingerprint `6c8d1db1fdf35693523f578734b19dffa3662da2c46f6ff981ece3e56308a6b9`

## Review boundary

The change reuses the existing release ledger and its existing smoke. No adjacent runtime refactor is warranted for this documentation-only closeout.
