### PR TITLE
feat(explore): add opt-in receipt-bound pre-universe discovery

### DIFF
--- a/loopx/capabilities/explore/README.md
+++ b/loopx/capabilities/explore/README.md
@@ -887,6 +887,12 @@ sinks render public-safe explore projections for operators.
 
 ## CLI Surface
 
+For opt-in receipt-bound public discovery before a subject universe is frozen,
+see [Pre-universe discovery](docs/discovery.md). Its separate `discover`,
+`discovery-readback`, and `discovery-evaluate` commands remain disabled unless
+an explicit local binding enables them. They create no scheduler or research
+admission authority.
+
 ```text
 loopx explore schema
 loopx explore node --goal-id <id> --title <t> [--node-id ...] [--status ...] [--blocked-reason ...] [--parent ...]

--- a/loopx/capabilities/explore/discovery_contract.py
+++ b/loopx/capabilities/explore/discovery_contract.py
@@ -1,0 +1,423 @@
+"""Pure admission of receipt-backed discovery proposals, without effects.
+
+Source facts arrive from Core-captured collector/resolver results. Mechanism
+semantics remain model proposals even after canonical identity is assigned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from copy import deepcopy
+from datetime import datetime
+from urllib.parse import urlsplit
+
+from ...control_plane.runtime.public_safety import validate_public_safe_value
+
+MAX_OBSERVATIONS = 96
+MAX_PROPOSALS = 96
+MAX_SUBJECTS = 48
+MAX_BYTES = 750_000
+TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+def digest(value: object) -> str:
+    data = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return "sha256:" + hashlib.sha256(data.encode()).hexdigest()
+
+
+def exact(value: object, keys: str, label: str) -> dict:
+    if not isinstance(value, Mapping) or set(value) != set(keys.split()):
+        raise ValueError(f"{label} has missing or unknown fields")
+    validate_public_safe_value(value, path=label)
+    return dict(value)
+
+
+def token(value: object) -> str:
+    if not isinstance(value, str) or not TOKEN.fullmatch(value):
+        raise ValueError("discovery identity must be a bounded token")
+    return value
+
+
+def timestamp(value: object) -> datetime:
+    if not isinstance(value, str) or not TIMESTAMP.fullmatch(value):
+        raise ValueError("discovery time must be RFC3339 with an offset")
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def rows(value: object, limit: int, label: str) -> list:
+    if not isinstance(value, list) or len(value) > limit:
+        raise ValueError(f"{label} exceeds the bounded envelope")
+    return value
+
+
+def tokens(value: object, limit: int, *, nonempty: bool = False) -> list[str]:
+    values = [token(item) for item in rows(value, limit, "identities")]
+    if len(values) != len(set(values)) or (nonempty and not values):
+        raise ValueError(
+            "discovery identities must be unique and nonempty when required"
+        )
+    return sorted(values)
+
+
+def count(value: object) -> int:
+    if type(value) is not int or not 0 <= value <= 1_000_000:
+        raise ValueError("invalid bounded discovery count")
+    return value
+
+
+def text(value: object, limit: int = 500) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > limit:
+        raise ValueError("invalid bounded discovery statement")
+    return " ".join(value.split())
+
+
+def validate_policy(value: object, cutoff_at: str) -> dict:
+    policy = exact(
+        value,
+        "schema_version as_of method_revision market timezone max_subjects max_hypotheses causal_lenses families_by_horizon expires_at_by_horizon evaluation_operation",
+        "discovery policy",
+    )
+    if policy["schema_version"] != "loopx_explore_discovery_policy_v0" or timestamp(
+        policy["as_of"]
+    ) != timestamp(cutoff_at):
+        raise ValueError("discovery policy cutoff or schema mismatch")
+    for field in ("max_subjects", "max_hypotheses"):
+        if type(policy[field]) is not int or not 1 <= policy[field] <= MAX_SUBJECTS:
+            raise ValueError(
+                "discovery policy exceeds the 48-subject/hypothesis ceiling"
+            )
+    for field in ("method_revision", "market", "evaluation_operation"):
+        token(policy[field])
+    if policy["market"] != "US" or policy["timezone"] != "America/New_York":
+        raise ValueError("only the bounded US evaluator handoff is supported")
+    lenses = tokens(policy["causal_lenses"], 5, nonempty=True)
+    if len(lenses) != 5:
+        raise ValueError("discovery requires five ordered causal lenses")
+    families = policy["families_by_horizon"]
+    ceilings = policy["expires_at_by_horizon"]
+    if (
+        not isinstance(families, dict)
+        or not isinstance(ceilings, dict)
+        or set(families) != set(ceilings)
+        or len(families) != 3
+    ):
+        raise ValueError("discovery policy horizon/expiry mismatch")
+    for horizon, values in families.items():
+        token(horizon)
+        tokens(values, 8, nonempty=True)
+        if timestamp(ceilings[horizon]) <= timestamp(cutoff_at):
+            raise ValueError("discovery policy expiry must follow cutoff")
+    return policy
+
+
+def validate_observations(
+    value: object, *, cutoff_at: str, public_origins: list[str]
+) -> dict:
+    packet = exact(
+        value,
+        "schema_version observations overflow_count",
+        "collector observation packet",
+    )
+    if packet["schema_version"] != "loopx_explore_public_observations_v0":
+        raise ValueError("unsupported collector observation schema")
+    count(packet["overflow_count"])
+    cutoff = timestamp(cutoff_at)
+    seen = set()
+    for observation in rows(packet["observations"], MAX_OBSERVATIONS, "observations"):
+        row = exact(
+            observation,
+            "source_id uri entity_ids as_of available_at content_digest summary relation",
+            "public observation",
+        )
+        source_id = token(row["source_id"])
+        if source_id in seen:
+            raise ValueError("duplicate observation identity")
+        seen.add(source_id)
+        tokens(row["entity_ids"], 8, nonempty=True)
+        if not timestamp(row["as_of"]) <= timestamp(row["available_at"]) <= cutoff:
+            raise ValueError("observation was not available at the frozen cutoff")
+        if not isinstance(row["content_digest"], str) or not DIGEST.fullmatch(
+            row["content_digest"]
+        ):
+            raise ValueError("observation requires a content digest")
+        text(row["summary"])
+        url = urlsplit(row["uri"])
+        if (
+            url.scheme != "https"
+            or url.username
+            or url.password
+            or url.query
+            or url.fragment
+            or f"https://{url.netloc}" not in public_origins
+        ):
+            raise ValueError("observation URL is outside the reviewed public origins")
+        if row["relation"] is not None:
+            relation = exact(
+                row["relation"], "from_entity to_entity kind", "public relation"
+            )
+            if relation["kind"] not in {"producer", "customer", "substitute"}:
+                raise ValueError("unsupported public relation")
+            if relation["from_entity"] == relation["to_entity"] or not {
+                relation["from_entity"],
+                relation["to_entity"],
+            } <= set(row["entity_ids"]):
+                raise ValueError("public relation does not bind its entities")
+    return packet
+
+
+def validate_resolutions(value: object, *, observations: dict, cutoff_at: str) -> dict:
+    packet = exact(value, "schema_version resolutions", "resolver packet")
+    if packet["schema_version"] != "loopx_explore_subject_resolutions_v0":
+        raise ValueError("unsupported resolver schema")
+    sources = {row["source_id"]: row for row in observations["observations"]}
+    entities = {entity for row in sources.values() for entity in row["entity_ids"]}
+    resolved = set()
+    for item in rows(packet["resolutions"], MAX_OBSERVATIONS * 8, "resolutions"):
+        row = exact(
+            item,
+            "entity_id subject_id source_ids as_of available_at",
+            "subject resolution",
+        )
+        entity = token(row["entity_id"])
+        if entity not in entities or entity in resolved:
+            raise ValueError("resolution has an unknown or duplicate entity")
+        resolved.add(entity)
+        refs = tokens(row["source_ids"], 8, nonempty=row["subject_id"] is not None)
+        if any(
+            ref not in sources or entity not in sources[ref]["entity_ids"]
+            for ref in refs
+        ):
+            raise ValueError("resolution lacks entity-bound source evidence")
+        if (
+            not timestamp(row["as_of"])
+            <= timestamp(row["available_at"])
+            <= timestamp(cutoff_at)
+        ):
+            raise ValueError("resolution was not available at cutoff")
+        if any(
+            timestamp(sources[ref]["available_at"]) > timestamp(row["available_at"])
+            for ref in refs
+        ):
+            raise ValueError("resolution predates its supporting public sources")
+        subject = row["subject_id"]
+        if subject is not None and (
+            not isinstance(subject, str)
+            or not re.fullmatch(r"US\.[A-Z0-9][A-Z0-9.-]{0,24}", subject)
+        ):
+            raise ValueError("resolution is not a listed US subject identity")
+    if resolved != entities:
+        raise ValueError("resolver must preserve explicit unresolved entities")
+    return packet
+
+
+PROPOSAL_FIELDS = "mechanism_id mechanism thesis_digest family causal_lens entity_ids industry_chain_id proxies falsification_ids horizon expires_at supporting_source_ids counter_source_ids missing_evidence_ids conflict_source_ids adjacent_relation_source_id interaction_source_id"
+
+
+def _proposal(
+    value: object, *, policy: dict, sources: dict, resolutions: dict, cutoff_at: str
+) -> dict:
+    p = deepcopy(exact(value, PROPOSAL_FIELDS, "mechanism proposal"))
+    token(p["mechanism_id"])
+    p["mechanism"] = text(p["mechanism"])
+    if p["thesis_digest"] != digest({"mechanism": p["mechanism"]}):
+        raise ValueError("thesis digest does not bind the proposed mechanism")
+    token(p["industry_chain_id"])
+    entities = tokens(p["entity_ids"], 8, nonempty=True)
+    if any(
+        entity not in resolutions or resolutions[entity] is None for entity in entities
+    ):
+        raise ValueError("unresolved proposal entity")
+    if p["causal_lens"] not in policy["causal_lenses"] or p["family"] not in policy[
+        "families_by_horizon"
+    ].get(p["horizon"], []):
+        raise ValueError("unsupported hypothesis family, horizon, or causal lens")
+    if (
+        not timestamp(cutoff_at)
+        < timestamp(p["expires_at"])
+        <= timestamp(policy["expires_at_by_horizon"][p["horizon"]])
+    ):
+        raise ValueError("proposal exceeds provider-owned expiry")
+    p["falsification_ids"] = tokens(p["falsification_ids"], 4, nonempty=True)
+    p["missing_evidence_ids"] = tokens(p["missing_evidence_ids"], 16)
+    bound = set()
+    for field in ("supporting_source_ids", "counter_source_ids", "conflict_source_ids"):
+        p[field] = tokens(p[field], 12)
+        for ref in p[field]:
+            if ref not in sources or not set(sources[ref]["entity_ids"]) & set(
+                entities
+            ):
+                raise ValueError("proposal source is not receipt-bound to its entities")
+            bound.add(ref)
+    if not p["supporting_source_ids"]:
+        raise ValueError("proposal requires an observable supporting source")
+    proxies = rows(p["proxies"], 8, "proxies")
+    if not proxies:
+        raise ValueError("proposal requires an observable public proxy")
+    for proxy in proxies:
+        exact(proxy, "proxy_id source_ids", "proxy")
+        token(proxy["proxy_id"])
+        proxy["source_ids"] = tokens(proxy["source_ids"], 8, nonempty=True)
+        if not set(proxy["source_ids"]) <= bound:
+            raise ValueError("proxy is not bound to proposal sources")
+    relation_ref = p["adjacent_relation_source_id"]
+    interaction_ref = p["interaction_source_id"]
+    if relation_ref is not None:
+        if relation_ref not in bound or sources[relation_ref]["relation"] is None:
+            raise ValueError("adjacent transfer requires an explicit public relation")
+        relation = sources[relation_ref]["relation"]
+        if {relation["from_entity"], relation["to_entity"]} != set(entities):
+            raise ValueError("adjacent transfer is limited to one evidenced edge")
+    if len(entities) > 1:
+        if interaction_ref not in bound or not set(entities) <= set(
+            sources[interaction_ref]["entity_ids"]
+        ):
+            raise ValueError(
+                "combination requires a receipt-bound interaction observation"
+            )
+    elif interaction_ref is not None:
+        raise ValueError("single-entity proposal cannot claim an interaction")
+    p["entity_ids"] = entities
+    p["subject_ids"] = sorted({resolutions[entity] for entity in entities})
+    p["proxies"] = sorted(proxies, key=lambda row: row["proxy_id"])
+    # Caller/model ids are labels. Core owns the canonical hypothesis identity.
+    identity = {key: val for key, val in p.items() if key != "mechanism_id"}
+    p["canonical_id"] = "hyp-" + digest(identity)[7:31]
+    p["mechanism_id"] = (
+        "mechanism-"
+        + digest(
+            {"mechanism": p["mechanism"], "industry_chain_id": p["industry_chain_id"]}
+        )[7:31]
+    )
+    return p
+
+
+def canonicalize_proposals(
+    value: object,
+    *,
+    policy: dict,
+    observations: dict,
+    resolutions: dict,
+    cutoff_at: str,
+    session_ordinal: int,
+) -> dict:
+    packet = exact(
+        value,
+        "schema_version proposals unclassified_source_ids overflow_count",
+        "proposal packet",
+    )
+    if packet["schema_version"] != "loopx_explore_mechanism_proposals_v0":
+        raise ValueError("unsupported mechanism proposal schema")
+    count(packet["overflow_count"])
+    proposals = rows(packet["proposals"], MAX_PROPOSALS, "proposals")
+    sources = {row["source_id"]: row for row in observations["observations"]}
+    resolved = {
+        row["entity_id"]: row["subject_id"] for row in resolutions["resolutions"]
+    }
+    unclassified = tokens(packet["unclassified_source_ids"], MAX_OBSERVATIONS)
+    if not set(unclassified) <= set(sources):
+        raise ValueError("unclassified observations require receipt-bound references")
+    accepted, dropped = {}, []
+    for index, raw in enumerate(proposals):
+        # Unknown fields are an invocation-level structural boundary (including
+        # scores, dispositions, mutations, and caller-authored receipt fields).
+        if not isinstance(raw, dict) or set(raw) - set(PROPOSAL_FIELDS.split()):
+            raise ValueError("proposal contains unknown or authoritative fields")
+        try:
+            p = _proposal(
+                raw,
+                policy=policy,
+                sources=sources,
+                resolutions=resolved,
+                cutoff_at=cutoff_at,
+            )
+        except (ValueError, TypeError, KeyError) as exc:
+            dropped.append({"proposal_index": index, "reason": str(exc)})
+            continue
+        accepted.setdefault(p["canonical_id"], p)
+    lenses = policy["causal_lenses"]
+    offset = session_ordinal % len(lenses)
+    order = lenses[offset:] + lenses[:offset]
+    families = sorted(
+        {
+            family
+            for values in policy["families_by_horizon"].values()
+            for family in values
+        }
+    )
+    buckets = [
+        [
+            p
+            for p in sorted(accepted.values(), key=lambda row: row["canonical_id"])
+            if p["causal_lens"] == lens and p["family"] == family
+        ]
+        for lens in order
+        for family in families
+    ]
+    selected, subjects, transfer_count, overflow = [], set(), 0, 0
+    while any(buckets):
+        for bucket in buckets:
+            if not bucket:
+                continue
+            p = bucket.pop(0)
+            transfer = int(p["adjacent_relation_source_id"] is not None)
+            if (
+                len(subjects | set(p["subject_ids"])) > policy["max_subjects"]
+                or len(selected) >= policy["max_hypotheses"]
+                or transfer_count + transfer > 1
+            ):
+                overflow += 1
+                continue
+            subjects.update(p["subject_ids"])
+            selected.append(p)
+            transfer_count += transfer
+    represented = {
+        ref
+        for p in selected
+        for field in (
+            "supporting_source_ids",
+            "counter_source_ids",
+            "conflict_source_ids",
+        )
+        for ref in p[field]
+    }
+    unrepresented = sorted(set(sources) - represented - set(unclassified))
+    return {
+        "schema_version": "loopx_explore_discovery_canonical_v0",
+        "hypotheses": selected,
+        "subject_ids": sorted(subjects),
+        "lens_order": order,
+        "coverage": {
+            "observation_count": len(sources),
+            "input_proposal_count": len(proposals),
+            "accepted_hypothesis_count": len(selected),
+            "dropped_proposals": dropped,
+            "unclassified_source_ids": unclassified,
+            "unclassified_count": len(unclassified),
+            "unrepresented_source_ids": unrepresented,
+            "duplicate_proposal_count": len(proposals) - len(dropped) - len(accepted),
+            "collector_overflow_count": observations["overflow_count"],
+            "proposer_overflow_count": packet["overflow_count"],
+            "canonical_overflow_count": overflow,
+            "lens_counts": {
+                lens: sum(p["causal_lens"] == lens for p in selected) for lens in lenses
+            },
+            "family_counts": {
+                family: sum(p["family"] == family for p in selected)
+                for family in families
+            },
+        },
+        "semantic_authority": "model_proposal",
+    }

--- a/loopx/capabilities/explore/discovery_runtime.py
+++ b/loopx/capabilities/explore/discovery_runtime.py
@@ -1,0 +1,609 @@
+"""Core-owned capture, canonicalization, settlement and evaluator handoff.
+
+There is deliberately no JSON receipt-import API. Each provenance receipt is
+captured from a Goal-bound managed read-only invocation. The generator sees
+that evidence but owns neither the receipt journal nor Explore event writes.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlsplit
+from zoneinfo import ZoneInfo
+
+from ...extensions.capability_admission import (
+    invoke_external_capability,
+    prepare_external_capability_invocation,
+    validate_external_capability_result,
+)
+from ...extensions.runtime import default_extension_state_file
+from ...file_lock import exclusive_file_lock
+from ...registry import atomic_write_json
+from .discovery_contract import (
+    MAX_BYTES,
+    canonicalize_proposals,
+    digest,
+    exact,
+    rows,
+    timestamp,
+    token,
+    validate_observations,
+    validate_policy,
+    validate_resolutions,
+)
+from .result_log import (
+    append_explore_result_events,
+    build_explore_node_event,
+    explore_result_log_path,
+    load_explore_result_events_strict,
+)
+
+ROLES = ("policy", "collector", "resolver", "proposer")
+JOURNAL_SCHEMA = "loopx_explore_discovery_run_v0"
+
+
+def load_json(path: Path) -> dict:
+    if path.stat().st_size > 5_000_000:
+        raise ValueError("discovery local artifact exceeds its size envelope")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("discovery artifact must be an object")
+    return value
+
+
+def validate_binding(value: object) -> dict:
+    binding = exact(value, "enabled public_origins providers", "discovery binding")
+    if type(binding["enabled"]) is not bool:
+        raise ValueError("discovery enabled must be a boolean")
+    origins = rows(binding["public_origins"], 32, "public origins")
+    if not origins:
+        raise ValueError("discovery requires owner-reviewed public origins")
+    for origin in origins:
+        url = urlsplit(origin)
+        if (
+            url.scheme != "https"
+            or url.path
+            or url.query
+            or url.fragment
+            or url.username
+            or url.password
+            or not url.hostname
+            or "." not in url.hostname
+            or url.port
+            or url.hostname.endswith((".local", ".internal", ".localhost"))
+        ):
+            raise ValueError("discovery requires exact public HTTPS origins")
+        import ipaddress
+
+        try:
+            address = ipaddress.ip_address(url.hostname)
+        except ValueError:
+            pass
+        else:
+            if not address.is_global:
+                raise ValueError("private origins are not public research sources")
+    providers = exact(binding["providers"], " ".join(ROLES), "discovery providers")
+    for role, provider in providers.items():
+        ref = exact(provider, "capability_id operation", f"{role} binding")
+        token(ref["capability_id"])
+        token(ref["operation"])
+    return binding
+
+
+def _root(runtime_root: Path, goal_id: str) -> Path:
+    return runtime_root / "goals" / token(goal_id) / "explore-discovery"
+
+
+def _save(path: Path, journal: dict) -> None:
+    payload = deepcopy(journal)
+    payload.pop("journal_digest", None)
+    payload["journal_digest"] = digest(payload)
+    atomic_write_json(path, payload)
+
+
+def _load(path: Path) -> dict:
+    journal = load_json(path)
+    supplied_digest = journal.pop("journal_digest", None)
+    if (
+        supplied_digest != digest(journal)
+        or journal.get("schema_version") != JOURNAL_SCHEMA
+    ):
+        raise ValueError("discovery journal integrity failure")
+    if journal.get("run_id") != path.stem:
+        raise ValueError("discovery journal identity mismatch")
+    return journal
+
+
+def _context(journal: dict) -> list[dict]:
+    return [
+        {
+            "kind": "explore-discovery",
+            "ref": journal["run_id"],
+            "digest": digest(journal["session"]),
+        }
+    ]
+
+
+def _capture(
+    *, journal: dict, role: str, payload: dict, registry_path: Path, runtime_root: Path
+) -> dict:
+    if role in journal["captures"]:
+        capture = journal["captures"][role]
+        if capture["input"] != payload:
+            raise ValueError("discovery retry changed a frozen provider input")
+        return capture
+    provider = journal["binding"]["providers"][role]
+    args = dict(
+        state_file=default_extension_state_file(runtime_root),
+        registry_path=registry_path,
+        goal_id=journal["goal_id"],
+        capability_id=provider["capability_id"],
+        operation=provider["operation"],
+        provider_input={"context_refs": _context(journal), "input": payload},
+    )
+    prepared = prepare_external_capability_invocation(**args)
+    if prepared["operation_profile"]["effect_class"] != "read_only":
+        raise ValueError("discovery providers must be read-only")
+    receipt = invoke_external_capability(**args, execute=True)
+    if (
+        receipt["request_digest"] != prepared["request_digest"]
+        or receipt["invocation_id"] != prepared["invocation_id"]
+    ):
+        raise ValueError("discovery provider binding changed during capture")
+    capture = {
+        "input": payload,
+        "request": prepared["request"],
+        "operation_profile": prepared["operation_profile"],
+        "receipt": receipt,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _capture_observation(capture, journal=journal)
+    journal["captures"][role] = capture
+    return capture
+
+
+def _validate_receipt(receipt: dict, *, request: dict, operation: dict) -> dict:
+    result = validate_external_capability_result(
+        receipt["provider_result"],
+        invocation_id=request["invocation_id"],
+        operation=operation,
+    )
+    if (
+        operation["effect_class"] != "read_only"
+        or receipt.get("executed") is not True
+        or receipt.get("effect_class") != "read_only"
+        or receipt.get("status") != result["status"]
+        or receipt.get("effects", {}).get("provider_invoked") is not True
+        or any(
+            receipt.get("effects", {}).get(key) is not False
+            for key in (
+                "external_write_performed",
+                "loopx_state_written",
+                "quota_spent",
+            )
+        )
+        or receipt.get("invocation_id") != request["invocation_id"]
+        or receipt.get("capability_id") != request["capability_id"]
+        or receipt.get("operation") != request["operation"]
+        or receipt["request_digest"] != digest(request)
+        or receipt["provider_result_digest"] != digest(result)
+        or receipt["provider"] != request["provider"]
+        or receipt["goal_binding"]["goal_id"] != request["goal"]["goal_id"]
+        or receipt["goal_binding"]["binding_digest"]
+        != request["goal"]["capability_binding_digest"]
+    ):
+        raise ValueError("discovery requires a successful managed read-only receipt")
+    return result
+
+
+def _capture_observation(capture: dict, *, journal: dict) -> dict:
+    request = capture["request"]
+    result = _validate_receipt(
+        capture["receipt"], request=request, operation=capture["operation_profile"]
+    )
+    if (
+        request["goal"]["goal_id"] != journal["goal_id"]
+        or request["context_refs"] != _context(journal)
+        or request["input"] != capture["input"]
+    ):
+        raise ValueError(
+            "discovery capture is not bound to a successful managed invocation"
+        )
+    observations = rows(result["observations"], 1, "provider observations")
+    if len(observations) != 1 or len(json.dumps(observations).encode()) > MAX_BYTES:
+        raise ValueError("discovery provider requires one bounded observation packet")
+    if timestamp(capture["captured_at"]) < timestamp(journal["session"]["started_at"]):
+        raise ValueError("discovery capture predates its Core session")
+    return observations[0]
+
+
+def _reduce(journal: dict) -> dict:
+    cutoff = journal["session"]["cutoff_at"]
+    captures = journal["captures"]
+    for role in ROLES:
+        request = captures[role]["request"]
+        bound = journal["binding"]["providers"][role]
+        if (
+            request["capability_id"] != bound["capability_id"]
+            or request["operation"] != bound["operation"]
+        ):
+            raise ValueError(
+                "discovery capture differs from the Core provider-role binding"
+            )
+    if captures["policy"]["input"] != {"as_of": cutoff}:
+        raise ValueError("policy receipt does not bind the Core cutoff")
+    policy = validate_policy(
+        _capture_observation(captures["policy"], journal=journal), cutoff
+    )
+    observations = validate_observations(
+        _capture_observation(captures["collector"], journal=journal),
+        cutoff_at=cutoff,
+        public_origins=journal["binding"]["public_origins"],
+    )
+    resolutions = validate_resolutions(
+        _capture_observation(captures["resolver"], journal=journal),
+        observations=observations,
+        cutoff_at=cutoff,
+    )
+    ordinal = journal["session"]["ordinal"]
+    if type(ordinal) is not int or ordinal < 0:
+        raise ValueError("invalid Core discovery session ordinal")
+    lenses = policy["causal_lenses"]
+    offset = ordinal % len(lenses)
+    expected_inputs = {
+        "collector": {
+            "cutoff_at": cutoff,
+            "max_observations": 96,
+            "public_origins": journal["binding"]["public_origins"],
+        },
+        "resolver": {
+            "cutoff_at": cutoff,
+            "observations": observations,
+            "collector_receipt_digest": digest(captures["collector"]),
+        },
+        "proposer": {
+            "cutoff_at": cutoff,
+            "policy": policy,
+            "observations": observations,
+            "resolutions": resolutions,
+            "lens_order": lenses[offset:] + lenses[:offset],
+            "max_proposals": 96,
+            "max_adjacent_transfers": 1,
+            "receipt_digests": {role: digest(captures[role]) for role in ROLES[:-1]},
+        },
+    }
+    if any(
+        captures[role]["input"] != expected
+        for role, expected in expected_inputs.items()
+    ):
+        raise ValueError(
+            "discovery receipt chain does not bind exact upstream observations"
+        )
+    canonical = canonicalize_proposals(
+        _capture_observation(captures["proposer"], journal=journal),
+        policy=policy,
+        observations=observations,
+        resolutions=resolutions,
+        cutoff_at=cutoff,
+        session_ordinal=journal["session"]["ordinal"],
+    )
+    universe = {
+        "universe_id": journal["run_id"],
+        "source_id": journal["run_id"],
+        "frozen_at": cutoff,
+        "coverage_claim": "bounded_research_pool",
+        "completeness": "partial",
+        "subject_ids": canonical["subject_ids"],
+    }
+    return {
+        "schema_version": "loopx_explore_discovery_freeze_v0",
+        "goal_id": journal["goal_id"],
+        "run_id": journal["run_id"],
+        "captured_at": captures["proposer"]["captured_at"],
+        "session_receipt_digest": digest(journal["session"]),
+        "capture_receipt_digests": {role: digest(captures[role]) for role in ROLES},
+        "policy": policy,
+        "canonical": canonical,
+        "universe": universe,
+        "authority": "evaluation_scope_only",
+    }
+
+
+def _events(freeze: dict) -> list[dict]:
+    return [
+        build_explore_node_event(
+            goal_id=freeze["goal_id"],
+            node_id=p["canonical_id"],
+            title=p["mechanism"],
+            node_kind="hypothesis",
+            status="open",
+            summary="Canonical proposal for bounded evaluation; no research finding or lifecycle promotion.",
+            run_id=freeze["run_id"],
+            recorded_at=freeze["captured_at"],
+            evidence_refs=[
+                freeze["run_id"],
+                p["thesis_digest"],
+                *p["supporting_source_ids"][:12],
+            ],
+            tags=["discovery-proposal", p["family"], p["causal_lens"]],
+        )
+        for p in freeze["canonical"]["hypotheses"]
+    ]
+
+
+def run_discovery(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    binding: dict,
+    trigger_id: str,
+    cutoff_at: str,
+    execute: bool = False,
+) -> dict:
+    # Feature-off returns before provider resolution, journal reads, or writes.
+    if binding.get("enabled", False) is False:
+        return {"ok": True, "status": "disabled", "executed": False}
+    binding = validate_binding(binding)
+    token(goal_id)
+    token(trigger_id)
+    cutoff = timestamp(cutoff_at)
+    now = datetime.now(timezone.utc)
+    if cutoff > now:
+        raise ValueError("discovery cutoff cannot be in the future")
+    run_id = "discovery-" + digest({"goal_id": goal_id, "trigger_id": trigger_id})[7:31]
+    if not execute:
+        return {"ok": True, "status": "preview", "run_id": run_id, "executed": False}
+    root = _root(runtime_root, goal_id)
+    path = root / f"{run_id}.json"
+    with exclusive_file_lock(root / "sessions"):
+        if path.exists():
+            journal = _load(path)
+            if (
+                journal["binding"] != binding
+                or journal["session"]["cutoff_at"] != cutoff_at
+            ):
+                raise ValueError(
+                    "discovery trigger already binds another cutoff or configuration"
+                )
+        else:
+            prior = [
+                _load(p)["session"]["ordinal"] for p in root.glob("discovery-*.json")
+            ]
+            journal = {
+                "schema_version": JOURNAL_SCHEMA,
+                "goal_id": goal_id,
+                "run_id": run_id,
+                "binding": deepcopy(binding),
+                "captures": {},
+                "session": {
+                    "trigger_id": trigger_id,
+                    "cutoff_at": cutoff_at,
+                    "started_at": now.isoformat(),
+                    "ordinal": max(prior, default=-1) + 1,
+                },
+                "freeze": None,
+                "settlement": None,
+            }
+            _save(path, journal)
+        if journal["settlement"] is not None:
+            return read_discovery(
+                runtime_root=runtime_root, goal_id=goal_id, run_id=run_id
+            )
+        policy_capture = _capture(
+            journal=journal,
+            role="policy",
+            payload={"as_of": cutoff_at},
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+        )
+        policy = validate_policy(
+            _capture_observation(policy_capture, journal=journal), cutoff_at
+        )
+        _save(path, journal)
+        collector = _capture(
+            journal=journal,
+            role="collector",
+            payload={
+                "cutoff_at": cutoff_at,
+                "max_observations": 96,
+                "public_origins": binding["public_origins"],
+            },
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+        )
+        observations = validate_observations(
+            _capture_observation(collector, journal=journal),
+            cutoff_at=cutoff_at,
+            public_origins=binding["public_origins"],
+        )
+        _save(path, journal)
+        resolver = _capture(
+            journal=journal,
+            role="resolver",
+            payload={
+                "cutoff_at": cutoff_at,
+                "observations": observations,
+                "collector_receipt_digest": digest(collector),
+            },
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+        )
+        resolutions = validate_resolutions(
+            _capture_observation(resolver, journal=journal),
+            observations=observations,
+            cutoff_at=cutoff_at,
+        )
+        _save(path, journal)
+        ordinal = journal["session"]["ordinal"]
+        lenses = policy["causal_lenses"]
+        offset = ordinal % len(lenses)
+        _capture(
+            journal=journal,
+            role="proposer",
+            payload={
+                "cutoff_at": cutoff_at,
+                "policy": policy,
+                "observations": observations,
+                "resolutions": resolutions,
+                "lens_order": lenses[offset:] + lenses[:offset],
+                "max_proposals": 96,
+                "max_adjacent_transfers": 1,
+                "receipt_digests": {
+                    role: digest(journal["captures"][role]) for role in ROLES[:-1]
+                },
+            },
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+        )
+        freeze = _reduce(journal)
+        journal["freeze"] = freeze
+        _save(path, journal)
+        events = _events(freeze)
+        log = explore_result_log_path(runtime_root, goal_id)
+        # Validate the existing ledger strictly before using its idempotent writer.
+        load_explore_result_events_strict(log, goal_id=goal_id)
+        if events:
+            append_explore_result_events(log, events, expected_goal_id=goal_id)
+        existing = {
+            e["event_id"]: e
+            for e in load_explore_result_events_strict(log, goal_id=goal_id)
+        }
+        if any(existing.get(e["event_id"]) != e for e in events):
+            raise ValueError("discovery Explore settlement readback failed")
+        journal["settlement"] = {
+            "schema_version": "loopx_explore_discovery_settlement_v0",
+            "freeze_digest": digest(freeze),
+            "event_ids": [e["event_id"] for e in events],
+            "status": "scope_frozen" if events else "no_candidates",
+            "research_admission": False,
+            "lifecycle_promotion": False,
+        }
+        _save(path, journal)
+    return read_discovery(runtime_root=runtime_root, goal_id=goal_id, run_id=run_id)
+
+
+def read_discovery(*, runtime_root: Path, goal_id: str, run_id: str) -> dict:
+    journal = _load(_root(runtime_root, goal_id) / f"{token(run_id)}.json")
+    if journal["goal_id"] != goal_id or journal["settlement"] is None:
+        raise ValueError("discovery has no settled Core scope receipt")
+    freeze = _reduce(journal)
+    if journal["freeze"] != freeze or journal["settlement"]["freeze_digest"] != digest(
+        freeze
+    ):
+        raise ValueError("discovery frozen scope drifted from its receipts")
+    events = _events(freeze)
+    if journal["settlement"]["event_ids"] != [e["event_id"] for e in events]:
+        raise ValueError("discovery settlement event identity mismatch")
+    existing = {
+        e["event_id"]: e
+        for e in load_explore_result_events_strict(
+            explore_result_log_path(runtime_root, goal_id), goal_id=goal_id
+        )
+    }
+    if any(existing.get(e["event_id"]) != e for e in events):
+        raise ValueError("discovery settlement is absent from Core Explore history")
+    return {
+        "ok": True,
+        "status": journal["settlement"]["status"],
+        "run_id": run_id,
+        "freeze": freeze,
+        "settlement_receipt": journal["settlement"],
+        "readback_verified": True,
+    }
+
+
+def evaluate_discovery(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    goal_id: str,
+    run_id: str,
+    provider_input: dict,
+    binding: dict,
+    execute: bool = False,
+) -> dict:
+    if binding.get("enabled", False) is False:
+        return {"ok": True, "status": "disabled", "provider_invoked": False}
+    binding = validate_binding(binding)
+    result = read_discovery(runtime_root=runtime_root, goal_id=goal_id, run_id=run_id)
+    freeze = result["freeze"]
+    if not freeze["universe"]["subject_ids"]:
+        return {"ok": True, "status": "no_candidates", "provider_invoked": False}
+    journal_path = _root(runtime_root, goal_id) / f"{run_id}.json"
+    journal = _load(journal_path)
+    if journal["binding"] != binding:
+        raise ValueError(
+            "evaluation binding differs from the settled discovery configuration"
+        )
+    request = deepcopy(exact(provider_input, "context_refs input", "evaluation input"))
+    policy, cutoff = freeze["policy"], freeze["universe"]["frozen_at"]
+    payload = request["input"]
+    if (
+        payload.get("universe") != freeze["universe"]
+        or payload.get("cutoff_at") != cutoff
+        or payload.get("method_revision") != policy["method_revision"]
+        or payload.get("market") != policy["market"]
+        or payload.get("timezone") != policy["timezone"]
+        or payload.get("trading_date")
+        != timestamp(cutoff).astimezone(ZoneInfo(policy["timezone"])).date().isoformat()
+    ):
+        raise ValueError(
+            "evaluation input must exactly match the Core-frozen universe and method"
+        )
+    ref = {
+        "kind": "explore-discovery",
+        "ref": run_id,
+        "digest": digest(result["settlement_receipt"]),
+    }
+    if ref not in request["context_refs"]:
+        request["context_refs"].append(ref)
+    evaluator_binding = journal["binding"]["providers"]["policy"]
+    args = dict(
+        state_file=default_extension_state_file(runtime_root),
+        registry_path=registry_path,
+        goal_id=goal_id,
+        capability_id=evaluator_binding["capability_id"],
+        operation=policy["evaluation_operation"],
+        provider_input=request,
+    )
+    prepared = prepare_external_capability_invocation(**args)
+    if prepared["operation_profile"]["effect_class"] != "read_only":
+        raise ValueError("discovery evaluation must remain read-only")
+    if (
+        prepared["request"]["provider"]
+        != journal["captures"]["policy"]["request"]["provider"]
+    ):
+        raise ValueError("evaluation provider revision differs from frozen policy")
+    if not execute:
+        return invoke_external_capability(**args, execute=False)
+    with exclusive_file_lock(journal_path):
+        journal = _load(journal_path)
+        prior = journal.get("evaluation")
+        if prior is not None:
+            if prior["request_digest"] != prepared["request_digest"]:
+                raise ValueError(
+                    "settled discovery already binds another evaluation input"
+                )
+            _validate_receipt(
+                prior,
+                request=prepared["request"],
+                operation=prepared["operation_profile"],
+            )
+            return prior
+        receipt = invoke_external_capability(**args, execute=True)
+        if receipt["request_digest"] != prepared["request_digest"]:
+            raise ValueError("evaluation invocation changed after Core admission")
+        _validate_receipt(
+            receipt,
+            request=prepared["request"],
+            operation=prepared["operation_profile"],
+        )
+        journal["evaluation"] = receipt
+        _save(journal_path, journal)
+        if _load(journal_path)["evaluation"] != receipt:
+            raise ValueError("evaluation receipt readback failed")
+        return receipt

--- a/loopx/capabilities/explore/docs/discovery.md
+++ b/loopx/capabilities/explore/docs/discovery.md
@@ -1,0 +1,174 @@
+# Receipt-bound pre-universe discovery
+
+`loopx explore discover` is an opt-in Explore adapter that captures public
+observations before a research universe exists. It canonicalizes bounded
+mechanism proposals, freezes at most 48 subjects, and records hypotheses in
+the existing Explore result history. It does not admit research candidates or
+settle domain lifecycle transitions.
+
+## Ownership
+
+The implementation belongs to Explore: `discovery_runtime.py` calls the
+existing `extensions.capability_admission` prepare/invoke APIs, including
+installed-provider revision admission and durable Goal capability bindings.
+It uses `result_log.py` for idempotent hypothesis events and exact readback.
+`discovery_contract.py` is the pure structural canonicalizer. Neither module
+adds a public capability, scheduler, Goal state machine, or financial gate.
+
+The evaluator owns its method vocabulary, horizon ceilings, and evaluation
+operation. A managed read-only policy operation supplies those values; Core
+does not copy an evaluator's strategy taxonomy or exchange calendar. The
+current handoff supports US subjects and America/New_York only.
+
+## Activation and commands
+
+Discovery is off unless a local binding explicitly sets `enabled: true`.
+Omitting the switch, or setting it to false, returns before provider resolution
+or discovery-state access. Existing Explore commands do not invoke discovery.
+`--execute` is separately required to call providers and persist Core receipts.
+All downstream operations must remain read-only; Core writes only its own
+capture journal and Explore history.
+
+Example binding (provider names are illustrative, not bundled services):
+
+```json
+{
+  "enabled": false,
+  "public_origins": ["https://issuer.example"],
+  "providers": {
+    "policy": {"capability_id": "research-evaluator", "operation": "describe_discovery_policy"},
+    "collector": {"capability_id": "public-observations", "operation": "collect"},
+    "resolver": {"capability_id": "listed-entities", "operation": "resolve"},
+    "proposer": {"capability_id": "mechanism-proposals", "operation": "propose"}
+  }
+}
+```
+
+Install and doctor the exact provider revisions, bind all four operations and
+the policy-declared evaluation operation to the Goal through the existing
+extension workflow, then explicitly enable the reviewed local binding.
+
+```sh
+loopx explore discover --goal-id example --binding-file discovery-binding.json \
+  --trigger-id public-event-1 --cutoff-at 2026-08-28T20:00:00Z
+loopx explore discover --goal-id example --binding-file discovery-binding.json \
+  --trigger-id public-event-1 --cutoff-at 2026-08-28T20:00:00Z --execute
+loopx explore discovery-readback --goal-id example --run-id discovery-RUN_ID
+loopx explore discovery-evaluate --goal-id example --run-id discovery-RUN_ID \
+  --binding-file discovery-binding.json --input-file evaluation-input.json --execute
+```
+
+Use the `run_id` returned by discovery. Preview validates configuration and
+computes identity; it does not claim provider readiness. Disable the binding
+to stop new discovery and evaluation calls. Readback remains available.
+Manual, event, and existing LoopX scheduled callers can use the same commands;
+their existing Goal/Todo/quota admission remains the caller's responsibility.
+The adapter creates no schedule and does not consume or replenish quota.
+
+## Managed role contracts
+
+Every operation returns one observation packet inside the existing managed
+read-only result envelope. Mutations, effects, and transition proposals are
+rejected by existing Core admission. Packet validation adds strict fields,
+bounded text, public-safety checks, and a 750 KB observation-packet ceiling.
+
+| Role | Input supplied by Core | Observation schema |
+| --- | --- | --- |
+| Policy | `as_of` cutoff | `loopx_explore_discovery_policy_v0` |
+| Collector | cutoff, max 96 observations, reviewed public HTTPS origins | `loopx_explore_public_observations_v0` |
+| Resolver | cutoff, exact collected observations, collector receipt digest | `loopx_explore_subject_resolutions_v0` |
+| Proposer | cutoff, policy, observations, resolutions, rotated lens order, limits, upstream receipt digests | `loopx_explore_mechanism_proposals_v0` |
+
+The policy supplies method revision, market/timezone, caps no greater than 48,
+five ordered causal lenses, three horizon-to-family mappings, corresponding
+expiry ceilings, and the existing evaluation operation. Core allocates a
+session ordinal under a lock and rotates the five lenses; neither model nor
+caller can supply that ordinal.
+
+Each observation binds `source_id`, `uri`, `entity_ids`, `as_of`, `available_at`,
+`content_digest`, `summary`, and an optional relation. Both timestamps must be
+no later than cutoff, with observation time no later than availability. Source
+URLs must match the reviewed HTTPS origins and carry no credentials, query,
+or fragment. Relations bind two observed entities and a
+producer/customer/substitute edge. The packet includes `overflow_count`.
+
+The resolver explicitly returns every observed entity, including unresolved
+entities with null `subject_id`. Each listed US subject resolution must bind
+entity-specific observed sources and point-in-time availability. This
+identity is owned by the resolver; the model cannot propose a ticker directly.
+
+The proposer returns at most 96 proposals, bounded
+`unclassified_source_ids`, and `overflow_count`. Each proposal has exactly:
+
+```text
+mechanism_id mechanism thesis_digest family causal_lens entity_ids
+industry_chain_id proxies falsification_ids horizon expires_at
+supporting_source_ids counter_source_ids missing_evidence_ids conflict_source_ids
+adjacent_relation_source_id interaction_source_id
+```
+
+`thesis_digest` is SHA-256 over the canonical JSON object containing the
+whitespace-normalized `mechanism`; JSON is sorted, compact, and UTF-8 encoded.
+Proxy rows contain `proxy_id` and `source_ids`. Source labels and proxies must
+refer to receipt-bound observations. At least one falsification and one public
+proxy are required. Missing/invalid fields drop that proposal with an explicit
+reason; unknown fields such as score, confidence, disposition, factor judgment,
+or model-authored receipts fail the invocation.
+
+Multi-entity proposals require one observed interaction covering all affected
+entities. An adjacent-industry transfer additionally requires an explicit
+public edge; at most one transfer can enter the frozen scope. No pairwise
+combinations are generated by Core.
+
+## Canonicalization and settlement
+
+Core derives mechanism and hypothesis ids from normalized content, ignoring
+model identity labels. It preserves family/lens buckets using deterministic
+round-robin selection and canonical identity as the tie-breaker, admitting a
+proposal's complete subject set or none of it. The freeze contains coverage
+counts by lens and family, unclassified and unrepresented source references,
+drop reasons, duplicates, and collector/proposer/canonical overflow counts.
+The universe always declares `bounded_research_pool` and `partial` coverage.
+
+The Goal-local `explore-discovery` journal retains exact managed requests,
+successful executed receipts, provider revisions, request/result digests,
+capture times, canonical freeze, and the scope settlement. There is no receipt
+import API. Receipt binding establishes which admitted provider produced an
+observation; it is not independent verification of that observation's truth.
+Core runtime storage remains the trusted local authority, not a cryptographic
+attestation against an operator who can rewrite the entire runtime.
+
+Accepted proposals become `hypothesis/open` events in the existing Explore
+history. Readback revalidates the request/receipt chain, rederives the freeze,
+and requires exact event presence. Empty results settle as `no_candidates`.
+Neither path writes active-pool rows, tombstones, or research findings.
+
+The same Goal and trigger id resume the same run; changing its binding or
+cutoff fails. Captures are checkpointed, event writes are idempotent, and a
+crash after append can finish settlement on retry. A crash before a capture
+checkpoint can repeat that read-only invocation with the same identity. A new
+trigger advances the ordinal even when an earlier attempt failed.
+
+## Evaluator handoff and limits
+
+`discovery-evaluate` requires an existing evaluator input whose universe,
+cutoff, method, market, timezone, and trading date exactly match the freeze.
+It adds the scope settlement digest as managed context, admits the exact
+policy-provider revision, and invokes its read-only evaluation operation.
+Successful evaluation receipts are persisted and replayed only for the same
+request digest.
+
+This is a subject-scope handoff: discovered mechanism proposals remain in Core
+history. It does not convert their support/counter labels into research claims,
+factor evidence, or an assertion that those specific mechanisms were tested.
+The evaluator still requires its existing typed evidence input. Empty evidence
+may legitimately produce no actionable research result. Domain lifecycle
+settlement, reviewed thesis promotion, source truth verification, live source
+providers, and whole-market coverage remain separate integrations.
+
+Validation lives in `tests/capabilities/test_explore_discovery.py`: real
+installed subprocess providers and Goal bindings exercise capture, discovery
+outside a supplied watchlist, bounded selection, Core history readback,
+interrupted settlement, tamper rejection, and repeat evaluation. Domain
+providers should additionally run these seams against their production CLI
+and existing packet schemas before activation.

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -60,6 +60,11 @@ from .explore_feishu_commands import (
     register_explore_feishu_commands,
 )
 from .explore_planning_commands import register_explore_planning_commands
+from .explore_discovery_commands import (
+    DISCOVERY_COMMANDS,
+    handle_explore_discovery_command,
+    register_explore_discovery_commands,
+)
 
 
 PrintPayload = Callable[
@@ -198,6 +203,8 @@ def register_explore_commands(
         add_subcommand_format,
         _add_projection_limit_args,
     )
+
+    register_explore_discovery_commands(sub, add_subcommand_format)
 
     register_explore_feishu_commands(
         sub,
@@ -473,7 +480,13 @@ def handle_explore_command(
                 else registry_path
             )
         )
-        if args.explore_command == "schema":
+        if args.explore_command in DISCOVERY_COMMANDS:
+            payload = handle_explore_discovery_command(
+                args,
+                registry_path=Path(str(source_runtime_route["source_registry"])),
+                runtime_root=runtime_root,
+            )
+        elif args.explore_command == "schema":
             payload = lark_explore_schema_payload()
         elif args.explore_command == "node":
             event = build_explore_node_event(

--- a/loopx/cli_commands/explore_discovery_commands.py
+++ b/loopx/cli_commands/explore_discovery_commands.py
@@ -1,0 +1,79 @@
+"""Explicit opt-in discovery entrypoints; existing Explore paths stay unchanged."""
+
+from pathlib import Path
+
+from ..capabilities.explore.discovery_runtime import (
+    evaluate_discovery,
+    load_json,
+    read_discovery,
+    run_discovery,
+)
+
+DISCOVERY_COMMANDS = {"discover", "discovery-readback", "discovery-evaluate"}
+
+
+def register_explore_discovery_commands(sub, add_format) -> None:
+    discover = sub.add_parser(
+        "discover",
+        help="Preview a default-off receipt-bound discovery run; --execute captures and settles evaluation scope.",
+    )
+    add_format(discover)
+    discover.add_argument("--goal-id", required=True)
+    discover.add_argument(
+        "--binding-file",
+        required=True,
+        help="Owner-reviewed local provider bindings; enabled must explicitly be true.",
+    )
+    discover.add_argument(
+        "--trigger-id",
+        required=True,
+        help="Stable idempotency key; Core allocates the session ordinal.",
+    )
+    discover.add_argument("--cutoff-at", required=True)
+    discover.add_argument("--execute", action="store_true")
+    for command in ("discovery-readback", "discovery-evaluate"):
+        parser = sub.add_parser(
+            command,
+            help="Verify Core discovery receipts"
+            + (
+                " and invoke the frozen evaluator."
+                if command.endswith("evaluate")
+                else "."
+            ),
+        )
+        add_format(parser)
+        parser.add_argument("--goal-id", required=True)
+        parser.add_argument("--run-id", required=True)
+        if command.endswith("evaluate"):
+            parser.add_argument("--binding-file", required=True)
+            parser.add_argument(
+                "--input-file",
+                required=True,
+                help="Existing evaluator input with the exact frozen universe; proposals do not supply factor judgments.",
+            )
+            parser.add_argument("--execute", action="store_true")
+
+
+def handle_explore_discovery_command(
+    args, *, registry_path: Path, runtime_root: Path
+) -> dict:
+    common = {"runtime_root": runtime_root, "goal_id": args.goal_id}
+    if args.explore_command == "discover":
+        return run_discovery(
+            **common,
+            registry_path=registry_path,
+            binding=load_json(Path(args.binding_file)),
+            trigger_id=args.trigger_id,
+            cutoff_at=args.cutoff_at,
+            execute=args.execute,
+        )
+    if args.explore_command == "discovery-readback":
+        return read_discovery(**common, run_id=args.run_id)
+    return evaluate_discovery(
+        **common,
+        registry_path=registry_path,
+        run_id=args.run_id,
+        provider_input=load_json(Path(args.input_file)),
+        execute=args.execute,
+        binding=load_json(Path(args.binding_file)),
+    )

--- a/tests/capabilities/test_explore_discovery.py
+++ b/tests/capabilities/test_explore_discovery.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from loopx.capabilities.explore.discovery_contract import (
+    canonicalize_proposals,
+    digest,
+    validate_observations,
+    validate_resolutions,
+)
+from loopx.capabilities.explore.discovery_runtime import (
+    evaluate_discovery,
+    read_discovery,
+    run_discovery,
+)
+from loopx.capabilities.explore.result_log import explore_result_log_path
+from loopx.extensions.capability_admission import bind_external_capability_to_goal
+from loopx.extensions.runtime import default_extension_state_file, install_extension
+
+CUTOFF = "2026-08-28T20:00:00Z"
+LENSES = [
+    "lens-a",
+    "lens-b",
+    "lens-c",
+    "lens-d",
+    "lens-e",
+]
+POLICY = {
+    "schema_version": "loopx_explore_discovery_policy_v0",
+    "as_of": CUTOFF,
+    "method_revision": "fixture-method-v1",
+    "market": "US",
+    "timezone": "America/New_York",
+    "max_subjects": 48,
+    "max_hypotheses": 48,
+    "causal_lenses": LENSES,
+    "families_by_horizon": {
+        h: ["mechanism-a", "mechanism-b"]
+        for h in ["intraday", "short_1_5_sessions", "medium_1_3_months"]
+    },
+    "expires_at_by_horizon": {
+        "intraday": "2026-08-31T20:00:00Z",
+        "short_1_5_sessions": "2026-09-04T20:00:00Z",
+        "medium_1_3_months": "2026-11-27T18:00:00Z",
+    },
+    "evaluation_operation": "evaluate",
+}
+
+
+def observation(i=0):
+    return {
+        "source_id": f"source-{i}",
+        "uri": f"https://issuer.example/filings/{i}",
+        "entity_ids": [f"entity-{i}"],
+        "as_of": CUTOFF,
+        "available_at": CUTOFF,
+        "content_digest": digest({"public_observation": i}),
+        "summary": "Synthetic public operating observation.",
+        "relation": None,
+    }
+
+
+def proposal(i=0):
+    mechanism = f"Synthetic capacity change may shift the residual to entity {i}."
+    return {
+        "mechanism_id": f"mechanism-{i}",
+        "mechanism": mechanism,
+        "thesis_digest": digest({"mechanism": mechanism}),
+        "family": "mechanism-a",
+        "causal_lens": LENSES[i % 5],
+        "entity_ids": [f"entity-{i}"],
+        "industry_chain_id": "synthetic-chain",
+        "proxies": [{"proxy_id": "capacity", "source_ids": [f"source-{i}"]}],
+        "falsification_ids": ["capacity-declines"],
+        "horizon": "medium_1_3_months",
+        "expires_at": "2026-09-04T20:00:00Z",
+        "supporting_source_ids": [f"source-{i}"],
+        "counter_source_ids": [],
+        "missing_evidence_ids": ["cash-conversion"],
+        "conflict_source_ids": [],
+        "adjacent_relation_source_id": None,
+        "interaction_source_id": None,
+    }
+
+
+def packets(n=1):
+    return {
+        "policy": deepcopy(POLICY),
+        "collect": {
+            "schema_version": "loopx_explore_public_observations_v0",
+            "observations": [observation(i) for i in range(n)],
+            "overflow_count": 0,
+        },
+        "resolve": {
+            "schema_version": "loopx_explore_subject_resolutions_v0",
+            "resolutions": [
+                {
+                    "entity_id": f"entity-{i}",
+                    "subject_id": f"US.EX{i}",
+                    "source_ids": [f"source-{i}"],
+                    "as_of": CUTOFF,
+                    "available_at": CUTOFF,
+                }
+                for i in range(n)
+            ],
+        },
+        "propose": {
+            "schema_version": "loopx_explore_mechanism_proposals_v0",
+            "proposals": [proposal(i) for i in range(n)],
+            "unclassified_source_ids": [],
+            "overflow_count": 0,
+        },
+    }
+
+
+def installed(tmp_path: Path, data=None):
+    """Real installed subprocess provider; no mocked invocation or ledger."""
+    data = data or packets()
+    (tmp_path / "data.json").write_text(json.dumps(data))
+    provider = tmp_path / "provider"
+    provider.write_text(f"""#!{sys.executable}
+import json, sys
+from pathlib import Path
+if "--doctor" in sys.argv: raise SystemExit(0)
+r = json.load(sys.stdin)
+data = json.loads(Path(__file__).with_name("data.json").read_text())
+with Path(__file__).with_name("calls.jsonl").open("a") as f:
+    f.write(json.dumps(r) + "\\n")
+op = r["operation"]
+observation = data[op] if op != "evaluate" else {{"evaluated_universe": r["input"]["universe"]}}
+if op == "propose":
+    policy = r["input"]["policy"]
+    for i, proposal in enumerate(observation["proposals"]):
+        proposal["family"] = policy["families_by_horizon"][proposal["horizon"]][0]
+        proposal["causal_lens"] = policy["causal_lenses"][i % 5]
+json.dump({{"schema_version": "fixture_result_v0", "invocation_id": r["invocation_id"],
+    "status": data.get("result_status", "succeeded"), "observations": [observation], "domain_state_mutations": [],
+    "domain_transition_receipts": [], "transition_proposals": [], "effect_receipt": None,
+    "follow_up": {{"kind": "none"}}}}, sys.stdout)
+""")
+    provider.chmod(0o755)
+    profile = {
+        "schema_version": "loopx_external_domain_capability_profile_v0",
+        "capability_id": "fixture-discovery-data",
+        "protocol": "fixture_discovery_v0",
+        "operations": [
+            {
+                "id": op,
+                "effect_class": "read_only",
+                "required_permission": "public_data.read",
+                "request_schema": "fixture_request_v0",
+                "result_schema": "fixture_result_v0",
+            }
+            for op in ["policy", "collect", "resolve", "propose", "evaluate"]
+        ],
+    }
+    (tmp_path / "profile.json").write_text(json.dumps(profile))
+    manifest = tmp_path / "extension.toml"
+    manifest.write_text(f"""schema_version = "loopx_extension_manifest_v0"
+id = "fixture-discovery-provider"
+version = "0.1.0"
+requires_loopx_api = ">=1,<2"
+permissions = ["public_data.read"]
+[runtime]
+protocol = "fixture_discovery_v0"
+entrypoint = {json.dumps(str(provider))}
+doctor_args = ["--doctor"]
+required_permissions = ["public_data.read"]
+timeout_seconds = 10
+[[provides]]
+id = "fixture-discovery-data"
+kind = "public_observations"
+title = "Synthetic public observations"
+status = "active-preview"
+user_value = "Exercise the receipt-bound discovery contract."
+next_real_step = "Run isolated contract validation."
+real_world_anchor = "Synthetic public source fixtures."
+entry_command = "loopx capability invoke"
+visibility = "public"
+integration_profile = "profile.json"
+""")
+    runtime = tmp_path / "runtime"
+    state = default_extension_state_file(runtime)
+    install_extension(manifest, state_file=state, execute=True)
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_registry_v1",
+                "common_runtime_root": str(runtime),
+                "goals": [{"id": "discovery-test", "repo": str(tmp_path)}],
+            }
+        )
+    )
+    bind_external_capability_to_goal(
+        registry_path=registry,
+        goal_id="discovery-test",
+        state_file=state,
+        capability_id="fixture-discovery-data",
+        operations=["policy", "collect", "resolve", "propose", "evaluate"],
+        execute=True,
+    )
+    binding = {
+        "enabled": True,
+        "public_origins": ["https://issuer.example"],
+        "providers": {
+            role: {"capability_id": "fixture-discovery-data", "operation": op}
+            for role, op in [
+                ("policy", "policy"),
+                ("collector", "collect"),
+                ("resolver", "resolve"),
+                ("proposer", "propose"),
+            ]
+        },
+    }
+    return dict(
+        registry_path=registry,
+        runtime_root=runtime,
+        goal_id="discovery-test",
+        binding=binding,
+        trigger_id="public-event-1",
+        cutoff_at=CUTOFF,
+    )
+
+
+def test_disabled_and_preview_do_not_resolve_providers_or_write(tmp_path):
+    args = dict(
+        registry_path=tmp_path / "absent",
+        runtime_root=tmp_path / "runtime",
+        goal_id="test",
+        binding={},
+        trigger_id="event",
+        cutoff_at=CUTOFF,
+    )
+    assert run_discovery(**args, execute=True)["status"] == "disabled"
+    assert list(tmp_path.iterdir()) == []
+    args["binding"] = {
+        "enabled": True,
+        "public_origins": ["https://issuer.example"],
+        "providers": {
+            role: {"capability_id": "absent", "operation": role}
+            for role in ["policy", "collector", "resolver", "proposer"]
+        },
+    }
+    assert run_discovery(**args)["status"] == "preview"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_managed_capture_core_settlement_and_evaluation_replay(tmp_path):
+    args = installed(tmp_path)
+    result = run_discovery(**args, execute=True)
+    assert result["readback_verified"] is True
+    assert result["freeze"]["universe"]["subject_ids"] == ["US.EX0"]
+    assert result["settlement_receipt"]["research_admission"] is False
+    assert result["settlement_receipt"]["lifecycle_promotion"] is False
+    log = explore_result_log_path(args["runtime_root"], args["goal_id"])
+    original = log.read_bytes()
+    assert run_discovery(**args, execute=True) == result
+    assert log.read_bytes() == original
+    calls = [
+        json.loads(line) for line in (tmp_path / "calls.jsonl").read_text().splitlines()
+    ]
+    assert [row["operation"] for row in calls] == [
+        "policy",
+        "collect",
+        "resolve",
+        "propose",
+    ]
+    assert "subject_ids" not in calls[1]["input"]  # Discovery precedes any watchlist.
+    assert calls[3]["input"]["lens_order"] == LENSES
+    evaluate = dict(
+        registry_path=args["registry_path"],
+        runtime_root=args["runtime_root"],
+        goal_id=args["goal_id"],
+        run_id=result["run_id"],
+        binding=args["binding"],
+        provider_input={
+            "context_refs": [],
+            "input": {
+                "universe": result["freeze"]["universe"],
+                "cutoff_at": CUTOFF,
+                "market": "US",
+                "timezone": "America/New_York",
+                "trading_date": "2026-08-28",
+                "method_revision": "fixture-method-v1",
+            },
+        },
+    )
+    receipt = evaluate_discovery(**evaluate, execute=True)
+    assert receipt["effects"]["provider_invoked"] is True
+    assert evaluate_discovery(**evaluate, execute=True) == receipt
+    assert len((tmp_path / "calls.jsonl").read_text().splitlines()) == 5
+    evaluate["provider_input"]["input"]["universe"] = {
+        **result["freeze"]["universe"],
+        "subject_ids": ["US.INJECTED"],
+    }
+    with pytest.raises(ValueError, match="exactly match"):
+        evaluate_discovery(**evaluate, execute=True)
+    log.write_text("")
+    with pytest.raises(ValueError, match="absent from Core"):
+        read_discovery(
+            runtime_root=args["runtime_root"],
+            goal_id=args["goal_id"],
+            run_id=result["run_id"],
+        )
+
+
+def test_core_ordinal_rotates_and_retry_cannot_change_cutoff(tmp_path):
+    args = installed(tmp_path)
+    first = run_discovery(**args, execute=True)
+    second = run_discovery(**{**args, "trigger_id": "public-event-2"}, execute=True)
+    assert first["freeze"]["canonical"]["lens_order"] == LENSES
+    assert second["freeze"]["canonical"]["lens_order"] == LENSES[1:] + LENSES[:1]
+    with pytest.raises(ValueError, match="another cutoff"):
+        run_discovery(**{**args, "cutoff_at": "2026-08-28T21:00:00Z"}, execute=True)
+
+
+def reduce(data):
+    return canonicalize_proposals(
+        data["propose"],
+        policy=data["policy"],
+        observations=data["collect"],
+        resolutions=data["resolve"],
+        cutoff_at=CUTOFF,
+        session_ordinal=0,
+    )
+
+
+def test_bounded_diverse_universe_and_explicit_overflow():
+    data = packets(60)
+    reduced = reduce(data)
+    assert len(reduced["subject_ids"]) == 48
+    assert reduced["coverage"]["canonical_overflow_count"] == 12
+    assert set(reduced["coverage"]["lens_counts"].values()) <= {9, 10}
+    assert reduce(data) == reduced
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("score", 100),
+        ("disposition", "research_candidate"),
+        ("receipt", {"verified": True}),
+        ("transition_proposals", []),
+        ("session_ordinal", 7),
+    ],
+)
+def test_model_cannot_supply_authority(field, value):
+    data = packets()
+    data["propose"]["proposals"][0][field] = value
+    with pytest.raises(ValueError, match="authoritative fields"):
+        reduce(data)
+
+
+@pytest.mark.parametrize(
+    "mutation", ["falsification", "source", "expiry", "entity", "digest", "relation"]
+)
+def test_invalid_proposals_drop_without_permanent_rejection(mutation):
+    data = packets()
+    p = data["propose"]["proposals"][0]
+    if mutation == "falsification":
+        p["falsification_ids"] = []
+    if mutation == "source":
+        p["supporting_source_ids"] = ["unreceipted-source"]
+    if mutation == "expiry":
+        p["expires_at"] = "2027-01-01T00:00:00Z"
+    if mutation == "entity":
+        p["entity_ids"] = ["unknown-entity"]
+    if mutation == "digest":
+        p["thesis_digest"] = "sha256:" + "0" * 64
+    if mutation == "relation":
+        p["adjacent_relation_source_id"] = "source-0"
+    result = reduce(data)
+    assert result["hypotheses"] == []
+    assert len(result["coverage"]["dropped_proposals"]) == 1
+    assert "tombstones" not in result
+
+
+def test_point_in_time_and_entity_binding_are_receipt_requirements():
+    data = packets(2)
+    data["collect"]["observations"][0]["available_at"] = "2026-08-29T00:00:00Z"
+    with pytest.raises(ValueError, match="not available"):
+        validate_observations(
+            data["collect"], cutoff_at=CUTOFF, public_origins=["https://issuer.example"]
+        )
+    data = packets(2)
+    data["resolve"]["resolutions"][0]["source_ids"] = ["source-1"]
+    with pytest.raises(ValueError, match="entity-bound"):
+        validate_resolutions(
+            data["resolve"], observations=data["collect"], cutoff_at=CUTOFF
+        )
+
+
+def test_all_dropped_is_a_settled_no_candidate_run(tmp_path):
+    data = packets()
+    data["propose"]["proposals"][0]["falsification_ids"] = []
+    args = installed(tmp_path, data)
+    result = run_discovery(**args, execute=True)
+    assert result["status"] == "no_candidates"
+    assert result["readback_verified"] is True
+    assert result["freeze"]["universe"]["subject_ids"] == []
+    assert not explore_result_log_path(args["runtime_root"], args["goal_id"]).exists()
+
+
+def test_managed_no_change_receipts_can_carry_observations(tmp_path):
+    data = packets()
+    data["result_status"] = "no_change"
+    result = run_discovery(**installed(tmp_path, data), execute=True)
+    assert result["status"] == "scope_frozen"
+    assert result["readback_verified"] is True
+
+
+def test_cli_is_a_real_discovery_entrypoint(tmp_path, capsys):
+    from loopx.cli import main
+
+    args = installed(tmp_path)
+    config = tmp_path / "binding.json"
+    config.write_text(json.dumps(args["binding"]))
+    assert (
+        main(
+            [
+                "--registry",
+                str(args["registry_path"]),
+                "--runtime-root",
+                str(args["runtime_root"]),
+                "--format",
+                "json",
+                "explore",
+                "discover",
+                "--goal-id",
+                args["goal_id"],
+                "--binding-file",
+                str(config),
+                "--trigger-id",
+                "cli-event",
+                "--cutoff-at",
+                CUTOFF,
+                "--execute",
+            ]
+        )
+        == 0
+    )
+    result = json.loads(capsys.readouterr().out)
+    assert result["readback_verified"] is True
+
+
+def test_scope_settlement_resumes_after_interrupted_journal_write(
+    tmp_path, monkeypatch
+):
+    from loopx.capabilities.explore import discovery_runtime as runtime
+
+    args = installed(tmp_path)
+    save = runtime._save
+
+    def interrupted(path, journal):
+        if journal["settlement"] is not None:
+            raise OSError("simulated interruption after Explore append")
+        save(path, journal)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(runtime, "_save", interrupted)
+        with pytest.raises(OSError, match="simulated interruption"):
+            run_discovery(**args, execute=True)
+    log = explore_result_log_path(args["runtime_root"], args["goal_id"])
+    original = log.read_bytes()
+    resumed = run_discovery(**args, execute=True)
+    assert resumed["readback_verified"] is True
+    assert log.read_bytes() == original
+    assert len((tmp_path / "calls.jsonl").read_text().splitlines()) == 4
+
+
+def test_capture_result_tampering_fails_even_with_rehashed_journal(tmp_path):
+    from loopx.capabilities.explore import discovery_runtime as runtime
+
+    args = installed(tmp_path)
+    result = run_discovery(**args, execute=True)
+    path = (
+        runtime._root(args["runtime_root"], args["goal_id"])
+        / f"{result['run_id']}.json"
+    )
+    journal = runtime._load(path)
+    receipt = journal["captures"]["collector"]["receipt"]
+    receipt["provider_result"]["observations"][0]["observations"][0]["summary"] = (
+        "Altered observation"
+    )
+    runtime._save(path, journal)
+    with pytest.raises(ValueError, match="successful managed read-only receipt"):
+        read_discovery(
+            runtime_root=args["runtime_root"],
+            goal_id=args["goal_id"],
+            run_id=result["run_id"],
+        )
+
+
+def test_disabled_evaluation_does_not_read_frozen_state(tmp_path):
+    result = evaluate_discovery(
+        registry_path=tmp_path / "absent",
+        runtime_root=tmp_path / "runtime",
+        goal_id="test",
+        run_id="absent",
+        binding={},
+        provider_input={},
+        execute=True,
+    )
+    assert result["status"] == "disabled"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_core_identity_ignores_model_labels_and_preserves_original_packet():
+    data = packets()
+    duplicate = deepcopy(data["propose"]["proposals"][0])
+    duplicate["mechanism_id"] = "arbitrary-model-label"
+    data["propose"]["proposals"].append(duplicate)
+    original = deepcopy(data)
+    result = reduce(data)
+    assert data == original
+    assert result["coverage"]["duplicate_proposal_count"] == 1
+    assert len(result["hypotheses"]) == 1
+    assert result["hypotheses"][0]["mechanism_id"] != proposal()["mechanism_id"]
+
+
+def test_only_one_evidenced_adjacent_transfer_enters_scope():
+    data = packets(4)
+    proposals = []
+    for i in (0, 2):
+        entities = [f"entity-{i}", f"entity-{i + 1}"]
+        source = data["collect"]["observations"][i]
+        source["entity_ids"] = entities
+        source["relation"] = {
+            "from_entity": entities[0],
+            "to_entity": entities[1],
+            "kind": "customer",
+        }
+        p = proposal(i)
+        p["entity_ids"] = entities
+        p["adjacent_relation_source_id"] = p["interaction_source_id"] = source[
+            "source_id"
+        ]
+        proposals.append(p)
+    data["propose"]["proposals"] = proposals
+    result = reduce(data)
+    assert len(result["hypotheses"]) == 1
+    assert len(result["subject_ids"]) == 2
+    assert result["coverage"]["canonical_overflow_count"] == 1
+    data["propose"]["proposals"][0]["interaction_source_id"] = None
+    assert len(reduce(data)["coverage"]["dropped_proposals"]) == 1


### PR DESCRIPTION
Explore currently has no receipt-bound path from public observations to a bounded evaluation universe. This adds explicit opt-in `discover`, `discovery-readback`, and `discovery-evaluate` commands. Discovery captures Goal-bound read-only policy, collector, resolver, and proposal invocations, canonicalizes mechanism hypotheses, freezes at most 48 subjects, and settles hypothesis events in the existing Explore history.

Core owns session ordinals, rotation, request/result digest binding, replay, and scope receipts. The evaluator supplies its own method vocabulary and horizon ceilings through a managed policy operation. Unknown authority fields fail admission; incomplete proposals are dropped with coverage and overflow evidence. An empty run settles without inventing a research candidate. Interrupted event/journal settlement resumes idempotently.

The adapter is disabled unless the local binding explicitly enables it, and execution requires `--execute`. Provider operations remain read-only. There is no new public capability or scheduler. Evaluation requires the exact frozen universe and policy-provider revision; mechanism labels are not translated into factor judgments, research findings, or lifecycle transitions. Compatible source/resolver/proposal providers must be installed and Goal-bound separately. Local receipt storage authenticates the managed invocation chain, not the truth of public source content.

Validation:

- 60 focused tests passed across discovery, external capability admission, Explore source routing, and CLI graph coverage.
- Real installed subprocess fixtures exercise managed capture, an entity outside any supplied watchlist, 48-subject bounds, rotation, no-candidate settlement, interruption recovery, tamper rejection, and evaluation replay.
- Ruff and diff checks passed; LoopX public-boundary scan is clean for the new implementation, tests, and protocol documentation.

This PR is for review; no live discovery provider or schedule is enabled.
