### PR TITLE
release: prepare LoopX 1.0.2

### DIFF
--- a/docs/book/chapters/00-reading-guide.md
+++ b/docs/book/chapters/00-reading-guide.md
@@ -103,7 +103,7 @@ lifecycle 选择，不是所有贡献的默认终点。
 
 ## 版本基线
 
-当前内容以 LoopX GitHub release `v1.0.1` 为发布锚点；本地命令示例已按 `loopx 1.0.1` 的
+当前内容以 LoopX GitHub release `v1.0.2` 为发布锚点；本地命令示例已按 `loopx 1.0.2` 的
 公开 CLI 与协议表面复核。该版本要求 Python 3.11+ 与 Node.js 22.6+；后者运行由 LoopX 自动管理、
 空闲后退出的 TypeScript Effect runtime，用户不需要手工维护 daemon。
 

--- a/docs/book/en/chapters/00-reading-guide.md
+++ b/docs/book/en/chapters/00-reading-guide.md
@@ -114,8 +114,8 @@ Do not bypass a newer permission or lifecycle check just to make an older exampl
 
 ## Version baseline
 
-The current release anchor is LoopX GitHub release `v1.0.1`. Local command examples were checked against
-the public `loopx 1.0.1` CLI and protocol surface. This release requires Python 3.11+ and Node.js 22.6+.
+The current release anchor is LoopX GitHub release `v1.0.2`. Local command examples were checked against
+the public `loopx 1.0.2` CLI and protocol surface. This release requires Python 3.11+ and Node.js 22.6+.
 LoopX starts and reuses its managed, idle-exiting TypeScript Effect runtime automatically; users do not
 operate that runtime as a manual daemon.
 

--- a/docs/book/en/index.md
+++ b/docs/book/en/index.md
@@ -79,7 +79,7 @@ versioned or optional functionality, not the default shape of every contribution
 - Source format: Markdown
 - Site generator: MkDocs Material
 - Hosting: GitHub Pages
-- LoopX release anchor: `v1.0.1`
+- LoopX release anchor: `v1.0.2`
 - Runtime prerequisites: Python 3.11+ and Node.js 22.6+
 
 The official public protocols remain authoritative for protocol facts. Commands that change across

--- a/docs/book/index.md
+++ b/docs/book/index.md
@@ -70,7 +70,7 @@ Extension 只是可独立版本化和交付的一种路径。
 - 正文格式：Markdown；
 - 站点生成器：MkDocs Material；
 - 在线发布：GitHub Pages；
-- LoopX 发布锚点：`v1.0.1`；
+- LoopX 发布锚点：`v1.0.2`；
 - 运行时前提：Python 3.11+ 与 Node.js 22.6+。
 
 协议解释以 LoopX 官方公开合同为事实源。易变化的命令仍以对应发布物、官方文档和当前

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,4 +1,4 @@
-.TH LOOPX 1 "" "LoopX 1.0.1" "User Commands"
+.TH LOOPX 1 "" "LoopX 1.0.2" "User Commands"
 .SH NAME
 loopx \- control-plane helper for long-running agent work
 .SH SYNOPSIS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "1.0.1"
+version = "1.0.2"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- set the LoopX package version authority and public tag contract to `1.0.2` / `v1.0.2`;
- refresh the manpage and bilingual book release anchors;
- keep the release candidate limited to the seven established identity mirrors, with no runtime or provider behavior change.

The exact GitHub Release body is prepared separately and has passed the bilingual optional-surface usage gate. It covers promoted Todo lifecycle, versioned workflow skills, revision-bound PR review, traceable benchmark observations, and Desktop readiness diagnostics, including activation/readback, rollback, authority, and versioned documentation links.

## Validation

- `release-readiness-doc-smoke.py`: passed for the exact bilingual final body and five affected surfaces;
- `release-version-contract-smoke.py`: passed;
- `release-artifacts-smoke.py`: passed;
- isolated wheel + sdist build: passed; Twine accepted both `loopx-1.0.2` distributions;
- focused release/update tests: 27 passed, 1 platform-conditional skip;
- exact-release, wrapper-isolation, local-install-promotion, and modular-version smokes: passed;
- `loopx check` public/private boundary: 7 files, 0 violations;
- exact committed-head `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 4 direct checks + 10 selected canaries passed, 0 failures, 0 warnings, 0 manual holds;
- change-quality receipt: `cqr_4af2120c7c42fa77dc39`, fingerprint `4af2120c7c42fa77dc390c5f3df99baa1cdadc1e22eaed710586351a6186b33d`, valid for commit `4f931ee47cf940f6a6765c076a0d042d2f98b3b0`.

## Release boundary

- no default provider promotion, database migration, daemon, permission expansion, or project-state write;
- community attribution was derived from the exact `v1.0.1..candidate` merged-PR range;
- future-facing refactor pass: unnecessary for this patch because it reuses the existing release identity mirrors and qualification workflow; adding another abstraction would duplicate the current version authority.

## Merge and publish

After the owner approves the public Release first-screen preview, merge this PR without squashing so the qualified signed candidate commit remains the immutable `v1.0.2` tag target. Then publish the prepared GitHub Release, wait for artifact/PyPI automation, move `stable` only after the exact-source release gate passes, and read the remote body back through the same release-readiness validator.
