### PR TITLE
docs(contributing): make PR validation explicit and public-safe

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,39 @@
 
 ## Validation
 
-- [ ] `python3 -m py_compile loopx/*.py`
-- [ ] `loopx check --scan-root .`
-- [ ] Other:
+> Public-safe summaries only, including in HTML comments. Do not paste raw logs,
+> private data or prompts, private screenshots, credentials, internal URLs, connection
+> strings, or local paths. Use repository-relative commands without sensitive
+> arguments, aggregate results, and already-public CI links. If evidence is
+> private, report its category and limitations only; do not upload it to prove a claim.
+
+<!-- Replace placeholders; do not leave every enum alternative selected.
+Use one row per relevant check, including required checks not run or blocked.
+Delete the example row. Add rows as needed; there is no required test-count target.
+-->
+
+- Tested revision: <!-- public commit SHA; identify older runs after a code change -->
+- Run state: <!-- choose one: not_run | running | finished (not a claim of adequacy or success) -->
+- Input classes: <!-- choose all used: none | synthetic | public_fixture | authorized_private_read_only; use none alone -->
+
+| Check kind | Result | Public-safe evidence / limitation |
+| --- | --- | --- |
+| `unit` | `not_run` | Example only: repository-relative test path; behavior checked; aggregate outcome or generic reason not run. |
+
+<!-- Check kind: static | unit | integration | real_entrypoint | real_backend | regression_parity | manual
+Result: passed | failed | running | not_run | blocked | not_applicable
+Evidence: name the affected behavior and safe command/CI link; for a real backend,
+give only its product/version and isolation mode, never its address or credentials.
+Mocks/in-memory substitutes are not real_backend. For regression_parity, summarize
+baseline/head comparison and a failing-before or mutation check, not just test counts.
+-->
+
+- Coverage and gaps: <!-- Why do these checks cover the changed paths? Name untested paths,
+  skipped/failed checks and follow-up, or "none identified" with a brief rationale.
+  Documentation-only changes may use a static/manual row and explain runtime N/A.
+  A passing row does not waive required real-path/backend gates. -->
+
+See [validation disclosure guidance](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md#validation-disclosure).
 
 ## Type of Change
 
@@ -53,6 +83,8 @@
 <!--
 Complete this section only when the PR claims progress against the TypeScript
 control-plane migration or shared Goal Authority RFC. Otherwise write N/A.
+Apply the same public-safe rules here. Reference the validation rows above rather
+than attaching private fixtures, snapshot identifiers, raw output or infrastructure details.
 -->
 
 - Production-scale fixture schema:
@@ -62,7 +94,7 @@ control-plane migration or shared Goal Authority RFC. Otherwise write N/A.
 
 ## Boundary Checklist
 
-- [ ] I did not commit `.loopx/`, `.codex/goals/`, live `ACTIVE_GOAL_STATE.md`, credentials, private benchmark traces, verifier output, raw agent sessions, internal document links, or local machine paths.
+- [ ] Neither the diff nor this PR body/comments/attachments disclose private state, credentials, raw traces or verifier output, internal links, or local machine paths (including `.loopx/`, `.codex/goals/`, and live `ACTIVE_GOAL_STATE.md`).
 - [ ] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
 - [ ] I kept the change scoped to the linked issue/task.
 - [ ] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,3 +242,32 @@ Before opening a pull request:
 - confirm that no private/local runtime state was committed.
 
 Maintainers may ask for a smaller PR if the change mixes unrelated concerns.
+
+### Validation disclosure
+
+Use the [PR template](.github/PULL_REQUEST_TEMPLATE.md) to report facts, not a
+self-assessed quality grade. The enum values are author declarations, not an
+automated proof or merge gate. `finished` means execution ended, not that all
+checks passed or that coverage is sufficient. Record the tested commit; after
+changes, rerun affected checks or identify the stale evidence and remaining gap.
+
+Use one row per relevant check, including failures, skips (`not_run`), blocked
+checks and work still running. Static checks do not prove runtime behavior;
+unit/mocked tests do not prove the public entrypoint or a real backend. State
+the behavior checked and why the set covers the changed paths. Refactors need
+the real-path and parity evidence required by the
+[testing guide](docs/development/testing-and-quality.md#refactor-real-path-gate--重构真实路径门).
+Small documentation changes can report a link/render/static check and explain
+why runtime testing is not applicable; do not launch unrelated suites to fill rows.
+
+Keep evidence public-safe at the point of entry, including hidden HTML comments
+and attachments. Report repository-relative test commands, public fixture names,
+aggregate outcomes, backend product/version and isolation mode, or public CI links.
+Do not copy commands containing private arguments, raw logs, snapshots, prompts,
+private screenshots, infrastructure addresses, connection strings, local paths or
+credentials. `authorized_private_read_only` discloses only a data category: it
+neither grants permission to access live state nor requires publishing its content,
+identifiers or fingerprints. When evidence cannot be shared, describe the tested
+behavior and verification limitation; public reproducibility remains an explicit
+gap until a safe reproducer or authorized review is available. Never upload private
+evidence to make a checkbox green.


### PR DESCRIPTION
## Summary

- Replace the two generic validation checkboxes with fact-based enum hints: run state, tested revision, input classes, and per-check kind/result/evidence.
- Distinguish static/unit checks from real entrypoint/backend and regression parity evidence; require coverage rationale and outstanding gaps rather than a self-assessed "solid" grade.
- Put visible public-safe guidance before evidence fields, apply it to the shared-authority section, and extend the boundary checklist to the PR body, comments and attachments.
- Document reporting semantics in CONTRIBUTING. This remains a lightweight Markdown declaration, not a new CI parser or automatic proof/merge gate.

## Validation

- Tested revision: a454dca66ade6987e370a079dc5a0fa1e7a6a1cb
- Run state: finished
- Input classes: public_fixture

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| static | passed | `python examples/docs-governance-smoke.py`: existing documentation governance checks. |
| static | passed | `python examples/repository-hygiene-smoke.py`: repository hygiene and public/private boundary checks. |
| static | passed | `git diff HEAD^ HEAD --check`: no whitespace errors. |
| manual | passed | Reviewed not-run, failed, mocked-only, documentation-only, stale-revision and private-evidence reporting cases; checked guidance links and preserved existing template sections. |
| real_entrypoint | not_applicable | No executable product behavior or runtime backend changes; only contributor-facing Markdown. |

- Coverage and gaps: checks cover the two changed documentation surfaces. No runtime suite or browser automation was run. Enum declarations cannot verify truthfulness or guarantee redaction; maintainers must assess adequacy, and existing real-path gates remain unchanged. Public evidence is not demanded where it would reveal private data.

## Type of Change / Area

Documentation and contributor workflow. Base: main. Shared-authority fixture impact: N/A; no provider or fixture change. The related simplification replaces stale checkbox-only validation instead of introducing a validation framework.

## Boundary Checklist

- [x] Diff and PR contain only public-safe contributor guidance, repository-relative checks and aggregate results; no private raw evidence.
- [x] Change is scoped to PR validation disclosure.
- [x] Commit includes a DCO sign-off.

Review requested; no self-merge requested.
