### PR TITLE
fix(quota): preserve monitor-poll fence rejection

### DIFF
--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -42,6 +42,9 @@ from ..control_plane.quota.settlement_cli import (
     render_existing_heartbeat_receipt_payload,
 )
 from ..control_plane.quota.turn_envelope import build_turn_envelope
+from ..control_plane.coordination.legacy_writer_fence import (
+    LegacyCoordinationWriterFenced,
+)
 from ..control_plane.effect_runtime import EffectRuntimeRejected
 from ..control_plane.scheduler.execution_context import (
     GUIDED_START_TURN_RUNTIME_PROFILES,
@@ -238,6 +241,14 @@ def _quota_failure_payload(
         )
         if error.agent_id is not None:
             payload["agent_id"] = error.agent_id
+    elif isinstance(error, LegacyCoordinationWriterFenced):
+        payload.update(
+            {
+                "error_code": error.code,
+                "reason": str(error),
+                **error.payload,
+            }
+        )
     if lock_timeout_fields:
         payload["recommended_action"] = "inspect the lock holder before retrying"
     if command == "monitor-poll":

--- a/tests/control_plane/test_split_root_todo_writeback_fence.py
+++ b/tests/control_plane/test_split_root_todo_writeback_fence.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import pytest
 
+from loopx.cli import main
 from loopx.cli_commands.turn_todo_writeback import (
     write_turn_repair_update,
     write_turn_validated_completion,
@@ -237,6 +238,60 @@ def test_quota_monitor_poll_provider_writeback_blocked_under_override_fence(
         )
 
     assert OVERRIDE_POLL_HASH not in state.read_text(encoding="utf-8")
+
+
+def test_quota_monitor_poll_cli_preserves_fence_rejection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    registry, state, _runtime_registry, runtime_override = (
+        _write_split_root_goal(tmp_path)
+    )
+    _engage_fence_at(runtime_override)
+    _fence_check_blocks(monkeypatch)
+    before = state.read_bytes()
+
+    exit_code = main(
+        [
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_override),
+            "--format",
+            "json",
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--todo-id",
+            MONITOR_ID,
+            "--target-key",
+            "splitroot-review",
+            "--result-hash",
+            OVERRIDE_POLL_HASH,
+            "--next-due-at",
+            "2026-09-04T02:00:00+00:00",
+            "--execute",
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "legacy_coordination_writer_fenced"
+    assert payload["reason"] == (
+        "legacy coordination writer is fenced; use the promoted canonical "
+        f"authority (file_v0) for goal {GOAL_ID}; fence unknown; "
+        "the primary record was not changed"
+    )
+    assert payload["write_check"] == {
+        "status": "blocked",
+        "reason_code": "legacy_coordination_writer_fenced",
+        "authority_mode": "file_v0",
+    }
+    assert state.read_bytes() == before
 
 
 def test_turn_repair_update_blocked_when_override_root_is_fenced(


### PR DESCRIPTION
## Summary

- preserve the typed legacy-writer fence code, remediation, and nested write check through `quota monitor-poll --execute`
- add a public CLI regression proving the fenced write remains side-effect free

## Issue Or Task

- Follow-up to the quota adapter gap disclosed during #3985 review.
- Contributor task ID: core control-plane hardening

## Validation

- [x] `python3 -m pytest -q tests/control_plane/test_split_root_todo_writeback_fence.py tests/control_plane/test_quota_error_codes.py tests/test_cli_argument_diagnostics.py` (114 passed)
- [x] `python3 -m pytest -q tests/presentation/test_quota_markdown_renderers.py tests/control_plane/test_monitor_poll_cli_projection.py tests/control_plane/test_quota_monitor_poll_runtime.py` (11 passed)
- [x] `ruff check loopx/cli_commands/quota.py tests/control_plane/test_split_root_todo_writeback_fence.py`
- [x] `loopx canary premerge --from-git-diff` (17 selected checks passed, no manual holds)
- [x] `git diff --check`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: status/quota/monitor hardening

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

Future-facing pass: no adjacent refactor was needed; the owning quota CLI adapter already has the correct typed-exception extension point.