### PR TITLE
fix: recover nested material monitor settlement

### DIFF
--- a/loopx/control_plane/quota/monitor_poll_commit.ts
+++ b/loopx/control_plane/quota/monitor_poll_commit.ts
@@ -730,6 +730,7 @@ function buildRecord(request: MonitorRequest): JsonObject {
     generated_at: request.generated_at,
     goal_id: request.goal_id,
     classification: QUOTA_MONITOR_POLL_CLASSIFICATION,
+    material_change: material,
     recommended_action: request.decision.recommended_action ?? recommendationReason ??
       request.decision.reason,
     health_check: healthCheck,

--- a/loopx/control_plane/quota/refresh_recovery.ts
+++ b/loopx/control_plane/quota/refresh_recovery.ts
@@ -56,6 +56,14 @@ function canonical(value: unknown): string {
 
 type Decision = "append" | "replay" | "repair_receipt" | "supplement_checkpoint" | "supplement_workspace" | "reject";
 
+export function isMaterialMonitorPoll(run: JsonObject | null): boolean {
+  if (run?.classification !== "quota_monitor_poll") return false;
+  if (run.material_change !== undefined && run.material_change !== null) {
+    return run.material_change === true;
+  }
+  return jsonObject(run.monitor_event)?.material_change === true;
+}
+
 export function refreshRecovery(
   request: RefreshRetryRequest,
   prior: JsonObject | null,
@@ -97,8 +105,8 @@ export function refreshRecovery(
   // A material poll is not a completed refresh: its receipt-bound first
   // workspace supplement may author next-action/vision through normal refresh
   // validation. Once appended, the recovery digests restore strict replay.
-  const firstMonitorCloseout = missingWorkspace && prior.classification === "quota_monitor_poll" &&
-    prior.material_change === true && prior.refresh_recovery == null && checkpoint === null;
+  const firstMonitorCloseout = missingWorkspace && isMaterialMonitorPoll(prior) &&
+    prior.refresh_recovery == null && checkpoint === null;
   if (firstMonitorCloseout) {
     const unrelatedMutation = Object.entries(request.mutation).some(([key, value]) =>
       key !== "next_action" && value !== null && value !== false &&

--- a/loopx/control_plane/quota/refresh_recovery.ts
+++ b/loopx/control_plane/quota/refresh_recovery.ts
@@ -58,10 +58,7 @@ type Decision = "append" | "replay" | "repair_receipt" | "supplement_checkpoint"
 
 export function isMaterialMonitorPoll(run: JsonObject | null): boolean {
   if (run?.classification !== "quota_monitor_poll") return false;
-  if (run.material_change !== undefined && run.material_change !== null) {
-    return run.material_change === true;
-  }
-  return jsonObject(run.monitor_event)?.material_change === true;
+  return run.material_change === true;
 }
 
 export function refreshRecovery(

--- a/loopx/control_plane/quota/settlement_readback.ts
+++ b/loopx/control_plane/quota/settlement_readback.ts
@@ -29,7 +29,12 @@ import {
   receiptBoundReplayPhase,
 } from "./settlement_phase.ts";
 import { isTurnScopedSettlementOutcome } from "../work_items/delivery_outcome.ts";
-import { decodeRefreshRetry, refreshRecovery, type RefreshRetryRequest } from "./refresh_recovery.ts";
+import {
+  decodeRefreshRetry,
+  isMaterialMonitorPoll,
+  refreshRecovery,
+  type RefreshRetryRequest,
+} from "./refresh_recovery.ts";
 
 export const QUOTA_SETTLEMENT_READBACK_REQUEST_SCHEMA =
   "loopx_quota_settlement_readback_request_v0";
@@ -427,7 +432,7 @@ function inferPersistedIdentity(
     if (
       classification === "quota_slot_voided" ||
       classification === "quota_scheduler_ack" ||
-      (classification === "quota_monitor_poll" && run.material_change !== true) ||
+      (classification === "quota_monitor_poll" && !isMaterialMonitorPoll(run)) ||
       (classification === "state_refreshed" &&
         !isTurnScopedSettlementOutcome(
           run.delivery_outcome,
@@ -786,7 +791,7 @@ export async function readQuotaSettlement(value: unknown): Promise<JsonObject> {
     completion_event: completionEvent,
     monitor_phase: receiptBoundMonitorPhase({
       poll_present: monitorPoll !== null,
-      material_change: monitorPoll?.material_change === true,
+      material_change: isMaterialMonitorPoll(monitorPoll),
       durable_writeback_present: writeback.failure === null,
       quota_spend_present: spend.failure === null,
     }),

--- a/tests/control_plane_ts/quota_monitor_poll_commit.test.ts
+++ b/tests/control_plane_ts/quota_monitor_poll_commit.test.ts
@@ -120,8 +120,25 @@ test("event phase matches the legacy quiet monitor event", async () => {
   const event = result.record?.monitor_event as Record<string, unknown>;
   assert.equal(event.reason_summary, "Wait for a public transition.");
   assert.equal(event.material_change, false);
+  assert.equal(result.record?.material_change, false);
   assert.equal(result.record?.health_check, "monitor-only poll unchanged; no quota spend; no material transition");
   assert.equal(result.record?.delivery_outcome, "surface_only");
+});
+
+test("event phase preserves material change on the complete run record", async () => {
+  const result = await evaluateQuotaMonitorPollCommit(request({
+    observation: observation({
+      todo_id: "todo_public_monitor",
+      result_hash: "approved-42",
+      material_change: true,
+    }),
+  }));
+
+  assert.equal(result.record?.material_change, true);
+  assert.equal(
+    (result.record?.monitor_event as Record<string, unknown>).material_change,
+    true,
+  );
 });
 
 test("admission revalidates due, external, and exact blocked-wait modes", async () => {

--- a/tests/control_plane_ts/quota_settlement_readback.test.ts
+++ b/tests/control_plane_ts/quota_settlement_readback.test.ts
@@ -262,49 +262,6 @@ test("keeps partial settlement fail-closed without losing durable facts", async 
   assert.equal((result.writeback_run as any).delivery_outcome, "outcome_progress");
 });
 
-test("recovers an exact-turn material monitor persisted with nested evidence", async () => {
-  const runtimeRoot = await fixture({ workspace: true });
-  try {
-    await appendFile(
-      join(runtimeRoot, "goals", goalId, "runs", "index.jsonl"),
-      `${JSON.stringify({
-        classification: "quota_monitor_poll",
-        delivery_outcome: "outcome_progress",
-        goal_id: goalId,
-        agent_id: agentId,
-        todo_id: todoId,
-        turn_instance_id: turnId,
-        monitor_event: { material_change: true },
-      })}\n`,
-    );
-
-    const result = await readQuotaSettlement(request(runtimeRoot, {
-      refresh_retry: {
-        vision: { state: "vision_active" },
-        unchanged_reason: null,
-        merge_patch: false,
-        workspace_requested: true,
-        mutation: { next_action: "Validate the material successor." },
-        delivery_outcome: "outcome_progress",
-        delivery_batch_scale: null,
-        delivery_boundary: null,
-        progress_observation: null,
-      },
-    }));
-
-    assert.equal((result.writeback_run as any).material_change, undefined);
-    assert.equal((result.writeback_run as any).monitor_event.material_change, true);
-    assert.equal((result.refresh_recovery as any).decision, "supplement_workspace");
-    assert.equal(
-      (result.refresh_recovery as any).reason,
-      "complete_material_monitor_writeback",
-    );
-    assert.equal(result.monitor_phase, "settlement_pending");
-  } finally {
-    await rm(runtimeRoot, { recursive: true, force: true });
-  }
-});
-
 test("rejects non-ENOENT settlement readback I/O failures", async (t) => {
   const runtimeRoot = await fixture();
   const indexPath = join(runtimeRoot, "goals", goalId, "runs", "index.jsonl");

--- a/tests/control_plane_ts/quota_settlement_readback.test.ts
+++ b/tests/control_plane_ts/quota_settlement_readback.test.ts
@@ -262,6 +262,49 @@ test("keeps partial settlement fail-closed without losing durable facts", async 
   assert.equal((result.writeback_run as any).delivery_outcome, "outcome_progress");
 });
 
+test("recovers an exact-turn material monitor persisted with nested evidence", async () => {
+  const runtimeRoot = await fixture({ workspace: true });
+  try {
+    await appendFile(
+      join(runtimeRoot, "goals", goalId, "runs", "index.jsonl"),
+      `${JSON.stringify({
+        classification: "quota_monitor_poll",
+        delivery_outcome: "outcome_progress",
+        goal_id: goalId,
+        agent_id: agentId,
+        todo_id: todoId,
+        turn_instance_id: turnId,
+        monitor_event: { material_change: true },
+      })}\n`,
+    );
+
+    const result = await readQuotaSettlement(request(runtimeRoot, {
+      refresh_retry: {
+        vision: { state: "vision_active" },
+        unchanged_reason: null,
+        merge_patch: false,
+        workspace_requested: true,
+        mutation: { next_action: "Validate the material successor." },
+        delivery_outcome: "outcome_progress",
+        delivery_batch_scale: null,
+        delivery_boundary: null,
+        progress_observation: null,
+      },
+    }));
+
+    assert.equal((result.writeback_run as any).material_change, undefined);
+    assert.equal((result.writeback_run as any).monitor_event.material_change, true);
+    assert.equal((result.refresh_recovery as any).decision, "supplement_workspace");
+    assert.equal(
+      (result.refresh_recovery as any).reason,
+      "complete_material_monitor_writeback",
+    );
+    assert.equal(result.monitor_phase, "settlement_pending");
+  } finally {
+    await rm(runtimeRoot, { recursive: true, force: true });
+  }
+});
+
 test("rejects non-ENOENT settlement readback I/O failures", async (t) => {
   const runtimeRoot = await fixture();
   const indexPath = join(runtimeRoot, "goals", goalId, "runs", "index.jsonl");

--- a/tests/control_plane_ts/refresh_recovery.test.ts
+++ b/tests/control_plane_ts/refresh_recovery.test.ts
@@ -44,21 +44,17 @@ test("digest uses JSON structure, not property insertion order", () => {
 test("workspace supplements preserve the monitor compatibility boundary", () => {
   const monitor = { ...prior, classification: "quota_monitor_poll", material_change: true,
     vision_checkpoint: null, delivery_batch_scale: null };
-  const nestedMonitor = { ...monitor, material_change: undefined,
-    monitor_event: { material_change: true } };
   assert.equal(refreshRecovery({ ...request, workspace_requested: true }, monitor, true, "required", false).decision, "supplement_workspace");
   const closeout = { ...request, workspace_requested: true, vision: { state: "vision_active" },
     mutation: { next_action: "Validate the successor", autonomous_replan_recorded: false } };
   const admitted = refreshRecovery(closeout, monitor, false, "required", false);
   assert.equal(admitted.reason, "complete_material_monitor_writeback");
-  assert.equal(
-    refreshRecovery(closeout, nestedMonitor, false, "required", false).reason,
-    "complete_material_monitor_writeback",
-  );
   assert.equal(refreshRecovery(closeout, monitor, false, "required", true).decision, "reject");
   for (const invalid of [
     { ...monitor, material_change: false }, { ...monitor, classification: "ordinary_refresh" },
-    { ...nestedMonitor, material_change: false },
+    { ...monitor, material_change: undefined, monitor_event: { material_change: true } },
+    { ...monitor, material_change: null, monitor_event: { material_change: true } },
+    { ...monitor, material_change: "true", monitor_event: { material_change: true } },
     { ...monitor, refresh_recovery: admitted }, { ...monitor, vision_checkpoint: prior.vision_checkpoint },
   ]) assert.equal(refreshRecovery(closeout, invalid, false, "required", false).decision, "reject");
   for (const invalid of [

--- a/tests/control_plane_ts/refresh_recovery.test.ts
+++ b/tests/control_plane_ts/refresh_recovery.test.ts
@@ -44,14 +44,21 @@ test("digest uses JSON structure, not property insertion order", () => {
 test("workspace supplements preserve the monitor compatibility boundary", () => {
   const monitor = { ...prior, classification: "quota_monitor_poll", material_change: true,
     vision_checkpoint: null, delivery_batch_scale: null };
+  const nestedMonitor = { ...monitor, material_change: undefined,
+    monitor_event: { material_change: true } };
   assert.equal(refreshRecovery({ ...request, workspace_requested: true }, monitor, true, "required", false).decision, "supplement_workspace");
   const closeout = { ...request, workspace_requested: true, vision: { state: "vision_active" },
     mutation: { next_action: "Validate the successor", autonomous_replan_recorded: false } };
   const admitted = refreshRecovery(closeout, monitor, false, "required", false);
   assert.equal(admitted.reason, "complete_material_monitor_writeback");
+  assert.equal(
+    refreshRecovery(closeout, nestedMonitor, false, "required", false).reason,
+    "complete_material_monitor_writeback",
+  );
   assert.equal(refreshRecovery(closeout, monitor, false, "required", true).decision, "reject");
   for (const invalid of [
     { ...monitor, material_change: false }, { ...monitor, classification: "ordinary_refresh" },
+    { ...nestedMonitor, material_change: false },
     { ...monitor, refresh_recovery: admitted }, { ...monitor, vision_checkpoint: prior.vision_checkpoint },
   ]) assert.equal(refreshRecovery(closeout, invalid, false, "required", false).decision, "reject");
   for (const invalid of [


### PR DESCRIPTION
## Summary

- persist `material_change` on complete monitor-poll run records as well as nested monitor events
- recognize historical nested-only material monitor records during settlement recovery
- preserve fail-closed precedence when an explicit top-level `false` conflicts with nested evidence

## Validation

- `npm run typecheck:control-plane`
- `npm run test:control-plane` (850 passed, 0 failed, 1 skipped; run with Python 3.12 on PATH)
- focused quota monitor, refresh recovery, settlement readback, and Python lifecycle tests
- `loopx canary premerge --from-git-diff --goal-id loopx-product` (17/17 selected checks passed)
- `git diff --check`

## Review notes

- The TypeScript quota boundary remains the single settlement authority; no Python-side duplicate rule was added.
- The future-facing refactor pass reused one shared material-monitor classifier across recovery and readback. A broader refactor was unnecessary for this compatibility repair.
- No scheduler, scoring, permission, or public/private evidence boundary behavior changes.
