### PR TITLE
fix(install): record workflow skill versions and detect mismatches

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -381,6 +381,39 @@ update` now projects the active installation owner: PyPI environments stay
 package-manager owned, archive snapshots stay LoopX owned, and live source
 checkouts stay Git owned.
 
+### Workflow Skill Versions And Pinned Hosts
+
+Each installed skill, including the generated `$loopx` entry, records its source
+LoopX version in `.loopx-skill-version.json`. The root
+`.loopx-skill-install.json` also records `loopx_version`. Inspect with the CLI
+that the host will actually run:
+
+```bash
+loopx workflow-skills --skills-dir ./host-skills --format json
+loopx workflow-skills --install --skills-dir ./host-skills
+```
+
+The inspect result's `before` object reports `loopx_version`,
+`expected_loopx_version`, and `loopx_version_matches`; install reports these
+under `after`. A mismatch or missing/invalid marker makes the readback not
+ready. Legacy `loopx_skill_install_readback_v0` manifests require a one-time
+reinstall using a CLI that includes this version-marker fix. Reinstalling with
+an unpatched pinned CLI still writes unversioned metadata; upgrade that runtime
+or backport the fix first. This readiness rule also applies to
+Ark Managed Agent doctor, Ark/DeepSeek filesystem onboarding, and isolated
+native profiles. An isolated profile compares against its own installed CLI,
+even when its supervisor uses another LoopX version.
+
+User-level skill directories can be shared across hosts. For a pinned host,
+run its pinned executable (for example `./loopx-sidecar`) for both commands
+and use a separate `--skills-dir` for each runtime version. Configure the host
+to load that directory and compare the readback before loading skills; older
+or third-party hosts do not gain this check automatically. Restart the host
+after installing or repairing skills so its session reloads them. To roll
+back, reinstall into that same directory using the previous pinned executable.
+These commands only manage skill files; they grant no repository, network,
+credential, or merge authority.
+
 ### Host-Bundled / Frozen Workflow Skills
 
 PyInstaller hosts can bundle the existing skill data without Python distribution

--- a/loopx/capabilities/benchmark_toolkit/native_codex_profile.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_profile.py
@@ -463,11 +463,32 @@ def inspect_native_codex_profile(
     if resolved_release not in resolved_cli.parents:
         raise NativeCodexProfileError("profile_cli_not_release_snapshot")
 
+    env = _formal_install_environment(
+        paths=paths,
+        python_executable=_resolved_executable(None),
+        release_id=release_id,
+        base_env=base_env,
+    )
+    # The profile's CLI owns the loaded skills; the inspecting supervisor may
+    # run a different LoopX version.
+    try:
+        version_readback = subprocess.run(
+            [str(cli_bin), "--version"],
+            cwd=paths["root"], env=env, check=False, capture_output=True,
+            text=True, timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise NativeCodexProfileError("profile_cli_version_unavailable") from exc
+    version_parts = version_readback.stdout.split()
+    if version_readback.returncode or len(version_parts) != 2 or version_parts[0] != "loopx":
+        raise NativeCodexProfileError("profile_cli_version_invalid")
+
     expected_source = Path(source_root).expanduser().resolve() if source_root else None
     skill_readback = inspect_skill_install_readback(
         skills_dir=paths["skills_dir"],
         required_skill_ids=required,
         source_root=expected_source,
+        expected_loopx_version_override=version_parts[1],
     )
     if skill_readback.get("ready") is not True:
         status = re.sub(r"[^A-Za-z0-9_.:-]", "_", str(skill_readback.get("status")))
@@ -484,12 +505,6 @@ def inspect_native_codex_profile(
     if not isinstance(skills_digest, str) or not isinstance(source_revision, str):
         raise NativeCodexProfileError("profile_identity_missing")
 
-    env = _formal_install_environment(
-        paths=paths,
-        python_executable=_resolved_executable(None),
-        release_id=release_id,
-        base_env=base_env,
-    )
     doctor = _doctor_payload(cli_bin=cli_bin, paths=paths, env=env)
     release_manifest = (doctor.get("release_manifest") or {}).get("manifest") or {}
     release_source = release_manifest.get("source") or {}

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -11,9 +11,12 @@ import subprocess
 import tempfile
 from typing import Any, Mapping, Sequence
 
+from . import __version__
 
-SKILL_INSTALL_READBACK_SCHEMA_VERSION = "loopx_skill_install_readback_v0"
+SKILL_INSTALL_READBACK_SCHEMA_VERSION = "loopx_skill_install_readback_v1"
 SKILL_INSTALL_READBACK_FILENAME = ".loopx-skill-install.json"
+SKILL_VERSION_MARKER_SCHEMA_VERSION = "loopx_installed_skill_version_v0"
+SKILL_VERSION_MARKER_FILENAME = ".loopx-skill-version.json"
 SKILL_INSTALL_OWNER = "loopx_install_script"
 SKILL_INSTALL_INTEGRATION_MODE = "fixed_install_script"
 PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER = "loopx_workflow_skills_cli"
@@ -193,7 +196,11 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def hash_skill_tree(root: Path) -> dict[str, Any]:
+def hash_skill_tree(
+    root: Path,
+    *,
+    ignored_relative_paths: Sequence[str] = (),
+) -> dict[str, Any]:
     if not root.is_dir():
         return {
             "available": False,
@@ -202,8 +209,11 @@ def hash_skill_tree(root: Path) -> dict[str, Any]:
         }
     digest = hashlib.sha256()
     file_count = 0
+    ignored = set(ignored_relative_paths)
     for path in sorted(item for item in root.rglob("*") if item.is_file()):
         relative = path.relative_to(root).as_posix()
+        if relative in ignored:
+            continue
         file_hash = _sha256_file(path)
         digest.update(relative.encode("utf-8"))
         digest.update(b"\0")
@@ -314,6 +324,50 @@ def _skills_digest(items: Mapping[str, Any]) -> str:
     ).hexdigest()
 
 
+def _write_json_atomic(target: Path, payload: Mapping[str, Any]) -> None:
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=target.parent,
+            prefix=f"{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temporary, target)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def _normalized_install_identity(
+    *,
+    owner: str,
+    integration_mode: str,
+    loopx_version: str,
+) -> dict[str, str]:
+    if owner not in SKILL_INSTALL_OWNERS:
+        raise ValueError(f"unsupported skill install owner: {owner}")
+    if integration_mode not in SKILL_INSTALL_INTEGRATION_MODES:
+        raise ValueError(f"unsupported skill install integration mode: {integration_mode}")
+    if (owner, integration_mode) not in SKILL_INSTALL_PROFILES:
+        raise ValueError(
+            "skill install owner and integration mode do not form a supported profile"
+        )
+    normalized_version = loopx_version.strip()
+    if not normalized_version:
+        raise ValueError("loopx_version must not be empty")
+    return {
+        "owner": owner,
+        "integration_mode": integration_mode,
+        "loopx_version": normalized_version,
+    }
+
+
 def build_skill_install_readback(
     *,
     skills_dir: Path,
@@ -324,15 +378,11 @@ def build_skill_install_readback(
     installed_at: str | None = None,
     owner: str = SKILL_INSTALL_OWNER,
     integration_mode: str = SKILL_INSTALL_INTEGRATION_MODE,
+    loopx_version: str = __version__,
 ) -> dict[str, Any]:
-    if owner not in SKILL_INSTALL_OWNERS:
-        raise ValueError(f"unsupported skill install owner: {owner}")
-    if integration_mode not in SKILL_INSTALL_INTEGRATION_MODES:
-        raise ValueError(f"unsupported skill install integration mode: {integration_mode}")
-    if (owner, integration_mode) not in SKILL_INSTALL_PROFILES:
-        raise ValueError(
-            "skill install owner and integration mode do not form a supported profile"
-        )
+    identity = _normalized_install_identity(
+        owner=owner, integration_mode=integration_mode, loopx_version=loopx_version,
+    )
     normalized_ids = sorted(
         {skill_id.strip() for skill_id in skill_ids if skill_id.strip()}
     )
@@ -351,8 +401,7 @@ def build_skill_install_readback(
         source["kind"] = source_kind_override
     return {
         "schema_version": SKILL_INSTALL_READBACK_SCHEMA_VERSION,
-        "owner": owner,
-        "integration_mode": integration_mode,
+        **identity,
         "installed_at": installed_at
         or datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         "source": source,
@@ -374,31 +423,41 @@ def write_skill_install_readback(
     installed_at: str | None = None,
     owner: str = SKILL_INSTALL_OWNER,
     integration_mode: str = SKILL_INSTALL_INTEGRATION_MODE,
+    loopx_version: str = __version__,
 ) -> Path:
+    identity = _normalized_install_identity(
+        owner=owner, integration_mode=integration_mode, loopx_version=loopx_version,
+    )
+    normalized_ids = sorted(
+        {skill_id.strip() for skill_id in skill_ids if skill_id.strip()}
+    )
+    for skill_id in normalized_ids:
+        skill_dir = skills_dir / skill_id
+        if not skill_dir.is_dir():
+            raise FileNotFoundError(
+                f"cannot record the LoopX version for missing skill: {skill_id}"
+            )
     skills_dir.mkdir(parents=True, exist_ok=True)
+    for skill_id in normalized_ids:
+        _write_json_atomic(
+            skills_dir / skill_id / SKILL_VERSION_MARKER_FILENAME,
+            {
+                "schema_version": SKILL_VERSION_MARKER_SCHEMA_VERSION,
+                "skill_id": skill_id,
+                **identity,
+            },
+        )
     payload = build_skill_install_readback(
         skills_dir=skills_dir,
-        skill_ids=skill_ids,
+        skill_ids=normalized_ids,
         source_root=source_root,
         source_kind_override=source_kind_override,
         source_revision_override=source_revision_override,
         installed_at=installed_at,
-        owner=owner,
-        integration_mode=integration_mode,
+        **identity,
     )
     target = skills_dir / SKILL_INSTALL_READBACK_FILENAME
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=skills_dir,
-        prefix=f"{SKILL_INSTALL_READBACK_FILENAME}.",
-        suffix=".tmp",
-        delete=False,
-    ) as handle:
-        json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
-        handle.write("\n")
-        temporary = Path(handle.name)
-    os.replace(temporary, target)
+    _write_json_atomic(target, payload)
     return target
 
 
@@ -413,11 +472,13 @@ def inspect_skill_install_readback(
     required_skill_ids: Sequence[str],
     source_root: Path | None = None,
     expected_source_revision_override: str | None = None,
+    expected_loopx_version_override: str | None = None,
 ) -> dict[str, Any]:
     expected_source_revision = (
         expected_source_revision_override
         or (_source_revision_for_root(source_root) if source_root else None)
     )
+    expected_loopx_version = expected_loopx_version_override or __version__
     required_ids = sorted(
         {skill_id.strip() for skill_id in required_skill_ids if skill_id.strip()}
     )
@@ -432,9 +493,13 @@ def inspect_skill_install_readback(
             "materialized_skill_ids": [],
             "missing_skill_ids": required_ids,
             "digest_mismatches": [],
+            "version_marker_mismatches": [],
             "integrity_ok": False,
             "manifest_digest_valid": False,
             "integration_mode": None,
+            "loopx_version": None,
+            "expected_loopx_version": expected_loopx_version,
+            "loopx_version_matches": None,
             "source_revision": None,
             "expected_source_revision": expected_source_revision,
             "source_revision_matches": None,
@@ -493,6 +558,41 @@ def inspect_skill_install_readback(
         if source_revision and expected_source_revision
         else None
     )
+    raw_loopx_version = (
+        manifest.get("loopx_version") if isinstance(manifest, dict) else None
+    )
+    installed_loopx_version = (
+        raw_loopx_version.strip()
+        if isinstance(raw_loopx_version, str) and raw_loopx_version.strip()
+        else None
+    )
+    loopx_version_matches = (
+        installed_loopx_version == expected_loopx_version
+        if installed_loopx_version and expected_loopx_version
+        else None
+    )
+    manifest_owner = manifest.get("owner") if isinstance(manifest, dict) else None
+    manifest_integration_mode = (
+        manifest.get("integration_mode") if isinstance(manifest, dict) else None
+    )
+    version_marker_mismatches: list[str] = []
+    for skill_id in materialized_ids:
+        try:
+            marker = json.loads(
+                (root / skill_id / SKILL_VERSION_MARKER_FILENAME).read_text(
+                    encoding="utf-8"
+                )
+            )
+        except (OSError, UnicodeError, json.JSONDecodeError):
+            marker = None
+        if marker != {
+            "schema_version": SKILL_VERSION_MARKER_SCHEMA_VERSION,
+            "skill_id": skill_id,
+            "owner": manifest_owner,
+            "integration_mode": manifest_integration_mode,
+            "loopx_version": installed_loopx_version,
+        }:
+            version_marker_mismatches.append(skill_id)
     manifest_valid = bool(
         isinstance(manifest, dict)
         and manifest.get("schema_version") == SKILL_INSTALL_READBACK_SCHEMA_VERSION
@@ -503,6 +603,7 @@ def inspect_skill_install_readback(
         in SKILL_INSTALL_PROFILES
         and set(required_ids).issubset(manifest_ids)
         and source_revision
+        and installed_loopx_version
     )
     manifest_digest_valid = bool(
         isinstance(manifest_skills.get("digest"), str)
@@ -512,7 +613,9 @@ def inspect_skill_install_readback(
         manifest_valid
         and manifest_digest_valid
         and not digest_mismatches
+        and not version_marker_mismatches
         and source_revision_matches is not False
+        and loopx_version_matches is not False
     )
     ready = not missing_ids and integrity_ok
     if ready:
@@ -529,6 +632,15 @@ def inspect_skill_install_readback(
     elif not manifest_digest_valid:
         status = "manifest_digest_mismatch"
         reason = "install readback skill manifest digest does not match its items"
+    elif loopx_version_matches is False or version_marker_mismatches:
+        status = "loopx_version_mismatch"
+        reason = (
+            "installed workflow skill version markers do not match the install "
+            f"readback: {','.join(version_marker_mismatches)}"
+            if version_marker_mismatches
+            else f"installed workflow skills use LoopX {installed_loopx_version}; "
+            f"the active CLI uses {expected_loopx_version}"
+        )
     elif digest_mismatches:
         status = "skill_digest_mismatch"
         reason = f"skill content differs from install readback: {','.join(digest_mismatches)}"
@@ -552,11 +664,15 @@ def inspect_skill_install_readback(
         "materialized_skill_ids": materialized_ids,
         "missing_skill_ids": missing_ids,
         "digest_mismatches": digest_mismatches,
+        "version_marker_mismatches": version_marker_mismatches,
         "integrity_ok": integrity_ok,
         "manifest_digest_valid": manifest_digest_valid,
         "integration_mode": manifest.get("integration_mode")
         if isinstance(manifest, dict)
         else None,
+        "loopx_version": installed_loopx_version,
+        "expected_loopx_version": expected_loopx_version,
+        "loopx_version_matches": loopx_version_matches,
         "source_revision": source_revision,
         "expected_source_revision": expected_source_revision,
         "source_revision_matches": source_revision_matches,

--- a/loopx/workflow_skill_install.py
+++ b/loopx/workflow_skill_install.py
@@ -20,6 +20,7 @@ from .skill_install_readback import (
     PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
     SKILL_INSTALL_OWNERS,
     SKILL_INSTALL_READBACK_FILENAME,
+    SKILL_VERSION_MARKER_FILENAME,
     hash_skill_tree,
     inspect_skill_install_readback,
     write_skill_install_readback,
@@ -164,7 +165,10 @@ def _exclusive_install_lock(skills_dir: Path) -> Iterator[None]:
 
 
 def _install_one_skill(source: Path, target: Path) -> str:
-    if target.is_dir() and hash_skill_tree(source) == hash_skill_tree(target):
+    ignored = (SKILL_VERSION_MARKER_FILENAME,)
+    if target.is_dir() and hash_skill_tree(
+        source, ignored_relative_paths=ignored
+    ) == hash_skill_tree(target, ignored_relative_paths=ignored):
         return "unchanged"
 
     temporary = Path(
@@ -270,6 +274,7 @@ def workflow_skill_install(
         required_skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
         source_root=source_root,
         expected_source_revision_override=frozen_source_revision,
+        expected_loopx_version_override=__version__,
     )
     if uninstall:
         result = (
@@ -382,6 +387,7 @@ def workflow_skill_install(
             source_revision_override=frozen_source_revision,
             owner=PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
             integration_mode=PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
+            loopx_version=__version__,
         )
 
     after = inspect_skill_install_readback(
@@ -389,6 +395,7 @@ def workflow_skill_install(
         required_skill_ids=ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
         source_root=source_root,
         expected_source_revision_override=frozen_source_revision,
+        expected_loopx_version_override=__version__,
     )
     return {
         "ok": bool(after.get("ready")),
@@ -423,6 +430,7 @@ def _public_source(source: Mapping[str, Any]) -> dict[str, Any]:
 
 def render_workflow_skill_install_markdown(payload: Mapping[str, Any]) -> str:
     source = payload.get("source") or {}
+    readback = payload.get("after") or payload.get("before") or {}
     lines = [
         "# LoopX Workflow Skills",
         "",
@@ -431,6 +439,9 @@ def render_workflow_skill_install_markdown(payload: Mapping[str, Any]) -> str:
         f"- skills_dir: `{payload.get('skills_dir')}`",
         f"- source: `{source.get('kind')}`",
         f"- ready_before: `{(payload.get('before') or {}).get('ready')}`",
+        f"- installed_loopx_version: `{readback.get('loopx_version')}`",
+        f"- active_loopx_version: `{readback.get('expected_loopx_version')}`",
+        f"- loopx_version_matches: `{readback.get('loopx_version_matches')}`",
     ]
     if payload.get("install_command"):
         lines.append(f"- install: `{payload['install_command']}`")

--- a/tests/capabilities/test_native_codex_profile.py
+++ b/tests/capabilities/test_native_codex_profile.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from loopx import skill_install_readback
+from loopx.capabilities.benchmark_toolkit.native_codex_profile import (
+    NativeCodexProfileError,
+    inspect_native_codex_profile,
+    install_native_codex_profile,
+)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX release profile installer")
+def test_profile_compares_skills_with_its_own_runtime(tmp_path, monkeypatch):
+    source = Path(__file__).resolve().parents[2]
+    profile = install_native_codex_profile(
+        source, tmp_path / "profile", require_clean_source=False,
+    )
+    # The supervisor upgrades; the isolated profile and its CLI remain pinned.
+    monkeypatch.setattr(skill_install_readback, "__version__", "999.0.0")
+    verified = inspect_native_codex_profile(
+        profile.root, source_root=source, require_clean_source=False,
+    )
+    assert verified.skills_digest == profile.skills_digest
+
+    # A self-consistent manifest matching the supervisor must not mask a
+    # mismatch with the runtime that will actually load these skills.
+    skill_install_readback.write_skill_install_readback(
+        skills_dir=profile.skills_dir,
+        skill_ids=profile.required_skill_ids,
+        source_root=profile.release_root,
+        loopx_version="999.0.0",
+    )
+    with pytest.raises(NativeCodexProfileError, match="loopx_version_mismatch"):
+        inspect_native_codex_profile(profile.root, require_clean_source=False)

--- a/tests/test_skill_delivery_parity.py
+++ b/tests/test_skill_delivery_parity.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from loopx import __version__
 from loopx.skill_install_readback import (
     PACKAGED_HOST_SKILL_IDS,
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
@@ -97,6 +98,7 @@ class TestReadbackLifecycle:
             assert rb["schema_version"] == SKILL_INSTALL_READBACK_SCHEMA_VERSION
             assert rb["owner"] == "loopx_install_script"
             assert rb["integration_mode"] == "fixed_install_script"
+            assert rb["loopx_version"] == __version__
             assert sorted(rb["materialized_skill_ids"]) == sorted(
                 PACKAGED_HOST_SKILL_IDS)
             assert len(rb["skills"]["items"]) == len(PACKAGED_HOST_SKILL_IDS)
@@ -106,6 +108,19 @@ class TestReadbackLifecycle:
                 source_root=REPO_ROOT)
             assert m.is_file()
             assert m.name == SKILL_INSTALL_READBACK_FILENAME
+            for skill_id in PACKAGED_HOST_SKILL_IDS:
+                marker = json.loads(
+                    (d / skill_id / ".loopx-skill-version.json").read_text(
+                        encoding="utf-8"
+                    )
+                )
+                assert marker == {
+                    "integration_mode": "fixed_install_script",
+                    "loopx_version": __version__,
+                    "owner": "loopx_install_script",
+                    "schema_version": "loopx_installed_skill_version_v0",
+                    "skill_id": skill_id,
+                }
 
             ins = inspect_skill_install_readback(
                 skills_dir=d, required_skill_ids=PACKAGED_HOST_SKILL_IDS,
@@ -113,6 +128,10 @@ class TestReadbackLifecycle:
             assert ins["ready"] is True
             assert ins["status"] == "ready_for_host_load"
             assert ins["integrity_ok"]
+            assert ins["loopx_version"] == __version__
+            assert ins["expected_loopx_version"] == __version__
+            assert ins["loopx_version_matches"] is True
+            assert not ins["version_marker_mismatches"]
             assert not ins["missing_skill_ids"]
             assert not ins["digest_mismatches"]
             assert _public_safe(rb)
@@ -151,6 +170,64 @@ class TestReadbackLifecycle:
             assert ins["status"] == "skill_digest_mismatch"
             assert stale in ins["digest_mismatches"]
 
+    def test_active_runtime_version_mismatch_is_not_ready(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "skills"
+            for sid in PACKAGED_HOST_SKILL_IDS:
+                _write_fixture_skill(d, sid)
+            write_skill_install_readback(
+                skills_dir=d, skill_ids=PACKAGED_HOST_SKILL_IDS,
+                source_root=REPO_ROOT, loopx_version="0.0.0")
+
+            ins = inspect_skill_install_readback(
+                skills_dir=d, required_skill_ids=PACKAGED_HOST_SKILL_IDS,
+                source_root=REPO_ROOT)
+            assert ins["ready"] is False
+            assert ins["status"] == "loopx_version_mismatch"
+            assert ins["loopx_version"] == "0.0.0"
+            assert ins["expected_loopx_version"] == __version__
+            assert ins["loopx_version_matches"] is False
+            assert not ins["version_marker_mismatches"]
+
+    def test_missing_skill_version_marker_is_not_ready(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "skills"
+            for sid in PACKAGED_HOST_SKILL_IDS:
+                _write_fixture_skill(d, sid)
+            write_skill_install_readback(
+                skills_dir=d, skill_ids=PACKAGED_HOST_SKILL_IDS,
+                source_root=REPO_ROOT)
+            stale = "loopx-pr-program"
+            (d / stale / ".loopx-skill-version.json").unlink()
+
+            ins = inspect_skill_install_readback(
+                skills_dir=d, required_skill_ids=PACKAGED_HOST_SKILL_IDS,
+                source_root=REPO_ROOT)
+            assert ins["ready"] is False
+            assert ins["status"] == "loopx_version_mismatch"
+            assert ins["version_marker_mismatches"] == [stale]
+
+    def test_legacy_readback_requires_reinstall(self):
+        with tempfile.TemporaryDirectory() as td:
+            d = Path(td) / "skills"
+            for sid in PACKAGED_HOST_SKILL_IDS:
+                _write_fixture_skill(d, sid)
+            manifest_path = write_skill_install_readback(
+                skills_dir=d, skill_ids=PACKAGED_HOST_SKILL_IDS,
+                source_root=REPO_ROOT)
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["schema_version"] = "loopx_skill_install_readback_v0"
+            manifest.pop("loopx_version")
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8")
+
+            ins = inspect_skill_install_readback(
+                skills_dir=d, required_skill_ids=PACKAGED_HOST_SKILL_IDS,
+                source_root=REPO_ROOT)
+            assert ins["ready"] is False
+            assert ins["status"] == "manifest_contract_invalid"
+
     def test_null_dir_status(self):
         ins = inspect_skill_install_readback(
             skills_dir=None, required_skill_ids=["loopx"],
@@ -172,6 +249,26 @@ class TestReadbackLifecycle:
                     owner="loopx_install_script",
                     integration_mode="python_distribution_cli",
                 )
+
+    @pytest.mark.parametrize("invalid", [
+        {"owner": "unsupported"},
+        {"integration_mode": "python_distribution_cli"},
+        {"loopx_version": " "},
+        {"skill_ids": [*PACKAGED_HOST_SKILL_IDS, "missing-skill"]},
+    ])
+    def test_invalid_write_preserves_existing_install(self, tmp_path, invalid):
+        for sid in PACKAGED_HOST_SKILL_IDS:
+            _write_fixture_skill(tmp_path, sid)
+        options = dict(skills_dir=tmp_path, skill_ids=PACKAGED_HOST_SKILL_IDS,
+                       source_root=REPO_ROOT)
+        write_skill_install_readback(**options)
+        before = hash_skill_tree(tmp_path)
+
+        with pytest.raises((ValueError, FileNotFoundError)):
+            write_skill_install_readback(**{**options, "loopx_version": "0.0.0",
+                                           **invalid})
+
+        assert hash_skill_tree(tmp_path) == before
 
 
 # -- Install dedupe -----------------------------------------------------------

--- a/tests/test_workflow_skill_install.py
+++ b/tests/test_workflow_skill_install.py
@@ -10,6 +10,7 @@ from typing import Any, Iterator
 import pytest
 
 from loopx import file_lock
+from loopx import skill_install_readback
 from loopx import workflow_skill_install as install_module
 from loopx.skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
@@ -17,8 +18,10 @@ from loopx.skill_install_readback import (
     PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE,
     PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER,
     SKILL_INSTALL_READBACK_FILENAME,
+    SKILL_VERSION_MARKER_FILENAME,
 )
 from loopx.workflow_skill_install import (
+    render_workflow_skill_install_markdown,
     resolve_workflow_skill_source,
     workflow_skill_install,
 )
@@ -92,6 +95,15 @@ def test_install_is_idempotent_and_uninstall_removes_managed_skills(
     )
     assert manifest["owner"] == PYTHON_DISTRIBUTION_SKILL_INSTALL_OWNER
     assert manifest["integration_mode"] == PYTHON_DISTRIBUTION_SKILL_INSTALL_MODE
+    assert manifest["loopx_version"] == install_module.__version__
+    for skill_id in ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS:
+        marker = json.loads(
+            (skills_dir / skill_id / SKILL_VERSION_MARKER_FILENAME).read_text(
+                encoding="utf-8"
+            )
+        )
+        assert marker["skill_id"] == skill_id
+        assert marker["loopx_version"] == install_module.__version__
 
     repeated = workflow_skill_install(skills_dir=skills_dir, execute=True)
 
@@ -110,6 +122,102 @@ def test_install_is_idempotent_and_uninstall_removes_managed_skills(
         ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS
     )
     assert not (skills_dir / SKILL_INSTALL_READBACK_FILENAME).exists()
+
+
+def test_install_upgrades_legacy_unversioned_skills(tmp_path: Path) -> None:
+    skills_dir = tmp_path / "skills"
+    installed = workflow_skill_install(skills_dir=skills_dir, execute=True)
+    assert installed["ok"] is True
+
+    manifest_path = skills_dir / SKILL_INSTALL_READBACK_FILENAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["schema_version"] = "loopx_skill_install_readback_v0"
+    manifest.pop("loopx_version")
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8")
+    for skill_id in ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS:
+        (skills_dir / skill_id / SKILL_VERSION_MARKER_FILENAME).unlink()
+
+    preview = workflow_skill_install(skills_dir=skills_dir)
+    upgraded = workflow_skill_install(skills_dir=skills_dir, execute=True)
+
+    assert preview["before"]["status"] == "manifest_contract_invalid"
+    assert preview["install_required"] is True
+    assert upgraded["ok"] is True
+    assert upgraded["after"]["loopx_version_matches"] is True
+    assert not upgraded["after"]["version_marker_mismatches"]
+    assert set(upgraded["installed"].values()) == {"unchanged"}
+    for skill_id in ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS:
+        assert (skills_dir / skill_id / SKILL_VERSION_MARKER_FILENAME).is_file()
+
+
+def test_inspect_markdown_reports_installed_and_active_versions(
+    tmp_path: Path,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    assert workflow_skill_install(skills_dir=skills_dir, execute=True)["ok"] is True
+
+    inspected = workflow_skill_install(skills_dir=skills_dir)
+    markdown = render_workflow_skill_install_markdown(inspected)
+
+    assert f"- installed_loopx_version: `{install_module.__version__}`" in markdown
+    assert f"- active_loopx_version: `{install_module.__version__}`" in markdown
+    assert "- loopx_version_matches: `True`" in markdown
+
+
+@pytest.mark.parametrize("skill_id", ["loopx-project", "loopx"])
+def test_corrupt_version_marker_allows_inspection_and_reinstall(
+    tmp_path: Path, skill_id: str,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    assert workflow_skill_install(skills_dir=skills_dir, execute=True)["ok"] is True
+    (skills_dir / skill_id / SKILL_VERSION_MARKER_FILENAME).write_bytes(b"\xff")
+
+    inspected = workflow_skill_install(skills_dir=skills_dir)
+    assert inspected["before"]["status"] == "loopx_version_mismatch"
+    assert inspected["before"]["version_marker_mismatches"] == [skill_id]
+    assert inspected["install_required"] is True
+
+    removed = workflow_skill_install(
+        skills_dir=skills_dir, execute=True, uninstall=True,
+    )
+    assert removed["result"]["preserved_modified"] == [skill_id]
+    repaired = workflow_skill_install(skills_dir=skills_dir, execute=True)
+    assert repaired["ok"] is True
+    assert repaired["after"]["version_marker_mismatches"] == []
+
+
+@pytest.mark.parametrize("failure", ["write", "replace"])
+def test_failed_marker_write_preserves_readback_and_can_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failure: str,
+) -> None:
+    skills_dir = tmp_path / "skills"
+    assert workflow_skill_install(skills_dir=skills_dir, execute=True)["ok"] is True
+    replace = skill_install_readback.os.replace
+    dump = skill_install_readback.json.dump
+
+    def fail_marker_write(payload, handle, **kwargs):
+        if payload.get("skill_id") == "loopx":
+            handle.write("{")
+            raise OSError("synthetic marker failure")
+        return dump(payload, handle, **kwargs)
+
+    def fail_marker_replace(source, target):
+        if target == skills_dir / "loopx" / SKILL_VERSION_MARKER_FILENAME:
+            raise OSError("synthetic marker failure")
+        return replace(source, target)
+
+    with monkeypatch.context() as patch:
+        if failure == "write":
+            patch.setattr(skill_install_readback.json, "dump", fail_marker_write)
+        else:
+            patch.setattr(skill_install_readback.os, "replace", fail_marker_replace)
+        with pytest.raises(OSError, match="synthetic marker failure"):
+            workflow_skill_install(skills_dir=skills_dir, execute=True)
+
+    assert workflow_skill_install(skills_dir=skills_dir)["before"]["ready"] is True
+    assert workflow_skill_install(skills_dir=skills_dir, execute=True)["ok"] is True
 
 
 def test_uninstall_preserves_locally_modified_skill(tmp_path: Path) -> None:
@@ -270,7 +378,13 @@ def test_frozen_bundle_install_lifecycle(
     )
     assert installed["after"]["source_revision_matches"] is True
     for skill_id in PACKAGED_HOST_SKILL_IDS:
-        assert install_module.hash_skill_tree(target / skill_id) == install_module.hash_skill_tree(canonical / skill_id)
+        assert install_module.hash_skill_tree(
+            target / skill_id,
+            ignored_relative_paths=(SKILL_VERSION_MARKER_FILENAME,),
+        ) == install_module.hash_skill_tree(
+            canonical / skill_id,
+            ignored_relative_paths=(SKILL_VERSION_MARKER_FILENAME,),
+        )
     repeated = workflow_skill_install(skills_dir=target, execute=True)
     assert set(repeated["installed"].values()) == {"unchanged"}
     monkeypatch.setattr(install_module, "__version__", "999.0.0")


### PR DESCRIPTION
## Summary

Shared skill directories can contain workflow skills from a different LoopX version than a pinned host runtime. The installed files previously gave hosts no version to compare.

This change writes `.loopx-skill-version.json` into each installed workflow skill, including the generated `$loopx` entry, and records `loopx_version` in the root install manifest. Inspect output reports the installed and expected versions. Missing, invalid, or mismatched version metadata prevents the readback from reporting ready.

Isolated native profiles compare skills against their own CLI version, so a supervisor upgrade does not cause a false mismatch. Version checks stay in the existing readback module. The related refactor shares atomic JSON writing between markers and the manifest; no further extraction was needed.

## Issue Or Task

Closes #4082.

## Compatibility

The readback schema changes from v0 to v1. Existing installs need a one-time reinstall with a CLI containing this fix. An unpatched pinned CLI still writes unversioned metadata and needs an upgrade or backport first. The readiness change also affects Ark Managed Agent doctor and Ark/DeepSeek filesystem onboarding.

The guide explains separate skill directories, inspection, reinstall, restart, and rollback. Older and third-party hosts must implement the comparison themselves; these commands grant no additional authority.

## Validation

- Focused installer, readback, doctor, host, and profile tests: **136 passed, 13 skipped** on macOS. Skips require native Windows, Linux namespaces, tini, or native isolation prerequisites.
- `python3 examples/install-local-smoke.py`
- `python3 examples/codex-cli-packaged-install-smoke.py`
- `python3 -m py_compile loopx/*.py`
- Ruff on all changed Python files; `git diff --check`.
- Public boundary scan of all seven changed files: clean. The command reported two warnings because no local registry was configured.

The focused checks cover install, inspect, migration, corruption recovery, idempotence, and a real isolated profile installation. Full CI and native platform checks remain pending. `loopx canary premerge --from-git-diff --no-execute` flagged the native profile path for maintainer review. This was a plan preview, not an executed premerge pass. No benchmark jobs were launched.


<details>
<summary>Focused test and boundary scan commands</summary>

Run from the repository root with the test environment activated:

```bash
python3 -m pytest -q -rs \
  tests/test_workflow_skill_install.py \
  tests/test_skill_delivery_parity.py \
  tests/capabilities/test_native_codex_profile.py \
  tests/test_ark_managed_agent_host.py \
  tests/test_windows_install.py \
  tests/test_slash_command_install.py \
  tests/test_doctor_install_freshness.py \
  tests/test_doctor_installation_scope.py \
  tests/test_ark_managed_agent_issue_fix_matrix.py \
  tests/test_packaged_skill_metadata.py \
  tests/capabilities/test_native_codex_isolation.py

loopx check \
  --scan-path loopx/skill_install_readback.py \
  --scan-path loopx/workflow_skill_install.py \
  --scan-path loopx/capabilities/benchmark_toolkit/native_codex_profile.py \
  --scan-path tests/test_workflow_skill_install.py \
  --scan-path tests/test_skill_delivery_parity.py \
  --scan-path tests/capabilities/test_native_codex_profile.py \
  --scan-path docs/guides/getting-started.md
```

</details>

## Type of Change

- [x] Bug fix
- [x] Breaking change: legacy readback metadata requires reinstall
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Capability or extension (providers, adapters, skills)

Related areas: installer and host integration.

## Technical Direction

- [x] Shared Goal Authority and cross-host coordination
- Target base branch: `main`
- Direction tracker or promotion unit: #4082

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] No maintainer-owned benchmark work was duplicated.
- [x] The change is scoped to #4082.
- [x] Every commit includes a DCO `Signed-off-by` trailer.
