### PR TITLE
fix(chat): preserve managed Codex home ownership across upgrades

### DIFF
--- a/docs/integrations/session-runtime-control-plane-adapter.md
+++ b/docs/integrations/session-runtime-control-plane-adapter.md
@@ -40,6 +40,37 @@ recovers after approval; it should not become the default end-user console.
 
 ## Core Principle
 
+### Managed Codex home ownership (implemented)
+
+The managed Chat adapter captures `LOOPX_CHAT_CODEX_HOME`, then `CODEX_HOME`,
+then the host's default Codex home at controller startup. It explicitly passes
+that home to each app-server process, including catalog-compatibility retries.
+New managed Codex sessions persist this binding in owner-local session state.
+Resume and submit reject a different home before starting an upstream process
+or modifying a turn. Legacy sessions acquire the binding only after successful
+upstream restoration; startup alone neither rebinds nor copies their history.
+
+The macOS LaunchAgent installer preserves an existing binding on upgrade,
+including older shell-export plists. Use `LOOPX_CHAT_CODEX_HOME` explicitly when
+installing a deliberately different host profile. A later ambient `CODEX_HOME`
+does not overwrite it. Restore the original home to recover a home-mismatch
+gate; changing this variable is not a session-migration command.
+
+Sharing a host home does not by itself prove a SQLite lock failure. A desktop
+launcher should separate ordinary open (read-only identity/configuration checks)
+from offline account switching, migration, or rollback (exclusive ownership).
+Do not make a normal open perform hidden migrations, kill managed workers, or
+move sessions into another home to pass an overly broad file-open check.
+Sharing a home also does not authorize two clients to run the same thread
+concurrently. Account changes still require quiescing all users of that home;
+this binding does not implement credential copying or account-refresh logic.
+
+Validation: `python -m pytest tests/test_chat_codex_home.py tests/test_chat_agent.py`
+and `python examples/macos-dashboard-launchagent-status-smoke.py`. The latter
+exercises the actual installer with fixture LaunchAgents, not real services.
+
+### Projection boundary
+
 The host session log is the raw fact source. LoopX run history is a
 compact control projection. A projection may reference host ids such as session,
 event, tool call, artifact, approval, or outcome ids, but it must not copy full

--- a/examples/macos-dashboard-launchagent-status-smoke.py
+++ b/examples/macos-dashboard-launchagent-status-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import plistlib
 import subprocess
 import tempfile
 from pathlib import Path
@@ -27,6 +28,7 @@ def run_script(fake_bin: Path, home: Path, args: list[str], *, schema_version: i
         "FAKE_CONTROL_PLANE_WRITE_ENABLED": "true" if write_enabled else "false",
         "LOOPX_STATUS_CONTRACT_MIN_VERSION": "2",
         "CODEX_HOME": "",
+        "LOOPX_CHAT_CODEX_HOME": "",
         **(extra_env or {}),
     }
     return subprocess.run(
@@ -123,7 +125,7 @@ def main() -> int:
         assert "--port 8767" in default_chat_plist, default_chat_plist
         assert "--replace-existing-loopx-chat" in default_chat_plist, default_chat_plist
         assert "--no-open" in default_chat_plist, default_chat_plist
-        assert "export CODEX_HOME=" not in default_chat_plist, default_chat_plist
+        assert f"export CODEX_HOME={(home / '.codex').resolve()};" in default_chat_plist, default_chat_plist
         assert "export LOOPX_PYTHON=" in default_plist, default_plist
         assert "export LOOPX_PYTHON=" in default_chat_plist, default_chat_plist
         assert "/loopx --registry" in default_plist, default_plist
@@ -135,12 +137,36 @@ def main() -> int:
             home,
             ["--enable-control-plane-write-api", "restart"],
             schema_version=2,
-            extra_env={"CODEX_HOME": str(home / "selected-codex-home")},
+            extra_env={"LOOPX_CHAT_CODEX_HOME": str(home / "selected-codex-home")},
         )
         write_plist = status_plist.read_text(encoding="utf-8")
         selected_chat_plist = chat_plist.read_text(encoding="utf-8")
         assert "--enable-control-plane-write-api" in write_plist, write_plist
-        assert f"export CODEX_HOME={home / 'selected-codex-home'};" in selected_chat_plist, selected_chat_plist
+        selected = (home / 'selected-codex-home').resolve()
+        assert f"export CODEX_HOME={selected};" in selected_chat_plist, selected_chat_plist
+        run_script(fake_bin, home, ["install"], schema_version=2,
+                   extra_env={"CODEX_HOME": str(home / "unrelated-upgrader")})
+        assert plistlib.loads(chat_plist.read_bytes())["EnvironmentVariables"]["LOOPX_CHAT_CODEX_HOME"] == str(selected)
+
+        # Legacy generated plists used only a shell export. Preserve quoted
+        # paths across upgrades without ever executing their command contents.
+        legacy = plistlib.loads(chat_plist.read_bytes())
+        legacy.pop("EnvironmentVariables")
+        legacy_home = (home / "legacy home").resolve()
+        legacy["ProgramArguments"] = ["/bin/zsh", "-c", f"export CODEX_HOME='{legacy_home}'; exec loopx chat"]
+        chat_plist.write_bytes(plistlib.dumps(legacy))
+        run_script(fake_bin, home, ["install"], schema_version=2,
+                   extra_env={"CODEX_HOME": str(home / "unrelated-upgrader")})
+        assert plistlib.loads(chat_plist.read_bytes())["EnvironmentVariables"]["LOOPX_CHAT_CODEX_HOME"] == str(legacy_home)
+
+        chat_plist.write_bytes(b"invalid plist")
+        try:
+            run_script(fake_bin, home, ["install"], schema_version=2)
+        except subprocess.CalledProcessError:
+            pass
+        else:
+            raise AssertionError("malformed existing binding must fail closed")
+        assert chat_plist.read_bytes() == b"invalid plist"
 
     print("macos-dashboard-launchagent-status-smoke ok")
     return 0

--- a/loopx/chat_agent.py
+++ b/loopx/chat_agent.py
@@ -280,6 +280,7 @@ class CodexChatAgentSession:
         hard_timeout_sec: float = 900.0,
         resume_thread_id: str | None = None,
         execution_mode: bool = False,
+        codex_home: Path | None = None,
         _compatibility_catalog_path: Path | None = None,
     ) -> "CodexChatAgentSession":
         resolved = shutil.which(codex_bin)
@@ -292,6 +293,11 @@ class CodexChatAgentSession:
                 ),
             )
         root = work_dir.resolve()
+        # Pin the host store explicitly, including compatibility retries. Never
+        # redirect an existing thread by inheriting a different launch context.
+        runtime_home = (codex_home or Path(os.environ.get("CODEX_HOME") or "~/.codex")).expanduser().resolve()
+        runtime_env = os.environ.copy()
+        runtime_env["CODEX_HOME"] = str(runtime_home)
         command = [resolved, "app-server"]
         if _compatibility_catalog_path is not None:
             command.extend(
@@ -305,6 +311,7 @@ class CodexChatAgentSession:
             process = subprocess.Popen(
                 command,
                 cwd=str(root),
+                env=runtime_env,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
@@ -387,6 +394,7 @@ class CodexChatAgentSession:
                     hard_timeout_sec=hard_timeout_sec,
                     resume_thread_id=resume_thread_id,
                     execution_mode=execution_mode,
+                    codex_home=runtime_home,
                     _compatibility_catalog_path=catalog_path,
                 )
         except Exception:

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -55,6 +55,7 @@ class CodexAppServerAdapter:
         idle_timeout_sec: float = 180.0,
         hard_timeout_sec: float = 900.0,
         execution_mode: bool = False,
+        codex_home: Path | None = None,
     ) -> "CodexAppServerAdapter":
         return cls(
             CodexChatAgentSession.start(
@@ -67,6 +68,7 @@ class CodexAppServerAdapter:
                 hard_timeout_sec=hard_timeout_sec,
                 execution_mode=execution_mode,
                 resume_thread_id=resume_thread_id,
+                codex_home=codex_home,
             )
         )
 
@@ -214,6 +216,12 @@ class ChatRuntimeController:
     ) -> None:
         self.store = store
         self.codex_bin = codex_bin
+        # Capture once; the service's startup environment is not session identity.
+        self.codex_home = Path(
+            os.environ.get("LOOPX_CHAT_CODEX_HOME")
+            or os.environ.get("CODEX_HOME")
+            or "~/.codex"
+        ).expanduser().resolve()
         self.claude_bin = claude_bin
         self.startup_timeout_sec = startup_timeout_sec
         self.idle_timeout_sec = idle_timeout_sec
@@ -314,6 +322,7 @@ class ChatRuntimeController:
                     history_context = "\nPrevious visible Chat messages:\n" + "\n".join(history_lines)
             return CodexAppServerAdapter.start(
                 codex_bin=self.codex_bin,
+                codex_home=self.codex_home,
                 work_dir=work_dir,
                 goal_id=goal_id,
                 objective=f"{objective}{history_context}",
@@ -399,6 +408,7 @@ class ChatRuntimeController:
                 upstream_thread_id=adapter.upstream_thread_id,
                 upstream_mode="chat" if agent_id == "codex" else "default",
                 channel_id=selected_channel,
+                codex_home=str(self.codex_home) if agent_id == "codex" else None,
             )
             with self.lock:
                 self.adapters[persisted["session_id"]] = adapter
@@ -407,6 +417,18 @@ class ChatRuntimeController:
     def _session_adapter_lock(self, session_id: str) -> threading.Lock:
         with self.lock:
             return self.session_adapter_locks.setdefault(session_id, threading.Lock())
+
+    def _check_codex_home(self, session: dict[str, Any]) -> None:
+        if session.get("agent_id") != "codex" or session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
+            return
+        bound_home = session.get("codex_home")
+        if bound_home is not None and bound_home != str(self.codex_home):
+            raise CodexChatAgentError(
+                "This managed Session belongs to a different Codex home. Restart LoopX Chat "
+                "with its original LOOPX_CHAT_CODEX_HOME; do not copy or rebind its history.",
+                error_code="codex_home_mismatch",
+                gate=None,
+            )
 
     def _ensure_adapter(
         self,
@@ -436,6 +458,7 @@ class ChatRuntimeController:
         if current_session is None or current_session.get("status") == "closed":
             raise KeyError("chat session was not found")
         session = current_session
+        self._check_codex_home(session)
         if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
             raise CodexChatAgentError(
                 "The attached host Session must be served by its existing host bridge.",
@@ -528,12 +551,16 @@ class ChatRuntimeController:
         with self.lock:
             self.adapters[session_id] = adapter
         try:
+            if session.get("agent_id") == "codex" and session.get("codex_home") is None:
+                # A legacy session is bound only after successful upstream resume,
+                # not when a service happens to start in a new environment.
+                self.store.update_session(session_id, codex_home=str(self.codex_home))
             self.store.restore_managed_session_if_idle(
                 session_id,
                 upstream_thread_id=adapter.upstream_thread_id,
                 upstream_mode=self._managed_upstream_mode(session),
             )
-        except KeyError:
+        except Exception:
             with self.lock:
                 owns_adapter = self.adapters.get(session_id) is adapter
                 if owns_adapter:
@@ -1081,6 +1108,7 @@ class ChatRuntimeController:
             session = self.store.load_session(session_id)
             if session is None or session.get("status") == "closed":
                 raise KeyError("chat session was not found")
+            self._check_codex_home(session)
             if session.get("session_mode") == CHAT_SESSION_MODE_ATTACHED:
                 if session.get("active_turn_id"):
                     return session

--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -196,10 +196,16 @@ class ChatSessionStore:
         executor_endpoint_id: str | None = None,
         host_surface: str | None = None,
         attached_capabilities: dict[str, bool] | None = None,
+        codex_home: str | None = None,
     ) -> dict[str, Any]:
         now = utc_now()
         token = _opaque_id(session_id or uuid.uuid4().hex, field="session_id")
         normalized_mode = _opaque_id(session_mode, field="session_mode")
+        if codex_home is not None and (
+            not Path(codex_home).is_absolute() or agent_id != "codex"
+            or normalized_mode != CHAT_SESSION_MODE_MANAGED
+        ):
+            raise ValueError("codex_home must be an absolute managed Codex home")
         if normalized_mode not in {
             CHAT_SESSION_MODE_MANAGED,
             CHAT_SESSION_MODE_ATTACHED,
@@ -241,6 +247,7 @@ class ChatSessionStore:
             "adapter_kind": normalized_adapter_kind,
             "upstream_thread_id": normalized_upstream_thread_id,
             "upstream_mode": normalized_upstream_mode,
+            "codex_home": codex_home,
             "session_mode": normalized_mode,
             "host_surface": normalized_host_surface,
             "attached_capabilities": capabilities,
@@ -278,6 +285,7 @@ class ChatSessionStore:
                     "last_error_code",
                     "upstream_thread_id",
                     "upstream_mode",
+                    "codex_home",
                 }
                 unknown = set(changes) - allowed
                 if unknown:
@@ -286,6 +294,14 @@ class ChatSessionStore:
                     changes["upstream_thread_id"] = _upstream_id(changes["upstream_thread_id"])
                 if "upstream_mode" in changes:
                     changes["upstream_mode"] = _opaque_id(changes["upstream_mode"], field="upstream_mode")
+                if "codex_home" in changes:
+                    home = changes["codex_home"]
+                    if (not isinstance(home, str) or not Path(home).is_absolute()
+                            or payload.get("agent_id") != "codex"
+                            or payload.get("session_mode") != CHAT_SESSION_MODE_MANAGED):
+                        raise ValueError("codex_home must be an absolute managed Codex home")
+                    if payload.get("codex_home") not in (None, home):
+                        raise ValueError("cannot rebind a managed Codex home")
                 payload.update(changes)
                 payload["updated_at"] = utc_now()
                 _atomic_write_json(path, payload, preserve_mode=True)

--- a/scripts/macos-dashboard-launchagent.sh
+++ b/scripts/macos-dashboard-launchagent.sh
@@ -44,6 +44,7 @@ Environment overrides:
   LOOPX_CHAT_PORT
   LOOPX_DASHBOARD_HOST
   LOOPX_LAUNCH_LABEL_PREFIX
+  LOOPX_CHAT_CODEX_HOME  Explicit managed Codex home (upgrades preserve the existing binding)
 EOF
 }
 
@@ -154,9 +155,45 @@ raise SystemExit(1)
 PY
 }
 
+resolve_chat_codex_home() {
+  "$1" - "$chat_plist" <<'PY'
+import os
+from pathlib import Path
+import plistlib
+import shlex
+import sys
+
+target = Path(sys.argv[1])
+selected = os.environ.get("LOOPX_CHAT_CODEX_HOME")
+if not selected and target.exists():
+    # Decode, never execute, an old generated shell command. A malformed plist
+    # must fail closed rather than silently adopt the upgrader's account home.
+    with target.open("rb") as stream:
+        plist = plistlib.load(stream)
+    env = plist.get("EnvironmentVariables", {})
+    selected = env.get("LOOPX_CHAT_CODEX_HOME") or env.get("CODEX_HOME")
+    if not selected:
+        args = plist.get("ProgramArguments", [])
+        if len(args) == 3 and args[1] == "-c":
+            lexer = shlex.shlex(args[2], posix=True, punctuation_chars=";")
+            lexer.whitespace_split = True
+            words = list(lexer)
+            for index, word in enumerate(words[:-1]):
+                if word == "export" and words[index + 1].startswith("CODEX_HOME="):
+                    selected = words[index + 1].split("=", 1)[1]
+                    break
+    selected = selected or str(Path.home() / ".codex")
+selected = selected or os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
+path = Path(selected).expanduser()
+if not path.is_absolute():
+    raise SystemExit("LoopX Chat Codex home must be absolute")
+print(path.resolve())
+PY
+}
+
 write_plists() {
   local status_command python_command codex_command claude_command lark_cli_command
-  local path_prefix command_path command_dir status_shell chat_shell control_plane_write_arg lark_cli_arg codex_home_export
+  local path_prefix command_path command_dir status_shell chat_shell control_plane_write_arg lark_cli_arg codex_home_export chat_codex_home
   status_command="$(resolve_status_command)"
   python_command="$(resolve_loopx_python)"
   codex_command="$(resolve_optional_command codex)"
@@ -182,9 +219,8 @@ write_plists() {
   if [[ -n "$lark_cli_command" ]]; then
     lark_cli_arg=" --lark-cli-bin $(shell_quote "$lark_cli_command")"
   fi
-  if [[ -n "${CODEX_HOME:-}" ]]; then
-    codex_home_export=" export CODEX_HOME=$(shell_quote "$CODEX_HOME");"
-  fi
+  chat_codex_home="$(resolve_chat_codex_home "$python_command")"
+  codex_home_export=" export CODEX_HOME=$(shell_quote "$chat_codex_home"); export LOOPX_CHAT_CODEX_HOME=$(shell_quote "$chat_codex_home");"
   status_shell="export LOOPX_PYTHON=$(shell_quote "$python_command"); export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") serve-status --global-registry --host $(shell_quote "$host") --port $(shell_quote "$status_port") --limit $(shell_quote "$status_limit")$control_plane_write_arg"
   chat_shell="export LOOPX_PYTHON=$(shell_quote "$python_command");$codex_home_export export PATH=$(shell_quote "$path_prefix"):\$PATH; exec $(shell_quote "$status_command") --registry $(shell_quote "$registry") chat --global-registry --host $(shell_quote "$host") --port $(shell_quote "$chat_port") --codex-bin $(shell_quote "$codex_command") --claude-bin $(shell_quote "$claude_command")$lark_cli_arg --replace-existing-loopx-chat --no-open"
 
@@ -226,6 +262,11 @@ EOF
 <dict>
   <key>Label</key>
   <string>$chat_label</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>LOOPX_CHAT_CODEX_HOME</key>
+    <string>$(xml_escape "$chat_codex_home")</string>
+  </dict>
   <key>ProgramArguments</key>
   <array>
     <string>/bin/zsh</string>

--- a/tests/test_chat_agent.py
+++ b/tests/test_chat_agent.py
@@ -57,3 +57,24 @@ def test_codex_chat_app_server_stdio_uses_utf8(
         assert launch_options["encoding"] == "utf-8"
     finally:
         session.close()
+
+
+def test_codex_chat_pins_explicit_home_in_child_environment(monkeypatch, tmp_path):
+    options = {}
+
+    def popen(command, **kwargs):
+        options.update(kwargs)
+        return _FakeAppServerProcess()
+
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "ambient"))
+    monkeypatch.setattr(chat_agent.shutil, "which", lambda _: "codex")
+    monkeypatch.setattr(chat_agent.subprocess, "Popen", popen)
+    session = chat_agent.CodexChatAgentSession.start(
+        codex_bin="codex", work_dir=tmp_path, goal_id="fixture", objective="fixture",
+        codex_home=tmp_path / "bound",
+    )
+    try:
+        assert options["env"]["CODEX_HOME"] == str((tmp_path / "bound").resolve())
+        assert chat_agent.os.environ["CODEX_HOME"] == str(tmp_path / "ambient")
+    finally:
+        session.close()

--- a/tests/test_chat_codex_home.py
+++ b/tests/test_chat_codex_home.py
@@ -1,0 +1,99 @@
+"""A managed upstream thread's home is identity, not restart-time routing."""
+import pytest
+
+from loopx.chat_agent import CodexChatAgentError
+from loopx.chat_runtime import ChatRuntimeController
+from loopx.chat_store import ChatSessionStore
+
+
+class Adapter:
+    upstream_thread_id = "fixture-thread"
+    closed = False
+
+    def healthcheck(self):
+        return True
+
+    def close_session(self):
+        self.closed = True
+
+
+def controller(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOOPX_CHAT_CODEX_HOME", str(tmp_path / "bound"))
+    runtime = ChatRuntimeController(store=ChatSessionStore(tmp_path / "store"), codex_bin="fixture")
+    monkeypatch.setattr(runtime, "capabilities", lambda: [{
+        "agent_id": "codex", "available": True, "adapter_kind": "codex_app_server",
+    }])
+    monkeypatch.setattr(runtime, "_start_adapter", lambda **kwargs: Adapter())
+    return runtime
+
+
+def legacy(runtime):
+    return runtime.store.create_session(
+        goal_id="fixture", agent_id="codex", adapter_kind="codex_app_server",
+        upstream_thread_id="fixture-thread", upstream_mode="chat",
+    )
+
+
+def test_new_session_records_home_and_process_environment_cannot_rebind(tmp_path, monkeypatch):
+    runtime = controller(tmp_path, monkeypatch)
+    monkeypatch.setenv("LOOPX_CHAT_CODEX_HOME", str(tmp_path / "other"))
+    session, _ = runtime.open_session(goal_id="fixture", agent_id="codex",
+        work_dir=tmp_path, objective="fixture", mode="new")
+    assert session["codex_home"] == str((tmp_path / "bound").resolve())
+    with pytest.raises(ValueError, match="cannot rebind"):
+        runtime.store.update_session(session["session_id"], codex_home=str(tmp_path / "other"))
+    runtime.close()
+
+
+def test_restart_home_mismatch_refuses_before_resume_or_turn_write(tmp_path, monkeypatch):
+    runtime = controller(tmp_path, monkeypatch)
+    session = legacy(runtime)
+    runtime.store.update_session(session["session_id"], codex_home=str(tmp_path / "other"))
+    before = runtime.store.load_session(session["session_id"])
+    monkeypatch.setattr(runtime, "_start_adapter", lambda **kwargs: pytest.fail("must not start upstream"))
+    for operation in (
+        lambda: runtime.resume_session(session_id=session["session_id"], work_dir=tmp_path, objective="fixture"),
+        lambda: runtime.submit_turn(session_id=session["session_id"], client_turn_id="fixture-turn",
+            message="fixture", work_dir=tmp_path, objective="fixture"),
+    ):
+        with pytest.raises(CodexChatAgentError) as error:
+            operation()
+        assert error.value.error_code == "codex_home_mismatch"
+        assert runtime.store.load_session(session["session_id"]) == before
+    runtime.close()
+
+
+def test_legacy_home_bound_only_after_successful_resume(tmp_path, monkeypatch):
+    runtime = controller(tmp_path, monkeypatch)
+    session = legacy(runtime)
+    sid = session["session_id"]
+
+    def unavailable(**kwargs):
+        raise RuntimeError("upstream unavailable")
+
+    monkeypatch.setattr(runtime, "_start_adapter", unavailable)
+    with pytest.raises(CodexChatAgentError):
+        runtime.resume_session(session_id=sid, work_dir=tmp_path, objective="fixture")
+    assert runtime.store.load_session(sid)["codex_home"] is None
+    monkeypatch.setattr(runtime, "_start_adapter", lambda **kwargs: Adapter())
+    restored = runtime.resume_session(session_id=sid, work_dir=tmp_path, objective="fixture")
+    assert restored["codex_home"] == str((tmp_path / "bound").resolve())
+    assert restored["upstream_thread_id"] == "fixture-thread"
+    runtime.close()
+
+
+def test_attached_session_uses_existing_host_not_managed_adapter(tmp_path, monkeypatch):
+    runtime = controller(tmp_path, monkeypatch)
+    session = runtime.store.create_session(
+        goal_id="fixture", agent_id="codex", adapter_kind="codex_app_server",
+        upstream_thread_id="fixture-attached", session_mode="attached_host",
+        host_surface="codex-app",
+    )
+    monkeypatch.setattr(runtime, "_start_adapter", lambda **kwargs: pytest.fail("attached must not spawn"))
+    restored = runtime.resume_session(session_id=session["session_id"], work_dir=tmp_path, objective="fixture")
+    assert restored["codex_home"] is None
+    turn, created = runtime.submit_turn(session_id=session["session_id"], client_turn_id="attached-turn",
+        message="fixture", work_dir=tmp_path, objective="fixture")
+    assert created and turn["status"] == "queued"
+    assert not runtime.adapters
+    runtime.close()


### PR DESCRIPTION
## Summary
- Preserve the existing managed Codex home when reinstalling macOS LaunchAgents; only LOOPX_CHAT_CODEX_HOME explicitly selects another home. Decode legacy shell exports without executing them.
- Capture and pass the child home explicitly, persist managed session ownership, and reject mismatched resume/submit before upstream start or turn mutation. Legacy sessions bind after successful restoration; attached hosts retain their existing bridge.
- Document ordinary-open versus exclusive account/migration operations. No credential copying, history migration, automatic process killing, or account switching is added.

## Root cause
The LaunchAgent change in 90aee29aaa (2026-08-31) persisted ambient CODEX_HOME again on every reinstall. Managed sessions had no durable home binding. This can interact with external launchers that incorrectly require exclusive ownership for ordinary open; that launcher correction is local tooling, not included here.

## Validation
- 93 focused tests passed: chat agent, home binding, active-turn lifecycle, startup isolation, store validation, dashboard commands, attachments, CORS.
- Real installer smoke passed with fixture launchctl: default, explicit home, upgrade preservation, legacy quoted paths, malformed plist rejection.
- Ruff and bash syntax checks passed; git diff --check clean.
- LoopX public boundary scan clean for all 8 changed files; no errors (3 existing unrelated global-registry warnings).
- Local external-launcher tests: 43 passed, including a real SQLite/lsof holder that blocks mutations but not read-only open.

## Boundaries
Only public product code, docs and synthetic regression fixtures. No user paths, credentials, private configuration or raw session logs are included. Runtime behavior requires review; no automatic self-merge requested.