### PR TITLE
feat(codex-app): add bounded host prompt delivery readback

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -557,6 +557,71 @@ could not be resolved,
 `fallback_hint.available=false` and the pasteable heartbeat gate is the correct
 stop - never guess an automation id.
 
+### Optional Prompt-Delivery Canary / 可选提示词送达检查
+
+An installed `ACTIVE` automation and a successful scheduler ACK prove
+configuration, not prompt delivery or Agent startup. For #3927, the existing
+fallback executable also offers a **read-only**, explicit diagnostic:
+
+```bash
+loopx-apply-rrule --check-delivery \
+  --automation-id <automation-id> --goal-id <goal-id> --agent-id <agent-id> \
+  --scheduled-thread-id <host-thread-id> --scheduled-turn-id <host-turn-id>
+```
+
+Without independent host evidence this returns exit code `1` and
+`status=host_prompt_delivery_unverified`. It does not run `quota should-run`,
+touch SQLite, apply a schedule, ACK, create a receipt, or spend quota. The
+existing apply path is unchanged when `--check-delivery` is absent. There is no
+persistent activation; stop invoking the option to disable the check.
+
+To compare an observation, add `--delivery-observation <local-json-file>`.
+Choose the expected scheduled thread and **turn** independently in the host;
+do not copy the expected identity from the observation being checked. A prior
+turn in the same recurring thread is not proof for the selected turn.
+The trusted host observer must export exactly these compact fields:
+
+| Field | Required observation |
+| --- | --- |
+| `schema_version` | `codex_app_prompt_delivery_observation_v0` |
+| `automation_id`, `goal_id`, `agent_id`, `thread_id`, `turn_id` | Exact identities for the selected scheduled execution |
+| `prompt_sha256` | SHA-256 of the exact UTF-8 task body **received by that turn**, without trimming or newline normalization |
+| `prompt_delivered_at_ms` | Positive integer UTC epoch milliseconds, or `null` when delivery was not observed |
+| `agent_started_at_ms` | Positive integer UTC epoch milliseconds, or `null` when startup was not observed |
+| `observed_at_ms` | Positive integer UTC epoch milliseconds of host observation |
+
+This release does **not** ship a Codex App observation exporter or a hook into
+the host scheduler. Never manufacture the observation by copying the installed
+prompt digest, relabeling scheduler ACK, or using an Agent's completion claim.
+If the host cannot supply these facts, leave delivery unverified and use the
+generated heartbeat body in a visible session with the normal quota guard.
+
+The canary compares the observation with the installed heartbeat TOML and
+caller-selected identities. It accepts only an active heartbeat bound to that
+thread, the exact prompt digest, ordered delivery/start/observation timestamps,
+and a delivery age of at most 900 seconds. Override the window with
+`--delivery-max-age-seconds N` (1–86400). Re-reading an old observation does not
+refresh its delivery age. Invalid, extra, duplicate, oversized, stale or
+incomplete input fails closed. Observation input is limited to 4096 bytes and
+the manifest to 256 KiB; results expose fixed reason codes, never raw prompts,
+observation bodies, input paths or parser errors.
+
+Exit `0`, `status=host_observation_matched` means the supplied observation
+matches this selected turn; it is **not cryptographic host attestation**,
+future-run liveness, validated Todo completion or execution permission. This
+optional diagnostic does not change `automation_liveness_v0`, scheduler
+admission or notification policy. Repeating it produces no write or quota spend.
+
+中文：`ACTIVE` 和 scheduler ACK 仅证明配置已安装。显式运行上述只读检查时，
+缺少宿主独立观测就返回 `host_prompt_delivery_unverified` 和退出码 `1`。
+调用者须从宿主独立选择本轮 thread/turn，观测必须来自本轮实际收到的任务正文及
+Agent 启动事件，不能由安装器或 Agent 自报补造。本版本没有宿主观测导出器；宿主
+无法提供这些事实时保持未验证，并在可见会话中按正常 quota guard 测试 heartbeat。
+可用 `--delivery-observation` 传入严格限定字段的本地 JSON；默认时效为 900 秒，
+可用 `--delivery-max-age-seconds` 设置 1–86400 秒。匹配仅代表输入观测一致，
+不授予执行权限，也不证明未来调度活性或任务完成。检查不写入、不 ACK、不消费 quota，
+不读取会话日志，输出不含正文、路径或原始错误；不再调用该选项即停用。
+
 ```text
 Create a heartbeat automation starting at 3 minutes for the current thread;
 then apply `quota should-run.scheduler_hint`: update RRULE only when

--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -560,67 +560,77 @@ stop - never guess an automation id.
 ### Optional Prompt-Delivery Canary / 可选提示词送达检查
 
 An installed `ACTIVE` automation and a successful scheduler ACK prove
-configuration, not prompt delivery or Agent startup. For #3927, the existing
-fallback executable also offers a **read-only**, explicit diagnostic:
+configuration, not prompt delivery or Agent startup. For #3927, the fallback
+executable offers an explicit, read-only check of a caller-selected turn:
 
 ```bash
-loopx-apply-rrule --check-delivery \
+loopx-apply-rrule --check-delivery --observe-host \
   --automation-id <automation-id> --goal-id <goal-id> --agent-id <agent-id> \
   --scheduled-thread-id <host-thread-id> --scheduled-turn-id <host-turn-id>
 ```
 
-Without independent host evidence this returns exit code `1` and
-`status=host_prompt_delivery_unverified`. It does not run `quota should-run`,
-touch SQLite, apply a schedule, ACK, create a receipt, or spend quota. The
-existing apply path is unchanged when `--check-delivery` is absent. There is no
-persistent activation; stop invoking the option to disable the check.
+Select the scheduled thread and **turn** independently in the host. The command
+starts `codex app-server` and calls only `initialize` and `thread/read` with
+`includeTurns=true`; it never starts or resumes a thread or launches a model.
+Use `--codex-bin <executable>` when `codex` is not on PATH. The server must use
+the same Codex home as the desktop app. The existing apply path is unchanged
+without `--check-delivery`; stop invoking the option to disable this diagnostic.
 
-To compare an observation, add `--delivery-observation <local-json-file>`.
-Choose the expected scheduled thread and **turn** independently in the host;
-do not copy the expected identity from the observation being checked. A prior
-turn in the same recurring thread is not proof for the selected turn.
-The trusted host observer must export exactly these compact fields:
+The adapter recognizes the desktop heartbeat envelope as the initial user
+message or `codex_app.automation_update` function output when exposed by the
+read API. Stored histories that omit that function output remain unverified.
+It hashes the received
+instructions as exact UTF-8, preserving whitespace, and requires subsequent
+Agent activity in the same turn. Missing, ambiguous or unsupported envelopes,
+incomplete history, missing startup time, and read failures remain unverified.
+It uses the host's turn-start timestamp; it does not invent precise prompt
+arrival or first-output timestamps. The app-server read API is documented in
+[Codex App Server](https://developers.openai.com/codex/app-server).
+
+For a separately obtained compact observation, replace `--observe-host` with
+`--delivery-observation <local-json-file>`. These sources are mutually exclusive.
+Without either source, delivery remains unverified. The JSON schema is:
 
 | Field | Required observation |
 | --- | --- |
-| `schema_version` | `codex_app_prompt_delivery_observation_v0` |
-| `automation_id`, `goal_id`, `agent_id`, `thread_id`, `turn_id` | Exact identities for the selected scheduled execution |
-| `prompt_sha256` | SHA-256 of the exact UTF-8 task body **received by that turn**, without trimming or newline normalization |
-| `prompt_delivered_at_ms` | Positive integer UTC epoch milliseconds, or `null` when delivery was not observed |
-| `agent_started_at_ms` | Positive integer UTC epoch milliseconds, or `null` when startup was not observed |
-| `observed_at_ms` | Positive integer UTC epoch milliseconds of host observation |
+| `schema_version` | `codex_app_prompt_delivery_observation_v1` |
+| `automation_id`, `thread_id`, `turn_id` | Exact selected identities |
+| `goal_id`, `agent_id` | Caller correlation context; the host does not independently attest these |
+| `prompt_sha256` | SHA-256 of the exact received task body, or `null` if missing |
+| `turn_started_at_ms` | Host turn-start UTC epoch milliseconds, or `null` if unavailable |
+| `agent_activity_observed` | Boolean: Agent activity follows the initial delivery item |
+| `observed_at_ms` | UTC epoch milliseconds as of the check |
 
-This release does **not** ship a Codex App observation exporter or a hook into
-the host scheduler. Never manufacture the observation by copying the installed
-prompt digest, relabeling scheduler ACK, or using an Agent's completion claim.
-If the host cannot supply these facts, leave delivery unverified and use the
-generated heartbeat body in a visible session with the normal quota guard.
+The canary requires an active heartbeat bound to that thread, an exact digest
+match against the installed TOML, and a turn age of at most 900 seconds.
+Override with `--delivery-max-age-seconds N` (1–86400). Re-reading an old turn
+does not refresh its age. Compact input is limited to 4096 bytes and the manifest
+to 256 KiB. Host reads are bounded to 10 seconds, 128 messages and 2 MiB; a large
+thread can therefore remain unverified. Thread history is read into memory only
+and never printed or persisted by the adapter. The host process may maintain
+its own runtime metadata. Results expose fixed reason codes, never raw prompts,
+history, paths or host errors.
 
-The canary compares the observation with the installed heartbeat TOML and
-caller-selected identities. It accepts only an active heartbeat bound to that
-thread, the exact prompt digest, ordered delivery/start/observation timestamps,
-and a delivery age of at most 900 seconds. Override the window with
-`--delivery-max-age-seconds N` (1–86400). Re-reading an old observation does not
-refresh its delivery age. Invalid, extra, duplicate, oversized, stale or
-incomplete input fails closed. Observation input is limited to 4096 bytes and
-the manifest to 256 KiB; results expose fixed reason codes, never raw prompts,
-observation bodies, input paths or parser errors.
+Exit `0`, `status=host_observation_matched` means the observed facts match this
+selected turn. Exit `1`, `status=host_prompt_delivery_unverified` means evidence
+is missing or inconsistent. A matching envelope is **not cryptographic scheduler
+attestation**: a manually supplied envelope could match too. Neither result
+grants execution permission or proves future liveness or Todo completion.
+The check does not query quota, modify automation TOML/SQLite, ACK, create a
+receipt, or change `automation_liveness_v0`, admission or notification policy.
+If host evidence is unavailable, inspect the selected turn and test the generated
+heartbeat body in a visible session using the normal LoopX quota guard.
 
-Exit `0`, `status=host_observation_matched` means the supplied observation
-matches this selected turn; it is **not cryptographic host attestation**,
-future-run liveness, validated Todo completion or execution permission. This
-optional diagnostic does not change `automation_liveness_v0`, scheduler
-admission or notification policy. Repeating it produces no write or quota spend.
-
-中文：`ACTIVE` 和 scheduler ACK 仅证明配置已安装。显式运行上述只读检查时，
-缺少宿主独立观测就返回 `host_prompt_delivery_unverified` 和退出码 `1`。
-调用者须从宿主独立选择本轮 thread/turn，观测必须来自本轮实际收到的任务正文及
-Agent 启动事件，不能由安装器或 Agent 自报补造。本版本没有宿主观测导出器；宿主
-无法提供这些事实时保持未验证，并在可见会话中按正常 quota guard 测试 heartbeat。
-可用 `--delivery-observation` 传入严格限定字段的本地 JSON；默认时效为 900 秒，
-可用 `--delivery-max-age-seconds` 设置 1–86400 秒。匹配仅代表输入观测一致，
-不授予执行权限，也不证明未来调度活性或任务完成。检查不写入、不 ACK、不消费 quota，
-不读取会话日志，输出不含正文、路径或原始错误；不再调用该选项即停用。
+中文：使用上述 `--check-delivery --observe-host` 命令回读宿主中独立选定的
+thread/turn；必要时用 `--codex-bin` 指定同一 Codex home 下的宿主程序。
+检查核对本轮初始 heartbeat 正文摘要、宿主启动时间和后续 Agent 活动，不启动
+模型、不修改自动化、不 ACK、不消费 quota。缺失或不一致返回未验证和退出码 1；
+匹配返回退出码 0，但不证明定时器来源、未来活性或任务完成，也不授予执行权限。
+可用 `--delivery-observation` 替代宿主回读，传入上述 v1 JSON；goal/agent 仅为
+调用者关联信息。默认时效 900 秒，可设为 1–86400 秒。读取上限为 10 秒和 2 MiB，
+超限保持未验证；历史仅在内存中处理，输出不含正文、路径或原始错误，宿主进程
+可能维护自身运行元数据。停止调用选项即停用；无法获得证据时，在可见会话中按
+正常 quota guard 测试 heartbeat，不能把配置安装成功当成正文送达。
 
 ```text
 Create a heartbeat automation starting at 3 minutes for the current thread;

--- a/loopx/control_plane/runtime/codex_app_delivery.py
+++ b/loopx/control_plane/runtime/codex_app_delivery.py
@@ -1,0 +1,167 @@
+"""Read-only Codex App delivery canary; never a scheduler admission receipt."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+OBSERVATION_SCHEMA = "codex_app_prompt_delivery_observation_v0"
+RESULT_SCHEMA = "codex_app_prompt_delivery_canary_v0"
+MAX_OBSERVATION_BYTES = 4096
+MAX_MANIFEST_BYTES = 256 * 1024
+_IDENTITY = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}\Z")
+_DIGEST = re.compile(r"[a-f0-9]{64}\Z")
+_FIELDS = frozenset(
+    {
+        "schema_version",
+        "automation_id",
+        "goal_id",
+        "agent_id",
+        "thread_id",
+        "turn_id",
+        "prompt_sha256",
+        "prompt_delivered_at_ms",
+        "agent_started_at_ms",
+        "observed_at_ms",
+    }
+)
+_FALLBACK = (
+    "Inspect the selected scheduled turn in the host. If its prompt or agent-start "
+    "observation is unavailable, test the generated heartbeat body in a visible "
+    "session with the normal LoopX quota guard. Installation/ACK is configuration "
+    "evidence only; do not spend quota or repeat external effects for this check."
+)
+
+
+def _result(reason: str, *, matched: bool = False) -> dict[str, Any]:
+    # Do not echo input values, prompts, paths, host errors or observation bodies.
+    return {
+        "schema_version": RESULT_SCHEMA,
+        "ok": matched,
+        "status": "host_observation_matched"
+        if matched
+        else "host_prompt_delivery_unverified",
+        "reason_code": reason,
+        "read_only": True,
+        "grants_execution_authority": False,
+        "fallback": None if matched else _FALLBACK,
+    }
+
+
+def _read_bounded(path: Path, limit: int) -> str:
+    with path.open("rb") as stream:
+        data = stream.read(limit + 1)
+    if len(data) > limit:
+        raise ValueError("input exceeds size limit")
+    return data.decode("utf-8")
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError("duplicate JSON key")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> None:
+    raise ValueError("non-standard JSON number")
+
+
+def check_codex_app_delivery(
+    *,
+    manifest_path: Path,
+    observation_path: Path | None,
+    automation_id: str,
+    goal_id: str,
+    agent_id: str,
+    thread_id: str,
+    turn_id: str,
+    now_ms: int,
+    max_age_seconds: int = 900,
+) -> dict[str, Any]:
+    """Compare a caller-selected turn with a trusted host observer's compact facts.
+
+    The caller must obtain the turn identity independently of the observation.
+    This checks consistency, not authenticity; no host observer is synthesized
+    from a manifest, scheduler ACK, process exit status, or an agent claim.
+    """
+    expected = {
+        "automation_id": automation_id,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "thread_id": thread_id,
+        "turn_id": turn_id,
+    }
+    if any(
+        not isinstance(v, str) or not _IDENTITY.fullmatch(v) for v in expected.values()
+    ):
+        return _result("invalid_expected_identity")
+    if (
+        type(now_ms) is not int
+        or not 0 < now_ms <= 2**53 - 1
+        or type(max_age_seconds) is not int
+        or not 1 <= max_age_seconds <= 86400
+    ):
+        return _result("invalid_observation_window")
+    try:
+        manifest = tomllib.loads(_read_bounded(manifest_path, MAX_MANIFEST_BYTES))
+    except (OSError, UnicodeError, ValueError):
+        return _result("manifest_unreadable_or_invalid")
+    if manifest.get("id") != automation_id:
+        return _result("manifest_automation_mismatch")
+    if manifest.get("kind") != "heartbeat":
+        return _result("unsupported_automation_kind")
+    if manifest.get("status") != "ACTIVE":
+        return _result("automation_not_active")
+    if manifest.get("target_thread_id") != thread_id:
+        return _result("manifest_thread_mismatch")
+    prompt = manifest.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _result("installed_prompt_missing")
+    if observation_path is None:
+        return _result("host_observation_missing")
+    try:
+        observation = json.loads(
+            _read_bounded(observation_path, MAX_OBSERVATION_BYTES),
+            object_pairs_hook=_unique_object,
+            parse_constant=_reject_constant,
+        )
+    except FileNotFoundError:
+        return _result("host_observation_missing")
+    except (OSError, UnicodeError, ValueError, RecursionError):
+        return _result("host_observation_invalid")
+    if not isinstance(observation, dict) or set(observation) != _FIELDS:
+        return _result("host_observation_invalid")
+    if observation["schema_version"] != OBSERVATION_SCHEMA:
+        return _result("host_observation_schema_mismatch")
+    if any(observation[key] != value for key, value in expected.items()):
+        return _result("host_observation_identity_mismatch")
+    digest = observation["prompt_sha256"]
+    if not isinstance(digest, str) or not _DIGEST.fullmatch(digest):
+        return _result("host_observation_invalid")
+    if digest != hashlib.sha256(prompt.encode("utf-8")).hexdigest():
+        return _result("host_prompt_digest_mismatch")
+    delivered = observation["prompt_delivered_at_ms"]
+    started = observation["agent_started_at_ms"]
+    observed = observation["observed_at_ms"]
+    if delivered is None:
+        return _result("prompt_delivery_not_observed")
+    if started is None:
+        return _result("agent_start_not_observed")
+    if any(
+        type(t) is not int or not 0 < t <= 2**53 - 1
+        for t in (delivered, started, observed)
+    ):
+        return _result("host_observation_invalid")
+    if not delivered <= started <= observed <= now_ms:
+        return _result("host_observation_time_mismatch")
+    # Re-observing an old turn must not extend its delivery freshness.
+    if now_ms - delivered > max_age_seconds * 1000:
+        return _result("host_observation_stale")
+    return _result("selected_turn_delivery_and_start_matched", matched=True)

--- a/loopx/control_plane/runtime/codex_app_delivery.py
+++ b/loopx/control_plane/runtime/codex_app_delivery.py
@@ -9,7 +9,7 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-OBSERVATION_SCHEMA = "codex_app_prompt_delivery_observation_v0"
+OBSERVATION_SCHEMA = "codex_app_prompt_delivery_observation_v1"
 RESULT_SCHEMA = "codex_app_prompt_delivery_canary_v0"
 MAX_OBSERVATION_BYTES = 4096
 MAX_MANIFEST_BYTES = 256 * 1024
@@ -24,8 +24,8 @@ _FIELDS = frozenset(
         "thread_id",
         "turn_id",
         "prompt_sha256",
-        "prompt_delivered_at_ms",
-        "agent_started_at_ms",
+        "turn_started_at_ms",
+        "agent_activity_observed",
         "observed_at_ms",
     }
 )
@@ -84,6 +84,8 @@ def check_codex_app_delivery(
     turn_id: str,
     now_ms: int,
     max_age_seconds: int = 900,
+    observe_host: bool = False,
+    codex_bin: str = "codex",
 ) -> dict[str, Any]:
     """Compare a caller-selected turn with a trusted host observer's compact facts.
 
@@ -124,18 +126,35 @@ def check_codex_app_delivery(
     prompt = manifest.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         return _result("installed_prompt_missing")
-    if observation_path is None:
-        return _result("host_observation_missing")
-    try:
-        observation = json.loads(
-            _read_bounded(observation_path, MAX_OBSERVATION_BYTES),
-            object_pairs_hook=_unique_object,
-            parse_constant=_reject_constant,
+    if observe_host and observation_path is not None:
+        return _result("conflicting_observation_sources")
+    if observe_host:
+        from .codex_app_delivery_observer import (
+            HostObservationError,
+            observe_codex_app_delivery,
         )
-    except FileNotFoundError:
+
+        try:
+            observation = observe_codex_app_delivery(
+                codex_bin=codex_bin,
+                expected=expected,
+                observed_at_ms=now_ms,
+            )
+        except HostObservationError as exc:
+            return _result(exc.reason_code)
+    elif observation_path is None:
         return _result("host_observation_missing")
-    except (OSError, UnicodeError, ValueError, RecursionError):
-        return _result("host_observation_invalid")
+    else:
+        try:
+            observation = json.loads(
+                _read_bounded(observation_path, MAX_OBSERVATION_BYTES),
+                object_pairs_hook=_unique_object,
+                parse_constant=_reject_constant,
+            )
+        except FileNotFoundError:
+            return _result("host_observation_missing")
+        except (OSError, UnicodeError, ValueError, RecursionError):
+            return _result("host_observation_invalid")
     if not isinstance(observation, dict) or set(observation) != _FIELDS:
         return _result("host_observation_invalid")
     if observation["schema_version"] != OBSERVATION_SCHEMA:
@@ -143,25 +162,24 @@ def check_codex_app_delivery(
     if any(observation[key] != value for key, value in expected.items()):
         return _result("host_observation_identity_mismatch")
     digest = observation["prompt_sha256"]
+    if digest is None:
+        return _result("prompt_delivery_not_observed")
     if not isinstance(digest, str) or not _DIGEST.fullmatch(digest):
         return _result("host_observation_invalid")
     if digest != hashlib.sha256(prompt.encode("utf-8")).hexdigest():
         return _result("host_prompt_digest_mismatch")
-    delivered = observation["prompt_delivered_at_ms"]
-    started = observation["agent_started_at_ms"]
+    started = observation["turn_started_at_ms"]
+    activity = observation["agent_activity_observed"]
     observed = observation["observed_at_ms"]
-    if delivered is None:
-        return _result("prompt_delivery_not_observed")
-    if started is None:
+    if activity is False or started is None:
         return _result("agent_start_not_observed")
-    if any(
-        type(t) is not int or not 0 < t <= 2**53 - 1
-        for t in (delivered, started, observed)
-    ):
+    if type(activity) is not bool:
         return _result("host_observation_invalid")
-    if not delivered <= started <= observed <= now_ms:
+    if any(type(t) is not int or not 0 < t <= 2**53 - 1 for t in (started, observed)):
+        return _result("host_observation_invalid")
+    if not started <= observed <= now_ms:
         return _result("host_observation_time_mismatch")
-    # Re-observing an old turn must not extend its delivery freshness.
-    if now_ms - delivered > max_age_seconds * 1000:
+    # Re-observing an old turn must not extend its freshness.
+    if now_ms - started > max_age_seconds * 1000:
         return _result("host_observation_stale")
     return _result("selected_turn_delivery_and_start_matched", matched=True)

--- a/loopx/control_plane/runtime/codex_app_delivery_observer.py
+++ b/loopx/control_plane/runtime/codex_app_delivery_observer.py
@@ -1,0 +1,215 @@
+"""Bounded, read-only app-server observation of one caller-selected turn."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import queue
+import re
+import subprocess
+import threading
+import time
+from typing import Any
+
+from .codex_app_delivery import OBSERVATION_SCHEMA, _reject_constant, _unique_object
+
+_MAX_BYTES = 2 * 1024 * 1024
+_HEARTBEAT = re.compile(
+    r"<heartbeat>\n  <automation_id>([A-Za-z0-9._:-]+)</automation_id>\n"
+    r"  <current_time_iso>\d{4}-\d{2}-\d{2}T[0-9:.]+Z</current_time_iso>\n"
+    r"  <instructions>\n(.*)\n  </instructions>\n</heartbeat>\n",
+    re.DOTALL,
+)
+_ACTIVITY = frozenset(
+    {"agentMessage", "reasoning", "commandExecution", "mcpToolCall", "dynamicToolCall"}
+)
+
+
+class HostObservationError(Exception):
+    """Only fixed public-safe reason codes cross the adapter boundary."""
+
+    def __init__(self, reason_code: str):
+        super().__init__(reason_code)
+        self.reason_code = reason_code
+
+
+def _read_thread(
+    codex_bin: str, thread_id: str, *, timeout: float = 10
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    try:
+        process = subprocess.Popen(
+            [codex_bin, "app-server", "--listen", "stdio://"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        raise HostObservationError("host_observer_unavailable") from None
+    messages: queue.Queue = queue.Queue(maxsize=129)
+
+    def read() -> None:
+        total = 0
+        try:
+            for _ in range(128):
+                line = process.stdout.readline(_MAX_BYTES - total + 1)
+                total += len(line)
+                if not line or total > _MAX_BYTES:
+                    break
+                messages.put_nowait(
+                    json.loads(
+                        line,
+                        object_pairs_hook=_unique_object,
+                        parse_constant=_reject_constant,
+                    )
+                )
+        except (OSError, ValueError, RecursionError, queue.Full):
+            pass
+        finally:
+            messages.put_nowait(None)
+
+    reader = threading.Thread(target=read, daemon=True)
+    reader.start()
+
+    def send(payload: dict) -> None:
+        process.stdin.write((json.dumps(payload) + "\n").encode())
+        process.stdin.flush()
+
+    def receive(request_id: int) -> dict:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise HostObservationError("host_observer_timeout")
+            try:
+                message = messages.get(timeout=remaining)
+            except queue.Empty:
+                raise HostObservationError("host_observer_timeout") from None
+            if not isinstance(message, dict):
+                raise HostObservationError("host_observer_response_invalid")
+            if message.get("id") == request_id:
+                if "error" in message or not isinstance(message.get("result"), dict):
+                    raise HostObservationError("host_observer_read_failed")
+                return message["result"]
+            # Never answer host requests, including requests for approval.
+            if "id" in message:
+                raise HostObservationError("host_observer_response_invalid")
+
+    try:
+        send(
+            {
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "clientInfo": {"name": "loopx_delivery_canary", "version": "1"}
+                },
+            }
+        )
+        receive(1)
+        send({"method": "initialized"})
+        send(
+            {
+                "id": 2,
+                "method": "thread/read",
+                "params": {"threadId": thread_id, "includeTurns": True},
+            }
+        )
+        return receive(2)
+    except (OSError, ValueError):
+        raise HostObservationError("host_observer_response_invalid") from None
+    finally:
+        if process.poll() is None:
+            process.kill()
+        process.wait()
+        reader.join(timeout=1)
+        process.stdin.close()
+        process.stdout.close()
+
+
+def _input_text(item: dict) -> str | None:
+    if item.get("type") == "userMessage":
+        content = item.get("content")
+        if (
+            isinstance(content, list)
+            and len(content) == 1
+            and isinstance(content[0], dict)
+            and content[0].get("type") == "text"
+        ):
+            return content[0].get("text")
+    if (
+        item.get("type") == "functionCallOutput"
+        and item.get("name") == "automation_update"
+        and item.get("namespace") == "codex_app"
+    ):
+        output = item.get("output")
+        if isinstance(output, str):
+            return output
+        if (
+            isinstance(output, list)
+            and len(output) == 1
+            and isinstance(output[0], dict)
+            and output[0].get("type") == "input_text"
+        ):
+            return output[0].get("text")
+    return None
+
+
+def observe_codex_app_delivery(
+    *, codex_bin: str, expected: dict[str, str], observed_at_ms: int
+) -> dict[str, Any]:
+    result = _read_thread(codex_bin, expected["thread_id"])
+    thread = result.get("thread")
+    if (
+        not isinstance(thread, dict)
+        or thread.get("id") != expected["thread_id"]
+        or not isinstance(thread.get("turns"), list)
+    ):
+        raise HostObservationError("host_observer_response_invalid")
+    turns = [
+        t
+        for t in thread["turns"]
+        if isinstance(t, dict) and t.get("id") == expected["turn_id"]
+    ]
+    if len(turns) != 1:
+        raise HostObservationError("host_selected_turn_unavailable")
+    turn = turns[0]
+    items = turn.get("items")
+    if (
+        turn.get("itemsView", "full") != "full"
+        or not isinstance(items, list)
+        or any(not isinstance(i, dict) for i in items)
+    ):
+        raise HostObservationError("host_selected_turn_incomplete")
+    # The initial input must carry the envelope. Later steering cannot repair it.
+    first_input = next(
+        (
+            i
+            for i, item in enumerate(items)
+            if item.get("type") in {"userMessage", "functionCallOutput"}
+        ),
+        None,
+    )
+    matches = []
+    for index, item in enumerate(items):
+        text = _input_text(item)
+        match = _HEARTBEAT.fullmatch(text) if isinstance(text, str) else None
+        if match and match[1] == expected["automation_id"]:
+            matches.append((index, match[2]))
+    digest = None
+    activity = False
+    if len(matches) == 1 and matches[0][0] == first_input:
+        index, body = matches[0]
+        try:
+            digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        except UnicodeError:
+            raise HostObservationError("host_observer_response_invalid") from None
+        activity = any(item.get("type") in _ACTIVITY for item in items[index + 1 :])
+    started = turn.get("startedAt")
+    return {
+        "schema_version": OBSERVATION_SCHEMA,
+        **expected,
+        "prompt_sha256": digest,
+        "turn_started_at_ms": started * 1000 if type(started) is int else None,
+        "agent_activity_observed": activity,
+        # The check's as-of time; no per-item timestamps are fabricated.
+        "observed_at_ms": observed_at_ms,
+    }

--- a/scripts/codex_app_apply_rrule.py
+++ b/scripts/codex_app_apply_rrule.py
@@ -492,11 +492,21 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         help="Read-only host delivery canary; never query quota, apply an RRULE or ACK.",
     )
     parser.add_argument("--delivery-observation", type=Path)
+    parser.add_argument(
+        "--observe-host",
+        action="store_true",
+        help="Read the selected stored turn through Codex App Server.",
+    )
+    parser.add_argument("--codex-bin", default="codex")
     parser.add_argument("--scheduled-thread-id")
     parser.add_argument("--scheduled-turn-id")
     parser.add_argument("--delivery-max-age-seconds", type=int, default=900)
     args = parser.parse_args(argv)
     if args.check_delivery:
+        if args.observe_host and args.delivery_observation is not None:
+            parser.error(
+                "--observe-host and --delivery-observation are mutually exclusive"
+            )
         if not args.scheduled_thread_id or not args.scheduled_turn_id:
             parser.error(
                 "--check-delivery requires --scheduled-thread-id and --scheduled-turn-id"
@@ -508,6 +518,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         or args.scheduled_thread_id is not None
         or args.scheduled_turn_id is not None
         or args.delivery_max_age_seconds != 900
+        or args.observe_host
+        or args.codex_bin != "codex"
     ):
         parser.error("delivery observation options require --check-delivery")
     return args
@@ -532,6 +544,8 @@ def main(argv: list[str] | None = None) -> int:
             turn_id=args.scheduled_turn_id,
             now_ms=_now_ms(),
             max_age_seconds=args.delivery_max_age_seconds,
+            observe_host=args.observe_host,
+            codex_bin=args.codex_bin,
         )
         print(json.dumps(result, sort_keys=True))
         return 0 if result["ok"] else 1

--- a/scripts/codex_app_apply_rrule.py
+++ b/scripts/codex_app_apply_rrule.py
@@ -32,7 +32,6 @@ from typing import Any
 
 from loopx.turn_identity import normalize_turn_instance_id
 
-
 _FAILURE_OUTPUT_LIMIT = 2_000
 
 
@@ -128,7 +127,9 @@ def _heartbeat_task_body(
     try:
         payload = json.loads(completed.stdout)
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"loopx heartbeat-prompt returned invalid JSON: {exc}") from exc
+        raise SystemExit(
+            f"loopx heartbeat-prompt returned invalid JSON: {exc}"
+        ) from exc
     body = payload.get("task_body") if isinstance(payload, dict) else None
     if not isinstance(body, str) or not body.strip():
         raise SystemExit("loopx heartbeat-prompt returned no task_body")
@@ -425,8 +426,7 @@ def _update_sqlite(
         connection.commit()
         if cursor.rowcount != 1:
             raise SystemExit(
-                f"automation row not found or not updated in {db_path}: "
-                f"{automation_id}"
+                f"automation row not found or not updated in {db_path}: {automation_id}"
             )
     finally:
         connection.close()
@@ -486,11 +486,55 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--dry-run", action="store_true")
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--check-delivery",
+        action="store_true",
+        help="Read-only host delivery canary; never query quota, apply an RRULE or ACK.",
+    )
+    parser.add_argument("--delivery-observation", type=Path)
+    parser.add_argument("--scheduled-thread-id")
+    parser.add_argument("--scheduled-turn-id")
+    parser.add_argument("--delivery-max-age-seconds", type=int, default=900)
+    args = parser.parse_args(argv)
+    if args.check_delivery:
+        if not args.scheduled_thread_id or not args.scheduled_turn_id:
+            parser.error(
+                "--check-delivery requires --scheduled-thread-id and --scheduled-turn-id"
+            )
+        if args.dry_run:
+            parser.error("--check-delivery is already read-only; omit --dry-run")
+    elif (
+        args.delivery_observation is not None
+        or args.scheduled_thread_id is not None
+        or args.scheduled_turn_id is not None
+        or args.delivery_max_age_seconds != 900
+    ):
+        parser.error("delivery observation options require --check-delivery")
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
+    if args.check_delivery:
+        from loopx.control_plane.runtime.codex_app_delivery import (
+            check_codex_app_delivery,
+        )
+
+        result = check_codex_app_delivery(
+            manifest_path=args.automations_root
+            / args.automation_id
+            / "automation.toml",
+            observation_path=args.delivery_observation,
+            automation_id=args.automation_id,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            thread_id=args.scheduled_thread_id,
+            turn_id=args.scheduled_turn_id,
+            now_ms=_now_ms(),
+            max_age_seconds=args.delivery_max_age_seconds,
+        )
+        print(json.dumps(result, sort_keys=True))
+        return 0 if result["ok"] else 1
     codex_app, stateful = _load_scheduler_hint(
         loopx=args.loopx,
         registry=args.registry,

--- a/tests/test_codex_app_delivery_canary.py
+++ b/tests/test_codex_app_delivery_canary.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from loopx.control_plane.runtime.codex_app_delivery import check_codex_app_delivery
+from scripts.codex_app_apply_rrule import main
+
+NOW = 1_800_000_000_000
+PROMPT = "Advance the synthetic goal.\n先运行 quota guard。\n"
+
+
+@pytest.fixture
+def delivery(tmp_path: Path):
+    manifest = tmp_path / "automations" / "synthetic" / "automation.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        'version = 1\nid = "synthetic"\nkind = "heartbeat"\nstatus = "ACTIVE"\n'
+        'target_thread_id = "synthetic-thread"\n'
+        f"prompt = {json.dumps(PROMPT, ensure_ascii=False)}\n",
+        encoding="utf-8",
+    )
+    observation = {
+        "schema_version": "codex_app_prompt_delivery_observation_v0",
+        "automation_id": "synthetic",
+        "goal_id": "synthetic-goal",
+        "agent_id": "synthetic-agent",
+        "thread_id": "synthetic-thread",
+        "turn_id": "scheduled-turn-1",
+        "prompt_sha256": hashlib.sha256(PROMPT.encode("utf-8")).hexdigest(),
+        "prompt_delivered_at_ms": NOW - 2000,
+        "agent_started_at_ms": NOW - 1000,
+        "observed_at_ms": NOW,
+    }
+    observation_path = tmp_path / "observation.json"
+    observation_path.write_text(json.dumps(observation), encoding="utf-8")
+    kwargs = {
+        "manifest_path": manifest,
+        "observation_path": observation_path,
+        "automation_id": "synthetic",
+        "goal_id": "synthetic-goal",
+        "agent_id": "synthetic-agent",
+        "thread_id": "synthetic-thread",
+        "turn_id": "scheduled-turn-1",
+        "now_ms": NOW,
+    }
+    return kwargs, observation
+
+
+def test_installation_is_not_delivery_evidence(delivery):
+    kwargs, _ = delivery
+    kwargs["observation_path"].unlink()
+    result = check_codex_app_delivery(**kwargs)
+    assert result["status"] == "host_prompt_delivery_unverified"
+    assert result["reason_code"] == "host_observation_missing"
+    assert not result["ok"]
+    kwargs["observation_path"] = None
+    assert check_codex_app_delivery(**kwargs) == result
+
+
+def test_exact_observed_turn_replays_without_writes_or_authority(delivery):
+    kwargs, _ = delivery
+    paths = [kwargs["manifest_path"], kwargs["observation_path"]]
+    before = [(p.read_bytes(), p.stat().st_mtime_ns) for p in paths]
+    first = check_codex_app_delivery(**kwargs)
+    assert first["ok"]
+    assert first["status"] == "host_observation_matched"
+    assert first["grants_execution_authority"] is False
+    assert check_codex_app_delivery(**kwargs) == first
+    assert before == [(p.read_bytes(), p.stat().st_mtime_ns) for p in paths]
+
+
+@pytest.mark.parametrize(
+    "field", ["automation_id", "goal_id", "agent_id", "thread_id", "turn_id"]
+)
+def test_other_identity_never_satisfies_selected_turn(delivery, field):
+    kwargs, observation = delivery
+    observation[field] = "another-identity"
+    kwargs["observation_path"].write_text(json.dumps(observation))
+    result = check_codex_app_delivery(**kwargs)
+    assert not result["ok"]
+    assert result["reason_code"] == "host_observation_identity_mismatch"
+
+
+@pytest.mark.parametrize(
+    "field, value, reason",
+    [
+        ("prompt_sha256", "0" * 64, "host_prompt_digest_mismatch"),
+        ("schema_version", "future-v99", "host_observation_schema_mismatch"),
+        ("prompt_delivered_at_ms", None, "prompt_delivery_not_observed"),
+        ("agent_started_at_ms", None, "agent_start_not_observed"),
+        ("agent_started_at_ms", True, "host_observation_invalid"),
+        ("observed_at_ms", "1800000000000", "host_observation_invalid"),
+        ("observed_at_ms", 2**53, "host_observation_invalid"),
+        ("observed_at_ms", NOW + 1, "host_observation_time_mismatch"),
+        ("agent_started_at_ms", NOW - 3000, "host_observation_time_mismatch"),
+        ("prompt_delivered_at_ms", NOW - 900001, "host_observation_stale"),
+    ],
+)
+def test_reject_missing_changed_or_stale_host_facts(delivery, field, value, reason):
+    kwargs, observation = delivery
+    observation[field] = value
+    kwargs["observation_path"].write_text(json.dumps(observation))
+    result = check_codex_app_delivery(**kwargs)
+    assert not result["ok"]
+    assert result["reason_code"] == reason
+
+
+def test_fresh_readback_does_not_extend_old_delivery(delivery):
+    kwargs, observation = delivery
+    observation["prompt_delivered_at_ms"] = NOW - 900000
+    kwargs["observation_path"].write_text(json.dumps(observation))
+    assert check_codex_app_delivery(**kwargs)["ok"]
+    kwargs["now_ms"] += 1
+    assert check_codex_app_delivery(**kwargs)["reason_code"] == "host_observation_stale"
+
+
+def test_prompt_identity_is_exact_and_invalidated_after_edit(delivery):
+    kwargs, _ = delivery
+    manifest = kwargs["manifest_path"]
+    manifest.write_text(manifest.read_text().replace("quota guard", "quota  guard"))
+    assert (
+        check_codex_app_delivery(**kwargs)["reason_code"]
+        == "host_prompt_digest_mismatch"
+    )
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "{}",
+        "[]",
+        "null",
+        "{",
+        '{"schema_version": "v0", "schema_version": "v1"}',
+        '{"value": NaN}',
+        "[" * 1200,
+        "x" * 4097,
+    ],
+)
+def test_malformed_input_never_echoes_or_verifies(delivery, contents):
+    kwargs, _ = delivery
+    kwargs["observation_path"].write_text(contents)
+    result = check_codex_app_delivery(**kwargs)
+    assert result["reason_code"] == "host_observation_invalid"
+    assert not result["ok"]
+
+
+def test_private_extra_fields_fail_closed_without_echo(delivery):
+    kwargs, observation = delivery
+    observation["raw_prompt"] = "synthetic-private-sentinel"
+    kwargs["observation_path"].write_text(json.dumps(observation))
+    result = check_codex_app_delivery(**kwargs)
+    assert not result["ok"]
+    assert "synthetic-private-sentinel" not in json.dumps(result)
+    assert str(kwargs["manifest_path"]) not in json.dumps(result)
+    assert PROMPT not in json.dumps(result, ensure_ascii=False)
+
+
+@pytest.mark.parametrize(
+    "old, new, reason",
+    [
+        ('id = "synthetic"', 'id = "other"', "manifest_automation_mismatch"),
+        ('kind = "heartbeat"', 'kind = "cron"', "unsupported_automation_kind"),
+        ('status = "ACTIVE"', 'status = "PAUSED"', "automation_not_active"),
+        (
+            'target_thread_id = "synthetic-thread"',
+            'target_thread_id = "other"',
+            "manifest_thread_mismatch",
+        ),
+    ],
+)
+def test_manifest_binding_is_required(delivery, old, new, reason):
+    kwargs, _ = delivery
+    path = kwargs["manifest_path"]
+    path.write_text(path.read_text().replace(old, new))
+    assert check_codex_app_delivery(**kwargs)["reason_code"] == reason
+
+
+def _argv(kwargs):
+    return [
+        "--check-delivery",
+        "--automations-root",
+        str(kwargs["manifest_path"].parents[1]),
+        "--automation-id",
+        "synthetic",
+        "--goal-id",
+        "synthetic-goal",
+        "--agent-id",
+        "synthetic-agent",
+        "--scheduled-thread-id",
+        "synthetic-thread",
+        "--scheduled-turn-id",
+        "scheduled-turn-1",
+        "--delivery-observation",
+        str(kwargs["observation_path"]),
+    ]
+
+
+def test_diagnostic_bypasses_all_quota_and_host_mutations(
+    delivery, monkeypatch, capsys
+):
+    kwargs, _ = delivery
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("read-only delivery check reached the mutation/query path")
+
+    for name in (
+        "_load_scheduler_hint",
+        "_sqlite_row_exists",
+        "_update_toml",
+        "_update_sqlite",
+        "_run_ack",
+    ):
+        monkeypatch.setattr(f"scripts.codex_app_apply_rrule.{name}", forbidden)
+    monkeypatch.setattr("scripts.codex_app_apply_rrule._now_ms", lambda: NOW)
+    assert main(_argv(kwargs)) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "host_observation_matched"
+    kwargs["observation_path"].unlink()
+    assert main(_argv(kwargs)) == 1
+    assert (
+        json.loads(capsys.readouterr().out)["status"]
+        == "host_prompt_delivery_unverified"
+    )
+
+
+@pytest.mark.parametrize("observed", [False, True])
+def test_real_cli_reports_delivery_without_creating_host_state(
+    delivery, tmp_path, observed
+):
+    kwargs, observation = delivery
+    if observed:
+        now = time.time_ns() // 1_000_000
+        observation.update(
+            prompt_delivered_at_ms=now - 2000,
+            agent_started_at_ms=now - 1000,
+            observed_at_ms=now,
+        )
+        kwargs["observation_path"].write_text(json.dumps(observation))
+    else:
+        kwargs["observation_path"].unlink()
+    before = sorted(str(p) for p in tmp_path.rglob("*"))
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.codex_app_apply_rrule",
+            *_argv(kwargs),
+            "--db-path",
+            str(tmp_path / "absent-host.db"),
+            "--loopx",
+            "must-not-launch",
+        ],
+        cwd=Path(__file__).parents[1],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert completed.returncode == (0 if observed else 1)
+    result = json.loads(completed.stdout)
+    assert result["ok"] is observed
+    assert completed.stderr == ""
+    assert before == sorted(str(p) for p in tmp_path.rglob("*"))
+
+
+@pytest.mark.parametrize(
+    "changes, reason",
+    [
+        ({"automation_id": "../other"}, "invalid_expected_identity"),
+        ({"turn_id": ""}, "invalid_expected_identity"),
+        ({"max_age_seconds": 0}, "invalid_observation_window"),
+        ({"max_age_seconds": 86401}, "invalid_observation_window"),
+        ({"now_ms": True}, "invalid_observation_window"),
+    ],
+)
+def test_invalid_expected_context_fails_before_reading(delivery, changes, reason):
+    kwargs, _ = delivery
+    kwargs.update(changes)
+    kwargs["manifest_path"].unlink()
+    assert check_codex_app_delivery(**kwargs)["reason_code"] == reason
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--check-delivery"],
+        ["--delivery-observation", "fixture.json"],
+        ["--scheduled-turn-id", "scheduled-turn-1"],
+    ],
+)
+def test_incomplete_or_mixed_modes_are_rejected(argv):
+    with pytest.raises(SystemExit) as raised:
+        main(argv)
+    assert raised.value.code == 2

--- a/tests/test_codex_app_delivery_canary.py
+++ b/tests/test_codex_app_delivery_canary.py
@@ -27,15 +27,15 @@ def delivery(tmp_path: Path):
         encoding="utf-8",
     )
     observation = {
-        "schema_version": "codex_app_prompt_delivery_observation_v0",
+        "schema_version": "codex_app_prompt_delivery_observation_v1",
         "automation_id": "synthetic",
         "goal_id": "synthetic-goal",
         "agent_id": "synthetic-agent",
         "thread_id": "synthetic-thread",
         "turn_id": "scheduled-turn-1",
         "prompt_sha256": hashlib.sha256(PROMPT.encode("utf-8")).hexdigest(),
-        "prompt_delivered_at_ms": NOW - 2000,
-        "agent_started_at_ms": NOW - 1000,
+        "turn_started_at_ms": NOW - 2000,
+        "agent_activity_observed": True,
         "observed_at_ms": NOW,
     }
     observation_path = tmp_path / "observation.json"
@@ -93,14 +93,16 @@ def test_other_identity_never_satisfies_selected_turn(delivery, field):
     [
         ("prompt_sha256", "0" * 64, "host_prompt_digest_mismatch"),
         ("schema_version", "future-v99", "host_observation_schema_mismatch"),
-        ("prompt_delivered_at_ms", None, "prompt_delivery_not_observed"),
-        ("agent_started_at_ms", None, "agent_start_not_observed"),
-        ("agent_started_at_ms", True, "host_observation_invalid"),
+        ("prompt_sha256", None, "prompt_delivery_not_observed"),
+        ("turn_started_at_ms", None, "agent_start_not_observed"),
+        ("agent_activity_observed", False, "agent_start_not_observed"),
+        ("agent_activity_observed", 1, "host_observation_invalid"),
+        ("turn_started_at_ms", True, "host_observation_invalid"),
         ("observed_at_ms", "1800000000000", "host_observation_invalid"),
         ("observed_at_ms", 2**53, "host_observation_invalid"),
         ("observed_at_ms", NOW + 1, "host_observation_time_mismatch"),
-        ("agent_started_at_ms", NOW - 3000, "host_observation_time_mismatch"),
-        ("prompt_delivered_at_ms", NOW - 900001, "host_observation_stale"),
+        ("turn_started_at_ms", NOW + 1, "host_observation_time_mismatch"),
+        ("turn_started_at_ms", NOW - 900001, "host_observation_stale"),
     ],
 )
 def test_reject_missing_changed_or_stale_host_facts(delivery, field, value, reason):
@@ -114,7 +116,7 @@ def test_reject_missing_changed_or_stale_host_facts(delivery, field, value, reas
 
 def test_fresh_readback_does_not_extend_old_delivery(delivery):
     kwargs, observation = delivery
-    observation["prompt_delivered_at_ms"] = NOW - 900000
+    observation["turn_started_at_ms"] = NOW - 900000
     kwargs["observation_path"].write_text(json.dumps(observation))
     assert check_codex_app_delivery(**kwargs)["ok"]
     kwargs["now_ms"] += 1
@@ -238,8 +240,8 @@ def test_real_cli_reports_delivery_without_creating_host_state(
     if observed:
         now = time.time_ns() // 1_000_000
         observation.update(
-            prompt_delivered_at_ms=now - 2000,
-            agent_started_at_ms=now - 1000,
+            turn_started_at_ms=now - 2000,
+            agent_activity_observed=True,
             observed_at_ms=now,
         )
         kwargs["observation_path"].write_text(json.dumps(observation))
@@ -299,3 +301,31 @@ def test_incomplete_or_mixed_modes_are_rejected(argv):
     with pytest.raises(SystemExit) as raised:
         main(argv)
     assert raised.value.code == 2
+
+
+def test_host_read_is_explicit_and_never_falls_back_to_supplied_facts(
+    delivery, monkeypatch
+):
+    from loopx.control_plane.runtime import codex_app_delivery_observer as observer
+
+    kwargs, _ = delivery
+    calls = []
+
+    def unavailable(**args):
+        calls.append(args)
+        raise observer.HostObservationError("host_observer_unavailable")
+
+    monkeypatch.setattr(observer, "observe_codex_app_delivery", unavailable)
+    assert check_codex_app_delivery(**kwargs)["ok"]
+    assert calls == []
+    kwargs["observe_host"] = True
+    assert (
+        check_codex_app_delivery(**kwargs)["reason_code"]
+        == "conflicting_observation_sources"
+    )
+    assert calls == []
+    kwargs["observation_path"] = None
+    assert (
+        check_codex_app_delivery(**kwargs)["reason_code"] == "host_observer_unavailable"
+    )
+    assert len(calls) == 1

--- a/tests/test_codex_app_delivery_observer.py
+++ b/tests/test_codex_app_delivery_observer.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+
+import pytest
+
+from loopx.control_plane.runtime import codex_app_delivery_observer as observer
+
+BODY = "Do the synthetic work.\n先检查 quota。\n"
+ENVELOPE = (
+    "<heartbeat>\n  <automation_id>synthetic</automation_id>\n"
+    "  <current_time_iso>2027-01-15T08:00:00.000Z</current_time_iso>\n"
+    f"  <instructions>\n{BODY}\n  </instructions>\n</heartbeat>\n"
+)
+EXPECTED = dict(
+    automation_id="synthetic",
+    goal_id="goal",
+    agent_id="agent",
+    thread_id="thread",
+    turn_id="turn",
+)
+
+
+def user(text):
+    return {"type": "userMessage", "content": [{"type": "text", "text": text}]}
+
+
+def observe(monkeypatch, items, **changes):
+    turn = {"id": "turn", "startedAt": 1800000000, "items": items, **changes}
+    monkeypatch.setattr(
+        observer,
+        "_read_thread",
+        lambda *args: {"thread": {"id": "thread", "turns": [turn]}},
+    )
+    return observer.observe_codex_app_delivery(
+        codex_bin="unused", expected=EXPECTED, observed_at_ms=1800000001000
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        user(ENVELOPE),
+        {
+            "type": "functionCallOutput",
+            "namespace": "codex_app",
+            "name": "automation_update",
+            "output": ENVELOPE,
+        },
+    ],
+)
+def test_readback_hashes_received_body_and_observes_following_activity(
+    monkeypatch, source
+):
+    receipt = observe(
+        monkeypatch, [source, {"type": "agentMessage", "text": "working"}]
+    )
+    assert receipt["prompt_sha256"] == hashlib.sha256(BODY.encode()).hexdigest()
+    assert receipt["agent_activity_observed"] is True
+    assert receipt["turn_started_at_ms"] == 1800000000000
+    assert BODY not in json.dumps(receipt, ensure_ascii=False)
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [],
+        [user("ordinary message")],
+        [user(ENVELOPE.replace("synthetic", "other"))],
+        [user("original"), user(ENVELOPE)],
+        [user(ENVELOPE), user(ENVELOPE)],
+        [user("prefix" + ENVELOPE)],
+        [
+            {
+                "type": "functionCallOutput",
+                "namespace": "untrusted",
+                "name": "automation_update",
+                "output": ENVELOPE,
+            }
+        ],
+    ],
+)
+def test_missing_wrong_or_ambiguous_initial_delivery_is_unverified(monkeypatch, items):
+    receipt = observe(monkeypatch, items + [{"type": "agentMessage", "text": "done"}])
+    assert receipt["prompt_sha256"] is None
+    assert receipt["agent_activity_observed"] is False
+
+
+@pytest.mark.parametrize(
+    "items", [[user(ENVELOPE)], [{"type": "agentMessage"}, user(ENVELOPE)]]
+)
+def test_prior_activity_or_completed_status_does_not_prove_agent_started(
+    monkeypatch, items
+):
+    assert (
+        observe(monkeypatch, items, status="completed")["agent_activity_observed"]
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    "changes,reason",
+    [
+        ({"id": "other"}, "host_selected_turn_unavailable"),
+        ({"itemsView": "notLoaded"}, "host_selected_turn_incomplete"),
+    ],
+)
+def test_requires_selected_full_turn(monkeypatch, changes, reason):
+    with pytest.raises(observer.HostObservationError, match=reason):
+        observe(monkeypatch, [user(ENVELOPE)], **changes)
+
+
+def test_transport_only_initializes_and_reads_selected_thread(tmp_path, monkeypatch):
+    script = tmp_path / "fake.py"
+    script.write_text("""import json, sys
+first = json.loads(sys.stdin.readline())
+assert first['method'] == 'initialize'
+print(json.dumps({'id': 1, 'result': {}}), flush=True)
+assert json.loads(sys.stdin.readline()) == {'method': 'initialized'}
+request = json.loads(sys.stdin.readline())
+assert request == {'id': 2, 'method': 'thread/read', 'params': {'threadId': 'thread', 'includeTurns': True}}
+print(json.dumps({'id': 2, 'result': {'thread': {'id': 'thread', 'turns': []}}}), flush=True)
+sys.stdin.read()
+""")
+    original = observer.subprocess.Popen
+    monkeypatch.setattr(
+        observer.subprocess,
+        "Popen",
+        lambda argv, **kwargs: original([sys.executable, str(script)], **kwargs),
+    )
+    assert observer._read_thread("codex", "thread")["thread"]["id"] == "thread"
+
+
+@pytest.mark.parametrize(
+    "code,reason",
+    [
+        ("import time; time.sleep(30)", "host_observer_timeout"),
+        (
+            "print('private-invalid-response', flush=True)",
+            "host_observer_response_invalid",
+        ),
+        (
+            "print('x' * (2 * 1024 * 1024 + 1), flush=True)",
+            "host_observer_response_invalid",
+        ),
+        (
+            """print('{"id": 1, "error": {"message": "private"}}', flush=True)""",
+            "host_observer_read_failed",
+        ),
+    ],
+)
+def test_transport_is_bounded_and_errors_do_not_expose_host_data(
+    monkeypatch, code, reason
+):
+    original = observer.subprocess.Popen
+    children = []
+
+    def launch(argv, **kwargs):
+        child = original([sys.executable, "-c", code], **kwargs)
+        children.append(child)
+        return child
+
+    monkeypatch.setattr(observer.subprocess, "Popen", launch)
+    with pytest.raises(observer.HostObservationError) as exc:
+        observer._read_thread("codex", "thread", timeout=0.3)
+    assert str(exc.value) == reason
+    assert all(child.poll() is not None for child in children)
+
+
+@pytest.mark.parametrize("delivered", [True, False])
+def test_native_app_server_cli_with_isolated_synthetic_session(
+    tmp_path, monkeypatch, delivered
+):
+    """Opt-in real backend read; no model, scheduler or private session access."""
+    import os
+    import subprocess
+    import time
+    import uuid
+    from datetime import datetime, timezone
+    from pathlib import Path
+
+    codex = os.environ.get("LOOPX_TEST_CODEX_BIN")
+    if not codex:
+        pytest.skip("set LOOPX_TEST_CODEX_BIN to qualify the installed app-server")
+    home = tmp_path / "codex"
+    monkeypatch.setenv("CODEX_HOME", str(home))
+    thread_id, turn_id = str(uuid.uuid4()), str(uuid.uuid4())
+    now = int(time.time())
+    timestamp = (
+        datetime.fromtimestamp(now, timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    session = (
+        home
+        / "sessions"
+        / datetime.fromtimestamp(now, timezone.utc).strftime("%Y/%m/%d")
+        / f"rollout-{timestamp.replace(':', '-')}-{thread_id}.jsonl"
+    )
+    session.parent.mkdir(parents=True)
+    received = ENVELOPE if delivered else "synthetic missing heartbeat"
+    events = [
+        (
+            "session_meta",
+            {
+                "id": thread_id,
+                "timestamp": timestamp,
+                "cwd": str(tmp_path),
+                "originator": "synthetic-canary",
+                "cli_version": "0.153.4",
+                "source": "cli",
+                "model_provider": "openai",
+            },
+        ),
+        (
+            "event_msg",
+            {
+                "type": "task_started",
+                "turn_id": turn_id,
+                "started_at": now,
+                "model_context_window": 100000,
+                "collaboration_mode_kind": "default",
+            },
+        ),
+        (
+            "response_item",
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": received}],
+            },
+        ),
+        (
+            "event_msg",
+            {
+                "type": "user_message",
+                "message": received,
+                "images": [],
+                "local_images": [],
+                "text_elements": [],
+            },
+        ),
+        (
+            "response_item",
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "synthetic activity"}],
+            },
+        ),
+        ("event_msg", {"type": "agent_message", "message": "synthetic activity"}),
+        (
+            "event_msg",
+            {
+                "type": "task_complete",
+                "turn_id": turn_id,
+                "last_agent_message": "synthetic activity",
+            },
+        ),
+    ]
+    session.write_text(
+        "".join(
+            json.dumps({"timestamp": timestamp, "type": kind, "payload": payload})
+            + "\n"
+            for kind, payload in events
+        )
+    )
+    manifest = home / "automations" / "synthetic" / "automation.toml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        f'id = "synthetic"\nkind = "heartbeat"\nstatus = "ACTIVE"\ntarget_thread_id = "{thread_id}"\nprompt = {json.dumps(BODY)}\n'
+    )
+    before = manifest.read_bytes(), session.read_bytes()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.codex_app_apply_rrule",
+            "--check-delivery",
+            "--observe-host",
+            "--codex-bin",
+            codex,
+            "--automation-id",
+            "synthetic",
+            "--goal-id",
+            "goal",
+            "--agent-id",
+            "agent",
+            "--scheduled-thread-id",
+            thread_id,
+            "--scheduled-turn-id",
+            turn_id,
+        ],
+        cwd=Path(__file__).parents[1],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    assert result.returncode == (0 if delivered else 1), result.stdout
+    assert json.loads(result.stdout)["ok"] is delivered
+    assert BODY not in result.stdout
+    assert result.stderr == ""
+    assert before == (manifest.read_bytes(), session.read_bytes())


### PR DESCRIPTION
An installed Codex App automation can appear active even when its scheduled turn receives no heartbeat body or produces no Agent activity. This adds an opt-in delivery canary to `loopx-apply-rrule`: `--check-delivery --observe-host` reads the caller-selected stored turn through Codex App Server, checks the exact received heartbeat digest against the installed manifest, and requires subsequent Agent activity and a fresh host turn-start timestamp.

Missing, mismatched, incomplete, stale or unreadable evidence returns `host_prompt_delivery_unverified` and exit 1 with a safe fallback. Successful observation is consistency evidence only, not scheduler attestation or execution permission. No quota query, RRULE mutation, ACK, model launch or thread resume occurs. The default apply path is unchanged.

The host reader is bounded to 10 seconds, 128 messages and 2 MiB, and emits no raw history or host errors. `--delivery-observation` alternatively accepts the documented compact v1 schema; it uses actual turn-start and activity facts rather than invented per-item timestamps. The provider-specific reader stays in the existing control-plane runtime boundary; the related refactor separates host I/O from receipt validation without adding another scheduler authority.

Validation:
- 81 targeted tests passed, including existing RRULE/ACK tests and native Codex App Server 0.153.4 CLI positive/negative readback against isolated synthetic stored sessions.
- Standard premerge: 16 selected checks passed, plus diff hygiene and Python compilation.
- Ruff and formatting passed (existing script EXE001 excluded); six-file public-boundary scan: no errors or warnings.

Related to #3927. This draft implements the optional adapter canary, not the remaining scheduler-liveness admission change. A real desktop timer-triggered run has not yet been qualified; synthetic native-session readback is not evidence that the desktop scheduler delivered a prompt. Some stored histories omit function-output inputs and therefore remain unverified. Goal/agent IDs are caller correlation context, not independently attested host facts. Documentation includes activation, limits, fallback and disable guidance in English and Chinese.
