### PR TITLE
refactor(goal-channel): extract runtime CLI ownership

### DIFF
--- a/loopx/cli_commands/goal_channel.py
+++ b/loopx/cli_commands/goal_channel.py
@@ -31,15 +31,9 @@ from ..extensions.runtime import (
 from ..control_plane.runtime.runtime_projection_route import (
     resolve_goal_source_runtime_route,
 )
-from ..control_plane.goals.botmux_runtime import (
-    BOTMUX_DEFAULT_ENDPOINT,
-    BOTMUX_DEFAULT_TOKEN_ENV,
-    default_botmux_runtime_binding_path,
-    disable_botmux_runtime,
-    doctor_botmux_runtime,
-    setup_botmux_runtime,
-    status_botmux_runtime,
-    trigger_botmux_runtime,
+from .goal_channel_runtime import (
+    register_goal_channel_runtime_commands,
+    run_goal_channel_runtime,
 )
 from ..history import load_registry
 from ..paths import registry_project_root, resolve_runtime_root
@@ -194,65 +188,7 @@ def register_goal_channel_commands(
     )
     notify.add_argument("--execute", action="store_true")
 
-    runtime = sub.add_parser(
-        "runtime",
-        help="Bind and drive an optional IM/runtime provider for a Goal Channel.",
-    )
-    runtime_sub = runtime.add_subparsers(
-        dest="goal_channel_runtime_command",
-        required=True,
-    )
-    runtime_setup = runtime_sub.add_parser(
-        "setup",
-        help="Verify and bind one botmux runtime. Dry-run unless --execute.",
-    )
-    add_subcommand_format(runtime_setup)
-    _add_runtime_common_args(runtime_setup)
-    runtime_setup.add_argument("--endpoint", default=BOTMUX_DEFAULT_ENDPOINT)
-    runtime_setup.add_argument("--bot-id", required=True)
-    runtime_setup.add_argument("--chat-id", required=True)
-    runtime_setup.add_argument("--token-env", default=BOTMUX_DEFAULT_TOKEN_ENV)
-    runtime_setup.add_argument("--execute", action="store_true")
-
-    runtime_doctor = runtime_sub.add_parser(
-        "doctor",
-        help="Verify the configured botmux daemon, bot, project, and chat route.",
-    )
-    add_subcommand_format(runtime_doctor)
-    _add_runtime_common_args(runtime_doctor)
-
-    runtime_trigger = runtime_sub.add_parser(
-        "trigger",
-        help="Queue one bounded LoopX turn through the configured botmux runtime.",
-    )
-    add_subcommand_format(runtime_trigger)
-    _add_runtime_common_args(runtime_trigger)
-    runtime_trigger.add_argument("--instruction")
-    runtime_trigger.add_argument(
-        "--turn-key",
-        help="Explicit semantic revision key for a deliberate new runtime turn.",
-    )
-    runtime_trigger.add_argument("--execute", action="store_true")
-
-    runtime_status = runtime_sub.add_parser(
-        "status",
-        help="Read the typed lifecycle result of the current botmux runtime turn.",
-    )
-    add_subcommand_format(runtime_status)
-    _add_runtime_common_args(runtime_status)
-    runtime_status.add_argument(
-        "--execute",
-        action="store_true",
-        help="Persist the observed runtime state into the local-private receipt.",
-    )
-
-    runtime_disable = runtime_sub.add_parser(
-        "disable",
-        help="Disable this goal's botmux runtime binding. Dry-run unless --execute.",
-    )
-    add_subcommand_format(runtime_disable)
-    _add_runtime_common_args(runtime_disable)
-    runtime_disable.add_argument("--execute", action="store_true")
+    register_goal_channel_runtime_commands(sub, add_subcommand_format)
 
 
 def _add_common_args(parser: argparse.ArgumentParser) -> None:
@@ -262,14 +198,6 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         help="Local-private Goal Channel binding path beside the project registry.",
     )
     parser.add_argument("--target-path", help=argparse.SUPPRESS)
-
-
-def _add_runtime_common_args(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument("--goal-id", required=True)
-    parser.add_argument(
-        "--runtime-binding-path",
-        help="Local-private botmux runtime binding path beside the project registry.",
-    )
 
 
 def _error_packet(
@@ -492,73 +420,9 @@ def handle_goal_channel_command(
             registry_path=registry_path,
             goal_id=goal_id,
         )
-        runtime_binding_path = (
-            Path(str(args.runtime_binding_path)).expanduser()
-            if getattr(args, "runtime_binding_path", None)
-            else default_botmux_runtime_binding_path(source_registry_path)
+        payload = run_goal_channel_runtime(
+            args, registry=source_registry, registry_path=source_registry_path
         )
-        runtime_command = str(args.goal_channel_runtime_command)
-        try:
-            if runtime_command == "setup":
-                payload = setup_botmux_runtime(
-                    registry=source_registry,
-                    registry_path=source_registry_path,
-                    goal_id=goal_id,
-                    binding_path=runtime_binding_path,
-                    endpoint=args.endpoint,
-                    bot_id=args.bot_id,
-                    chat_id=args.chat_id,
-                    token_env=args.token_env,
-                    execute=execute,
-                )
-            elif runtime_command == "doctor":
-                payload = doctor_botmux_runtime(
-                    goal_id=goal_id,
-                    binding_path=runtime_binding_path,
-                )
-            elif runtime_command == "trigger":
-                payload = trigger_botmux_runtime(
-                    registry=source_registry,
-                    registry_path=source_registry_path,
-                    goal_id=goal_id,
-                    binding_path=runtime_binding_path,
-                    instruction=args.instruction,
-                    turn_key=args.turn_key,
-                    execute=execute,
-                )
-            elif runtime_command == "status":
-                payload = status_botmux_runtime(
-                    goal_id=goal_id,
-                    binding_path=runtime_binding_path,
-                    execute=execute,
-                )
-            elif runtime_command == "disable":
-                payload = disable_botmux_runtime(
-                    goal_id=goal_id,
-                    binding_path=runtime_binding_path,
-                    execute=execute,
-                )
-            else:
-                raise ValueError(
-                    f"unknown goal-channel runtime command: {runtime_command}"
-                )
-        except ValueError:
-            payload = {
-                "schema_version": "loopx_goal_channel_runtime_operation_v0",
-                "ok": False,
-                "goal_id": goal_id,
-                "provider": "botmux",
-                "operation": f"runtime_{runtime_command}",
-                "execute": execute,
-                "status": "blocked",
-                "external_write_performed": False,
-                "readback_verified": False,
-                "idempotency_key": None,
-                "receipt_id": None,
-                "public_summary": "the botmux runtime configuration is invalid",
-                "private_provider_payload_captured": False,
-                "blocker": "invalid_configuration",
-            }
         print_payload(payload, output_format(args), render_goal_channel_markdown)
         return 0 if payload.get("ok") else 1
     if command == "configure" and bool(args.auto_notify_human_gates):

--- a/loopx/cli_commands/goal_channel_runtime.py
+++ b/loopx/cli_commands/goal_channel_runtime.py
@@ -1,0 +1,168 @@
+"""Registration and dispatch for the built-in Goal Channel runtime CLI."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..control_plane.goals.botmux_runtime import (
+    BOTMUX_DEFAULT_ENDPOINT,
+    BOTMUX_DEFAULT_TOKEN_ENV,
+    default_botmux_runtime_binding_path,
+    disable_botmux_runtime,
+    doctor_botmux_runtime,
+    setup_botmux_runtime,
+    status_botmux_runtime,
+    trigger_botmux_runtime,
+)
+
+
+def register_goal_channel_runtime_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    runtime = subparsers.add_parser(
+        "runtime",
+        help="Bind and drive an optional IM/runtime provider for a Goal Channel.",
+    )
+    runtime_sub = runtime.add_subparsers(
+        dest="goal_channel_runtime_command",
+        required=True,
+    )
+    runtime_setup = runtime_sub.add_parser(
+        "setup",
+        help="Verify and bind one botmux runtime. Dry-run unless --execute.",
+    )
+    add_subcommand_format(runtime_setup)
+    _add_runtime_common_args(runtime_setup)
+    runtime_setup.add_argument("--endpoint", default=BOTMUX_DEFAULT_ENDPOINT)
+    runtime_setup.add_argument("--bot-id", required=True)
+    runtime_setup.add_argument("--chat-id", required=True)
+    runtime_setup.add_argument("--token-env", default=BOTMUX_DEFAULT_TOKEN_ENV)
+    runtime_setup.add_argument("--execute", action="store_true")
+
+    runtime_doctor = runtime_sub.add_parser(
+        "doctor",
+        help="Verify the configured botmux daemon, bot, project, and chat route.",
+    )
+    add_subcommand_format(runtime_doctor)
+    _add_runtime_common_args(runtime_doctor)
+
+    runtime_trigger = runtime_sub.add_parser(
+        "trigger",
+        help="Queue one bounded LoopX turn through the configured botmux runtime.",
+    )
+    add_subcommand_format(runtime_trigger)
+    _add_runtime_common_args(runtime_trigger)
+    runtime_trigger.add_argument("--instruction")
+    runtime_trigger.add_argument(
+        "--turn-key",
+        help="Explicit semantic revision key for a deliberate new runtime turn.",
+    )
+    runtime_trigger.add_argument("--execute", action="store_true")
+
+    runtime_status = runtime_sub.add_parser(
+        "status",
+        help="Read the typed lifecycle result of the current botmux runtime turn.",
+    )
+    add_subcommand_format(runtime_status)
+    _add_runtime_common_args(runtime_status)
+    runtime_status.add_argument(
+        "--execute",
+        action="store_true",
+        help="Persist the observed runtime state into the local-private receipt.",
+    )
+
+    runtime_disable = runtime_sub.add_parser(
+        "disable",
+        help="Disable this goal's botmux runtime binding. Dry-run unless --execute.",
+    )
+    add_subcommand_format(runtime_disable)
+    _add_runtime_common_args(runtime_disable)
+    runtime_disable.add_argument("--execute", action="store_true")
+
+
+def _add_runtime_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--goal-id", required=True)
+    parser.add_argument(
+        "--runtime-binding-path",
+        help="Local-private botmux runtime binding path beside the project registry.",
+    )
+
+
+def run_goal_channel_runtime(
+    args: argparse.Namespace,
+    *,
+    registry: dict[str, Any],
+    registry_path: Path,
+) -> dict[str, object]:
+    goal_id = str(args.goal_id)
+    execute = bool(getattr(args, "execute", False))
+    runtime_binding_path = (
+        Path(str(args.runtime_binding_path)).expanduser()
+        if getattr(args, "runtime_binding_path", None)
+        else default_botmux_runtime_binding_path(registry_path)
+    )
+    runtime_command = str(args.goal_channel_runtime_command)
+    try:
+        if runtime_command == "setup":
+            payload = setup_botmux_runtime(
+                registry=registry,
+                registry_path=registry_path,
+                goal_id=goal_id,
+                binding_path=runtime_binding_path,
+                endpoint=args.endpoint,
+                bot_id=args.bot_id,
+                chat_id=args.chat_id,
+                token_env=args.token_env,
+                execute=execute,
+            )
+        elif runtime_command == "doctor":
+            payload = doctor_botmux_runtime(
+                goal_id=goal_id,
+                binding_path=runtime_binding_path,
+            )
+        elif runtime_command == "trigger":
+            payload = trigger_botmux_runtime(
+                registry=registry,
+                registry_path=registry_path,
+                goal_id=goal_id,
+                binding_path=runtime_binding_path,
+                instruction=args.instruction,
+                turn_key=args.turn_key,
+                execute=execute,
+            )
+        elif runtime_command == "status":
+            payload = status_botmux_runtime(
+                goal_id=goal_id,
+                binding_path=runtime_binding_path,
+                execute=execute,
+            )
+        elif runtime_command == "disable":
+            payload = disable_botmux_runtime(
+                goal_id=goal_id,
+                binding_path=runtime_binding_path,
+                execute=execute,
+            )
+        else:
+            raise ValueError(f"unknown goal-channel runtime command: {runtime_command}")
+    except ValueError:
+        payload = {
+            "schema_version": "loopx_goal_channel_runtime_operation_v0",
+            "ok": False,
+            "goal_id": goal_id,
+            "provider": "botmux",
+            "operation": f"runtime_{runtime_command}",
+            "execute": execute,
+            "status": "blocked",
+            "external_write_performed": False,
+            "readback_verified": False,
+            "idempotency_key": None,
+            "receipt_id": None,
+            "public_summary": "the botmux runtime configuration is invalid",
+            "private_provider_payload_captured": False,
+            "blocker": "invalid_configuration",
+        }
+    return payload

--- a/tests/control_plane/test_goal_channel_runtime_cli.py
+++ b/tests/control_plane/test_goal_channel_runtime_cli.py
@@ -1,0 +1,182 @@
+"""Public CLI characterization for the Goal Channel runtime command family."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from loopx.cli import build_parser
+from loopx.cli_commands import goal_channel, goal_channel_runtime
+
+
+@pytest.fixture
+def registry_path(tmp_path):
+    path = tmp_path / ".loopx" / "registry.json"
+    path.parent.mkdir()
+    path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": "synthetic-goal",
+                        "repo": str(tmp_path),
+                        "state_file": str(tmp_path / "state.md"),
+                    }
+                ]
+            }
+        )
+    )
+    return path
+
+
+def argv(operation):
+    args = ["goal-channel", "runtime", operation, "--goal-id", "synthetic-goal"]
+    if operation == "setup":
+        args += ["--bot-id", "synthetic-bot", "--chat-id", "synthetic-chat"]
+    return args
+
+
+@pytest.mark.parametrize(
+    "operation", ["setup", "doctor", "trigger", "status", "disable"]
+)
+@pytest.mark.parametrize("execute", [False, True])
+def test_runtime_dispatch_preserves_arguments_and_rendering(
+    registry_path, monkeypatch, operation, execute
+):
+    calls, printed = [], []
+    expected = {"ok": True, "provider": "botmux", "operation": f"runtime_{operation}"}
+
+    def backend(**kwargs):
+        calls.append(kwargs)
+        return expected
+
+    monkeypatch.setattr(goal_channel_runtime, f"{operation}_botmux_runtime", backend)
+    options = argv(operation) + [
+        "--runtime-binding-path",
+        str(registry_path.parent / "binding.json"),
+        "--format",
+        "json",
+    ]
+    if execute and operation != "doctor":
+        options += ["--execute"]
+    args = build_parser().parse_args(options)
+    code = goal_channel.handle_goal_channel_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=str(registry_path.parent / "runtime"),
+        print_payload=lambda *items: printed.append(items),
+        output_format=lambda args: args.subcommand_format,
+    )
+    assert code == 0
+    assert len(calls) == 1
+    actual = calls[0]
+    assert actual["goal_id"] == "synthetic-goal"
+    assert actual["binding_path"] == registry_path.parent / "binding.json"
+    if operation != "doctor":
+        assert actual["execute"] is execute
+    if operation in {"setup", "trigger"}:
+        assert actual["registry_path"] == registry_path
+        assert actual["registry"]["goals"][0]["id"] == "synthetic-goal"
+    if operation == "setup":
+        assert actual["endpoint"] == "http://127.0.0.1:7891"
+        assert actual["bot_id"] == "synthetic-bot"
+        assert actual["chat_id"] == "synthetic-chat"
+    if operation == "trigger":
+        assert actual["instruction"] is None
+        assert actual["turn_key"] is None
+    assert printed == [(expected, "json", goal_channel.render_goal_channel_markdown)]
+
+
+@pytest.mark.parametrize(
+    "operation", ["setup", "doctor", "trigger", "status", "disable"]
+)
+def test_runtime_invalid_configuration_preserves_safe_error(
+    registry_path, monkeypatch, operation
+):
+    def backend(**kwargs):
+        raise ValueError("synthetic-private-error")
+
+    monkeypatch.setattr(goal_channel_runtime, f"{operation}_botmux_runtime", backend)
+    printed = []
+    args = build_parser().parse_args(argv(operation))
+    code = goal_channel.handle_goal_channel_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=str(registry_path.parent / "runtime"),
+        print_payload=lambda payload, *_: printed.append(payload),
+        output_format=lambda _: "json",
+    )
+    assert code == 1
+    assert printed[0]["schema_version"] == "loopx_goal_channel_runtime_operation_v0"
+    assert printed[0]["operation"] == f"runtime_{operation}"
+    assert printed[0]["blocker"] == "invalid_configuration"
+    assert printed[0]["external_write_performed"] is False
+    assert "synthetic-private-error" not in json.dumps(printed)
+
+
+@pytest.mark.parametrize("operation", ["doctor", "trigger", "status", "disable"])
+def test_real_cli_missing_binding_preserves_unconfigured_state(
+    registry_path, operation
+):
+    before = registry_path.read_bytes()
+    result = run_cli(registry_path, argv(operation))
+    assert result.returncode == (0 if operation == "disable" else 1)
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is (operation == "disable")
+    assert payload["provider"] == "botmux"
+    assert payload["external_write_performed"] is False
+    assert registry_path.read_bytes() == before
+    assert not (registry_path.parent / "goal-channel-runtime.json").exists()
+
+
+def run_cli(registry_path, options):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(registry_path.parent / "runtime"),
+            "--format",
+            "json",
+            *options,
+        ],
+        cwd=Path(__file__).parents[2],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_real_cli_disable_preserves_preview_then_persists(registry_path):
+    binding_path = registry_path.parent / "goal-channel-runtime.json"
+    binding_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_goal_channel_botmux_binding_v0",
+                "bindings": {
+                    "synthetic-goal": {
+                        "enabled": True,
+                        "session": {"session_id": "synthetic-session"},
+                    }
+                },
+            }
+        )
+    )
+    original = binding_path.read_bytes()
+    preview = run_cli(registry_path, argv("disable"))
+    assert preview.returncode == 0
+    assert json.loads(preview.stdout)["execute"] is False
+    assert binding_path.read_bytes() == original
+    executed = run_cli(registry_path, [*argv("disable"), "--execute"])
+    assert executed.returncode == 0
+    assert json.loads(executed.stdout)["status"] == "disabled"
+    persisted = json.loads(binding_path.read_text())["bindings"]["synthetic-goal"]
+    assert persisted["enabled"] is False
+    assert persisted["session"] == {}


### PR DESCRIPTION
## Summary

Move the existing `goal-channel runtime setup/doctor/trigger/status/disable` parser registration and operation dispatch from `goal_channel.py` into `goal_channel_runtime.py`. The parent retains shared source-registry resolution, output rendering and exit-code handling; the existing botmux backend remains authoritative.

Public command names, flags, defaults, dry-run behavior, result/error packets and receipts are unchanged. The old implementation is removed instead of retained as a compatibility copy. This reduces the parent module by 136 lines while keeping the built-in Goal Channel runtime in its nearest CLI owner.

## Issue Or Task

Closes #3710. Contributor task: GH-C06. Base: main.

## Validation

- Run state: finished. Input classes: synthetic.
- **85 passed** across `tests/control_plane/test_goal_channel_runtime_cli.py`, `tests/control_plane/test_botmux_goal_channel_runtime.py` and `tests/extensions/test_lark_goal_channel.py`.
- The 20 new CLI characterization cases also passed against the unmodified main implementation. Coverage includes all five dispatch routes, configuration errors, rendering, missing bindings and the real CLI's preview/execute persistence behavior.
- `regression/cli-command-module-contract.py`: passed with the checkout's CLI wrapper on PATH.
- Standard premerge: all **4 selected catalog checks passed**, including maintainability, CLI output budget and command modularization; diff hygiene and compilation passed.
- Ruff and the three-file public-boundary scan passed with no findings.
- Real entrypoint/local backend: actual CLI subprocesses read and update disposable binding files. The existing botmux/Lark protocol tests use synthetic requesters; no live botmux daemon, Lark service or model was invoked. Provider implementations are unchanged.

## Scope and boundaries

Behavior-preserving CLI ownership extraction only. Goal Channel remains the existing capability owner, with botmux as the built-in runtime route; no new provider, lifecycle contract, option or authority is introduced. The related refactor removes the duplicate ownership in the parent without introducing a generic dispatch framework. Shared-authority migration is not applicable. No private state, credentials, raw traces or local paths are included; every commit carries a DCO sign-off.
