### PR TITLE
Fix direct homepage anchor links after React rendering

### DIFF
--- a/apps/presentation/site/src/App.tsx
+++ b/apps/presentation/site/src/App.tsx
@@ -776,6 +776,21 @@ export function App() {
     window.history.replaceState({}, "", url);
   }, [language]);
 
+  useEffect(() => {
+    // The static shell has no section IDs. Replay initial fragment navigation
+    // once React has committed them; ordinary links/history stay browser-owned.
+    let id: string;
+    try {
+      id = decodeURIComponent(window.location.hash.slice(1));
+    } catch {
+      return; // Malformed fragments should leave the normal page entry intact.
+    }
+    const target = document.getElementById(id);
+    // :target may also be unresolved when the browser parsed an empty shell.
+    target?.closest(".reveal-block")?.setAttribute("data-anchor-entry", "");
+    target?.scrollIntoView({ behavior: "instant" });
+  }, []);
+
   async function copySetup(option: "agent" | "shell") {
     const text = option === "agent" ? setupPrompts[language] : shellSetupCommand;
     try {

--- a/apps/presentation/site/src/styles.css
+++ b/apps/presentation/site/src/styles.css
@@ -806,6 +806,14 @@ body[data-language="zh"] .hero h1 {
   transform: none;
 }
 
+/* A fragment destination must not move or fade while the browser aligns it. */
+.reveal-block[data-anchor-entry],
+.reveal-block:has(:target) {
+  opacity: 1;
+  transform: none;
+  transition: none;
+}
+
 .capability-section,
 .learn-section,
 .showcase-section,

--- a/docs/product/surfaces/frontstage-dashboard-interaction-baseline.md
+++ b/docs/product/surfaces/frontstage-dashboard-interaction-baseline.md
@@ -12,6 +12,11 @@ and Ops boards are retired.
 - English and Chinese navigation use the corresponding localized pages where
   available; the DeepSWE article is identified as Chinese in English copy.
 - Contributor tools remain discoverable at `/developers/projections/`.
+- Direct fragment URLs must land on the rendered section after the React shell
+  mounts, including cold loads and reloads. Fragment targets must remain visible
+  and stationary during entrance effects. Browser tests must assert the initial
+  viewport before calling any scroll or focus helpers; checking URL text or
+  clicking a link after render does not validate a shared deep link.
 - Do not link primary navigation to retired or deprecated surfaces.
 - Old bookmarks redirect to the current owner; public aliases discard live
   status parameters instead of passing them into the local workspace.

--- a/examples/dashboard-frontstage-browser-smoke.mjs
+++ b/examples/dashboard-frontstage-browser-smoke.mjs
@@ -31,6 +31,16 @@ const staticServer = createServer(async (req, res) => {
 });
 await new Promise((done) => staticServer.listen(0, "127.0.0.1", done));
 const publicOrigin = `http://127.0.0.1:${staticServer.address().port}`;
+async function assertAnchorInView(page, id) {
+  await page.waitForFunction((id) => {
+    const section = document.getElementById(id);
+    if (!section) return false;
+    const top = section.getBoundingClientRect().top;
+    const heading = section.querySelector("h2")?.getBoundingClientRect();
+    return top >= -2 && top < 80 && heading && heading.top >= 0 && heading.bottom < innerHeight;
+  }, id, { timeout: 4000 });
+}
+
 let browser;
 try {
   for (let i = 0; ; i++) {
@@ -39,6 +49,39 @@ try {
     await new Promise((done) => setTimeout(done, 200));
   }
   browser = await chromium.launch({ headless: true });
+  // A shared fragment URL must land on its section without any test-driven
+  // scroll or focus. Use cold pages and delayed JS to cover pre-React parsing.
+  for (const reducedMotion of ["no-preference", "reduce"]) {
+    for (const width of [1440, 390]) {
+      const entryContext = await browser.newContext({ reducedMotion, viewport: { width, height: 900 } });
+      const entry = await entryContext.newPage();
+      const entryErrors = [];
+      entry.on("pageerror", (error) => entryErrors.push(error.message));
+      await entry.route("**/site-assets/*.js", async (route) => {
+        await new Promise((done) => setTimeout(done, 250));
+        await route.continue();
+      });
+      for (const lang of ["en", "zh"]) {
+        await entry.goto("about:blank");
+        await entry.goto(`${publicOrigin}/loopx/?lang=${lang}#explore`);
+        await assertAnchorInView(entry, "explore");
+        await entry.reload();
+        await assertAnchorInView(entry, "explore");
+      }
+      for (const fragment of ["learn", "%65xplore"]) {
+        await entry.goto(`${publicOrigin}/loopx/?lang=zh#${fragment}`);
+        await assertAnchorInView(entry, decodeURIComponent(fragment));
+      }
+      for (const fragment of ["", "missing-section", "%zz"]) {
+        await entry.goto("about:blank");
+        await entry.goto(`${publicOrigin}/loopx/?lang=zh#${fragment}`);
+        await entry.locator("#explore").waitFor();
+        assert.equal(await entry.evaluate(() => scrollY), 0, "missing fragments must preserve normal page entry");
+      }
+      assert.deepEqual(entryErrors, [], "fragment entry must not raise runtime errors");
+      await entryContext.close();
+    }
+  }
   const context = await browser.newContext({ reducedMotion: "reduce" });
   const page = await context.newPage();
   await page.route((url) => url.pathname === "/status.example.json", async (route) => route.fulfill({ contentType: "application/json", body: await readFile(resolve(root, "examples/status.example.json"), "utf8") }));
@@ -91,7 +134,7 @@ try {
         await page.screenshot({ path: resolve(output, `home-${lang}-desktop.png`) });
         await page.locator('.desktop-nav a[href="#explore"]').click();
       }
-      await page.locator("#explore").scrollIntoViewIfNeeded();
+      await assertAnchorInView(page, "explore");
       await page.locator("#explore .resource-card").first().focus();
       assert.ok(await page.locator("#explore .resource-card").first().evaluate((a) => a === document.activeElement));
       assert.ok(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth + 1), "horizontal overflow");


### PR DESCRIPTION
Opening the homepage directly at `?lang=zh#explore` left the viewport at the hero because the static shell did not contain the section when the browser resolved the fragment. React added it later without replaying fragment navigation; even `:target` remained unresolved on cold entry.

Resolve the URL fragment after the homepage mounts, align the matching element immediately, and keep its Reveal wrapper stationary and visible. Missing or malformed fragments leave normal page entry intact. Ordinary in-page links and history remain browser-owned.

The browser regression now starts from cold fragment URLs with delayed JavaScript, asserts the actual section/heading viewport before any scroll or focus helper, and covers reloads, both languages, desktop/mobile, motion preferences, encoded IDs, and invalid/missing fragments. The old test's manual scrolling no longer masks navigation failures. This requirement is also recorded in the presentation interaction baseline.

Validation: the new cold-entry assertion failed against the pre-fix build; all cases pass with the fix. Production homepage/dashboard export, strict documentation build, complete-site browser smoke, public share-bundle smoke, design boundary check, final changed-path boundary scan, and diff hygiene passed. Live reproduction before the fix recorded scrollY=0 with the section over 2,800px below the viewport; the fixed production preview lands at its top.

Scope/future-facing review: a bounded fix in the existing homepage and Reveal CSS, with no new abstraction, backend behavior, permission change, or scrolling listeners. The risk-based premerge set covers rendering, fragment timing, motion, URL input handling, and the public publication path; no manual holds remain.
