### PR TITLE
fix: return a typed error for oversized runtime requests

### DIFF
--- a/loopx/control_plane/effect_runtime_server.ts
+++ b/loopx/control_plane/effect_runtime_server.ts
@@ -63,12 +63,25 @@ const server = createServer((socket) => {
   resetIdleTimer(server);
   socket.setEncoding("utf8");
   let raw = "";
+  let receivedBytes = 0;
   socket.on("data", (chunk: string) => {
-    raw += chunk;
-    if (Buffer.byteLength(raw, "utf8") > MAX_REQUEST_BYTES) {
-      socket.destroy();
+    receivedBytes += Buffer.byteLength(chunk, "utf8");
+    if (receivedBytes > MAX_REQUEST_BYTES) {
+      raw = "";
+      socket.pause();
+      socket.removeAllListeners("data");
+      writeResponse(socket, {
+        schema_version: RESPONSE_SCHEMA,
+        request_id: "unknown",
+        ok: false,
+        error: effectRuntimeErrorPayload(new EffectRuntimeRequestError(
+          "Effect runtime request exceeds the 2 MiB limit",
+          "request_too_large",
+        )),
+      });
       return;
     }
+    raw += chunk;
     if (!raw.includes("\n")) return;
     socket.pause();
     void (async () => {

--- a/tests/control_plane/test_effect_runtime_integration.py
+++ b/tests/control_plane/test_effect_runtime_integration.py
@@ -797,6 +797,44 @@ def test_oversized_request_is_rejected_before_runtime_dispatch(
     )
 
 
+@pytest.mark.parametrize("unit", [b"x", "界".encode()])
+def test_oversized_raw_socket_request_returns_typed_error(
+    tmp_path: Path,
+    monkeypatch,
+    unit: bytes,
+) -> None:
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setattr(effect_runtime, "_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setenv("LOOPX_EFFECT_RUNTIME_IDLE_MS", "1000")
+
+    ping = effect_runtime.effect_runtime_result("runtime.ping", {})
+    fingerprint = effect_runtime._runtime_fingerprint()
+    info = effect_runtime._read_info(
+        effect_runtime._runtime_info_path(fingerprint),
+        fingerprint=fingerprint,
+    )
+    assert info is not None
+    repeats = effect_runtime.MAX_REQUEST_BYTES // len(unit) + 1
+
+    response = _raw_runtime_response(info, unit * repeats)
+
+    assert response == {
+        "schema_version": effect_runtime.EFFECT_RUNTIME_RESPONSE_SCHEMA_VERSION,
+        "request_id": "unknown",
+        "ok": False,
+        "error": {
+            "kind": "request_rejected",
+            "code": "request_too_large",
+            "message": "Effect runtime request exceeds the 2 MiB limit",
+        },
+    }
+    assert (
+        effect_runtime.effect_runtime_result("runtime.ping", {})["pid"]
+        == ping["pid"]
+    )
+    effect_runtime.effect_runtime_result("runtime.shutdown", {}, retry_safe=False)
+
+
 def test_non_object_json_request_is_rejected_at_the_socket_boundary(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- track incoming Effect Runtime request bytes incrementally
- return a bounded `request_too_large` response envelope instead of resetting the socket
- stop buffering and detach the data listener after the limit is crossed
- add ASCII and multibyte UTF-8 raw-socket regressions and verify the runtime remains healthy

## Validation

- `python -m pytest tests/control_plane/test_effect_runtime_integration.py` (29 passed)
- `npm run typecheck:control-plane`

Closes #4108
