### PR TITLE
fix(scheduler): avoid secret-shaped transport chunks

### DIFF
--- a/loopx/control_plane/coordination/legacy_writer_fence.ts
+++ b/loopx/control_plane/coordination/legacy_writer_fence.ts
@@ -142,10 +142,12 @@ export async function loadLegacyCoordinationWriterFence(
     return { status: "loaded", fence };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { status: "missing" };
+    const path = (error as NodeJS.ErrnoException).path;
+    const reason = error instanceof Error ? error.message : "legacy writer fence read failed";
     return {
       status: "failed",
       reason_code: "legacy_writer_fence_read_failed",
-      reason: error instanceof Error ? error.message : "legacy writer fence read failed",
+      reason: typeof path === "string" ? reason.replace(` '${path}'`, "") : reason,
     };
   }
 }

--- a/loopx/control_plane/scheduler/heartbeat_followup_cli.ts
+++ b/loopx/control_plane/scheduler/heartbeat_followup_cli.ts
@@ -148,7 +148,7 @@ function decodeSchedulerHostFactsChunks(chunks: string[]): Record<string, unknow
   if (
     chunks.length === 0 ||
     encoded.length > MAX_ENCODED_FACTS_CHARS ||
-    !/^[A-Za-z0-9_-]+$/.test(encoded)
+    !/^[A-Za-z0-9_+\/-]+$/.test(encoded)
   ) {
     throw new EffectRuntimeRequestError(
       "scheduler host facts are missing or exceed the encoded boundary",

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -269,20 +269,14 @@ def _scheduler_host_followup_transport_args(
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
-    encoded = base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode("ascii")
+    encoded = base64.b64encode(zlib.compress(raw, level=9)).decode("ascii")
     encoded = encoded.rstrip("=")
     if len(encoded) > SCHEDULER_HOST_FACTS_MAX_ENCODED_CHARS:
         raise ValueError("scheduler host facts exceed the native CLI transport bound")
     result: list[str] = []
     for index in range(0, len(encoded), SCHEDULER_HOST_FACTS_CHUNK_CHARS):
         chunk = encoded[index : index + SCHEDULER_HOST_FACTS_CHUNK_CHARS]
-        if chunk.startswith("-"):
-            # argparse treats a separate value beginning with "-" as another
-            # option. Bind only that ambiguous chunk with ``=``; retain the
-            # established two-argument shape for ordinary chunks.
-            result.append(f"{SCHEDULER_HOST_FACTS_CHUNK_FLAG}={chunk}")
-        else:
-            result.extend([SCHEDULER_HOST_FACTS_CHUNK_FLAG, chunk])
+        result.extend([SCHEDULER_HOST_FACTS_CHUNK_FLAG, chunk])
     return result
 
 

--- a/tests/control_plane/test_scheduler_host_followup_hint_transport.py
+++ b/tests/control_plane/test_scheduler_host_followup_hint_transport.py
@@ -12,6 +12,7 @@ from loopx.control_plane.scheduler.scheduler_hint import (
     build_codex_app_scheduler_ack_hint,
     build_codex_app_scheduler_failure_hint,
 )
+from loopx.control_plane.runtime.public_safety import SECRET_LIKE_SURFACE_PATTERN
 
 FACTS_FLAG = "--scheduler-host-facts-chunk"
 
@@ -176,14 +177,13 @@ def test_oversized_native_facts_fail_instead_of_falling_back_to_python() -> None
         )
 
 
-def test_native_facts_bind_dash_prefixed_chunks_as_option_values(
+def test_native_facts_chunks_do_not_look_like_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    encoded = ("A" * 384 + "-tail").encode("ascii")
     monkeypatch.setattr(
-        scheduler_hint.base64,
-        "urlsafe_b64encode",
-        lambda _value: encoded,
+        scheduler_hint.zlib,
+        "compress",
+        lambda _value, *, level: base64.urlsafe_b64decode("-ak-"),
     )
 
     args = scheduler_hint._scheduler_host_followup_transport_args(
@@ -192,11 +192,8 @@ def test_native_facts_bind_dash_prefixed_chunks_as_option_values(
         use_current_hint=True,
     )
 
-    assert args == [
-        FACTS_FLAG,
-        "A" * 384,
-        f"{FACTS_FLAG}=-tail",
-    ]
+    assert args == [FACTS_FLAG, "+ak+"]
+    assert SECRET_LIKE_SURFACE_PATTERN.search(args[-1]) is None
 
 
 def test_legacy_hint_builder_without_host_facts_keeps_the_compatibility_route() -> None:

--- a/tests/control_plane_ts/scheduler_heartbeat_followup_cli.test.ts
+++ b/tests/control_plane_ts/scheduler_heartbeat_followup_cli.test.ts
@@ -75,7 +75,8 @@ function hintPayload(): Record<string, unknown> {
 
 function chunks(value: unknown): string[] {
   const encoded = deflateSync(Buffer.from(JSON.stringify(value), "utf8"))
-    .toString("base64url");
+    .toString("base64")
+    .replace(/=+$/, "");
   return encoded.match(/.{1,384}/g) ?? [];
 }
 


### PR DESCRIPTION
## Summary

- encode scheduler host-fact chunks with the standard Base64 alphabet
- let the native TypeScript decoder accept both old URL-safe and new standard Base64 chunks
- remove the now-unreachable dash-prefixed argv workaround
- prevent opaque transport bytes from accidentally matching the public credential detector

## Root cause

URL-safe Base64 can emit hyphen and underscore. A generated chunk containing -ak- or -sk- is then mistaken for an access/secret-key marker, causing unrelated model-behavior tests and PR merge gates to fail. Standard Base64 avoids those marker shapes, while the native decoder keeps accepting both alphabets for compatibility.

## Validation

- regression test failed before the implementation change and passes after it
- 45 focused Python scheduler/native-launcher/portfolio tests passed
- 878 TypeScript control-plane tests passed, 1 skipped
- TypeScript typecheck passed
- Ruff and git diff --check passed
- LoopX premerge gate passed: 17/17 selected checks, 0 failures, 0 warnings, 0 manual holds

Signed-off-by: duanjialing.777 <duanjialing.777@bytedance.com>