### PR TITLE
test(ci): verify Sonar guards semantically

### DIFF
--- a/tests/test_sonarcloud_workflow.py
+++ b/tests/test_sonarcloud_workflow.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
 WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "sonarcloud.yml"
+
+
+def _workflow_steps(workflow: str) -> list[str]:
+    return re.findall(
+        r"(?ms)^      - name: .+?(?=^      - name: |\Z)",
+        workflow,
+    )
 
 
 def test_missing_sonar_token_reaches_a_successful_skip_step() -> None:
@@ -19,7 +27,19 @@ def test_missing_sonar_token_reaches_a_successful_skip_step() -> None:
 def test_sonar_steps_remain_guarded_by_the_token() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
-    assert workflow.count("if: steps.sonar-token.outputs.available == 'true'") == 3
+    sensitive_actions = (
+        "uses: actions/checkout@",
+        "uses: actions/download-artifact@",
+        "uses: SonarSource/sonarqube-scan-action@",
+    )
+    steps = _workflow_steps(workflow)
+    for action in sensitive_actions:
+        matching_steps = [step for step in steps if action in step]
+        assert matching_steps
+        assert all(
+            "if: steps.sonar-token.outputs.available == 'true'" in step
+            for step in matching_steps
+        )
     assert workflow.count("SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}") == 2
     assert "\n    env:\n      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}" not in workflow
 


### PR DESCRIPTION
## Summary

Repair the current-main pytest failure after SonarCloud gained another token-guarded step.

- Replace the brittle assertion that exactly three guard expressions exist.
- Require every checkout, coverage-download, and Sonar scan action to carry the token-availability guard.
- Keep workflow behavior unchanged and avoid a new YAML dependency.

## Validation

- `tests/test_sonarcloud_workflow.py`: 3 passed.
- The production Stage 2C command collects 213 selected tests without an import-file mismatch.
- Ruff and `git diff --check`: passed.
- Public/private scan: changed path clean; unrelated registry warnings excluded.
- Change Quality: `cqr_408f66781ec2dba14ca0` for head `d9df13e84c54a7acee9c84cc123bc19e8733119f`.
- Premerge: passed, no manual holds, self-merge allowed.

This fixes the independent shard failure observed while qualifying #4096 and #4065. No workflow, permission, secret scope, or runtime behavior is changed.
