### PR TITLE
docs(desktop): propose bounded computer use in Manager workspace

### DIFF
--- a/docs/architecture/rfcs/desktop-execution-frontends-v0.md
+++ b/docs/architecture/rfcs/desktop-execution-frontends-v0.md
@@ -577,6 +577,120 @@ document content remain owner-local. LoopX durable state keeps only public-safe
 capability and operation identity, provider revision and profile digests,
 bounded evidence references, and admitted receipts.
 
+## Optional computer use in the Manager workspace
+
+Implementation tracker: [#4114](https://github.com/huangruiteng/loopx/issues/4114).
+
+### Product decision and ownership
+
+Add an opt-in desktop-operation entry to the existing Manager workspace for
+bounded work that lacks a suitable API or CLI. Prefer a declared API/CLI when
+it can perform and verify the same authorized effect. A first useful task is
+preparing a draft in an approved application and stopping before submission.
+The entry must resolve an explicit Goal, Todo, Agent, and existing working
+session before dispatch. It neither inserts a relay manager Agent nor starts
+a third execution mode. Attached sessions use only host-advertised tools;
+managed sessions may explicitly enable an optional provider.
+
+Placement: the first outcome owner is `content-ops` for draft preparation;
+computer use remains a provider execution surface under
+[`computer_use_runtime_v0`](../../reference/protocols/computer-use-runtime-v0.md),
+not a new built-in capability. A candidate provider id is `maka-cu`, delivered
+as an optional extension/package if selected. Its install, doctor, disable,
+and compatibility belong to the provider; the existing Desktop broker owns
+presentation. The capability interprets receipts and proposes transitions;
+the Kernel retains Todo, gate, evidence, and quota authority. Existing schemas
+and the contract validator are the starting point, not another builder layer.
+
+### Implementation evidence and adoption boundary
+
+The reference is Apache Maka at commit
+[`87797378`](https://github.com/apache/maka/tree/87797378cec89e2a31351f64656dc8d26a10e73d).
+This is a source inspection, not a LoopX live qualification:
+
+- Its [model tool](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/packages/runtime/src/computer-use-tools.ts)
+  exposes application discovery, observation, semantic element actions,
+  keyboard input, and window operations. Observation defaults to an element
+  tree; screenshots are explicit. Raw coordinate input is excluded from the
+  production model action space. Ordered element sequences re-observe per step.
+- The [host adapter](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/packages/computer-use/README.md)
+  connects Runtime to a supervised native child through `maka.cu/2` JSON-RPC
+  over stdio, with digest verification, handshake, cancellation, and generation
+  invalidation. Desktop cursor/PiP is downstream presentation, not authority.
+- The [pinned executor manifest](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/apps/desktop/bundled-tools.json)
+  names native commit `4a9787d2`, ad-hoc signing, missing notarization, and
+  `distributionReady: false`. The product selector enables only macOS with a
+  supplied executable and digest. A downloadable Desktop does not prove CU
+  executor availability or cross-platform readiness.
+- [Host-event limitations](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/docs/computer-use-host-events-contract.md)
+  distinguish typed intervention from UI content changes and explicitly leave
+  global physical-input attribution and stronger process-instance identity
+  incomplete. [Evidence classes](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/docs/computer-use-evidence-classes.md)
+  separate real-runtime qualification, injected failures, protocol tests, and
+  static checks; none substitutes for the others.
+
+Adopt the observation/action/readback and takeover design. Keep provider
+selection open until an isolated live slice proves it. The
+[native implementation](https://github.com/maka-agent/maka-cu/tree/4a9787d2c7f2fbc6a29b33d691916c6b84543661/packages/OpenComputerUseKit/Sources/OpenComputerUseKit)
+uses Swift, macOS Accessibility, and private SkyLight input paths. Its
+[provenance record](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/docs/computer-use-provenance.md)
+distinguishes MIT-derived code from proprietary-binary observations. Any
+redistribution needs its own provenance, notice, signing, and compatibility
+review; this RFC does not select the entire Maka runtime or copy its cursor.
+
+### Required behavior
+
+1. **Visible scope.** Show the chosen application/window, bounded objective,
+   permitted effect, stop condition, provider readiness, and screenshot/model
+   routing before activation. Enablement grants neither logged-in account
+   access nor new external-write authority. Reuse valid scoped authorization;
+   installation and OS permissions alone are insufficient.
+2. **Fresh target binding.** Bind each action to the current observation and
+   target process/window generation. Reject stale or ambiguous targets; never
+   fall back to foreground/global input. Re-observe after actions and require
+   effect-specific readback before claiming completion. Transport success alone
+   cannot complete a Todo.
+3. **Human control.** Show compact progress and an immediate Stop/Take over
+   control in the existing workspace and Goal Chat. Stop revokes pending input
+   authority; already-dispatched unknown effects require reconciliation.
+   Lock, disconnect, target restart, or attributable intervention invalidate
+   observations. Resume requires fresh observation and current scope. Unknown
+   modals and new permission decisions return a concrete human gate.
+4. **Bounded execution.** Serialize competing operations on the same target
+   across Agents, bound action/time/retry budgets, and never blindly replay a
+   mutation after service loss. Provider detail remains typed and local; map
+   receipts to the existing closed stop-reason enum without adding ad hoc
+   strings. Persist uncertain outcome facts for reconciliation, not retry
+   instructions inferred from prose.
+5. **Private evidence.** Keep screenshots, AX text, typed values, titles, and
+   replay data in the host-owned private boundary. Model transmission requires
+   the selected provider's consent and modality policy. Shared projections use
+   redacted facts/handles; viewing private evidence requires owner access.
+6. **Default-off isolation.** Disabled or unavailable providers expose no CU
+   tools, launch no executor, and request no OS permissions. Disable revokes
+   sessions and stops the child; uninstall removes its managed package and
+   documents OS-permission revocation. Neither operation alters Goal state.
+
+### First delivery slice and acceptance
+
+Implement one `content-ops` draft-until-review flow through an optional
+provider and the existing working session, then project its receipt and
+human gate in Manager/Goal Chat. Do not add shared session/handoff protocols
+until a second real consumer demonstrates the need. This is a proposed slice,
+not a claim of shipped commands or a commitment to Maka as the runtime.
+
+Acceptance requires the production entrypoint, a real model and native
+executor, and an isolated synthetic application with independently checked
+field values and an untouched Submit control. Also cover a decoy window,
+stale observation, app restart, concurrent target claims, user takeover,
+screen lock, uncertain dispatch, and disable/re-enable. Distinguish actual
+host events from injected failures. Record exact provider/model/executor
+versions, completion, latency, action count, interventions, forbidden effects,
+and privacy checks; a recorded fixture or schema-only smoke is insufficient.
+Prove feature-off parity in both frontend modes, including tool exposure,
+process startup, ingress, projection, and writeback. Preview any visible UI
+change for owner approval before committing its implementation.
+
 ## State and identity boundaries
 
 The frontend stores one Agent-scoped working-session binding whose public

--- a/docs/architecture/rfcs/desktop-execution-frontends-v0.zh-CN.md
+++ b/docs/architecture/rfcs/desktop-execution-frontends-v0.zh-CN.md
@@ -487,6 +487,90 @@ provider 直接变更 Goal 或 Todo 状态。
 owner-local。LoopX 持久状态只保存 public-safe 的 capability 与 operation
 身份、provider revision 与 profile digest、有界证据引用和已准入回执。
 
+## 管家工作区中的可选 Computer Use
+
+实施跟踪：[#4114](https://github.com/huangruiteng/loopx/issues/4114)。
+
+### 产品决策与归属
+
+在现有管家工作区增加显式启用的桌面操作入口，处理缺少合适 API 或 CLI 的有界任务。
+当声明过的 API/CLI 可以完成并验证同一授权效果时，优先使用它。首个场景是：在指定应用
+准备草稿，停在提交前。派发前必须确定 Goal、Todo、Agent 和已有工作会话；不增加中转
+管家 Agent，也不增加第三种执行模式。挂接模式只使用宿主声明的工具；托管模式可以
+显式启用可选 provider。
+
+归属：首个草稿场景由 `content-ops` 拥有；Computer Use 沿用
+[`computer_use_runtime_v0`](../../reference/protocols/computer-use-runtime-v0.md)
+的 provider 执行面定位，不新增内置 capability。候选 provider id 为 `maka-cu`，若被
+选用则通过可选 extension/package 交付，负责安装、doctor、禁用和兼容性；现有 Desktop
+broker 负责呈现。Capability 解释回执并提出状态迁移，Kernel 保留 Todo、gate、evidence
+和 quota 权威。复用现有 schema 和契约校验器，不再平行增加一套 builder。
+
+### 实现证据与采用边界
+
+参考 Apache Maka 的固定提交
+[`87797378`](https://github.com/apache/maka/tree/87797378cec89e2a31351f64656dc8d26a10e73d)。
+以下是源码核查结果，不代表已通过 LoopX 真机资格验证：
+
+- [模型工具](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/packages/runtime/src/computer-use-tools.ts)
+  提供应用发现、观察、语义元素操作、键盘输入和窗口操作。观察默认返回元素树，截图显式
+  请求；生产模型动作面排除裸坐标输入，有序元素操作在每一步重新观察。
+- [宿主适配层](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/packages/computer-use/README.md)
+  通过 stdio 上的 `maka.cu/2` JSON-RPC 连接 Runtime 与受监督的 native 子进程，包含
+  摘要校验、握手、取消和 generation 失效处理。Desktop 的光标/PiP 是下游呈现，不拥有
+  动作权威。
+- [执行器清单](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/apps/desktop/bundled-tools.json)
+  固定 native 提交 `4a9787d2`，标记 ad-hoc 签名、缺少 notarization、
+  `distributionReady: false`。产品选择器仅在 macOS 且提供执行器与摘要时启用。
+  Desktop 可下载，不等于 CU 执行器可用或已支持跨平台。
+- [宿主事件边界](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/docs/computer-use-host-events-contract.md)
+  区分 typed intervention 与 UI 内容变化，并明确全局物理输入归因、更强的进程实例身份
+  仍有缺口。[证据分级](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/docs/computer-use-evidence-classes.md)
+  区分 real-runtime、故障注入、协议测试和静态检查，各类证据不能互相替代。
+
+采用其观察、动作、回读与接管设计；provider 选型待隔离真机切片验证。
+[原生实现](https://github.com/maka-agent/maka-cu/tree/4a9787d2c7f2fbc6a29b33d691916c6b84543661/packages/OpenComputerUseKit/Sources/OpenComputerUseKit)
+使用 Swift、macOS Accessibility 和私有 SkyLight 输入路径。
+[来源记录](https://github.com/apache/maka/blob/87797378cec89e2a31351f64656dc8d26a10e73d/docs/computer-use-provenance.md)
+区分 MIT 派生代码与专有二进制行为观察。若分发执行器，需要单独完成来源、notice、签名
+和兼容性审查；本 RFC 不选用整套 Maka runtime，也不复制其光标实现。
+
+### 必需行为
+
+1. **范围可见。** 启用前展示目标应用/窗口、有界目标、允许的效果、停止条件、provider
+   就绪状态和截图/model 路由。启用不授予登录账户访问或新的外部写权限；复用有效的
+   范围授权，安装和 OS 权限本身不构成任务授权。
+2. **目标新鲜度。** 每次动作绑定当前 observation 和目标进程/窗口 generation，拒绝
+   过期或歧义目标，不回退到前台或全局输入。动作后重新观察，完成声明必须有对应效果
+   的回读；传输成功不能直接完成 Todo。
+3. **人可接管。** 在现有工作区与 Goal Chat 展示简洁进度和即时 Stop/Take over 入口。
+   停止撤销待执行输入的权限；已派发但效果未知的动作需要核对结果。锁屏、断连、目标
+   重启或可归因的用户介入使旧观察失效，恢复前重新观察并核对范围。未知弹窗与新权限
+   决策进入具体的人类 gate。
+4. **执行有界。** 对不同 Agent 竞争同一目标的操作串行化，限制动作数、时间和重试预算，
+   服务丢失后不盲目重放写动作。Provider 细节保留为本地 typed 状态，回执映射到现有
+   封闭 stop-reason 枚举，不随意扩展字符串。持久化未知效果的事实用于恢复核对，不从
+   自然语言推断重试指令。
+5. **证据私有。** 截图、AX 文本、输入值、窗口标题和 replay 数据留在宿主私有边界。
+   发给模型须满足所选 provider 的用户同意与模态策略。共享投影仅包含脱敏事实/句柄，
+   查看私有证据仍需要 owner 访问权限。
+6. **默认关闭隔离。** 禁用或不可用时不暴露 CU 工具、不启动执行器、不请求 OS 权限。
+   禁用撤销会话并停止子进程；卸载移除受管包并说明如何撤销 OS 权限。两者均不改变
+   Goal 状态。
+
+### 首个交付切片与验收
+
+通过可选 provider 和已有工作会话完成一个 `content-ops` 草稿至复核流程，将回执与
+人类 gate 投影到管家/Goal Chat。第二个真实消费者证明需求前，不增加共享 session/handoff
+协议。这是待实现切片，不代表已有可运行命令，也不承诺将 Maka 作为 runtime。
+
+验收必须经过生产入口、真实模型与 native executor，操作隔离的合成应用，独立检查字段值
+与 Submit 控件未被触发。另须覆盖干扰窗口、过期观察、应用重启、并发目标占用、用户接管、
+锁屏、派发结果未知、禁用再启用；真实宿主事件与故障注入分别记账。记录 provider/model/
+executor 精确版本、完成情况、延迟、动作数、人工介入、禁止效果和隐私检查。录制 fixture
+或 schema smoke 不足以证明通过。两种前端模式均须证明关闭时的工具暴露、进程启动、入口
+路由、投影和 writeback 对等；实现可见 UI 变化时，先提供预览并取得 owner 批准再提交。
+
 ## 状态与身份边界
 
 前端存储一个 Agent 级的工作会话绑定，其公开投影足以重连并解释所有权。传输


### PR DESCRIPTION
The Manager workspace needs a bounded way for an existing Agent to operate an application when an API/CLI cannot complete the authorized task. Add matching English/Chinese requirements to the Desktop Execution Frontends RFC: an optional provider, fresh observation-bound actions, visible stop/takeover, private evidence, and a draft-until-review acceptance slice.

The design is grounded in exact Maka and native-executor source revisions. It records the macOS selection and unsigned/not-distribution-ready executor boundary, keeps Maka as a candidate, and reuses LoopX's existing computer-use protocol. No runtime or visible UI behavior changes.

Tracks #4114; related historical schema task #3110 and landed contract #3279. This PR documents the requirement and does not close the implementation issue.

Validation: `git diff --check`; bilingual relative-link check; candidate-path private/credential scan; `uv run --no-project --with jsonschema python examples/computer-use-runtime-contract-smoke.py` passed 12 cases (4 accepted, 8 rejected). The initial system-Python attempt lacked jsonschema; the isolated uv environment resolved it. No live desktop/model qualification was run or claimed.

Future-facing scope pass: reuse the existing content-ops/provider/Kernel boundary; defer shared session/handoff extraction until a second real consumer. No code refactor is needed for this documentation-only change. Only the two RFC files are included.
