### PR TITLE
fix(pr-review): require independent community review

### DIFF
--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -854,6 +854,11 @@ def _review_conclusion(
         key=lambda item: _parse_updated_epoch(item.get("submittedAt")),
         reverse=True,
     )
+    reviewer_owns_pr = bool(
+        reviewer_login
+        and pr_author
+        and reviewer_login.casefold() == pr_author.casefold()
+    )
     if not reviews:
         return {
             "schema_version": REVIEW_CONCLUSION_SCHEMA_VERSION,
@@ -871,17 +876,18 @@ def _review_conclusion(
         english_verdict = _english_review_verdict(body)
         review_author = str(_as_dict(review.get("author")).get("login") or "").strip()
         commit_oid = str(_as_dict(review.get("commit")).get("oid") or "").strip()
-        author_owned = bool(
+        review_is_by_pr_author = bool(
             review_author
             and pr_author
             and review_author.casefold() == pr_author.casefold()
         )
+        author_owned_fallback = review_is_by_pr_author and reviewer_owns_pr
         reasons: list[str] = []
         if not head_oid or commit_oid.casefold() != head_oid.casefold():
             reasons.append("review_not_bound_to_current_head")
         if not _review_body_has_required_format(body, head_oid=head_oid):
             reasons.append("review_body_missing_standalone_bilingual_format")
-        if author_owned:
+        if author_owned_fallback:
             expected_title = {
                 "APPROVE": AUTHOR_OWNED_APPROVAL_FALLBACK_TITLE,
                 "REQUEST_CHANGES": AUTHOR_OWNED_REQUEST_CHANGES_FALLBACK_TITLE,

--- a/tests/test_pr_review_github_scan.py
+++ b/tests/test_pr_review_github_scan.py
@@ -487,3 +487,65 @@ def test_latest_review_and_author_owned_fallback_are_enforced(monkeypatch) -> No
     )["pull_requests"][0]
     assert ordinary_comment["review_conclusion"]["status"] == "valid"
     assert ordinary_comment["review_action_kind"] is None
+
+
+def test_community_author_self_review_does_not_satisfy_maintainer_queue(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(pr_review_module, "_now_iso", lambda: "2026-08-18T12:00:00Z")
+    row = _queue_pr(
+        3660,
+        author="community-author",
+        ready_at="2026-08-18T07:00:00Z",
+        updated_at="2026-08-18T11:00:00Z",
+    )
+    head = str(row["headRefOid"])
+    row["reviews"] = [
+        {
+            "author": {"login": "community-author"},
+            "body": _full_review_body(head, author_fallback=True),
+            "commit": {"oid": head},
+            "state": "COMMENTED",
+            "submittedAt": "2026-08-18T11:00:00Z",
+        }
+    ]
+
+    self_review_only = pr_review_module.build_pr_review_packet(
+        pull_requests=[row],
+        repository="owner/repo",
+        limit=10,
+        source="fixture",
+        state_filter="open",
+        reviewer_login="maintainer",
+    )["pull_requests"][0]
+
+    assert self_review_only["review_conclusion"]["status"] == "invalid"
+    assert (
+        "formal_review_state_required"
+        in self_review_only["review_conclusion"]["invalid_reasons"]
+    )
+    assert self_review_only["review_action_kind"] == "review_pull_request_exact_head"
+
+    row["reviews"].append(
+        {
+            "author": {"login": "maintainer"},
+            "body": _full_review_body(head),
+            "commit": {"oid": head},
+            "state": "APPROVED",
+            "submittedAt": "2026-08-18T10:00:00Z",
+        }
+    )
+    independently_reviewed = pr_review_module.build_pr_review_packet(
+        pull_requests=[row],
+        repository="owner/repo",
+        limit=10,
+        source="fixture",
+        state_filter="open",
+        reviewer_login="maintainer",
+    )["pull_requests"][0]
+
+    assert independently_reviewed["review_conclusion"]["status"] == "valid"
+    assert independently_reviewed["review_conclusion"]["reviewer"] == "maintainer"
+    assert independently_reviewed["review_action_kind"] == (
+        "qualify_pull_request_merge_readiness"
+    )


### PR DESCRIPTION
## Summary

- distinguish the authenticated reviewer's PR ownership from each review author's identity
- accept the titled `COMMENTED` self-review fallback only for reviewer-owned PRs
- keep community-author self-reviews from suppressing maintainer exact-head work
- retain the existing scan for an earlier valid independent/formal review

## Root cause

A community PR author's exact-head `COMMENTED` self-review was classified as a valid author-owned fallback solely because the review author matched the PR author. The queue therefore treated a maintainer conclusion as complete even when the authenticated maintainer had not reviewed that head. PR #3660 exposed this starvation path after its current head was pushed.

## Validation

| Check | Result | Scope |
| --- | --- | --- |
| PR-review pytest set | passed: 81; skipped: 8 existing provider-dependent cases | queue, result consistency, behavior, GitHub scan |
| `python examples/pr-review-command-smoke.py` | passed | public CLI fixture path |
| Historical-defect sensitivity | passed | fails on the base arm; passes on this head |
| Ruff | passed | changed Python files |
| repository-configured mypy | passed: 21 files | configured strict set |
| public/private boundary | passed | 2 changed paths |
| `git diff --check` | passed | exact diff |
| `loopx canary premerge --from-git-diff --goal-id loopx-meta` | passed: standard tier, 1 selected canary, 0 failures, 0 manual holds | exact rebased diff |
| change-quality receipt | valid: `cqr_d7bbcbd783a3194582e3` | exact base/head fingerprint |

## Scope and residuals

- Changed surfaces: `loopx/pr_review.py` and one focused regression test.
- No schema, CLI option, permission, merge authority, or external-write behavior changes.
- The 8 skipped tests retain their existing provider-dependent conditions; the focused regression and public CLI smoke both executed and passed.
- Ignored local sensitivity scripts and LoopX runtime/receipt state are excluded.
- Future-facing pass: kept the existing evaluator and fallback scan; only separated the two identity questions, avoiding a parallel policy abstraction.
