### PR TITLE
feat(desktop): consume status service readiness without restart

### DIFF
--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -38,7 +38,7 @@ impl ServiceKind {
 
     fn probe_path(self) -> &'static str {
         match self {
-            Self::Status => "/",
+            Self::Status => "/?readiness=1",
             Self::Chat => "/api/chat/capabilities",
         }
     }
@@ -81,6 +81,7 @@ impl ServiceKind {
 #[derive(Debug, Eq, PartialEq)]
 enum Probe {
     Matching,
+    NotReady,
     Unavailable,
     Unresponsive,
     Foreign,
@@ -138,6 +139,7 @@ impl ServiceSet {
         loop {
             match probe(kind, expected_runtime_identity.as_ref()) {
                 Probe::Matching => return Ok(()),
+                Probe::NotReady => return Err(status_readiness_error(kind)),
                 Probe::Foreign => {
                     return Err(ServiceError(format!(
                         "port {} is occupied by a service that is not LoopX {}",
@@ -185,6 +187,7 @@ impl ServiceSet {
             while Instant::now() < deadline {
                 match probe(kind, expected_runtime_identity.as_ref()) {
                     Probe::Matching => return Ok(()),
+                    Probe::NotReady => return Err(status_readiness_error(kind)),
                     Probe::Foreign => {
                         return Err(ServiceError(format!(
                             "LoopX {} startup reached an unexpected service on port {}",
@@ -227,6 +230,7 @@ impl ServiceSet {
         while Instant::now() < deadline {
             match probe(kind, expected_runtime_identity.as_ref()) {
                 Probe::Matching => return Ok(()),
+                Probe::NotReady => return Err(status_readiness_error(kind)),
                 Probe::Foreign => {
                     return Err(ServiceError(format!(
                         "LoopX {} startup reached an unexpected service on port {}",
@@ -650,6 +654,14 @@ fn runtime_identity_for_executable_with_path(
     runtime_identity_from_manifest(&payload)
 }
 
+fn status_readiness_error(kind: ServiceKind) -> ServiceError {
+    ServiceError(format!(
+        "LoopX {} is responding on port {} but its registry is invalid or unreadable; repair the registry configuration and retry",
+        kind.label(),
+        kind.port()
+    ))
+}
+
 fn probe(kind: ServiceKind, expected_runtime_identity: Option<&serde_json::Value>) -> Probe {
     probe_on_port(kind, kind.port(), expected_runtime_identity)
 }
@@ -719,6 +731,32 @@ fn classify_response(
         if let Some(expected) = expected_runtime_identity {
             if payload.get("runtime_identity") != Some(expected) {
                 return Probe::Stale;
+            }
+        }
+        if kind == ServiceKind::Status {
+            if let Some(readiness) = payload.get("readiness") {
+                if readiness
+                    .get("schema_version")
+                    .and_then(serde_json::Value::as_str)
+                    != Some("loopx_status_readiness_v0")
+                {
+                    return Probe::Foreign;
+                }
+                return match (
+                    readiness.get("state").and_then(serde_json::Value::as_str),
+                    readiness.get("reason").and_then(serde_json::Value::as_str),
+                ) {
+                    (Some("ready"), Some("registry_readable")) => Probe::Matching,
+                    (Some("failed"), Some("registry_invalid" | "registry_unavailable")) => {
+                        Probe::NotReady
+                    }
+                    _ => Probe::Foreign,
+                };
+            }
+            // Legacy status servers ignore the query and retain the existing
+            // release-fingerprint check. An advertised contract cannot vanish.
+            if payload.get("readiness_url").is_some() {
+                return Probe::Foreign;
             }
         }
         return Probe::Matching;

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services_tests.rs
@@ -1,6 +1,46 @@
 use super::*;
 
 #[test]
+fn status_readiness_is_explicit_and_fails_closed() {
+    assert_eq!(ServiceKind::Status.probe_path(), "/?readiness=1");
+    for (readiness, expected) in [
+        (
+            serde_json::json!({"schema_version":"loopx_status_readiness_v0","state":"ready","reason":"registry_readable"}),
+            Probe::Matching,
+        ),
+        (
+            serde_json::json!({"schema_version":"loopx_status_readiness_v0","state":"failed","reason":"registry_invalid"}),
+            Probe::NotReady,
+        ),
+        (
+            serde_json::json!({"schema_version":"loopx_status_readiness_v0","state":"failed","reason":"registry_unavailable"}),
+            Probe::NotReady,
+        ),
+        (
+            serde_json::json!({"schema_version":"loopx_status_readiness_v0","state":"ready","reason":"registry_invalid"}),
+            Probe::Foreign,
+        ),
+        (
+            serde_json::json!({"schema_version":"future","state":"ready","reason":"registry_readable"}),
+            Probe::Foreign,
+        ),
+        (serde_json::Value::Null, Probe::Foreign),
+    ] {
+        let body = serde_json::json!({"source":"serve-status","readiness":readiness});
+        let response = format!("HTTP/1.1 200 OK\r\n\r\n{body}");
+        assert_eq!(
+            classify_response(ServiceKind::Status, &response, None),
+            expected
+        );
+    }
+    assert_eq!(classify_response(
+        ServiceKind::Status,
+        "HTTP/1.1 200 OK\r\n\r\n{\"source\":\"serve-status\",\"readiness_url\":\"/?readiness=1\"}",
+        None,
+    ), Probe::Foreign);
+}
+
+#[test]
 #[cfg(target_os = "macos")]
 fn finder_runtime_path_includes_tools_without_loading_shell_profiles() {
     let path = runtime_search_path(

--- a/docs/development/status-service-readiness.md
+++ b/docs/development/status-service-readiness.md
@@ -1,0 +1,36 @@
+# Status service readiness
+
+The local status service exposes `GET /?readiness=1` for Desktop startup.
+The existing root payload and runtime identity are returned with a
+`loopx_status_readiness_v0` object containing `state` and `reason`.
+
+| State | Reason | Meaning |
+| --- | --- | --- |
+| `ready` | `registry_readable` | Existing registry loading returns a JSON object. An absent registry remains a valid empty installation. |
+| `failed` | `registry_invalid` | Invalid JSON, encoding, or a non-object root. |
+| `failed` | `registry_unavailable` | An I/O error prevents registry loading. |
+
+HTTP 200 means the probe was served, not that the component is ready. `ok`
+retains its root-response meaning. Consumers must inspect the typed state.
+The route accepts loopback browser origins only, returns no exception text or
+registry paths, and makes no writes, Goal projections, provider calls or scans.
+`/healthz` remains liveness-only; the ordinary root request does not read the
+registry. The response is not cached and readiness is read again on retry.
+
+Desktop requests this query and rejects failed or malformed readiness before
+accepting an otherwise matching service. A failed registry produces an
+actionable startup error without treating the responding listener as hung.
+Legacy servers that do not advertise readiness keep the existing exact-release
+fingerprint behavior. Advertising readiness but omitting its result fails closed.
+
+This is a bounded existing-service prerequisite for
+[#3930](https://github.com/huangruiteng/loopx/issues/3930), not the unified daemon
+contract or complete M1 delivery. It does not establish service-profile identity,
+validate individual Goals, prove writable storage, qualify launchd lifecycle,
+or assert Chat/provider readiness. Profile identity, supervisor composition and
+migration remain separate implementation work.
+
+To diagnose failure, repair the registry selected by the service and retry the
+Desktop connection. Existing CLI registry selection and authority are unchanged.
+There is no daemon activation or persisted-state migration in this slice;
+reverting the client/server changes restores the previous startup probe.

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -937,6 +937,7 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "runtime_identity": release_runtime_identity(),
             "status_url": self.server.status_path,
             "health_url": "/healthz",
+            "readiness_url": "/?readiness=1",
             "review_material_url": DEFAULT_REVIEW_MATERIAL_PATH,
             "presentation_surfaces_url": (
                 DEFAULT_EXTENSION_PRESENTATION_SURFACES_PATH
@@ -953,6 +954,25 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             if self.server.control_plane_write_enabled
             else None,
             "control_plane_write_enabled": self.server.control_plane_write_enabled,
+        }
+
+    def _status_readiness(self) -> dict[str, str]:
+        # Read only the existing configuration boundary, not Goal projections,
+        # provider health, or repository scans. An absent registry is a valid
+        # empty installation under load_registry's existing contract.
+        reason = "registry_readable"
+        try:
+            registry = load_registry(self.server.registry_path)
+            if not isinstance(registry, dict):
+                reason = "registry_invalid"
+        except (ValueError, UnicodeError):
+            reason = "registry_invalid"
+        except OSError:
+            reason = "registry_unavailable"
+        return {
+            "schema_version": "loopx_status_readiness_v0",
+            "state": "ready" if reason == "registry_readable" else "failed",
+            "reason": reason,
         }
 
     def do_GET(self) -> None:
@@ -984,10 +1004,27 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             self._handle_ssh_hosts()
             return
         if path in {"", "/"}:
+            readiness = query.get("readiness")
+            if readiness is not None and readiness != ["1"]:
+                self._send_json(
+                    {"ok": False, "error": "readiness must be specified once as 1"},
+                    status=400,
+                )
+                return
+            if readiness is not None and (
+                not is_loopback_host(str(self.server.server_address[0]))
+                or not is_loopback_origin(self.headers.get("Origin"))
+            ):
+                self._send_json(
+                    {"ok": False, "error": "readiness requires loopback access"},
+                    status=403,
+                )
+                return
             self._send_json(
                 {
                     "ok": True,
                     **self._local_dashboard_api_payload(),
+                    **({"readiness": self._status_readiness()} if readiness is not None else {}),
                 }
             )
             return

--- a/tests/test_status_server_fast_path.py
+++ b/tests/test_status_server_fast_path.py
@@ -125,6 +125,74 @@ def test_status_service_identity_is_public_and_versioned(tmp_path: Path) -> None
     }
 
 
+def test_readiness_checks_registry_without_projecting_goals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_projection(**kwargs: object) -> dict[str, object]:
+        raise AssertionError("readiness must not project goals")
+
+    monkeypatch.setattr("loopx.status_server.collect_status", forbidden_projection)
+    with _status_server(tmp_path) as base_url:
+        with urllib.request.urlopen(f"{base_url}/?readiness=1", timeout=5) as response:
+            payload = json.load(response)
+        assert payload["readiness"] == {
+            "schema_version": "loopx_status_readiness_v0",
+            "state": "ready",
+            "reason": "registry_readable",
+        }
+        assert payload["runtime_identity"]["schema_version"] == "loopx_runtime_identity_v1"
+        (tmp_path / "registry.json").write_text("{", encoding="utf-8")
+        with urllib.request.urlopen(f"{base_url}/?readiness=1", timeout=5) as response:
+            failed = json.load(response)
+        assert failed["readiness"]["state"] == "failed"
+        assert failed["readiness"]["reason"] == "registry_invalid"
+        assert str(tmp_path) not in json.dumps(failed)
+        with urllib.request.urlopen(f"{base_url}/healthz", timeout=5) as response:
+            assert json.load(response) == {"ok": True}
+        with urllib.request.urlopen(base_url, timeout=5) as response:
+            assert "readiness" not in json.load(response)
+        (tmp_path / "registry.json").unlink()
+        with urllib.request.urlopen(f"{base_url}/?readiness=1", timeout=5) as response:
+            assert json.load(response)["readiness"]["state"] == "ready"
+
+
+@pytest.mark.parametrize("content", ["[]", "null", "42", '"text"'])
+def test_readiness_rejects_non_object_registry(tmp_path: Path, content: str) -> None:
+    with _status_server(tmp_path) as base_url:
+        (tmp_path / "registry.json").write_text(content, encoding="utf-8")
+        with urllib.request.urlopen(f"{base_url}/?readiness=1", timeout=5) as response:
+            assert json.load(response)["readiness"]["reason"] == "registry_invalid"
+
+
+def test_readiness_reports_io_failure_without_exception_text(tmp_path: Path) -> None:
+    with _status_server(tmp_path) as base_url:
+        registry = tmp_path / "registry.json"
+        registry.unlink()
+        registry.mkdir()
+        with urllib.request.urlopen(f"{base_url}/?readiness=1", timeout=5) as response:
+            payload = json.load(response)
+        assert payload["readiness"]["reason"] == "registry_unavailable"
+        assert str(tmp_path) not in json.dumps(payload)
+
+
+@pytest.mark.parametrize("query", ["readiness=", "readiness=0", "readiness=1&readiness=1"])
+def test_readiness_rejects_ambiguous_query(tmp_path: Path, query: str) -> None:
+    with _status_server(tmp_path) as base_url:
+        with pytest.raises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(f"{base_url}/?{query}", timeout=5)
+        assert raised.value.code == 400
+
+
+def test_readiness_rejects_public_browser_origin(tmp_path: Path) -> None:
+    with _status_server(tmp_path) as base_url:
+        request = urllib.request.Request(
+            f"{base_url}/?readiness=1", headers={"Origin": "https://example.com"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(request, timeout=5)
+        assert raised.value.code == 403
+
+
 def test_status_endpoint_rejects_blank_goal_activation_scope(tmp_path: Path) -> None:
     """A blank `?goal_activation=` value must fail closed with HTTP 400."""
     with _status_server(tmp_path) as base_url:


### PR DESCRIPTION
## Problem and behavior

Desktop accepts the status service after its release fingerprint responds, even when the registry cannot be decoded or read. Add a read-only `/?readiness=1` probe to the existing status root and consume its typed result in the real Desktop startup path. An invalid/unreadable registry now produces an actionable startup error rather than accepting the service or treating it as hung.

Refs #3930 and design PR #4054. This is an existing-service readiness prerequisite, not complete M1 or unified `loopxd` delivery. No profile-identity store, daemon, service-manager registration, or migration is introduced.

## Contract and compatibility

- Reuse the current registry loader: an absent registry still represents a valid empty installation. Readiness does not validate individual Goals, writable storage, Chat or providers.
- Keep `/healthz` liveness-only and the ordinary root fast. The query performs no Goal projection, scan, write, or provider call; errors contain bounded reasons rather than paths/exception text.
- The root advertises the readiness query. Legacy services retain fingerprint behavior; malformed or advertised-but-missing readiness fails closed.
- A typed `NotReady` result exits startup with a configuration error rather than entering stale/hung listener termination. Existing cleanup of Desktop-owned children remains unchanged.
- Reuse the existing status handler and Desktop service owner; no speculative runtime framework is added.

## Validation

- Python status fast-path/CORS/SSH-host tests: **48 passed**, using temporary real HTTP servers.
- Original Desktop services module, compiled through an isolated Cargo harness including its existing tests: **14 passed**, including real disposable listener-process tests.
- Compiled Rust probe connected to the actual Python status server: **4 passed** (ready, malformed JSON, non-object JSON, repaired registry).
- Ruff, Rust formatting, staged diff check and public-boundary scan of all five changed paths: passed.

The targeted checks cover both changed runtime boundaries and their HTTP interaction. A full Tauri application build and live launchd qualification were not run; this does not qualify daemon installation, profile isolation or migration. No active Goal or installed service was modified during validation.
