### PR TITLE
docs(readme): add restrained benchmark evidence links

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,18 @@ These are the three strongest current cases, not the full inventory. Browse the
 [complete Showcase catalog](docs/showcases/README.md) for contributor cases,
 creator dogfooding, reproducible demos, and explicit evidence-strength labels.
 
+### Exploratory Benchmark Studies
+
+- **[SWE-Marathon](https://huangruiteng.github.io/loopx/benchmarks/swe-marathon/):**
+  Five execution modes on 15 matched tasks compare self-verification, scores,
+  and cost. More self-verification did not consistently yield higher scores.
+- **[DeepSWE behavior analysis](https://huangruiteng.github.io/loopx/benchmarks/deepswe/behavior-discovery/)** (Chinese):
+  Selected cases examine how domain hints relate to requirement retention and
+  verification choices, offering mechanism hypotheses for further testing.
+
+SWE-Marathon has one trial per task and mode; DeepSWE uses selected cases and
+post-hoc analysis. Neither establishes a general performance gain.
+
 More inspectable surfaces:
 
 - the [public homepage](https://huangruiteng.github.io/loopx/) for the product

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,6 +195,17 @@ deterministic CPU evaluator、dev / held-out 命令均在仓库内。可按
 creator dogfooding、reproducible demo 和证据强度标签见
 [Showcase 全量目录](docs/showcases/README.md)。
 
+### 探索性 Benchmark 研究
+
+- **[SWE-Marathon](https://huangruiteng.github.io/loopx/benchmarks/swe-marathon/?lang=zh)**：
+  在相同的 15 个任务上对照 5 种执行模式，比较自验证行为、得分与成本。
+  更多自验证并未稳定转化为更高得分。
+- **[DeepSWE 行为分析](https://huangruiteng.github.io/loopx/benchmarks/deepswe/behavior-discovery/)**：
+  通过精选案例观察领域提示、需求保留与验证选择之间的关系，提出有待复验的机制假设。
+
+SWE-Marathon 每个任务、每种模式仅运行一次；DeepSWE 包含精选案例与事后分析。
+目前两者均不足以证明普遍的性能提升。
+
 更多可检查入口：
 
 - [产品首页](https://huangruiteng.github.io/loopx/)：查看产品叙事、快速开始和长程证据；


### PR DESCRIPTION
Add a compact bilingual benchmark-study subsection to the existing README evidence section. It links the published SWE-Marathon and DeepSWE reports, summarizes their scope, and keeps single-trial, selected-case, and generalization limits beside the links.

Validation: existing README/demo and star-history smokes; source review against the published study materials; live destination HTTP checks; public-boundary scan; `git diff --check`. Only the two READMEs change.
