### PR TITLE
feat(todos): automatically recover missing canonical Markdown displays

### DIFF
--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -119,12 +119,12 @@ Directly editing a projection is not a state transition.
 
 ## Markdown Ownership Boundary
 
-Markdown is not one undifferentiated database row. Its free-form rationale,
-notes, and operator narrative remain human-authored. Sections that correspond
-to the versioned coordination contract may later be regenerated as a
-deterministic compatibility projection after authority promotion. Promotion
-must not make unrelated prose generated or discard text that is outside the
-machine-owned record contract.
+Markdown is not one undifferentiated database row. Agents generate and maintain
+both its structured sections and narrative through LoopX. The distinction is
+canonical ownership, not human versus Agent authorship: after promotion,
+sections covered by the versioned coordination contract are regenerated from
+that authority. Content outside that contract must remain intact until its own
+canonical source can reconstruct it.
 
 The cutover is deliberately section-sized, not document-sized:
 
@@ -132,7 +132,8 @@ The cutover is deliberately section-sized, not document-sized:
   unchanged;
 - after promotion, the versioned Todo records live in the canonical provider
   head and Markdown's Todo section is a compatibility/workbench projection;
-- free-form rationale and operator narrative remain Markdown-owned;
+- other generated sections remain in Markdown until their canonical ownership
+  migrates; Todo promotion does not silently discard or reinterpret them;
 - a provider outage after promotion fails closed and never makes stale
   Markdown authoritative again.
 
@@ -143,12 +144,12 @@ supply a task-lease idempotency key and optional expected version so the claim,
 canonical lease, and durable receipt commit in one provider transaction; the
 write scopes come from the canonical Todo rather than caller input. After
 promotion, `loopx todo project-markdown` can explicitly
-regenerate the two active Todo sections from the exact provider revision. It
+regenerate active and archived Todo sections from the exact provider revision. It
 never runs before promotion and never turns Markdown back into authority.
 
 The projection command has four safety properties:
 
-- it replaces only the active user and agent Todo section spans;
+- it replaces only the machine-owned active user, agent and archived Todo regions;
 - it preserves every segment outside those spans byte-for-byte;
 - it fails closed when a canonical field cannot be represented by the current
   Markdown metadata grammar, rather than dropping that field;
@@ -166,7 +167,7 @@ nested, mismatched or missing markers, and non-generated content inside a marked
 region, fail closed. No ordinary Goal is rewritten or opted in by installation.
 Legacy unmarked readers and bootstrap output remain unchanged.
 
-Narrative byte preservation and canonical Todo parse/render parity are separate
+Non-Todo byte preservation and canonical Todo parse/render parity are separate
 checks: the former compares untouched source slices, while the latter reads only
 the generated regions. Neither marker is provider authority or a current-head
 freshness guarantee.
@@ -190,20 +191,57 @@ Todo sections, but must not promote stale Markdown back to canonical truth.
 
 The projector accepts complete legacy records and native `TodoDomainRecord`
 manifests. Native records receive display-only section/index provenance; that
-provenance never enters the canonical record. Archived records render only
-inside an existing machine-owned `Completed Work Archive` region and retain
-their original `role`. Unknown canonical fields, missing sections, and unsafe
-region ownership continue to fail closed.
+provenance never enters the canonical record. Archived records render in a
+machine-owned `Completed Work Archive` region (created when needed) and retain
+their original `role`. Unknown canonical fields and unsafe region ownership
+continue to fail closed.
 
 For promoted provider-first Todo create, claim, and narrow text/note update,
 the committed authority journal is the transaction-bound projection outbox:
 the canonical mutation, complete head, cursor, revision, and receipt land in
 one provider transaction. After that commit, the Python compatibility adapter
 renders the latest head under the Markdown lock and durably reads it back. A
-missing target or renderer/write failure leaves typed `pending` delivery
+renderer/write failure leaves typed `pending` delivery
 evidence without reversing or hiding the canonical commit. A later successful
 mutation or `todo project-markdown --execute` replays the current head
 idempotently. This is projection recovery, not a second authority path.
+
+### Generated display recovery / 生成式展示恢复
+
+LoopX state documents are generated and maintained by Agents through LoopX.
+There is no separate hand-written-document workflow or recovery approval gate.
+After promotion, a missing Markdown target is automatically regenerated during
+normal projection delivery. The existing command is also sufficient:
+
+```bash
+loopx --format json todo list --goal-id <goal-id>
+# Use provider_revision from that read; omitting --execute previews only.
+loopx todo project-markdown --goal-id <goal-id> --provider-revision <revision>
+loopx todo project-markdown --goal-id <goal-id> --provider-revision <revision> --execute
+```
+
+The generated document states its recovery scope. The current coordination
+provider contains Todo and lease state, not every Objective, operating contract,
+vision, Next Action or progress-ledger section. A missing-file rebuild therefore
+reports `recovery_scope=todo_sections_only` and `narrative_preserved=false`;
+it is not a complete Goal-state restore. Existing non-Todo content is preserved
+regardless of who generated it. Those remaining state families must converge
+on their own canonical sources before whole-document reconstruction can be
+claimed; do not introduce a second Markdown authority or fill gaps from prose.
+
+Publication uses the existing source lock and source-ownership checks. New files
+are private (`0600` on POSIX) and published atomically without replacing a file
+concurrently restored by another writer. Existing malformed or non-UTF-8 files
+remain untouched and delivery stays pending. A stale requested revision or
+unavailable canonical provider cannot rebuild the target. Normal reads never
+write it. Recovery does not rerun the business transaction or validation command;
+private validation declarations must still match the canonical digest.
+
+缺失的展示文件由投影交付自动重建，不增加手写文档假设、人工确认或额外开关；原有
+`project-markdown` 仍默认预览。当前只恢复 canonical Todo 的活动与归档区域，并明确
+报告 `todo_sections_only`，不冒充完整 Goal 状态恢复。已有的非 Todo 内容无论由谁生成
+都保持原样；其权威源归一化是后续状态迁移，不是人工补文档流程。损坏文件不静默覆盖，
+revision 不匹配或 provider 不可用时不重建；交付失败只重试投影，不重复业务事务。
 
 1. Emit this projection from active-state Markdown.
 2. Add parity smokes comparing it with existing status todo summaries.

--- a/loopx/cli_commands/todo_event.py
+++ b/loopx/cli_commands/todo_event.py
@@ -37,7 +37,7 @@ def todo_error_payload(args: argparse.Namespace, exc: Exception) -> dict[str, ob
         "dry_run": True
         if args.todo_command == "suggest"
         else not bool(args.execute)
-        if args.todo_command == "archive-completed"
+        if args.todo_command in {"archive-completed", "project-markdown"}
         else bool(args.dry_run),
         "added": False,
         "already_exists": False,

--- a/loopx/control_plane/todos/machine_section_projection.py
+++ b/loopx/control_plane/todos/machine_section_projection.py
@@ -42,6 +42,7 @@ from .contract import (
     TODO_STATUS_OPEN,
     format_todo_metadata_line,
     normalize_todo_status,
+    require_todo_decision_scope,
     todo_marker_for_status,
 )
 from .todo_summary import canonical_todo_read_record
@@ -309,7 +310,7 @@ def _projection_record(
     *,
     display_index: int,
 ) -> dict[str, object]:
-    return dict(canonical_todo_read_record(
+    projected = dict(canonical_todo_read_record(
         {
             **record,
             "schema_version": TODO_ITEM_SCHEMA_VERSION,
@@ -322,6 +323,12 @@ def _projection_record(
         },
         reject_unknown=True,
     ))
+    if "decision_scope" in projected:
+        # The Markdown codec spells out the optional scope schema version on
+        # readback. Normalize that display representation, never the provider
+        # record or its digest, before comparing the same semantic scope.
+        projected["decision_scope"] = require_todo_decision_scope(projected["decision_scope"])
+    return projected
 
 
 _DERIVED_READ_MODEL_FIELDS = {

--- a/loopx/control_plane/todos/provider_projection.py
+++ b/loopx/control_plane/todos/provider_projection.py
@@ -11,6 +11,7 @@ current head idempotently.
 from __future__ import annotations
 
 import os
+import json
 import stat
 import tempfile
 from collections.abc import Mapping
@@ -49,10 +50,10 @@ def _fsync_parent_directory(path: Path) -> None:
         os.close(descriptor)
 
 
-def _atomic_write_text(path: Path, text: str) -> None:
+def _atomic_write_text(path: Path, text: str, *, create_only: bool = False) -> None:
     """Durably replace a compatibility projection without changing its mode."""
 
-    original_mode = stat.S_IMODE(path.stat().st_mode)
+    original_mode = 0o600 if create_only else stat.S_IMODE(path.stat().st_mode)
     descriptor, temporary = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
     )
@@ -63,7 +64,12 @@ def _atomic_write_text(path: Path, text: str) -> None:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temporary_path, path)
+        if create_only:
+            # Publish a complete file without clobbering a concurrently restored
+            # document, even if that writer does not participate in our lock.
+            os.link(temporary_path, path)
+        else:
+            os.replace(temporary_path, path)
         _fsync_parent_directory(path)
     finally:
         temporary_path.unlink(missing_ok=True)
@@ -91,9 +97,6 @@ def project_current_canonical_todos(
     )
     if goal is None:
         raise ValueError(f"goal {goal_id!r} is not present in the registry")
-    if not state_path.exists():
-        raise ValueError("Todo Markdown projection target does not exist")
-
     with exclusive_cross_runtime_file_lock(
         state_path, operation="project_canonical_todo_sections"
     ):
@@ -116,7 +119,19 @@ def project_current_canonical_todos(
                 "Todo Markdown projection provider revision does not match the "
                 "canonical read head"
             )
-        source = _read_text_exact(state_path)
+        recovered_missing = False
+        try:
+            source = _read_text_exact(state_path)
+        except FileNotFoundError:
+            recovered_missing = True
+            source = (
+                f"---\ngoal_id: {json.dumps(goal_id, ensure_ascii=False)}\n---\n\n"
+                "# Recovered Todo projection\n\n"
+                "> Regenerated from canonical Todo authority. Non-Todo sections "
+                "are not in this provider snapshot and were not recovered. "
+                "This is a Todo projection, not a complete Goal-state restore.\n\n"
+                "## Agent Todo\n"
+            )
         projection = render_canonical_todo_sections(
             source,
             authority_read["todos"],
@@ -141,7 +156,10 @@ def project_current_canonical_todos(
                 goal_id=goal_id,
                 state_file=state_path,
             )
-            _atomic_write_text(state_path, projection.markdown)
+            if recovered_missing:
+                _atomic_write_text(state_path, projection.markdown, create_only=True)
+            else:
+                _atomic_write_text(state_path, projection.markdown)
             if _read_text_exact(state_path) != projection.markdown:
                 raise RuntimeError("Todo Markdown projection readback mismatch")
 
@@ -166,7 +184,8 @@ def project_current_canonical_todos(
         "narrative_sha256": projection.narrative_sha256,
         "section_record_sha256": projection.section_record_sha256,
         "parse_render_parity": True,
-        "narrative_preserved": True,
+        "narrative_preserved": not recovered_missing,
+        **({"recovery_scope": "todo_sections_only"} if recovered_missing else {}),
         "legacy_fallback_used": False,
     }
 
@@ -217,6 +236,11 @@ def settle_canonical_todo_projection(
             "reason_code": reason_code,
             "error_class": error.__class__.__name__,
             "retryable": True,
+            "recommended_action": (
+                "Repair the display or provider error, read the current provider revision "
+                "with todo list, then retry todo project-markdown for that revision."
+            ),
+            "retry_business_mutation": False,
         }
     if isinstance(trigger_revision, str) and trigger_revision:
         delivery["trigger_provider_revision"] = trigger_revision

--- a/tests/control_plane/test_shadow_observable_native_e2e.py
+++ b/tests/control_plane/test_shadow_observable_native_e2e.py
@@ -60,6 +60,9 @@ def test_canonical_argument_intent_and_atomic_claim(caller: Caller) -> None:
     assert native(w, 'read', {}) == before
     applied = w.call(*claim)
     assert applied['status'] == 'applied', applied
+    assert applied['projection_delivery'] == 'delivered', applied
+    recovered = w.state.read_bytes()
+    assert b'claimed_by=agent-a' in recovered
     replay = w.call(*claim)
     assert replay['status'] == 'replayed' and replay['original_receipt'] == applied['original_receipt']
     stored = native(w, 'read', {})['head']['head']
@@ -70,7 +73,7 @@ def test_canonical_argument_intent_and_atomic_claim(caller: Caller) -> None:
     assert rejected.get('error_code') == 'update_owner_mismatch', rejected
     assert rejected['error'] == rejected['reason'] == "Todo update cannot edit another claim owner's work"
     assert native(w, 'read', {}) == before
-    assert not w.state.exists()
+    assert w.state.read_bytes() == recovered
 
 
 def test_native_unclaimed_edit_and_explicit_note_clear(caller: Caller) -> None:
@@ -81,7 +84,10 @@ def test_native_unclaimed_edit_and_explicit_note_clear(caller: Caller) -> None:
     projection = w.invoke([sys.executable, '-c', builder, json.dumps(record)], ['fixture-projection', json.dumps(record)])
     assert native(w, 'seed', projection)['status'] == 'applied'
     w.state.unlink()
-    assert w.call('todo', 'update', '--todo-id', todo, '--agent-id', 'agent-b', '--note', 'Claim-neutral context')['ok'] is True
+    updated = w.call('todo', 'update', '--todo-id', todo, '--agent-id', 'agent-b', '--note', 'Claim-neutral context')
+    assert updated['ok'] is True and updated['projection_delivery'] == 'delivered', updated
+    recovered = w.state.read_bytes()
+    assert todo.encode() in recovered
     stored = native(w, 'read', {})['head']['head']
     assert stored['todos'][0]['note'] == 'Claim-neutral context'
     assert not stored['todos'][0].get('claimed_by') and stored['leases'] == []
@@ -99,7 +105,9 @@ def test_native_unclaimed_edit_and_explicit_note_clear(caller: Caller) -> None:
         'todo_id': 'todo_missing', 'actor_agent_id': 'unknown', 'patch': {'text': 'Must not persist'}, 'clear_fields': []})
     assert rejected['status'] in {'failed', 'rejected'}, rejected
     assert native(w, 'read', {}) == after
-    assert not w.state.exists()
+    # Native transactions do not own display delivery; only the CLI facade
+    # regenerated it. Neither direct-native update nor rejection rewrites it.
+    assert w.state.read_bytes() == recovered
 
 
 HTTP = r"""

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -253,6 +253,30 @@ def test_projection_creates_archive_region_for_archived_records() -> None:
     assert replay.changed is False
 
 
+@pytest.mark.parametrize("corrupt_scope", [False, True])
+def test_optional_scope_version_is_display_only_not_permission_to_change_scope(monkeypatch, corrupt_scope):
+    from loopx.control_plane.todos import machine_section_projection as module
+
+    records = _records()
+    records[1]["decision_scope"].pop("schema_version")
+    before = deepcopy(records)
+    original = module._render_record
+
+    def render(record, **kwargs):
+        if corrupt_scope and record.get("decision_scope"):
+            record = {**record, "decision_scope": {**record["decision_scope"], "scope_key": "different_scope"}}
+        return original(record, **kwargs)
+
+    monkeypatch.setattr(module, "_render_record", render)
+    if corrupt_scope:
+        with pytest.raises(TodoSectionProjectionError, match="parity mismatch"):
+            render_canonical_todo_sections(SOURCE, records, provider_revision="scope-version")
+    else:
+        rendered = render_canonical_todo_sections(SOURCE, records, provider_revision="scope-version")
+        assert "direction:action:authority_cutover" in rendered.markdown
+    assert records == before
+
+
 def test_projection_rejects_duplicate_sections_and_unsafe_revision() -> None:
     duplicate = SOURCE + "\n## Agent Todo\n\n- [ ] duplicate\n"
     with pytest.raises(TodoSectionProjectionError, match="multiple agent"):

--- a/tests/control_plane/test_todo_projection_recovery.py
+++ b/tests/control_plane/test_todo_projection_recovery.py
@@ -1,0 +1,278 @@
+"""Recover the display through the public CLI without repairing authority."""
+from __future__ import annotations
+
+import json
+import hashlib
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from canonical_authority_fixture import initialize_canonical_authority
+from loopx.control_plane.coordination.local_authority import read_canonical_todos_if_promoted
+from loopx.control_plane.coordination.runtime_shadow import build_todo_runtime_shadow_projection
+from loopx.control_plane.coordination.coordination_state_contract import (
+    TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION, TODO_DOMAIN_RECORD_FIELDS,
+)
+from loopx.control_plane.coordination.local_authority_shadow_projection import canonical_bytes
+from loopx.control_plane.todos import provider_projection
+from loopx.control_plane.todos.completion_validation_store import (
+    persist_completion_validation_declaration,
+)
+
+
+@pytest.fixture
+def canonical_display(tmp_path):
+    state = tmp_path / "state.md"
+    state.write_text("# Goal\n\nAgent-generated acceptance is not in the Todo store.\n\n## Agent Todo\n")
+    runtime = tmp_path / "runtime"
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({
+        "common_runtime_root": str(runtime),
+        "goals": [{"id": "goal-a", "repo": str(tmp_path), "state_file": state.name,
+                   "coordination": {"registered_agents": ["agent-a"]}}],
+    }))
+    records = [
+        {"schema_version": "todo_item_v0", "todo_id": "todo_active", "role": "agent",
+         "status": "open", "done": False, "text": "Retain the current claim.",
+         "task_class": "advancement_task",
+         "archive_state": "active", "source_section": "Agent Todo", "index": 1,
+         "claimed_by": "agent-a"},
+        {"schema_version": "todo_item_v0", "todo_id": "todo_archived", "role": "user",
+         "status": "done", "done": True, "text": "Retain the historical decision.",
+         "archive_state": "archive", "source_section": "Completed Work Archive", "index": 1},
+    ]
+    projection = build_todo_runtime_shadow_projection(goal_id="goal-a", todos=records, handoff_mode="soft_claim")
+    for record in projection["todos"]:
+        record["schema_version"] = "todo_domain_record_v0"
+        record.pop("index")
+        record.pop("source_section")
+    projection["todo_read_model"] = {
+        "schema_version": TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION,
+        "contract_fields": list(TODO_DOMAIN_RECORD_FIELDS),
+        "todo_count": len(records),
+        "records_sha256": hashlib.sha256(canonical_bytes(projection["todos"])).hexdigest(),
+    }
+    initialize_canonical_authority(runtime, "goal-a", projection, state_path=state)
+    return registry, runtime, state
+
+
+def _read(runtime):
+    return read_canonical_todos_if_promoted(runtime_root=runtime, goal_id="goal-a")
+
+
+def _cli(registry: Path, *options: str):
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--registry", str(registry), "--format", "json",
+         "todo", *options],
+        capture_output=True, text=True, timeout=60, check=False,
+    )
+    return result.returncode, json.loads(result.stdout) if result.stdout else result.stderr
+
+
+def _run(registry: Path, revision: str, *options: str):
+    return _cli(registry, "project-markdown", "--goal-id", "goal-a",
+                "--provider-revision", revision, *options)
+
+
+def test_public_rebuild_missing_preview_execute_and_replay(canonical_display):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    state.unlink()
+    revision = before["provider_revision"]
+    code, preview = _run(registry, revision)
+    assert code == 0, preview
+    assert preview["dry_run"] is True
+    assert preview["narrative_preserved"] is False
+    assert preview["recovery_scope"] == "todo_sections_only"
+    assert not state.exists()
+    code, delivered = _run(registry, revision, "--execute")
+    assert code == 0, delivered
+    assert delivered["status"] == "delivered"
+    assert delivered["narrative_preserved"] is False
+    text = state.read_text()
+    assert "todo_active" in text and "todo_archived" in text
+    assert "claimed_by=agent-a" in text
+    assert "Agent-generated acceptance is not in the Todo store." not in text
+    assert "not recovered" in text
+    if os.name == "posix":
+        assert stat.S_IMODE(state.stat().st_mode) == 0o600
+    code, replay = _run(registry, revision, "--execute")
+    assert code == 0 and replay["status"] == "current", replay
+    assert state.read_text() == text
+    assert _read(runtime) == before
+
+
+def test_committed_update_automatically_recovers_missing_display(canonical_display):
+    registry, runtime, state = canonical_display
+    state.unlink()
+    code, result = _cli(
+        registry, "update", "--goal-id", "goal-a", "--role", "agent",
+        "--todo-id", "todo_active", "--agent-id", "agent-a", "--text", "Committed without a display.",
+    )
+    assert code == 0, json.dumps(result)
+    assert result["projection_delivery"] == "delivered"
+    assert result["projection_outbox"]["recovery_scope"] == "todo_sections_only"
+    committed = _read(runtime)
+    assert committed["todos"][0]["text"] == "Committed without a display."
+    code, repaired = _run(registry, committed["provider_revision"], "--execute")
+    assert code == 0, repaired
+    assert "Committed without a display." in state.read_text()
+    assert _read(runtime) == committed  # Recovery did not repeat the business transaction.
+
+
+@pytest.mark.parametrize("case", ["stale_revision", "no_provider"])
+def test_rebuild_requires_exact_available_authority(canonical_display, case):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    state.unlink()
+    revision = "stale-revision" if case == "stale_revision" else before["provider_revision"]
+    if case == "no_provider":
+        (runtime / "authority" / "file-v0").rename(runtime / "unavailable")
+    code, result = _run(registry, revision, "--execute")
+    assert code == 1, result
+    assert not state.exists()
+    if case == "stale_revision":
+        assert "does not match" in result["error"]
+    else:
+        (runtime / "unavailable").rename(runtime / "authority" / "file-v0")
+    assert _read(runtime) == before
+
+
+@pytest.mark.parametrize("source", [
+    b"\xffgenerated document",
+    b"## Agent Todo\n<!-- loopx:todo-region-v0 role=agent begin -->\nUnstructured content\n",
+])
+def test_rebuild_never_discards_an_existing_damaged_document(canonical_display, source):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    state.write_bytes(source)
+    code, result = _run(registry, before["provider_revision"], "--execute")
+    assert code == 1, result
+    assert state.read_bytes() == source
+    assert _read(runtime) == before
+
+
+def test_recovery_preserves_existing_generated_non_todo_sections(canonical_display):
+    registry, runtime, state = canonical_display
+    source = state.read_bytes()
+    revision = _read(runtime)["provider_revision"]
+    code, result = _run(registry, revision, "--execute")
+    assert code == 0, result
+    assert result["narrative_preserved"] is True
+    assert "recovery_scope" not in result
+    assert state.read_bytes().startswith(source.split(b"## Agent Todo")[0])
+
+
+def test_concurrent_document_restoration_is_not_overwritten(canonical_display, monkeypatch):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    state.unlink()
+    real_link = os.link
+
+    def restore_before_publish(source, destination):
+        Path(destination).write_text("Another writer concurrently restored the generated document.\n")
+        return real_link(source, destination)
+
+    monkeypatch.setattr(provider_projection.os, "link", restore_before_publish)
+    with pytest.raises(FileExistsError):
+        provider_projection.project_current_canonical_todos(
+            registry_path=registry, runtime_root=runtime, goal_id="goal-a",
+            expected_provider_revision=before["provider_revision"],
+        )
+    assert state.read_text() == "Another writer concurrently restored the generated document.\n"
+    assert not list(state.parent.glob(".state.md.*.tmp"))
+    assert _read(runtime) == before
+
+
+@pytest.mark.parametrize("failure_point", ["fsync", "link", "directory_fsync"])
+def test_interrupted_rebuild_is_safe_and_retryable(canonical_display, monkeypatch, failure_point):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    state.unlink()
+
+    def fail(*_args):
+        raise OSError("injected publication failure")
+
+    with monkeypatch.context() as patch:
+        if failure_point == "directory_fsync":
+            patch.setattr(provider_projection, "_fsync_parent_directory", fail)
+        else:
+            patch.setattr(provider_projection.os, failure_point, fail)
+        with pytest.raises(OSError, match="injected publication failure"):
+            provider_projection.project_current_canonical_todos(
+                registry_path=registry, runtime_root=runtime, goal_id="goal-a",
+                expected_provider_revision=before["provider_revision"],
+            )
+    assert not list(state.parent.glob(".state.md.*.tmp"))
+    assert state.exists() is (failure_point == "directory_fsync")
+    code, repaired = _run(registry, before["provider_revision"], "--execute")
+    assert code == 0, repaired
+    assert "todo_active" in state.read_text() and "todo_archived" in state.read_text()
+    assert _read(runtime) == before
+
+
+def test_todo_read_does_not_write_a_missing_display(canonical_display):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    state.unlink()
+    code, result = _cli(registry, "list", "--goal-id", "goal-a")
+    assert code == 0, result
+    assert not state.exists()
+    assert _read(runtime) == before
+
+
+def test_unpromoted_missing_document_is_not_regenerated(canonical_display):
+    from loopx.control_plane.coordination.legacy_writer_fence import legacy_coordination_writer_fence_path
+
+    registry, runtime, state = canonical_display
+    revision = _read(runtime)["provider_revision"]
+    state.unlink()
+    legacy_coordination_writer_fence_path(runtime_root=runtime, goal_id="goal-a").unlink()
+    code, result = _run(registry, revision, "--execute")
+    assert code == 1 and "requires promoted canonical authority" in result["error"]
+    assert not state.exists()
+
+
+def test_production_scale_rebuild_retains_order_and_requires_private_declaration(tmp_path):
+    # Reuse the shared RFC envelope, not a second large fixture or live data.
+    script = (
+        "import {productionScaleCoordinationFixture, PRODUCTION_SCALE_VALIDATION_DECLARATION} "
+        "from './tests/control_plane_ts/production_scale_coordination_fixture.ts';"
+        "process.stdout.write(JSON.stringify({fixture:productionScaleCoordinationFixture('goal-a'),"
+        "declaration:PRODUCTION_SCALE_VALIDATION_DECLARATION}));"
+    )
+    generated = subprocess.run(
+        ["node", "--no-warnings", "--experimental-strip-types", "--input-type=module", "-e", script],
+        capture_output=True, text=True, check=True, timeout=30,
+    )
+    data = json.loads(generated.stdout)
+    projection = data["fixture"]["projection"]
+    runtime, state, registry = tmp_path / "runtime", tmp_path / "state.md", tmp_path / "registry.json"
+    state.write_text("## Agent Todo\n")
+    registry.write_text(json.dumps({"common_runtime_root": str(runtime), "goals": [
+        {"id": "goal-a", "repo": str(tmp_path), "state_file": state.name},
+    ]}))
+    initialize_canonical_authority(runtime, "goal-a", projection, state_path=state)
+    before = _read(runtime)
+    state.unlink()
+    code, rejected = _run(registry, before["provider_revision"], "--execute")
+    assert code == 1 and "private validation declaration" in rejected["error"]
+    assert not state.exists()  # Do not erase a validation obligation to make recovery pass.
+    persist_completion_validation_declaration(
+        runtime_root=runtime, goal_id="goal-a", todo_id=data["fixture"]["completion_todo_id"],
+        declaration=data["declaration"],
+    )
+    code, result = _run(registry, before["provider_revision"], "--execute")
+    assert code == 0, result
+    assert result["todo_count"] == 464
+    rendered = state.read_text()
+    for role, count in (("agent", 256), ("user", 208)):
+        positions = [rendered.index(f"todo_id=todo_fixture_{role}_{index:03d} ") for index in range(count)]
+        assert positions == sorted(positions)
+    assert _read(runtime) == before
+    code, replay = _run(registry, before["provider_revision"], "--execute")
+    assert code == 0 and replay["changed"] is False

--- a/tests/control_plane/test_todo_provider_projection.py
+++ b/tests/control_plane/test_todo_provider_projection.py
@@ -135,7 +135,12 @@ def test_settlement_preserves_commit_and_replays_after_projection_failure(
     assert committed["status"] == "applied"
     assert committed["changed"] is True
     assert committed["projection_delivery"] == "pending"
-    assert committed["projection_outbox"] == {
+    outbox = dict(committed["projection_outbox"])
+    recommendation = outbox.pop("recommended_action")
+    assert "todo list" in recommendation
+    assert "todo project-markdown" in recommendation
+    assert outbox.pop("retry_business_mutation") is False
+    assert outbox == {
         "schema_version": "loopx_todo_projection_delivery_v0",
         "status": "pending",
         "source": "committed_authority_journal",


### PR DESCRIPTION
## Summary

Make permanent Markdown Todo projections recoverable through the existing delivery path. A promoted Goal can commit a canonical Todo mutation even when its generated display has disappeared; successful projection delivery now recreates that display automatically instead of leaving an avoidable pending repair.

- Regenerate active and archived Todo sections from the canonical head, using the existing renderer, ownership checks and private validation declarations. Normal reads remain read-only; `todo project-markdown` still previews unless `--execute` is supplied.
- Publish a missing file atomically with no-clobber semantics and private POSIX permissions. Preserve existing non-Todo bytes. Malformed existing documents, unavailable authority and stale requested revisions still fail closed.
- Report `recovery_scope=todo_sections_only` and `narrative_preserved=false` for missing-file recovery. The provider does not yet own Objective, operating-contract or other non-Todo sections; this is not whole-Goal restoration.
- Preserve the canonical commit when display delivery fails, with an actionable projection-only retry and `retry_business_mutation=false`.
- Normalize optional `decision_scope.schema_version` through the existing codec for display parity only. A production-scale fixture exposed this representation mismatch; canonical records/digests remain untouched and semantic changes still fail parity.

## Architecture and compatibility

The ownership distinction is canonical state versus generated display, not human-authored versus Agent-authored Markdown. Documentation removes that stale assumption. This batch closes the display-recovery boundary without adding a flag, approval lifecycle, second outbox or storage framework.

TypeScript retains Todo transition/provider authority. Python changes stay in the existing Markdown codec and filesystem delivery boundary. There is no automatic promotion, fallback to Markdown authority, business-command replay or validation re-execution. Existing unpromoted Goals are unchanged. The disclosed default change is limited to missing display files on promoted Goals: delivery now attempts automatic reconstruction.

## Validation

- 83 Python projection/authority/fence integration tests after rebasing to current main; both malformed-display cases additionally rerun after a wording-only fixture refinement.
- Public CLI sensitivity: identical isolated missing-file fixture fails on baseline and succeeds on the candidate; canonical head remains unchanged during regeneration.
- 34 integration tests against isolated real PostgreSQL 16.15; 36 NoKV tests, zero skips in both suites.
- Read-only three-arm rehearsal using disposable runtimes: 436 Todos and 58 leases; exact active semantics, provider heads, ordering, unchanged non-target state and receipts verified. The source was unchanged; no private source content is included here.
- Shared 464-record synthetic envelope covers active/archive ordering and private validation declaration enforcement without copying live data into tests.
- Ruff, configured mypy (21 files), TypeScript typecheck, diff and public-boundary scans pass.
- The existing native-caller oracles now require automatic display delivery while retaining owner/lease/replay checks. All six affected cases pass across absent/disabled/enabled shadow settings; both note-loss and incorrect unclaimed-rejection mutants remain killed by assertions. No tests were removed.
- 18 risk-based premerge checks passed on the production implementation; the subsequent test-only oracle update was qualified separately by the six cases, two mutation controls/regressions, Ruff and diff checks.
- Rebased onto merged #4093 (`b8742e852`). Both commit patches are unchanged by range-diff; 55 projection recovery, renderer and canonical-status cases passed after rebase.
- CI oracle fix at `4b147a565`: 58 projection/recovery/renderer/status tests pass. Both injected business-retry and missing-guidance defects fail assertions. Only the stale test changed; product code is unchanged.
- Exact eight-file quality receipt: `cqr_4e19da1830f61a46169f` (`4b147a565`). One bounded documentation refinement; no unresolved quality findings.

## Sequencing / holds

Complements #4093's merged canonical consumer closure and is now rebased onto that main. The duplicate pytest module blocker is resolved. Requires refreshed hosted CI and review; no self-merge is authorized for this PR. No production Goal was promoted or rewritten for qualification, and no local installation is part of this PR.
