### PR TITLE
ci: adopt Node 24 LTS as the primary runtime

### DIFF
--- a/.github/workflows/desktop-release-artifacts.yml
+++ b/.github/workflows/desktop-release-artifacts.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: |
             apps/desktop/loopx-control-plane/package-lock.json

--- a/.github/workflows/desktop-updater.yml
+++ b/.github/workflows/desktop-updater.yml
@@ -81,7 +81,7 @@ jobs:
           ref: ${{ needs.identity.outputs.ref }}
       - uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/frontstage-pages.yml
+++ b/.github/workflows/frontstage-pages.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
           cache-dependency-path: |
             apps/presentation/dashboard/package-lock.json

--- a/.github/workflows/full-public-smokes.yml
+++ b/.github/workflows/full-public-smokes.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22.6"
+          node-version: "24"
 
       - name: Install smoke runtime dependencies
         run: python -m pip install --disable-pip-version-check "jsonschema>=4.23,<5"

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up the TypeScript Effect runtime
         uses: actions/setup-node@v6
         with:
-          node-version: "22.6"
+          node-version: "24"
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -114,6 +114,43 @@ jobs:
           LOOPX_CLI_OUTPUT_BASE_REF: origin/${{ github.event.pull_request.base.ref || 'main' }}
         run: python examples/control_plane/cli-output-budget-regression-smoke.py
 
+  node-minimum-compatibility:
+    needs: changes
+    if: needs.changes.outputs.core_tests == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.6"
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Qualify the public minimum Node.js runtime
+        run: |
+          npm ci --ignore-scripts
+          npm run typecheck:control-plane
+          npm run test:control-plane
+
+  node-forward-compatibility:
+    needs: changes
+    if: needs.changes.outputs.core_tests == 'true'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "26"
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Probe the next Node.js runtime
+        run: |
+          npm ci --ignore-scripts
+          npm run typecheck:control-plane
+          npm run test:control-plane
+
   test-shard:
     needs: changes
     if: needs.changes.outputs.core_tests == 'true'
@@ -133,7 +170,7 @@ jobs:
           cache: pip
       - uses: actions/setup-node@v6
         with:
-          node-version: "22.6"
+          node-version: "24"
           cache: npm
           cache-dependency-path: package-lock.json
       - name: Install test dependencies
@@ -223,7 +260,7 @@ jobs:
           cache-dependency-path: tests/requirements-stage2c-linux-py311.txt
       - uses: actions/setup-node@v6
         with:
-          node-version: "22.6"
+          node-version: "24"
           cache: npm
       - name: Install locked test and package build tools
         run: |
@@ -314,7 +351,7 @@ jobs:
       - name: Set up the TypeScript Effect runtime
         uses: actions/setup-node@v6
         with:
-          node-version: "22.6"
+          node-version: "24"
 
       - name: Install test dependencies
         run: python -m pip install --disable-pip-version-check -e ".[test]"
@@ -341,7 +378,7 @@ jobs:
   merge-gate:
     # Always publish one stable outcome, including documentation-only PRs.
     if: always()
-    needs: [changes, pytest, stage2c-correctness-e2e, windows-powershell]
+    needs: [changes, pytest, node-minimum-compatibility, stage2c-correctness-e2e, windows-powershell]
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up the packaged TypeScript control-plane runtime
         uses: actions/setup-node@v6
         with:
-          node-version: "22.6"
+          node-version: "24"
 
       - name: Resolve and validate release identity
         id: identity

--- a/README.md
+++ b/README.md
@@ -245,11 +245,11 @@ More inspectable surfaces:
 
 ## Try LoopX
 
-Requirements: Python 3.11+ and Node.js 22.6+. Use an active Python environment
-whose console scripts are on `PATH`; macOS and Linux use a POSIX shell, while
-native Windows uses PowerShell 7. Node.js runs the managed, idle-exiting
-TypeScript Effect core; LoopX starts it automatically. Git is only needed for
-contributor clone/canary workflows.
+Requirements: Python 3.11+ and Node.js 22.6+; Node.js 24 LTS is recommended.
+Use an active Python environment whose console scripts are on `PATH`; macOS and
+Linux use a POSIX shell, while native Windows uses PowerShell 7. Node.js runs
+the managed, idle-exiting TypeScript Effect core; LoopX starts it automatically.
+Git is only needed for contributor clone/canary workflows.
 
 Install from PyPI without cloning:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,10 +218,10 @@ SWE-Marathon 每个任务、每种模式仅运行一次；DeepSWE 包含精选�
 
 ## 试用 LoopX
 
-要求：Python 3.11+ 与 Node.js 22.6+。使用 console scripts 已加入 `PATH` 的
-Python 环境；macOS 和 Linux 使用 POSIX shell，原生 Windows 使用 PowerShell 7。
-Node.js 运行 LoopX 自动启动、空闲退出的 TypeScript Effect core，无需手工维护 daemon。
-Git 仅用于源码贡献与 clone/canary 工作流。
+要求：Python 3.11+ 与 Node.js 22.6+，推荐使用 Node.js 24 LTS。使用 console
+scripts 已加入 `PATH` 的 Python 环境；macOS 和 Linux 使用 POSIX shell，原生
+Windows 使用 PowerShell 7。Node.js 运行 LoopX 自动启动、空闲退出的 TypeScript
+Effect core，无需手工维护 daemon。Git 仅用于源码贡献与 clone/canary 工作流。
 
 无需 clone，直接从 PyPI 安装：
 

--- a/docs/guides/installing-loopx.md
+++ b/docs/guides/installing-loopx.md
@@ -24,10 +24,11 @@ development and qualification surface, not a second implicit package channel.
 The archive snapshot remains a recovery path rather than a competing default.
 
 LoopX's Effect Program core runs in a managed, idle-exiting TypeScript runtime
-and requires Node.js 22.6 or later. LoopX starts and reuses that local runtime
-automatically; users do not run a daemon manually. The runtime binds only to
-loopback, authenticates requests with a user-private token, rotates when the
-packaged Effect core changes, and exits after an idle period. `loopx doctor`
+and requires Node.js 22.6 or later; Node.js 24 LTS is the recommended primary
+runtime. LoopX starts and reuses that local runtime automatically; users do not
+run a daemon manually. The runtime binds only to loopback, authenticates
+requests with a user-private token, rotates when the packaged Effect core
+changes, and exits after an idle period. `loopx doctor`
 reports it as `ready`, `missing`, `unsupported`, or `probe_failed`; a missing
 or stale runtime fails closed instead of falling back to a second Python rule
 engine. The same doctor projection exposes `runtime_lifecycle.state` as

--- a/examples/frontstage-pages-workflow-smoke.py
+++ b/examples/frontstage-pages-workflow-smoke.py
@@ -76,7 +76,7 @@ def main() -> int:
         "github.event.pull_request.number",
         "|| 'deployment'",
         "cancel-in-progress: true",
-        'node-version: "20"',
+        'node-version: "24"',
         "npm install -g npm@11",
         "npm ci --include=dev --no-audit --no-fund --registry=https://registry.npmjs.org",
         "docs/showcases/**",

--- a/examples/full-public-smokes-workflow-smoke.py
+++ b/examples/full-public-smokes-workflow-smoke.py
@@ -39,7 +39,7 @@ def main() -> int:
         "actions/setup-python@",
         "python-version: \"3.11\"",
         "actions/setup-node@v6",
-        "node-version: \"22.6\"",
+        "node-version: \"24\"",
         "python3 examples/run-smokes.py",
         "--suite full-public",
         "--offset \"${{ matrix.offset }}\"",

--- a/examples/github-actions-runtime-smoke.py
+++ b/examples/github-actions-runtime-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import re
 
@@ -16,6 +17,10 @@ NODE24_ACTION_MAJORS = {
     "actions/setup-python": "v6",
     "actions/upload-artifact": "v7",
 }
+
+PRIMARY_NODE_VERSION = "24"
+MINIMUM_NODE_VERSION = "22.6"
+FORWARD_NODE_VERSION = "26"
 
 
 def declared_major(reference: str) -> str:
@@ -32,9 +37,11 @@ def declared_major(reference: str) -> str:
 
 
 def main() -> int:
-    workflow_text = "\n".join(
-        path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.yml"))
-    )
+    workflows = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(WORKFLOWS.glob("*.yml"))
+    }
+    workflow_text = "\n".join(workflows.values())
 
     for action, major in NODE24_ACTION_MAJORS.items():
         references = [
@@ -45,7 +52,34 @@ def main() -> int:
         assert references, f"missing workflow reference for {action}"
         assert all(declared_major(reference) == major for reference in references), references
 
-    print("github-actions-runtime-smoke ok")
+    declared_versions = {
+        name: re.findall(r'^\s*node-version:\s*["\']([^"\']+)["\']\s*$', text, re.MULTILINE)
+        for name, text in workflows.items()
+    }
+    for name, versions in declared_versions.items():
+        if not versions:
+            continue
+        expected = (
+            {PRIMARY_NODE_VERSION, MINIMUM_NODE_VERSION, FORWARD_NODE_VERSION}
+            if name == "python-tests.yml"
+            else {PRIMARY_NODE_VERSION}
+        )
+        assert set(versions) <= expected, (name, versions)
+
+    python_versions = declared_versions["python-tests.yml"]
+    assert python_versions.count(MINIMUM_NODE_VERSION) == 1, python_versions
+    assert python_versions.count(FORWARD_NODE_VERSION) == 1, python_versions
+    assert PRIMARY_NODE_VERSION in python_versions, python_versions
+
+    python_workflow = workflows["python-tests.yml"]
+    assert "node-forward-compatibility:" in python_workflow
+    assert "continue-on-error: true" in python_workflow
+    assert "needs: [changes, pytest, node-minimum-compatibility," in python_workflow
+
+    package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+    assert package["engines"]["node"] == f">={MINIMUM_NODE_VERSION}"
+
+    print("github-actions-runtime-smoke ok: Node 24 primary, 22.6 minimum, 26 forward")
     return 0
 
 

--- a/scripts/ci/review_gate.py
+++ b/scripts/ci/review_gate.py
@@ -9,7 +9,12 @@ from pathlib import PurePosixPath
 import subprocess
 
 
-CORE_JOBS = ("pytest", "stage2c-correctness-e2e", "windows-powershell")
+CORE_JOBS = (
+    "pytest",
+    "node-minimum-compatibility",
+    "stage2c-correctness-e2e",
+    "windows-powershell",
+)
 ROOT_DOCS = {"README.md", "README.zh-CN.md", "CHANGELOG.md", "CONTRIBUTING.md"}
 
 

--- a/tests/test_python_ci_workflow.py
+++ b/tests/test_python_ci_workflow.py
@@ -109,7 +109,10 @@ def test_merge_gate_runs_on_all_prs_and_checks_every_core_aggregate() -> None:
     assert "paths:" not in trigger and "paths-ignore:" not in trigger
     gate = WORKFLOW.split("  merge-gate:", 1)[1]
     assert "if: always()" in gate
-    assert "needs: [changes, pytest, stage2c-correctness-e2e, windows-powershell]" in gate
+    assert (
+        "needs: [changes, pytest, node-minimum-compatibility, "
+        "stage2c-correctness-e2e, windows-powershell]"
+    ) in gate
     assert "NEEDS_JSON: ${{ toJSON(needs) }}" in gate
     assert "run: python scripts/ci/review_gate.py verify" in gate
     assert "continue-on-error" not in gate

--- a/tsconfig.control-plane.json
+++ b/tsconfig.control-plane.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "forceConsistentCasingInFileNames": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary

- Make Node.js 24 LTS the primary runtime for required tests, public smokes, release artifacts, desktop packaging, and Frontstage Pages.
- Preserve Node.js 22.6 as the public minimum with a dedicated required compatibility job that participates in the fail-closed merge gate.
- Add a non-blocking Node.js 26 forward-compatibility probe and enable `erasableSyntaxOnly` for native TypeScript stripping compatibility.
- Recommend Node.js 24 LTS in the bilingual quick start and installation guide without raising the public minimum.
- Keep the pre-existing merge-gate structure test aligned with the new required Node 22.6 dependency.

## Issue Or Task

- Closes #
- Contributor task ID: N/A

## Validation

- Tested revision: `75c0100cf11b5e262ad37a69907fca2ad52d97a0`
- Run state: finished
- Input classes: synthetic, public_fixture

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| `static` | `passed` | Actionlint accepted all six changed workflows; Ruff and repository MyPy targets passed. |
| `unit` | `passed` | Python CI workflow and review-gate suites passed: 35 tests and 38 subtests. |
| `regression_parity` | `passed` | TypeScript compile plus 912 native control-plane tests passed with one skip on both Node.js 22.6 and Node.js 24. |
| `integration` | `passed` | Existing GitHub Actions runtime, Frontstage Pages, and full-public workflow contract smokes passed. |
| `real_entrypoint` | `passed` | `loopx canary premerge --from-git-diff --goal-id loopx-meta --timeout-seconds 240` passed 18/18 checks with no manual hold; the exact-head install smoke passed in 170.6 seconds. |
| `regression_parity` | `failed` | The intentionally non-blocking Node.js 26 forward probe compiled successfully but retained six known `EISDIR` message-parity differences because Node 26 includes the read path. This PR does not claim Node 26 support; the lane surfaces the gap without weakening Node 22.6 or Node 24 gates. |
| `static` | `passed` | Public/private boundary validation covered all 15 changed files with zero boundary errors. |

- Change-quality receipt: `cqr_2d9e72b01398f7c4067b` for fingerprint `2d9e72b01398f7c4067b925eddf96e61244f95eea2a54daef28fa46e79d44224`.
- Coverage and gaps: Required Node.js 22.6 and primary Node.js 24 paths are covered by the same native TypeScript suite. Node.js 26 remains an explicit non-blocking compatibility signal until its observable error contract is reconciled.

See [validation disclosure guidance](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md#validation-disclosure).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [x] Build, packaging, installer, or CI
- [ ] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: N/A

## Shared-authority RFC fixture impact

N/A. This changes runtime qualification policy and does not change authority semantics, provider routing, promotion, or compatibility projection.

## Boundary Checklist

- [x] Neither the diff nor this PR body/comments/attachments disclose private state, credentials, raw traces or verifier output, internal links, or local machine paths (including `.loopx/`, `.codex/goals/`, and live `ACTIVE_GOAL_STATE.md`).
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
