### PR TITLE
fix(status): consume canonical Todos and align authority retirement RFCs

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2463,36 +2463,65 @@ the read-only three-arm rehearsal as a separate promotion gate.
 
 ### Next delivery and parallel provider work
 
-The immediate kernel sequence is: (1) finish the remaining provider-first Todo
-command inventory behind the same runtime boundary; (2) explicit v0 import plus
-sustained consumer/capture/recovery qualification; (3) reviewed promotion with
-fenced export and cleanup. Each slice must prove an end-to-end transaction, not
-merely another schema identifier consolidation. Native contract acceptance
-alone is not permission to bypass any promotion hold.
+Markdown is a **permanent first-class readable projection**. Retire its database
+and business-writer authority, not its human/agent presentation. The
+[TS RFC's delivery sequence](typescript-control-plane-migration-v0.md#next-delivery-sequence)
+owns business-rule unification and caller deletion; this RFC owns one durable
+truth, recovery and cutover. Native CLI conversion and a daemon are not
+prerequisites, and PostgreSQL deployment must not hold local adoption hostage.
 
-The first replacement-first `claim` slice routes both the default Markdown
-writer and the promoted provider transaction through one TypeScript decision.
-Python's default path retains only locked commit and existing projection-
-compatibility duties. This closes duplicate claim policy; it neither promotes
-Markdown to authority nor replaces the remaining unified
-create/update/complete/archive transactions and projection outbox.
+```text
+CLI / Agent / Dashboard → one TS Todo transaction owner → canonical authority
+                                                        ├ structured consumers
+                                                        └ Markdown projection
+```
 
-The following `create` slice routes promoted `todo add` through a native
-provider transaction. The legacy CLI surface remains, but after argument
-validation it performs one typed crossing; TypeScript owns semantic duplicate
-resolution, actor/owner eligibility, CAS, replay receipts, and the projection
-outbox mutation. A deleted Markdown state file stays absent in real subprocess
-CLI preview and apply tests. This removes Markdown commit authority for create
-on promoted goals without claiming that update/complete/archive are ready for
-live promotion; those commands remain fenced until their own transaction
-types land behind the same runtime boundary.
+There are only two authority phases per goal: before cutover, Markdown feeds
+qualified shadow capture; after cutover, the selected canonical provider feeds
+one-way projections. Do not add a third TS-Markdown backend, bidirectional
+live synchronization, or per-command split authority. Unsupported post-cutover
+commands fail closed; they do not fall back to the old writer.
 
-Use file-v0 for bounded conformance and import rehearsal only. Start the
-Section 7.2 embedded-store slice alongside the provider-first Todo caller; both
-converge before long-goal local qualification and promotion. PostgreSQL
-service/deployment work remains parallel; it is not a local-promotion dependency. NoKV remains independently gated by its own lineage and recovery
-qualification. The shared authority owns decisions and receipts; providers own
-durable CAS/transactions, never a second Todo state machine.
+The next complete stage packages are:
+
+1. **Command/consumer closure.** Reuse the merged create, claim, update and
+   #4053 terminal/successor/archive paths. Inventory remaining public mutations
+   and reads against actual callers. Status/attention now joins `todo list` in
+   reading canonical Todo summaries after promotion, without requiring the
+   Markdown file. Missing providers fail closed and empty canonical collections
+   never revive legacy Todos. This is consumer progress, not promotion proof:
+   Turn, quota, planning, standing decisions, leases and monitor writeback still
+   need their own parity inventory. Read authority does not grant writeback.
+2. **Permanent projection closure.** Reuse `provider_projection.py`, the
+   Todo-section renderer and existing journal/outbox. Preserve non-owned human
+   narrative; render owned sections from a known canonical revision, with
+   idempotent repair and freshness/readback evidence. Pending projection delivery
+   is independent of business commit/replay. Direct Markdown edits must never
+   import themselves into authority. Explicit validated edit/import tooling is
+   a separate proposal, not a second writer hidden inside rendering. Current
+   missing-file behavior remains pending, not silent recreation: a future
+   explicit rebuild must distinguish recoverable Todo sections from lost human
+   narrative. Validate stale/missing/malformed display, crash/retry, revision
+   races, narrative preservation and private-field boundaries.
+3. **One qualified local profile and fenced cutover.** Section 7.2's embedded
+   candidate must prove bounded head/index growth, historical receipts, crash
+   recovery, real CLI readback, capacity and >=10-day soak. File-v0 conformance
+   is not that evidence. Bind one exact lineage/revision/manifest, drain capture,
+   reconcile consumers, fence writers and verify projection recovery plus fenced
+   export/rollback before explicit promotion approval. Do not promote active
+   goals for development tests. PostgreSQL deployment and NoKV qualification
+   proceed independently; changed shared transactions still qualify each
+   affected provider, including a real isolated PostgreSQL server.
+4. **Retirement with named callers.** Remove old Markdown business writers and
+   capture/reference/bridge code only when their final callers and migration
+   windows close. Keep the permanent renderer, qualified import/export, and
+   durable regression coverage. Publish the retained-seam inventory and next
+   deletion condition, rather than indefinitely expanding dual paths.
+
+The current default and Appendix C promotion holds remain unchanged. This plan
+does not declare the whole Todo family, long-goal profile, or shared deployment
+production-ready. Providers keep CAS/transactions durable; they never own a
+second Todo state machine.
 
 ### Parallel delivery plan
 

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -1954,30 +1954,50 @@ promotion gate。
 
 ### 下一步交付与并行 provider 工作
 
-kernel 的近期顺序是：（1）在同一 runtime boundary 后补完剩余 provider-first Todo
-command inventory；（2）显式 v0 import 加持续 consumer/capture/recovery 资格化；
-（3）具备 fenced export 和 cleanup 的已评审 promotion。每个切片必须证明端到端
-transaction，不能只做另一轮 schema identifier 统一。接受 native contract 不等于
-可以绕过任何 promotion hold。
+Markdown 是**长期保留的一等可读投影**。退役的是它的数据库及业务 writer 权威，
+不是面向 human/agent 的展示。[TS RFC 交付顺序](typescript-control-plane-migration-v0.zh-CN.md#下一步交付顺序)
+负责业务规则统一和 caller 删除；本 RFC 负责唯一 durable truth、恢复和 cutover。
+CLI 原生 TS 化与 daemon 不是前提，PostgreSQL 部署不能阻塞本地采用。
 
-`claim` 的第一个 replacement-first 切片把默认 Markdown writer 与 promotion 后的
-provider transaction 接到同一个 TS decision；Python 默认路径只保留持锁提交和既有
-投影兼容职责。它关闭 claim policy 的双实现，但不把 Markdown 提升为 authority，
-也不替代剩余 create/update/complete/archive 的统一 transaction 与 projection outbox。
+```text
+CLI / Agent / Dashboard → 唯一 TS Todo 事务 owner → canonical authority
+                                                   ├ structured consumers
+                                                   └ Markdown 投影
+```
 
-随后的 `create` 切片让 promotion 后的 `todo add` 进入原生 provider transaction。
-旧 CLI 表面仍保留，但参数验证之后只跨一次 typed boundary；语义重复判断、actor/owner
-资格、CAS、replay receipt 与 projection outbox mutation 都由 TypeScript 持有。真实
-subprocess CLI 的 preview/apply 测试会先删除 Markdown state file，并证明它不会被重新
-创建。这消除了 promoted goal 上 create 的 Markdown 提交权威，但不宣称
-update/complete/archive 已可用于活跃 goal promote；这些命令要等各自 transaction
-类型进入同一 runtime boundary 前继续被 fence。
+每个 goal 只有两个 authority 阶段：cutover 前，Markdown 向已资格化 shadow capture
+供数；cutover 后，所选 canonical provider 向单向投影供数。不增加第三种 TS-Markdown
+backend、实时双向同步或按命令拆开的权威；晋升后不支持的命令 fail closed，不能回退旧 writer。
 
-file-v0 只用于有界 conformance 与 import 演练。第 7.2 节嵌入式存储切片与 provider-first
-Todo caller 同时推进，在长程本地资格化与晋升前汇合。PostgreSQL service/deployment
-继续并行，不成为本地晋升的依赖；NoKV 独立通过自己的 lineage/recovery 资格门禁。
-shared authority 持有 decision 与 receipt；provider 只持有 durable CAS/transaction，
-不再实现第二份 Todo 状态机。
+后续完整阶段包按以下顺序推进：
+
+1. **命令/consumer 闭合。** 复用已合入的 create、claim、update 和 #4053
+   terminal/successor/archive 路径。按实际 caller 盘点剩余公开 mutation 和 read。
+   status/attention 现在与 `todo list` 一样，在 promotion 后读 canonical Todo summary，
+   不要求 Markdown 文件存在；provider 缺失 fail closed，canonical 空集合不能复活旧
+   Todo。这是 consumer 进展，不是 promotion 证明：Turn、quota、planning、standing
+   decision、lease、monitor writeback 仍需各自的 parity 清单。读权威不授予写回能力。
+2. **永久投影闭合。** 复用 `provider_projection.py`、Todo-section renderer 和既有
+   journal/outbox。保留非托管的人工叙述，从已知 canonical revision 渲染托管 section，
+   提供幂等修复与 freshness/readback 证据。投影 pending 独立于业务 commit/replay。
+   直接编辑 Markdown 不能自动导入 authority；显式验证的 edit/import 工具另提方案，
+   不能藏在 renderer 内成为第二个 writer。当前文件缺失仍保持 pending，不静默重建；
+   后续显式 rebuild 要区分可恢复 Todo section 与已丢失人工叙述。验证陈旧/缺失/非法
+   展示、crash/retry、revision race、叙述保留与私有字段边界。
+3. **一个已资格化的本地 profile 与 fenced cutover。** 第 7.2 节嵌入式候选证明
+   head/index 增长有界、历史 receipt、crash recovery、真实 CLI readback、容量和
+   >=10 天 soak；file-v0 conformance 不能代替这些证据。绑定精确 lineage/revision/
+   manifest、排空 capture、对齐 consumer、fence writer，并验证投影恢复及 fenced
+   export/rollback 后，才请求显式 promotion 批准。不能拿活跃 goal 做开发晋升测试。
+   PostgreSQL 部署与 NoKV 资格化独立推进；shared transaction 改动仍验证每个受影响
+   provider，包括真实隔离 PostgreSQL server。
+4. **列明 caller 后退役。** 最后 caller 和迁移窗口关闭后，删除旧 Markdown 业务
+   writer 与 capture/reference/bridge；保留永久 renderer、已资格化 import/export 和
+   持久回归覆盖。公布保留 seam 清单及下一删除条件，不无限扩大双路径。
+
+当前默认和附录 C promotion hold 均不改变。这份计划不宣称完整 Todo 命令族、长程
+profile 或 shared deployment 已生产就绪。provider 负责 durable CAS/transaction，
+不拥有第二份 Todo 状态机。
 
 ### 并行交付计划
 

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -197,33 +197,48 @@ slice; they must not be reported as migrated or globally free of prose rules.
 
 ### Next delivery sequence
 
-1. **One provider-first Todo transaction family.** Route native create, claim,
-   update, complete-with-successor, archive, and their lease effects through
-   the existing TS authority owner. Deliver coherent vertical slices with the
-   real CLI caller, replay/CAS/error tests, and removal of the replaced Python
-   decisions. A schema or constants-only PR does not satisfy this exit.
-   A single-command slice (for example `todo update --text/--note` through a
-   shared compatibility editor) is a validation milestone for synthetic or
-   qualification goals, never a real-goal promotion: once a goal is promoted,
-   every other legacy writer is still fenced fail-closed. Promoting a live goal
-   therefore waits until the write-command family its agents actually use routes
-   through the same unified TS commit authority (per-command transaction types
-   behind one effect-runtime boundary, not parallel semantic owners) and until capture/projection outbox
-   delivery is flushed. The deletion payoff lands only when the in-place
-   Markdown editor is replaced by a pure projection renderer behind that one
-   entry point.
+The destination retains Markdown as a **permanent readable projection**, not a
+second database. This RFC owns one typed business-rule/transaction owner and
+its deletion payoff; the [shared-authority RFC](shared-goal-authority-state-provider-v0.md#next-delivery-and-parallel-provider-work)
+owns durable truth, recovery, cutover, and projection delivery. Neither a fully
+TypeScript CLI nor `loopxd` is a prerequisite for removing Python decisions.
+An input adapter or external-effect executor may remain Python.
 
-2. **Qualification before activation.** Join that path with the shared-authority
-   RFC's explicit v0 import, consumer parity, writer fencing, capture/projection
-   outbox recovery and fenced export. Integrate the local-persistence slice
-   above, including historical receipt retention, volume and >=10-day soak
-   evidence. File-v0 conformance is insufficient for long-goal promotion. No
-   default authority flip or dependency on PostgreSQL service readiness.
-3. **Retire the bridge, then converge entrypoints.** Delete the replaced
-   reference aggregate and Python facades when their last callers switch;
-   reuse the same kernel from native CLI/App and optional daemon. Report
-   product LOC removed, bridge LOC added, crossings, and remaining deletion
-   conditions per slice. Stop and replan after two scaffolding-only slices.
+1. **Close the actual command and consumer inventory.** Build on the merged
+   create/claim/update and #4053 terminal/successor/archive transactions; do not
+   recreate them. Inventory remaining field-edit, monitor, lease, and event
+   callers against their real contracts. Move their decisions to the existing
+   TS owner and delete the replaced decisions in the same slice. Reuse the
+   canonical Todo summary for reads: `todo list` and status/attention must not
+   select stale Markdown or event Todos after promotion, even when the display
+   is missing or the canonical collection is empty. Audit Turn, quota, planning,
+   Dashboard and standing-decision consumers separately; fixing one does not
+   qualify all consumers. Prove real-entrypoint parity and unavailable-provider
+   rejection, not just transport snapshots.
+2. **Make the display a recoverable one-way projection.** Reuse the canonical
+   journal/outbox and Todo-section renderer. Keep human narrative, source
+   revision, idempotent delivery and actionable pending repair. A failed render
+   must not undo a committed mutation or authorize a Markdown fallback.
+   Projection recovery must not replay the business operation. No third
+   TS-Markdown backend or automatic bidirectional synchronization is needed.
+3. **Qualify one local store, then cut over whole goals.** Close import,
+   ordering/consumer parity, writer fencing, capture/projection recovery,
+   historical receipts, capacity and >=10-day soak for the selected profile.
+   File-v0 conformance alone is not long-goal readiness. Do not route complete
+   to a provider while leaving update authoritative in Markdown for the same
+   goal. Until qualification and explicit promotion approval, keep the existing
+   default and fail-closed fences. Local qualification does not wait for the
+   PostgreSQL service; affected PostgreSQL transactions still require real
+   integration coverage.
+4. **Collect deletion payoff at each closed boundary.** After the last caller
+   and explicit migration window end, remove old Markdown business writers,
+   capture-only glue, duplicate reference aggregates and redundant bridges.
+   Keep the Markdown renderer and qualified import/export tools. List the exact
+   remaining callers and exit condition for each retained seam; a full native
+   CLI rewrite must not become a blanket reason to retain duplicate semantics.
+   Report product LOC removed, bridge LOC added and crossings separately from
+   tests/generated contracts. Stop and replan after two scaffolding-only slices;
+   net-negative LOC is useful evidence, not a quota that excuses lost behavior.
 
 Stacked schema-identifier cleanup is independent maintenance, not a prerequisite
 for this sequence. Absorb a downstream change only when the selected complete
@@ -642,7 +657,7 @@ not start a second independent operation while that handler may still be live.
 | Cross-runtime calls | Measured at the public facade: promoted complete without validation, supersede, and archive use three request/responses (`todo_list`, terminal/archive transaction, projection readback). A validated complete uses four (`todo_list`, terminal preflight, terminal finalization, projection readback) plus one declared host-local validation effect. After an injected post-commit projection crash, the first attempt uses two calls and the receipt replay uses three. The promoted happy path did not exist before this cutover; a legacy terminal call uses the existing TS admission decision and adds one coarse successor-derivation call only when it has generated successor intent. |
 | Product-code net change | Final merge-base classification is +4,051/−364 product LOC, net +3,687; tests/fixtures/examples are +3,594/−156, net +3,438; generated contracts are +3/−0 and docs are excluded. The increase delivers a complete provider-neutral transaction, one successor semantic owner, real File/PostgreSQL conformance, public facade parity, and durable mutation gates; it is not counted as deletion payoff. |
 | Migration scaffolding | The production-scale fixture, three-arm rehearsal, provider conformance, public legacy/promoted parity matrix, and mutation cases remain because they express durable migration contracts. The compatibility facade and its call-count assertions exit with the facade; provider-neutral transaction and archive-order mutation coverage remain. |
-| Facade exit | Delete `provider_terminal_lifecycle.py`, the successor wire adapter, their Python call-count tests, and `resolve_todo_state_path` after the top-level Todo CLI runs in-process TypeScript, registry/lifecycle facts arrive through the native caller, validation is executed by a native host adapter, and compatibility consumers drain the canonical journal directly. Delete the legacy successor-derivation and archive-selection crossings when the default Markdown/event writers migrate. |
+| Facade exit | Retire the legacy successor-derivation/archive-selection crossings and their call-count tests when the last Markdown/event business writer migrates. Remove terminal facade portions as registry/lifecycle inputs and journal consumers converge; a native CLI permits full transport removal but is not required to delete duplicated decisions. Keep only caller-required input, private validation execution and projection-delivery adapters, even if they remain Python. Delete `resolve_todo_state_path` only after its concrete path consumers disappear; keep permanent Markdown rendering and qualified import/export. |
 | Correctness evidence | Independent archive-order/standing-receipt semantics kill an oldest-selection mutant; optional `note`/`evidence`/`reason` cover `None`, empty, ordinary, Python-Unicode-whitespace-only, and whitespace compaction before/after promotion. Public-entry tests prove canonical commit followed by Turn-journal crash/retry settles once, logical retry tolerates prose changes but rejects different successor intent, rejected/concurrent/crash-recovered validated create publishes only the accepted digest sidecar, and legacy/promoted illegal actors retain a domain-rejection class. Independent successor tests pin priority, binding, exclusion, continuation, and predecessor-link inheritance. Stage 2C proves provider-first fence routing, live-lease import, orphan-history filtering, management-lock exclusion, replay, and zero-write previews. File and real PostgreSQL providers execute the same terminal conformance, while the independent legacy arm remains mandatory compatibility evidence. |
 
 The monitor-poll cutover removes the Python admission-policy and monitor-target

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -154,26 +154,34 @@ lifecycle classification code 或其他 cadence policy，不能宣称全局已�
 
 ### 下一步交付顺序
 
-1. **一组 provider-first Todo 完整事务。** 原生 create、claim、update、
-   complete-with-successor、archive 及相关 lease effect 经过现有 TS authority owner。
-   每个内聚的纵向切片包含真实 CLI caller、replay/CAS/error 测试，并删除被替代的
-   Python decision。仅统一 schema 或常量不满足退出条件。
-   单命令切片（例如通过同一兼容 editor 的 `todo update --text/--note`）只是
-   合成/资格化 goal 的验证里程碑，不是真实 goal 的 promote：一旦 promote，其余
-   legacy writer 仍被 fence 以 fail-closed 拦截。因此活跃 goal 的 promote 要等
-   到其 agent 实际使用的写命令族都经由同一个统一 TS 提交权威（同一入口的分命令
-   transaction 类型（共享同一个 effect-runtime 边界，而不是平行语义 owner），并且
-   capture/projection outbox 落盘接通之后。
-   删除的收益只在该入口背后的 in-place Markdown editor 被纯投影 renderer 替代时兑现。
+终态长期保留 Markdown 作为**可读投影**，不是第二个数据库。本 RFC 负责唯一 typed
+业务规则/事务 owner 及删除收益；[shared-authority RFC](shared-goal-authority-state-provider-v0.zh-CN.md#下一步交付与并行-provider-工作)
+负责 durable truth、恢复、cutover 与投影交付。删除 Python decision 不以前端 CLI
+全部改成 TypeScript 或 `loopxd` 落地为前提；输入适配和外部 effect 执行可以保留 Python。
 
-2. **先资格化，再启用。** 与 shared-authority RFC 的显式 v0 import、consumer
-   parity、writer fencing、capture/projection outbox recovery 和 fenced export 汇合。
-   集成上述本地持久化切片，包含历史 receipt 保留、容量与 >=10 天 soak 证据。
-   file-v0 conformance 不足以支持长程晋升；不默认切换 authority，也不依赖 PostgreSQL service。
-3. **删除 bridge，再收敛入口。** 最后一个 caller 切换后，删除被替代的 reference
-   aggregate 与 Python facade；native CLI/App 和可选 daemon 复用同一 kernel。
-   每个切片报告删除的 product LOC、新增 bridge LOC、crossings 与剩余删除条件。
-   连续两个切片只有 scaffolding 时，停止并重新规划。
+1. **闭合实际命令与 consumer 清单。** 基于已合入的 create/claim/update 和 #4053
+   terminal/successor/archive transaction 推进，不重复建设。按真实合同盘点剩余
+   字段编辑、monitor、lease、event caller，把规则迁入既有 TS owner，并在同一切片
+   删除被替代的 decision。读取复用 canonical Todo summary：promotion 后，`todo list`
+   和 status/attention 不得选择陈旧 Markdown/event Todo；投影缺失、canonical 集合为空
+   也不例外。另行审计 Turn、quota、planning、Dashboard、standing-decision consumer；
+   修好一条不等于全部合格。通过真实入口验证 parity 和 provider 故障拒绝，不能只比传输快照。
+2. **把展示闭合为可恢复的单向投影。** 复用 canonical journal/outbox 与 Todo-section
+   renderer，保留人工叙述、来源 revision、幂等交付和可操作的 pending repair。
+   渲染失败不能撤销已提交事务，也不能授权 Markdown fallback；恢复投影不能重跑业务操作。
+   不引入第三种 TS-Markdown backend 或自动双向同步。
+3. **资格化一个本地 store，再按完整 goal 切换。** 所选 profile 闭合 import、排序与
+   consumer parity、writer fencing、capture/projection recovery、历史 receipt、容量及
+   >=10 天 soak。file-v0 conformance 本身不等于长程就绪。不能让同一 goal 的 complete
+   走 provider、update 却仍以 Markdown 为权威。资格化与显式 promotion 批准前，保留
+   当前默认及 fail-closed fence。本地资格化不等待 PostgreSQL service；受影响的
+   PostgreSQL transaction 仍需真实集成验证。
+4. **每闭合一个边界就兑现删除。** 最后 caller 与显式迁移窗口结束后，删除旧 Markdown
+   业务 writer、仅供 capture 的 glue、重复 reference aggregate 和冗余 bridge；保留
+   Markdown renderer 与已资格化 import/export 工具。每条保留 seam 列出具体 caller
+   和退出条件，不能用“CLI 尚未全 TS 化”笼统保留重复语义。分别报告 product LOC 删除、
+   bridge LOC 增加、crossings，不能把测试/生成合同计为删除收益。连续两个切片只有
+   scaffolding 时停止并重规划；净减代码是证据，不是可以牺牲行为的配额。
 
 stack 中的 schema identifier 清理是独立维护，不是上述路线的前置条件。只吸收所选
 完整事务确实依赖的下游改动；base 合并后，其余工作再 rebase。
@@ -532,7 +540,7 @@ exactly-once 保证；原 handler 可能仍存活时，caller 不得启动第二
 | 跨 runtime 调用 | 从 public facade 实测：promotion 后无 validation 的 complete、supersede 与 archive 均为三次 request/response（`todo_list`、terminal/archive transaction、projection readback）。带 validation 的 complete 为四次（`todo_list`、terminal preflight、terminal finalization、projection readback），另执行一次声明式 host-local validation effect。注入 post-commit projection crash 后，首次尝试为两次调用，receipt replay 为三次。该 cutover 前不存在合法 promoted happy path；legacy terminal 调用沿用既有 TS admission decision，仅在存在 generated successor intent 时增加一次 coarse successor-derivation 调用。 |
 | 产品代码净增减 | 最终 merge-base 分类为产品代码 +4,051/−364，净增 3,687；test/fixture/example 为 +3,594/−156，净增 3,438；generated contract 为 +3/−0，docs 不计入。该增长交付完整 provider-neutral transaction、单一 successor semantic owner、真实 File/PostgreSQL conformance、public facade parity 与持久 mutation gate，不记作 deletion payoff。 |
 | 迁移 scaffolding | Production-scale fixture、三臂演练、provider conformance、public legacy/promoted parity matrix 与 mutation case 因表达持久迁移 contract 而保留。Compatibility facade 及其 call-count assertion 随 facade 退出；provider-neutral transaction 与 archive-order mutation coverage 保留。 |
-| Facade 退出 | 顶层 Todo CLI 在进程内执行 TypeScript、registry/lifecycle fact 由 native caller 提供、validation 由 native host adapter 执行、compatibility consumer 直接 drain canonical journal 后，删除 `provider_terminal_lifecycle.py`、successor wire adapter、Python call-count test 与 `resolve_todo_state_path`。默认 Markdown/event writer 迁移后，删除 legacy successor-derivation 与 archive-selection crossing。 |
+| Facade 退出 | 最后一个 Markdown/event 业务 writer 迁移后，退役 legacy successor-derivation/archive-selection crossing 及其 call-count test。随 registry/lifecycle 输入与 journal consumer 收敛，逐段删除 terminal facade；native CLI 允许全部移除 transport，但不是删除重复 decision 的前提。只保留实际 caller 需要的输入、私有 validation 执行和投影交付 adapter，即使它们仍是 Python。`resolve_todo_state_path` 的具体路径 consumer 消失后再删除；永久 Markdown renderer 与已资格化 import/export 保留。 |
 | 正确性证据 | 独立 archive order/standing receipt 语义可以 kill oldest-selection mutant；可选 `note`/`evidence`/`reason` 覆盖 promotion 前后的 `None`、empty、ordinary、Python Unicode 纯空白与空白压缩。Public-entry 测试证明 canonical commit 后 Turn-journal 崩溃重试只结算一次；logical retry 允许说明文本变化但拒绝不同 successor intent；validated create 在拒绝、并发与 canonical commit 后崩溃恢复时只发布 accepted digest sidecar；非法 actor 在 legacy/promoted 下都保持领域拒绝分类。独立 successor 测试钉住 priority、binding、exclusion、continuation 与 predecessor-link inheritance。Stage 2C 证明 provider-first fence routing、live-lease import、orphan-history filtering、management-lock exclusion、replay 与 zero-write preview。File 与真实 PostgreSQL provider 执行同一 terminal conformance，独立 legacy 臂仍是强制 compatibility evidence。 |
 
 Monitor-poll cutover 删除了 Python admission-policy、monitor-target module，以及

--- a/loopx/cli_commands/quota_context.py
+++ b/loopx/cli_commands/quota_context.py
@@ -5,6 +5,9 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..control_plane.coordination.legacy_writer_fence import (
+    require_legacy_coordination_write_allowed,
+)
 from ..control_plane.quota.error_codes import QuotaCommandValidationError
 from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,
@@ -221,6 +224,13 @@ def prepare_quota_command_context(
         registry_path=registry_path,
         runtime_root_override=runtime_root_arg,
     )
+    if command == "monitor-poll" and args.execute and (args.todo_id or args.target_key):
+        # This command still uses the legacy Todo writer. Preserve its typed
+        # rejection before collecting a promoted read model (which may itself
+        # be unavailable). The writer repeats the check under its mutation lock.
+        require_legacy_coordination_write_allowed(
+            runtime_root=runtime_root, goal_id=args.goal_id,
+        )
     status_goal_id = args.goal_id if command not in {"status", "plan"} else None
     projection_cache_ttl_seconds = int(
         getattr(args, "projection_cache_ttl_seconds", 120)

--- a/loopx/control_plane/coordination/local_authority.py
+++ b/loopx/control_plane/coordination/local_authority.py
@@ -241,6 +241,7 @@ def canonical_todo_summary_fields(
     """Adapt canonical records into the existing Todo summary read model."""
 
     from ..todos.active_state_editing import TODO_SECTION_HEADINGS
+    from ..todos.decision_scope import build_standing_decision_authority
     from ..todos.todo_summary import compact_todo_group, count_advancement_todos
 
     native_archived = {
@@ -278,6 +279,7 @@ def canonical_todo_summary_fields(
             items,
             source_section=TODO_SECTION_HEADINGS[role],
             role=role,
+            include_empty_source=True,
             resume_source_items=todos,
             rollout_events=rollout_events,
             item_limit=None,
@@ -298,4 +300,8 @@ def canonical_todo_summary_fields(
                         int(summary.get("advancement_done_count") or 0) + archived_done
                     )
             fields[f"{role}_todos"] = summary
+        if role == "user":
+            standing_authority = build_standing_decision_authority(items)
+            if standing_authority:
+                fields["standing_decision_authority"] = standing_authority
     return fields

--- a/loopx/control_plane/todos/active_state_todos.py
+++ b/loopx/control_plane/todos/active_state_todos.py
@@ -4,6 +4,11 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ..coordination.local_authority import (
+    canonical_todo_summary_fields,
+    read_canonical_todos_if_promoted,
+)
+
 MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
 
 
@@ -90,31 +95,47 @@ def active_state_todo_fields(
 ) -> dict[str, Any]:
     monitor_writeback_contract_writer = attach_monitor_writeback_contract or _attach_monitor_writeback_contract
     todo_field_redactor = redacted_status_todo_fields or _redacted_status_todo_fields
+    goal_id = str(goal.get("id") or "").strip()
+    # Inspect authority before the display file. A missing/stale projection is
+    # not an empty Todo collection, and an unavailable provider must fail closed.
+    canonical = (
+        read_canonical_todos_if_promoted(runtime_root=runtime_root, goal_id=goal_id)
+        if runtime_root is not None and goal_id else None
+    )
     state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
-    if state_path is None or not state_path.exists():
+    if canonical is None and (state_path is None or not state_path.exists()):
         return {}
     try:
-        state_text = state_path.read_text(encoding="utf-8")
+        state_text = state_path.read_text(encoding="utf-8") if state_path is not None else ""
     except OSError:
-        return {}
+        if canonical is None:
+            return {}
+        state_text = ""
+    except UnicodeError:
+        if canonical is None:
+            raise
+        state_text = ""
     next_action_entries = active_state_next_action_entries(state_text, limit=3)
     preferred_todo_ids: set[str] = set()
     for entry in next_action_entries:
         preferred_todo_ids.update(active_next_action_todo_ids(entry))
     rollout_events: list[dict[str, Any]] = []
-    goal_id = str(goal.get("id") or "").strip()
     if runtime_root is not None and goal_id:
         rollout_events = load_rollout_events(
             rollout_event_log_path(runtime_root, goal_id),
             limit=max_todo_index_rollout_events_per_goal,
         )
-    event_fields = active_state_event_projection_fields(
+    event_fields = {} if canonical is not None else active_state_event_projection_fields(
         goal,
         state_path=state_path,
         preferred_todo_ids=preferred_todo_ids,
         rollout_events=rollout_events,
     )
-    if event_fields.get("user_todos") or event_fields.get("agent_todos"):
+    if canonical is not None:
+        fields = canonical_todo_summary_fields(canonical["todos"], rollout_events=rollout_events)
+        # Reading canonical Todos does not qualify legacy monitor writeback.
+        monitor_writeback_contract_writer(fields, supported=False, source="file_authority")
+    elif event_fields.get("user_todos") or event_fields.get("agent_todos"):
         fields = event_fields
         markdown_fields = parse_active_state_todos(
             state_text,

--- a/tests/capabilities/test_native_codex_profile_skill_versions.py
+++ b/tests/capabilities/test_native_codex_profile_skill_versions.py
@@ -1,3 +1,4 @@
+"""Pinned capability profiles validate their own managed skill versions."""
 from __future__ import annotations
 
 import sys

--- a/tests/control_plane/test_canonical_status_todos.py
+++ b/tests/control_plane/test_canonical_status_todos.py
@@ -1,0 +1,154 @@
+"""Status reads the real promoted provider, not its Markdown display copy."""
+from __future__ import annotations
+
+import json
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from canonical_authority_fixture import initialize_canonical_authority
+
+from loopx.control_plane.coordination.local_authority import LocalCoordinationAuthorityUnavailable
+from loopx.control_plane.coordination.coordination_state_contract import (
+    TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION,
+    TODO_DOMAIN_RECORD_FIELDS,
+)
+from loopx.control_plane.coordination.local_authority_shadow_projection import canonical_bytes
+from loopx.control_plane.coordination.runtime_shadow import build_todo_runtime_shadow_projection
+from loopx.status import active_state_todo_fields
+
+
+@pytest.fixture(params=["legacy", "native"])
+def promoted_goal(tmp_path: Path, request):
+    state = tmp_path / "ACTIVE_GOAL_STATE.md"
+    state.write_text(
+        "# Goal\n\n## Next Action\n\nKeep the human narrative.\n\n"
+        "## Agent Todo\n\n- [ ] Stale display task\n"
+        "  <!-- loopx:todo todo_id=todo_stale status=open -->\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n- [x] Stale approval\n"
+        "  <!-- loopx:todo todo_id=todo_gate status=done task_class=user_gate "
+        "global_gate=true decision_scope=write_scope:goal:release decision_outcome=approve -->\n",
+        encoding="utf-8",
+    )
+    runtime = tmp_path / "runtime"
+    goal = {
+        "id": "goal-a", "repo": str(tmp_path), "state_file": str(state),
+        "domain": "software", "adapter": {"kind": "read_only_project_map_v0"},
+    }
+    records = [{
+        "schema_version": "todo_item_v0", "todo_id": "todo_canonical",
+        "index": 1, "role": "agent", "status": "open", "done": False,
+        "text": "Canonical work", "priority": "P1", "archive_state": "active",
+        "source_section": "Agent Todo", "claimed_by": "agent-a",
+    }, {
+        "schema_version": "todo_item_v0", "todo_id": "todo_gate",
+        "index": 2, "role": "user", "status": "done", "done": True,
+        "text": "Canonical rejection", "priority": "P1", "archive_state": "active",
+        "source_section": "User Todo / Owner Review Reading Queue",
+        "task_class": "user_gate", "global_gate": True,
+        "decision_scope": {
+            "schema_version": "decision_scope_v0", "kind": "write_scope",
+            "granularity": "goal", "scope_key": "release",
+        },
+        "decision_outcome": "reject",
+    }]
+    projection = build_todo_runtime_shadow_projection(goal_id=goal["id"], todos=records)
+    if request.param == "native":
+        for record in projection["todos"]:
+            record["schema_version"] = "todo_domain_record_v0"
+            record.pop("index")
+            record.pop("source_section")
+        projection["todo_read_model"] = {
+            "schema_version": TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION,
+            "contract_fields": list(TODO_DOMAIN_RECORD_FIELDS),
+            "todo_count": len(projection["todos"]),
+            "records_sha256": hashlib.sha256(canonical_bytes(projection["todos"])).hexdigest(),
+        }
+    initialize_canonical_authority(runtime, goal["id"], projection, state_path=state)
+    return goal, runtime, state
+
+
+@pytest.mark.parametrize("display", ["stale", "missing", "invalid_utf8"])
+def test_status_uses_provider_even_when_markdown_is_unusable(promoted_goal, display, monkeypatch):
+    goal, runtime, state = promoted_goal
+    if display == "invalid_utf8":
+        state.write_bytes(b"\xff")
+    original = state.read_bytes()
+    if display == "missing":
+        state.unlink()
+    for name in ("active_state_event_projection_fields", "parse_active_state_todos"):
+        monkeypatch.setattr(
+            f"loopx.status.{name}",
+            lambda *_args, **_kwargs: pytest.fail("promoted read must not parse legacy Todos"),
+        )
+    fields = active_state_todo_fields(goal, runtime_root=runtime)
+    items = fields["agent_todos"]["items"]
+    assert [item["todo_id"] for item in items] == ["todo_canonical"]
+    assert items[0]["claimed_by"] == "agent-a"
+    assert fields["standing_decision_authority"]["active_count"] == 0
+    assert fields["standing_decision_authority"]["entries"][0]["outcome"] == "reject"
+    assert fields["agent_todos"]["monitor_writeback"]["supported"] is False
+    if display == "missing":
+        assert not state.exists()  # A read must not recreate the display.
+    else:
+        assert state.read_bytes() == original
+        if display == "stale":
+            assert fields["active_state_next_action"] == "Keep the human narrative."
+
+
+def test_unavailable_provider_does_not_restore_stale_display_tasks(promoted_goal):
+    goal, runtime, state = promoted_goal
+    (runtime / "authority" / "file-v0").rename(runtime / "unavailable-provider")
+    with pytest.raises(LocalCoordinationAuthorityUnavailable):
+        active_state_todo_fields(goal, runtime_root=runtime)
+    assert "todo_stale" in state.read_text()
+
+
+def test_empty_canonical_collection_is_an_explicit_empty_read_model(tmp_path):
+    state = tmp_path / "state.md"
+    state.write_text("# Goal\n\n## Agent Todo\n\n- [ ] Stale work\n")
+    runtime = tmp_path / "runtime"
+    goal = {"id": "goal-a", "repo": str(tmp_path), "state_file": str(state)}
+    initialize_canonical_authority(
+        runtime, goal["id"],
+        build_todo_runtime_shadow_projection(goal_id=goal["id"], todos=[]),
+        state_path=state,
+    )
+    fields = active_state_todo_fields(goal, runtime_root=runtime)
+    for role in ("user", "agent"):
+        assert fields[f"{role}_todos"]["items"] == []
+        assert fields[f"{role}_todos"]["total_count"] == 0
+
+
+def test_unpromoted_status_retains_markdown_without_starting_authority(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "loopx.control_plane.coordination.local_authority.effect_runtime_result",
+        lambda *_args, **_kwargs: pytest.fail("unpromoted reads must not start TS authority"),
+    )
+    state = tmp_path / "state.md"
+    goal = {"id": "goal-a", "repo": str(tmp_path), "state_file": str(state)}
+    assert active_state_todo_fields(goal, runtime_root=tmp_path / "runtime") == {}
+    state.write_text("# Goal\n\n## Agent Todo\n\n- [ ] Legacy work\n")
+    fields = active_state_todo_fields(goal, runtime_root=tmp_path / "runtime")
+    assert fields["agent_todos"]["items"][0]["text"] == "Legacy work"
+
+
+def test_public_status_cli_reads_canonical_attention_without_markdown(promoted_goal, tmp_path):
+    goal, runtime, state = promoted_goal
+    state.unlink()
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({
+        "schema_version": 1, "common_runtime_root": str(runtime), "goals": [goal],
+    }))
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--registry", str(registry),
+         "--format", "json", "status", "--goal-id", goal["id"]],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "todo_canonical" in json.dumps(payload["attention_queue"])
+    assert "todo_stale" not in json.dumps(payload["attention_queue"])
+    assert not state.exists()

--- a/tests/control_plane/test_split_root_todo_writeback_fence.py
+++ b/tests/control_plane/test_split_root_todo_writeback_fence.py
@@ -258,6 +258,11 @@ def test_quota_monitor_poll_cli_preserves_fence_rejection(
     _fence_check_blocks(monkeypatch)
     before = state.read_bytes()
 
+    def unexpected_collection(**_kwargs: Any) -> dict[str, Any]:
+        pytest.fail("fenced monitor write must be rejected before status collection")
+
+    monkeypatch.setattr("loopx.cli_commands.quota.collect_status", unexpected_collection)
+
     exit_code = main(
         [
             "--registry",
@@ -298,6 +303,35 @@ def test_quota_monitor_poll_cli_preserves_fence_rejection(
         "authority_mode": "file_v0",
     }
     assert state.read_bytes() == before
+
+
+@pytest.mark.parametrize("command", ["should-run", "monitor-poll"])
+def test_read_only_quota_still_collects_promoted_state(
+    command: str, monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    from loopx.cli import build_parser
+    from loopx.cli_commands.quota_context import prepare_quota_command_context
+
+    registry, _state, _registered_root, runtime_override = _write_split_root_goal(tmp_path)
+    _engage_fence_at(runtime_override)
+    _fence_check_blocks(monkeypatch)
+    args = build_parser().parse_args([
+        "quota", command, "--goal-id", GOAL_ID, "--agent-id", AGENT_ID,
+        *(["--todo-id", MONITOR_ID] if command == "monitor-poll" else []),
+    ])
+    collected: list[object] = []
+
+    def collector(**kwargs: Any) -> dict[str, object]:
+        collected.append(kwargs["runtime_root_override"])
+        return {"runtime_root": str(runtime_override)}
+
+    context = prepare_quota_command_context(
+        args, registry_path=registry, runtime_root_arg=str(runtime_override),
+        status_collector=collector,
+        operator_inbox_urgency_projector_factory=lambda **_: lambda **__: {},
+    )
+    assert collected == [str(runtime_override)]
+    assert context.status_payload["runtime_root"] == str(runtime_override)
 
 
 def test_turn_repair_update_blocked_when_override_root_is_fenced(

--- a/tests/test_sonarcloud_workflow.py
+++ b/tests/test_sonarcloud_workflow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "sonarcloud.yml"
 
@@ -16,12 +17,43 @@ def test_missing_sonar_token_reaches_a_successful_skip_step() -> None:
     assert "non-blocking analysis skipped" in workflow
 
 
+def _assert_token_guards(workflow: str) -> None:
+    # Match the workflow's existing named-step convention, not its step count:
+    # adding another coverage artifact must not weaken or break token isolation.
+    steps = workflow.split("      - name: ")[1:]
+    assert steps
+    analysis_steps = []
+    for step in steps:
+        if "        id: sonar-token\n" in step:
+            continue
+        if step.startswith("Skip analysis when the token is unavailable\n"):
+            assert "if: steps.sonar-token.outputs.available != 'true'" in step
+            continue
+        assert "if: steps.sonar-token.outputs.available == 'true'" in step, step.splitlines()[0]
+        analysis_steps.append(step)
+    assert any("uses: actions/checkout@" in step for step in analysis_steps)
+    assert any("uses: SonarSource/sonarqube-scan-action@" in step for step in analysis_steps)
+    for artifact in ("python-coverage-xml", "typescript-control-plane-coverage"):
+        assert any(f"name: {artifact}\n" in step for step in analysis_steps)
+
+
 def test_sonar_steps_remain_guarded_by_the_token() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    assert workflow.count("if: steps.sonar-token.outputs.available == 'true'") == 3
+    _assert_token_guards(workflow)
     assert workflow.count("SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}") == 2
     assert "\n    env:\n      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}" not in workflow
+
+
+def test_each_missing_analysis_guard_is_rejected() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    guard = "        if: steps.sonar-token.outputs.available == 'true'\n"
+    fragments = workflow.split(guard)
+    assert len(fragments) > 1
+    for index in range(len(fragments) - 1):
+        mutant = guard.join(fragments[:index + 1]) + guard.join(fragments[index + 1:])
+        with pytest.raises(AssertionError):
+            _assert_token_guards(mutant)
 
 
 def test_sonar_reuses_same_run_coverage_without_a_privileged_trigger() -> None:


### PR DESCRIPTION
## Summary

Retain Markdown as a permanent readable projection while converging Todo business decisions and durable truth. Update both architecture RFCs in English and Chinese, and ship the first concrete consumer fix rather than another storage abstraction.

- After promotion, status/attention reads the existing canonical Todo authority used by `todo list`, before consulting the Markdown display. Stale, missing or non-UTF8 display content cannot hide canonical Todos or restore old tasks.
- Empty canonical collections produce explicit empty summaries. Standing decisions come from canonical records; a stale Markdown approval cannot override a canonical rejection. Provider failures fail closed. Unpromoted Markdown/event behavior stays unchanged, and canonical read support does not grant legacy monitor writeback.
- Replace obsolete RFC sequencing with command/consumer closure → permanent one-way projection recovery → one qualified local profile and whole-goal cutover → retirement of old writers and bridges. Keep Markdown rendering/import/export; a fully native CLI or daemon is not a prerequisite for deleting duplicate decisions.

## Scope and economics

The existing Todo read-model boundary is sufficient: reuse the TS authority reader, canonical summary, standing-decision reducer and redactor. No new capability/provider, schema, state machine, runtime, or bidirectional sync. Runtime changes are +33/−6 product lines; the focused regression suite is 154 lines. This removes a consumer's legacy-truth dependency, **not** the still-used legacy writers. The RFC names their remaining caller/qualification exit conditions instead of claiming premature deletion payoff.

Two signed commits separate runtime/regression changes from RFC alignment. No active goal is promoted and no default authority binding changes. Local/private state and raw rehearsal evidence are excluded.

## Validation

- 72 Python tests: canonical status, public/local authority, and decision-scope lifecycle/consistency. Real FileAuthorityStore and public `status` CLI; both legacy and native records.
- Public CLI baseline/head sensitivity using the same synthetic fixture: at `ef71fd000`, deleting Markdown hides the canonical Todo; candidate exposes it. Both exit successfully and neither recreates the display. Focused tests also poison both legacy parsers and reject unavailable canonical storage.
- PostgreSQL 16.15 (Homebrew), disposable isolated server: **34 passed, 0 skipped**. Server stopped afterward.
- NoKV provider tests: **36 passed**. Existing `coordination_production_scale_v0` dimensions retained unchanged: no new coordination field, storage/retention rule or provider transaction. The new consumer dimension is covered by focused stale/empty/missing/display-mutation tests.
- Read-only three-arm rehearsal: 430-Todo source; legacy/File/PostgreSQL archive semantics, relative ordering and non-target preservation agree; provider heads/receipts agree; source unchanged. This is regression evidence, not promotion authorization.
- `todo-readmodel-boundary-smoke.py`, `event-sourced-downstream-read-path-smoke.py`, `cli-output-budget-regression-smoke.py`: passed.
- Focused Ruff, configured mypy (21 files), `typecheck:control-plane`, public boundary scan and `git diff --check`: passed.
- Exact-scope change-quality receipt: `cqr_ce822b0b8b5dec99347c`, verified against `ce822b0b8b5dec99347c6daa4b7dd4bcbef1debc9eb268cdb52affd5e385bd18`.
- Candidate-checkout `canary premerge --from-git-diff --goal-id`: **18 selected checks passed, 0 failures**, plus diff hygiene/compilation and valid strict receipt.

## Holds and follow-up

Remaining public mutations/consumers, permanent projection rebuild and one local store's capacity/10-day qualification still need complete stage packages. No implicit Markdown import, automatic missing-file rebuild, production promotion, or shared-deployment readiness is claimed. Full hosted CI and owner review remain before merge; no self-merge is requested.

The owner authorized a one-command local Git time-window bypass for this branch/commits/PR only. No global hook configuration or remote merge gate was changed.
