### PR TITLE
perf(chat): skip redundant transcript scans

### DIFF
--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -489,9 +489,10 @@ class ChatSessionStore:
             "created_at": utc_now(),
         }
         with exclusive_file_lock(path, agent_id="loopx-chat", operation="append_chat_message"):
-            for existing in _read_jsonl(path):
-                if existing.get("message_id") == payload["message_id"]:
-                    return existing
+            if message_id:
+                for existing in _read_jsonl(path):
+                    if existing.get("message_id") == payload["message_id"]:
+                        return existing
             _append_jsonl(path, payload)
         return payload
 

--- a/tests/test_chat_session_active_turn.py
+++ b/tests/test_chat_session_active_turn.py
@@ -186,6 +186,52 @@ def test_chat_idempotency_keys_reject_different_requests(tmp_path: Path) -> None
         )
 
 
+def test_generated_message_id_skips_transcript_deduplication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ChatSessionStore(tmp_path)
+    session_id = str(
+        store.create_session(
+            goal_id="goal-one",
+            agent_id="codex",
+            executor_endpoint_id="codex",
+            adapter_kind="codex_app_server",
+            upstream_thread_id="thread-one",
+            upstream_mode="chat",
+        )["session_id"]
+    )
+    expected = store.append_message(
+        session_id,
+        role="agent",
+        text="durable completion",
+        message_id="completion-one",
+    )
+    assert (
+        store.append_message(
+            session_id,
+            role="agent",
+            text="ignored replay",
+            message_id="completion-one",
+        )
+        == expected
+    )
+
+    read_messages = chat_store._read_jsonl
+    monkeypatch.setattr(
+        chat_store,
+        "_read_jsonl",
+        lambda _path: pytest.fail("generated message IDs must not scan the transcript"),
+    )
+    appended = store.append_message(session_id, role="user", text="new message")
+
+    assert appended["message_id"] != "completion-one"
+    assert read_messages(store._session_dir(session_id) / "messages.jsonl") == [
+        expected,
+        appended,
+    ]
+
+
 @pytest.mark.parametrize("restart", [False, True])
 @pytest.mark.parametrize("with_image", [False, True])
 def test_managed_replay_compares_durable_attachments(


### PR DESCRIPTION
## Summary

- skip full transcript parsing when append_message generates a fresh UUID
- preserve transcript deduplication for caller-supplied idempotency keys
- add a regression proving generated-ID writes remain append-only while explicit-ID replay remains idempotent

## Performance evidence

Seven-run median for one generated-ID append, with fsync stubbed to isolate transcript scan cost:

| Existing messages | Before | After |
| ---: | ---: | ---: |
| 100 | 4.80 ms | 1.27 ms |
| 1,000 | 5.41 ms | 1.25 ms |
| 10,000 | 40.14 ms | 1.00 ms |

The common generated-ID path no longer scales with transcript length. No cache, index, schema, or migration was added.

## Validation

- 88 Chat tests passed
- Ruff check passed on both changed files
- git diff --check passed
- loopx canary premerge --from-git-diff passed

## Scope

A broader transcript index was considered and deferred: deterministic completion messages still need durable replay deduplication, and this change removes the unnecessary scan without adding state or recovery complexity.