### PR TITLE
perf(state): bound limited rollout log reads

### DIFF
--- a/loopx/rollout_event_log.py
+++ b/loopx/rollout_event_log.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections import Counter
+from collections import Counter, deque
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Mapping, Sequence
@@ -477,10 +477,10 @@ def iter_rollout_events(
 
 
 def load_rollout_events(log_path: Path, *, limit: int | None = None) -> list[dict[str, Any]]:
-    events = list(iter_rollout_events(log_path))
-    if limit is not None:
-        events = events[-max(0, limit) :]
-    return events
+    events = iter_rollout_events(log_path)
+    if limit is None or limit <= 0:
+        return list(events)
+    return list(deque(events, maxlen=limit))
 
 
 def _safe_event_view(event: Mapping[str, Any]) -> dict[str, Any]:

--- a/tests/test_rollout_event_log_loading.py
+++ b/tests/test_rollout_event_log_loading.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import loopx.rollout_event_log as rollout_event_log
+
+
+def test_limited_rollout_event_load_keeps_only_a_bounded_window(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    class TrackedEvent(dict[str, int]):
+        alive = 0
+        peak = 0
+
+        def __init__(self, index: int) -> None:
+            super().__init__(index=index)
+            type(self).alive += 1
+            type(self).peak = max(type(self).peak, type(self).alive)
+
+        def __del__(self) -> None:
+            type(self).alive -= 1
+
+    monkeypatch.setattr(
+        rollout_event_log,
+        "iter_rollout_events",
+        lambda _path: (TrackedEvent(index) for index in range(100)),
+    )
+
+    events = rollout_event_log.load_rollout_events(tmp_path / "unused", limit=3)
+
+    assert [event["index"] for event in events] == [97, 98, 99]
+    assert TrackedEvent.peak <= 4


### PR DESCRIPTION
## Summary

- Stream limited rollout-log reads through a bounded standard-library `deque` instead of retaining the full decoded log before slicing.
- Preserve unbounded behavior for omitted, zero, and negative limits.
- Add a regression check that verifies only the requested tail window remains live while the stream is consumed.

## Issue Or Task

- No linked issue; self-directed core hot-path optimization.
- Contributor task ID: N/A

## Validation

- [x] `uv run --no-project --with pytest pytest -q tests/test_rollout_event_log_loading.py tests/control_plane/test_heartbeat_receipt.py tests/control_plane/test_todo_decision_scope_cli_validation.py` (17 passed)
- [x] `uv run --no-project --with ruff ruff check loopx/rollout_event_log.py tests/test_rollout_event_log_loading.py`
- [x] `scripts/loopx canary premerge --from-git-diff` (6/6 selected canaries passed)
- [x] `git diff --check`
- [x] Synthetic benchmark: 100,000 events, tail limit 500; median 69.94 ms → 60.61 ms, peak 48.46 MiB → 0.27 MiB (~99.4% lower)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [x] Test update

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: N/A

## Shared-authority RFC fixture impact

N/A. This change does not alter the TypeScript control-plane migration or shared Goal Authority fixtures.

## Boundary Checklist

- [x] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the task above.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).