### PR TITLE
docs: complete the DevBook for LoopX 1.0

### DIFF
--- a/docs/book/chapters/00-reading-guide.md
+++ b/docs/book/chapters/00-reading-guide.md
@@ -62,6 +62,7 @@ LoopX Kernel 源码，也不需要理解所有 CLI 子命令。
 
 完成基础篇后：
 
+- 想先掌握 1.0 的日常操作面，从[操作 LoopX 1.0 Workspace](./workspace-v1.md)开始；
 - 只想管理自己的项目，从[连接你的 Git 项目](./05-connect-existing-project.md)开始；
 - 想给 LoopX 做任何公开贡献，从[开发者贡献地图与协议入口](./source-protocol-map.md)开始；
 - 已经确定需要独立安装、启停和升级的 Provider/package，再进入
@@ -160,6 +161,14 @@ CLI/App convergence 与 Stage 4 distribution cleanup 仍是后续方向。
 
 这张表是阅读导航，不是 release notes 的副本。某个 surface 是否可用，仍应从当前安装版本的
 `doctor`、`capability show`、对应 Host readback 和 versioned 文档判断。
+
+### 从 `v0.5.4` 进入 `v1.0.0` Workspace
+
+`v1.0.0` 的产品里程碑是 Personal Workspace，而不是一次对所有 staged authority 或可选 Provider
+的整体提升。它把跨 Goal 总览、Agent lane、已完成任务、Capability 设置、verified reports、
+Goal Channel 与桌面恢复汇集到一个 operator surface，同时保留 CLI、typed Kernel 与项目状态的
+事实所有权。沿[1.0 Workspace 操作章](./workspace-v1.md)完成启动、readback、preview/apply/receipt、
+配置与停用验收，再进入项目接入或开发者贡献主线。
 
 ## 本书的边界
 

--- a/docs/book/chapters/workspace-v1.md
+++ b/docs/book/chapters/workspace-v1.md
@@ -1,0 +1,198 @@
+# 操作 LoopX 1.0 Workspace
+
+LoopX 1.0 的里程碑不是“多了一个 Dashboard”，而是把跨会话、跨 Agent 的长程工作收拢到一个
+可检查、可操作的 Personal Workspace。Workspace 负责呈现和发起受治理的动作；Goal、Todo、
+Gate、事件、配置和回执仍由控制面事实源拥有。
+
+本章把 1.0 的操作面接回前六章的控制面模型。完成后，你应该能够：
+
+- 启动 Workspace，并确认页面和状态投影来自同一个 LoopX 运行时；
+- 从 Manager 总览进入单个 Goal，区分正在执行、等待确认、持续观察和已完成工作；
+- 解释为什么界面中的写操作必须经过 typed preview、governed apply 与 verified receipt；
+- 分开判断 Capability 可见性、Goal 配置、Provider readiness 和当前 Turn 可用性；
+- 理解 Goal Channel、周期报告与桌面更新各自增加了什么权限，以及如何停用。
+
+## 1.0 到底交付了什么
+
+`v1.0.0` 是 **Personal Workspace milestone**。它把以下入口汇集到一个本地 operator surface：
+
+| Workspace 表面 | 回答的问题 | 事实边界 |
+| --- | --- | --- |
+| Manager 总览 | 哪些 Goal 需要我、正在执行、持续观察或已经安排？ | 来自状态投影，不重新决定 Todo lifecycle |
+| Goal / Tasks | 当前 Agent lane、待确认项、执行中 Todo、Monitor 与完成历史是什么？ | Todo 与 Gate 仍由控制面 owner 决定 |
+| Chat | 如何在当前 Goal / Agent / Session 上继续协作？ | 会话不是 durable Goal state |
+| Files / Reports | 本轮交付了什么，哪些报告已经验证？ | 只展示 public-safe preview 与证据指针 |
+| Context / Settings | 当前 repository、Session、Goal Channel 和可选功能如何配置？ | 写入必须 preview、apply 并 read back |
+
+这不是一套新的事实源。浏览器不能绕开 Kernel 直接修改 registry、Todo、quota 或 Host
+automation；远端 SSH source 也保持只读。Stage 2C authority 与其他候选 Provider 仍按阶段提升，
+1.0 标签不代表所有 tenant 已经迁移。
+
+发布事实以 [LoopX v1.0.0 release](https://github.com/huangruiteng/loopx/releases/tag/v1.0.0)
+为准；界面细节与恢复路径见
+[Personal Workspace 使用指南](/loopx/docs/guides/personal-workspace-user-guide/)。
+
+## 启动并验证同一个运行时
+
+先确认安装版本与环境，再启动本地 Workspace：
+
+```bash
+loopx --version
+loopx doctor
+loopx dashboard --no-open
+```
+
+命令会打印实际 loopback URL；默认页面和状态投影可以这样读回：
+
+```bash
+curl -fsS http://127.0.0.1:8767/chat/ >/dev/null
+curl -fsS http://127.0.0.1:8767/status.json
+```
+
+`loopx dashboard` 同时提供打包后的 Workspace、状态投影和 Agent Chat。若相同版本的桌面壳已经
+启动了服务，它会复用通过 capability fingerprint 验证的进程，而不是启动第二套事实源。端口只是
+默认值；自动化检查应读取命令输出，不要把默认 URL 当成永久合同。
+
+打开 Workspace 后，先做三项读回：
+
+1. Manager 总览中的 Goal 数量和 `loopx status` 是否对应；
+2. 目标 Goal 的 Agent lane、Task 状态和 `loopx todo list --goal-id <goal-id>` 是否对应；
+3. Context 中的 repository / source 是否指向当前要操作的主机与 worktree。
+
+页面出现不等于控制面健康。如果 `status.json`、Goal 详情或当前 source 显示失败，先恢复对应
+运行时或投影，再执行写操作。
+
+## 从 Workspace 读一项工作
+
+Manager 的四条 lane 是 operator 投影，不是四种新的 Todo 状态：
+
+- **需要你：** User Todo、权限 Gate 或必须由 owner 决定的动作；
+- **执行中：** 当前可推进的 Agent Todo 与活跃 lane；
+- **观察中：** 有 cadence、触发条件或外部事实等待的 Monitor；
+- **已安排：** 已绑定 Host schedule，但当前没有到执行时间的工作。
+
+进入 Goal 后，再把卡片还原成控制面问题：
+
+```text
+Goal / Acceptance
+  -> selected Todo and owner
+  -> Gate, capability and workspace eligibility
+  -> current Session / Host
+  -> evidence, receipt and successor
+```
+
+已完成历史是只读证据，不会重新进入 frontier。Files 中的报告或产物摘要也不是完整原始文件；
+需要审计时，沿 `todo_id`、run identity、evidence pointer 或版本化 artifact 回到权威来源。
+
+## 写操作：preview、apply、receipt
+
+Workspace 中的 Goal、Todo、Heartbeat、Monitor 与设置变更遵循同一条安全链：
+
+```text
+typed preview -> human or policy review -> governed apply -> verified receipt -> refreshed projection
+```
+
+Preview 冻结规范化参数、影响范围和当前 revision。Apply 只能执行仍然匹配该 preview 的动作；
+状态已经变化时应返回 stale 或 Gate，而不是悄悄套用旧决定。Receipt 与 readback 才能证明写入完成；
+按钮点击或 HTTP 成功本身都不够。
+
+以暂停 Goal 为例，第一条命令只预览：
+
+```bash
+loopx goal-lifecycle --goal-id <goal-id> --operation stop
+loopx goal-lifecycle --goal-id <goal-id> --operation stop --execute
+loopx quota status --goal-id <goal-id>
+```
+
+暂停会让该 Goal 退出 active attention，并使有效自动运行 quota 投影为 0；Todo、历史、证据和配置
+仍保留。恢复使用显式 `resume --execute`，且不会绕过 Todo、Gate 或 quota。不要把 stop 写成
+“完成 Goal”，也不要用改 quota 的方式意外恢复一个被 owner 停止的 Goal。
+
+## 配置 Capability 与机器策略
+
+1.0 Workspace 能展示 Goal capability 与 typed machine policy，但四种事实必须分开：
+
+| 事实 | 读取入口 | 不代表什么 |
+| --- | --- | --- |
+| Capability 已发布 | `loopx capability list/show` | 不代表当前 Goal 已启用 |
+| Goal 已配置 | `loopx configure-goal --goal-id <goal-id>` | 不代表 Provider ready |
+| Provider ready | 对应 Extension / Provider doctor | 不代表当前 Turn 通过 Gate |
+| 当前 Turn 可用 | `quota should-run` 的 capability / workspace 结果 | 不授予额外外部权限 |
+
+先做只读发现：
+
+```bash
+loopx capability list --format json
+loopx machine-config describe
+loopx machine-config inspect --format json
+loopx configure-goal --goal-id <goal-id>
+```
+
+机器策略和 Goal 设置都必须先生成 delta / plan，再显式执行并读回 revision。不要从 Capability 名称
+猜配置 flag，也不要把“catalog 中可见”写成“已启用”。启用自适应子 Agent 等可选能力不会强制
+并行，也不会授予新的 Goal、repository、credential、发布或生产权限。
+
+## Goal Channel：消息不是隐式 authority
+
+Workspace 的 Lark / 飞书设置可以把一个 Goal 连接到具体 Topic 和目标 Agent。Capture scope
+只决定哪些消息进入连接；它不扩大 Agent 权限。Ingress mode 决定消息怎样进入运行时：
+
+- `live_steering`：只投递给该 Agent 当前精确的活跃 Turn；
+- `session_queue`：进入同一精确 Session 的有界 FIFO，当前 Turn 后处理；
+- `async_inbox`：进入 Agent 的本地私有 inbox，等待后续显式 drain。
+
+配置后应读回 Goal、Agent、Topic、ingress mode、Session binding 与监听状态。验证
+`async_inbox` 时，可以在自己发送一条新的测试消息后执行：
+
+```bash
+loopx lark-inbox drain --goal-id <goal-id> --agent-id <agent-id>
+```
+
+Disconnect 只移除该 Goal 的 Topic route，不删除 Goal、Session、历史或其他连接。消息到达也不
+代表 Agent 获得发送、仓库写入或生产权限；这些动作继续通过各自的 Gate 与 Provider readback。
+
+## 报告：一次生成与持续投递分开
+
+在活跃项目会话中明确请求“生成本周项目报告”，会启用一次 provider-free 的 Markdown / HTML
+生成。先用只读命令检查内置 profile：
+
+```bash
+loopx periodic-report inspect-profile --preset weekly --format json
+```
+
+回执中的 `active` 与 `generation_allowed` 应同时为 `true`。内置 weekly profile 没有 schedule，
+也没有 sink，因此一次生成不会创建周期任务或发送消息。
+
+持续报告是另一条授权链：自定义 profile 声明 cadence，Host Automation 负责唤醒；机器或 Goal
+subscription 的 `enabled: true` 与显式 `route_ref` 构成持续投递授权。暂停 Automation、禁用
+profile 或关闭 subscription 会停止对应路径。报告生成成功不等于外部发送成功；Provider、发送
+身份、route 和消息 readback 仍需分别验证。
+
+## 桌面更新与恢复
+
+1.0 的 macOS 桌面更新把 App 与内置 runtime 绑定到同一 revision。旧桌面壳需要一次手动替换；
+之后在 **Recovery & updates** 中显式选择 stable 或 main、安装并重启。
+
+- **验证：** 对照 App 版本、Workspace runtime identity、`loopx --version` 与 `loopx doctor`；
+- **修复：** **Repair this version** 重装当前 App 配套 runtime；
+- **回退：** 有已验证备份时使用 **Restore previous version**，重启后再次核对 identity；
+- **边界：** 更新只能来自固定官方 feed；macOS 使用 updater signature 与 ad-hoc code signing，
+  不应描述为 notarized。回退安装也不承诺逆转未来不兼容的 Goal schema。
+
+浏览器 / PWA 用户继续使用 CLI update 流程。CLI 更新不能修复原生壳的启动器或 updater 缺陷。
+
+## 1.0 操作验收表
+
+完成一次 Workspace 验收时，至少确认：
+
+- `loopx --version` 与预期 release 一致，`loopx doctor` 的必需检查通过；
+- Workspace 与 `status.json` 来自同一个已验证运行时；
+- Manager 和 Goal 页面能解释为现有 Goal / Todo / Gate / Monitor 状态；
+- 每个写操作都有 preview、apply、receipt 和 refreshed readback；
+- Capability、Goal config、Provider readiness 与 Turn eligibility 没有混为一个“已启用”；
+- Goal Channel 与报告的外部投递都有精确 route、identity 和 readback；
+- staged authority、SSH source 与浏览器 presentation 没有被误写成新的写权限。
+
+接下来可以按目标继续：管理现有项目回到[连接你的 Git 项目](./05-connect-existing-project.md)；
+修改 Workspace 或控制面实现时进入[开发者贡献地图](./source-protocol-map.md)；需要完整界面细节时
+查阅 [Personal Workspace 使用指南](/loopx/docs/guides/personal-workspace-user-guide/)。

--- a/docs/book/en/chapters/00-reading-guide.md
+++ b/docs/book/en/chapters/00-reading-guide.md
@@ -68,6 +68,8 @@ Developers ready to enter Kernel implementation can go directly to the
 
 After those chapters:
 
+- to learn the daily 1.0 operator surface first, start with
+  [Operate the LoopX 1.0 Workspace](./workspace-v1.md);
 - to manage your own repository, start with
   [Connect an existing Git project](./05-connect-existing-project.md);
 - to make any public LoopX contribution, start with the
@@ -175,6 +177,16 @@ If you read an earlier edition of the Dev Book, recalibrate these four areas fir
 
 This table is a reading map, not a copy of the release notes. Confirm whether a surface is usable through
 the installed release's `doctor`, `capability show`, Host readback, and versioned documentation.
+
+### From `v0.5.4` into the `v1.0.0` Workspace
+
+The `v1.0.0` product milestone is the Personal Workspace, not blanket promotion of every staged
+authority path or optional Provider. It brings cross-Goal overview, Agent lanes, completed work,
+Capability settings, verified reports, Goal Channels, and desktop recovery into one operator surface
+while preserving the authority of the CLI, typed Kernel, and project state. Follow the
+[1.0 Workspace operations chapter](./workspace-v1.md) through startup, readback,
+preview/apply/receipt, configuration, and disable checks before entering the project-onboarding or
+developer-contribution path.
 
 ## Deliberate scope
 

--- a/docs/book/en/chapters/workspace-v1.md
+++ b/docs/book/en/chapters/workspace-v1.md
@@ -1,0 +1,216 @@
+# Operate the LoopX 1.0 Workspace
+
+The LoopX 1.0 milestone is not merely a new Dashboard. It brings long-running work across sessions and
+Agents into one inspectable, operable Personal Workspace. The Workspace presents state and proposes
+governed actions; the control-plane sources still own Goals, Todos, Gates, events, configuration, and
+receipts.
+
+This chapter connects the 1.0 operator surface to the control-plane model in the first six chapters. By
+the end, you should be able to:
+
+- start the Workspace and confirm that the page and status projection come from one LoopX runtime;
+- move from the Manager overview into one Goal and distinguish active, attention, monitoring, and
+  completed work;
+- explain why Workspace writes pass through typed preview, governed apply, and verified receipt;
+- distinguish Capability visibility, Goal configuration, Provider readiness, and current-Turn eligibility;
+- understand what authority Goal Channels, periodic reports, and desktop updates add, and how to disable
+  each path.
+
+## What 1.0 actually ships
+
+`v1.0.0` is the **Personal Workspace milestone**. It brings these entrypoints into one local operator
+surface:
+
+| Workspace surface | Question it answers | Authority boundary |
+| --- | --- | --- |
+| Manager overview | Which Goals need me, are running, are being observed, or are scheduled? | Derived from status projections; it does not redefine Todo lifecycle |
+| Goal / Tasks | Which Agent lanes, decisions, active Todos, Monitors, and completed items exist? | Todo and Gate decisions remain with their control-plane owners |
+| Chat | How do I continue with the current Goal, Agent, and Session? | A conversation is not durable Goal state |
+| Files / Reports | What did a run deliver, and which reports were verified? | Shows public-safe previews and evidence pointers |
+| Context / Settings | How are the repository, Session, Goal Channel, and optional features configured? | Writes require preview, apply, and readback |
+
+This is not a new source of truth. The browser cannot bypass the Kernel to edit registries, Todos, quota,
+or Host automation. Remote SSH sources remain read-only. Stage 2C authority and other candidate Providers
+are still promoted in stages; the 1.0 label does not mean that every tenant has migrated.
+
+Use the [LoopX v1.0.0 release](https://github.com/huangruiteng/loopx/releases/tag/v1.0.0) for shipped
+facts and the [Personal Workspace guide](/loopx/docs/guides/personal-workspace-user-guide/) for detailed
+UI and recovery instructions.
+
+## Start and verify one runtime
+
+Confirm the installed version and environment, then start the local Workspace:
+
+```bash
+loopx --version
+loopx doctor
+loopx dashboard --no-open
+```
+
+The command prints the actual loopback URL. The default page and status projection can be read back with:
+
+```bash
+curl -fsS http://127.0.0.1:8767/chat/ >/dev/null
+curl -fsS http://127.0.0.1:8767/status.json
+```
+
+`loopx dashboard` serves the packaged Workspace, status projection, and Agent Chat together. If a matching
+desktop shell already runs the service, the command reuses the process only after validating its capability
+fingerprint; it does not start a second source of truth. Ports are defaults, not permanent contracts, so
+automation should consume the URL printed by the command.
+
+After opening the Workspace, perform three readbacks:
+
+1. compare the Manager Goal count with `loopx status`;
+2. compare the selected Goal's Agent lanes and Task states with
+   `loopx todo list --goal-id <goal-id>`;
+3. confirm that Context names the host and worktree you intend to operate.
+
+A rendered page is not proof of a healthy control plane. If `status.json`, Goal details, or the selected
+source fails, recover that runtime or projection before attempting a write.
+
+## Read one unit of work from the Workspace
+
+The Manager's four lanes are operator projections, not four new Todo states:
+
+- **Needs you:** User Todos, authority Gates, and decisions reserved for the owner;
+- **In progress:** runnable Agent Todos and active lanes;
+- **Observing:** Monitors with a cadence, trigger, or external-fact wait;
+- **Scheduled:** Host schedules that are bound but not currently due.
+
+Inside a Goal, reduce a card back to the control-plane questions:
+
+```text
+Goal / Acceptance
+  -> selected Todo and owner
+  -> Gate, capability and workspace eligibility
+  -> current Session / Host
+  -> evidence, receipt and successor
+```
+
+Completed history is read-only evidence and does not re-enter the frontier. Files and report summaries are
+not the complete raw artifact. For an audit, follow the `todo_id`, run identity, evidence pointer, or
+versioned artifact back to its authoritative source.
+
+## Writes: preview, apply, receipt
+
+Workspace changes to Goals, Todos, Heartbeats, Monitors, and settings follow one safety chain:
+
+```text
+typed preview -> human or policy review -> governed apply -> verified receipt -> refreshed projection
+```
+
+A preview freezes normalized parameters, scope, and the current revision. Apply may execute only while that
+preview still matches current state; changed state returns stale or a Gate rather than silently reusing an
+old decision. Only the receipt and readback prove the write. A button click or successful HTTP response is
+not enough.
+
+For example, the first Goal-stop command is preview-only:
+
+```bash
+loopx goal-lifecycle --goal-id <goal-id> --operation stop
+loopx goal-lifecycle --goal-id <goal-id> --operation stop --execute
+loopx quota status --goal-id <goal-id>
+```
+
+Stopping a Goal removes it from active attention and projects zero effective automatic-run quota while
+preserving Todos, history, evidence, and configuration. Explicit `resume --execute` restores scheduling
+eligibility but does not bypass Todo, Gate, or quota rules. Do not describe stop as completing the Goal, and
+do not use a quota edit to accidentally resume an owner-stopped Goal.
+
+## Configure Capabilities and machine policy
+
+The 1.0 Workspace exposes Goal capabilities and typed machine policy, but four facts remain distinct:
+
+| Fact | Read surface | What it does not prove |
+| --- | --- | --- |
+| Capability shipped | `loopx capability list/show` | The current Goal enabled it |
+| Goal configured | `loopx configure-goal --goal-id <goal-id>` | A Provider is ready |
+| Provider ready | The matching Extension / Provider doctor | The current Turn passed its Gates |
+| Current Turn eligible | Capability / workspace results from `quota should-run` | Any additional external authority |
+
+Start with read-only discovery:
+
+```bash
+loopx capability list --format json
+loopx machine-config describe
+loopx machine-config inspect --format json
+loopx configure-goal --goal-id <goal-id>
+```
+
+Machine policy and Goal settings must first produce a delta or plan, then be explicitly executed and read
+back at the resulting revision. Do not guess flags from Capability names or turn “visible in the catalog”
+into “enabled.” Enabling optional adaptive child-agent capacity does not force parallel execution or grant
+new Goal, repository, credential, publication, or production authority.
+
+## Goal Channels: messages are not implicit authority
+
+The Workspace's Lark settings can connect a Goal to an exact Topic and target Agent. Capture scope selects
+which messages enter the connection; it does not enlarge Agent authority. Ingress mode determines how a
+message enters the runtime:
+
+- `live_steering` targets the exact active Turn of that Agent;
+- `session_queue` enters a bounded FIFO for the same exact Session and runs after the current Turn;
+- `async_inbox` enters the Agent's local private inbox for an explicit later drain.
+
+After configuration, read back the Goal, Agent, Topic, ingress mode, Session binding, and listener state.
+To validate `async_inbox`, send a new test message yourself and then run:
+
+```bash
+loopx lark-inbox drain --goal-id <goal-id> --agent-id <agent-id>
+```
+
+Disconnect removes only this Goal's Topic route; it does not delete the Goal, Session, history, or another
+connection. Message arrival does not grant sending, repository-write, or production authority. Those
+effects continue through their own Gates and Provider readbacks.
+
+## Reports: one generation and standing delivery are separate
+
+An explicit request to “generate this week's project report” in an active project session enables one
+provider-free Markdown and HTML generation. Inspect the built-in profile first:
+
+```bash
+loopx periodic-report inspect-profile --preset weekly --format json
+```
+
+The receipt should report both `active: true` and `generation_allowed: true`. The built-in weekly profile
+has no schedule and no sink, so one generation does not create a recurring task or send a message.
+
+Standing reports use a separate authority chain: a custom profile declares cadence, a Host Automation
+wakes the work, and `enabled: true` plus an explicit `route_ref` on a machine or Goal subscription grants
+standing delivery. Pause the Automation, disable the profile, or disable the subscription to stop its
+corresponding path. Successful generation is not proof of successful external delivery; Provider, sender
+identity, route, and message readback are verified separately.
+
+## Desktop updates and recovery
+
+The 1.0 macOS updater pairs the App and bundled runtime at one revision. Older desktop shells require one
+manual replacement. Afterwards, use **Recovery & updates** to select stable or main explicitly, install,
+and restart.
+
+- **Validate:** compare the App version, Workspace runtime identity, `loopx --version`, and `loopx doctor`;
+- **Repair:** **Repair this version** reinstalls the runtime bundled with the current App;
+- **Roll back:** when a verified backup exists, use **Restore previous version**, restart, and recheck identity;
+- **Boundary:** updates use fixed official feeds. macOS uses updater signatures plus ad-hoc code signing and
+  must not be described as notarized. Restoring an install does not promise to reverse a future incompatible
+  Goal schema.
+
+Browser and PWA users continue through the CLI update flow. A CLI update cannot repair native shell startup
+or updater defects.
+
+## 1.0 acceptance checklist
+
+For one Workspace acceptance pass, confirm at least that:
+
+- `loopx --version` matches the intended release and required `loopx doctor` checks pass;
+- the Workspace and `status.json` come from the same verified runtime;
+- Manager and Goal views can be explained by existing Goal, Todo, Gate, and Monitor state;
+- every write has a preview, apply, receipt, and refreshed readback;
+- Capability, Goal config, Provider readiness, and Turn eligibility are not collapsed into one “enabled” bit;
+- Goal Channel and report delivery have exact route, identity, and readback evidence;
+- staged authority, SSH sources, and browser presentation are not mistaken for new write authority.
+
+Continue according to your task: return to [Connect an existing Git project](./05-connect-existing-project.md)
+for project operation, use the [Developer contribution map](./source-protocol-map.md) when changing the
+Workspace or control-plane implementation, or open the
+[Personal Workspace guide](/loopx/docs/guides/personal-workspace-user-guide/) for detailed UI behavior.

--- a/docs/book/mkdocs.en.yaml
+++ b/docs/book/mkdocs.en.yaml
@@ -59,6 +59,7 @@ nav:
   - Home: index.md
   - Start:
       - Welcome Wagon: welcome-wagon.md
+      - LoopX 1.0 Workspace: chapters/workspace-v1.md
       - How to use this book: chapters/00-reading-guide.md
   - Developer Course:
       - Control-Plane Course: chapters/12-control-plane-course.md

--- a/docs/book/mkdocs.zh.yaml
+++ b/docs/book/mkdocs.zh.yaml
@@ -62,6 +62,7 @@ nav:
   - 首页: index.md
   - 开始:
       - Welcome Wagon: welcome-wagon.md
+      - LoopX 1.0 Workspace: chapters/workspace-v1.md
       - 如何使用本书: chapters/00-reading-guide.md
   - 开发者课程:
       - Control-Plane Course: chapters/12-control-plane-course.md

--- a/examples/dev-book-publication-smoke.py
+++ b/examples/dev-book-publication-smoke.py
@@ -19,6 +19,7 @@ BRAND_STYLES = REPO_ROOT / "docs" / "stylesheets" / "loopx.css"
 HOMEPAGE = REPO_ROOT / "apps" / "presentation" / "site" / "src" / "App.tsx"
 
 CHAPTERS = (
+    "workspace-v1",
     "00-reading-guide",
     "01-from-session-to-loop",
     "02-session-goal-loopx",
@@ -182,6 +183,11 @@ def validate_rendered_site(site_dir: Path) -> None:
             "Dev Book 与 Control-Plane Course 如何配合",
             "/loopx/docs/development/control-plane-course/06-quota-decision-kernel/",
         ),
+        "chapters/workspace-v1/index.html": (
+            "操作 LoopX 1.0 Workspace",
+            "typed preview",
+            "live_steering",
+        ),
         "chapters/01-from-session-to-loop/index.html": (
             "从一次会话到长程任务",
         ),
@@ -195,6 +201,11 @@ def validate_rendered_site(site_dir: Path) -> None:
         "chapters/00-reading-guide/index.html": (
             "How the Dev Book and Control-Plane Course work together",
             "/loopx/docs/development/control-plane-course/06-quota-decision-kernel/",
+        ),
+        "chapters/workspace-v1/index.html": (
+            "Operate the LoopX 1.0 Workspace",
+            "typed preview",
+            "live_steering",
         ),
         "chapters/01-from-session-to-loop/index.html": (
             "From one session to long-running work",
@@ -370,6 +381,22 @@ def main() -> int:
         for page in COURSE_PAGES:
             assert f"/loopx/docs/development/control-plane-course/{page}/" in guide, page
 
+    assert_bilingual_concepts(
+        "chapters/workspace-v1.md",
+        "en/chapters/workspace-v1.md",
+        (
+            ("Personal Workspace milestone", "Personal Workspace milestone"),
+            ("不是一套新的事实源", "not a new source of truth"),
+            ("loopx dashboard --no-open", "loopx dashboard --no-open"),
+            ("typed preview -> human or policy review -> governed apply -> verified receipt -> refreshed projection", "typed preview -> human or policy review -> governed apply -> verified receipt -> refreshed projection"),
+            ("loopx machine-config inspect --format json", "loopx machine-config inspect --format json"),
+            ("`live_steering`", "`live_steering`"),
+            ("`session_queue`", "`session_queue`"),
+            ("`async_inbox`", "`async_inbox`"),
+            ("loopx periodic-report inspect-profile --preset weekly --format json", "loopx periodic-report inspect-profile --preset weekly --format json"),
+            ("Stage 2C authority", "Stage 2C authority"),
+        ),
+    )
     assert_bilingual_concepts(
         "index.md",
         "en/index.md",


### PR DESCRIPTION
## Summary

- add a bilingual DevBook chapter for the LoopX 1.0 Personal Workspace
- connect the chapter from both reading guides and public navigation
- extend the publication smoke with bilingual and rendered-route coverage

## Scope and authority boundaries

The chapter covers startup/readback, Manager and Goal projections, preview/apply/receipt writes, Capability and machine-policy configuration, Goal Channels, periodic reports, and desktop recovery. It keeps CLI, typed Kernel, and project state as the authoritative sources and does not promote staged authority or optional Providers by implication.

No generated site output, lockfile, local state, private evidence, or credentials are included.

## Validation

- `python3.12 examples/dev-book-publication-smoke.py`
- `python3.12 examples/dev-book-publication-smoke.py --site-dir /private/tmp/loopx-devbook-v1-rendered/docs/book`
- `python3.12 -m py_compile examples/dev-book-publication-smoke.py`
- isolated `mkdocs build --strict` for the root docs site
- isolated `mkdocs build --strict` for Chinese DevBook
- isolated `mkdocs build --strict` for English DevBook
- `loopx check` on all seven changed files: public boundary clean (two unrelated existing goal-state projection warnings)
- `git diff --cached --check`
- verified the `v1.0.0` release and referenced local documentation targets

## Presentation review

The public Start navigation and rendered Workspace chapter were previewed locally and approved by the owner before commit.

## Future-facing pass

No adjacent refactor was needed: the existing bilingual DevBook configs and publication smoke already own this surface, so the change extends those owners directly.
