### PR TITLE
fix(pr-review): decode GitHub JSON as UTF-8

### DIFF
--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -127,6 +127,8 @@ def _run_gh_json(args: list[str], *, cwd: Path | None = None) -> Any:
         cwd=cwd,
         check=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )

--- a/tests/test_pr_review_github_scan.py
+++ b/tests/test_pr_review_github_scan.py
@@ -677,7 +677,9 @@ def test_actionable_sequence_excludes_valid_merged_exact_head(monkeypatch) -> No
     forced_row = forced["pull_requests"][0]
     assert forced_row["review_action_kind"] == "audit_pull_request_exact_head"
     assert forced_row["fresh_audit_requested"] is True
-    assert forced_row["review_plan"]["target"]["exact_head_key"] == f"4141@{reviewed_head}"
+    assert (
+        forced_row["review_plan"]["target"]["exact_head_key"] == f"4141@{reviewed_head}"
+    )
     assert forced_row["review_template"]["sections"]
     assert forced_row["evidence_commands"]
     assert forced["review_sequence"][0]["number"] == 4141
@@ -796,3 +798,80 @@ def test_community_author_self_review_does_not_satisfy_maintainer_queue(
     assert independently_reviewed["review_action_kind"] == (
         "qualify_pull_request_merge_readiness"
     )
+
+
+def test_github_transport_preserves_utf8_under_gbk_locale(monkeypatch):
+    import json
+    import subprocess
+    import sys
+    from types import SimpleNamespace
+
+    payload = {"title": "修复中文标题 café 🚀"}
+    raw = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    run = subprocess.run
+
+    def child(_args, **kwargs):
+        return run(
+            [sys.executable, "-c", f"import sys; sys.stdout.buffer.write({raw!r})"],
+            **kwargs,
+        )
+
+    monkeypatch.setattr(subprocess, "_text_encoding", lambda: "gbk")
+    monkeypatch.setattr(
+        pr_review_module, "subprocess", SimpleNamespace(run=child, PIPE=subprocess.PIPE)
+    )
+    assert pr_review_module._run_gh_json(["pr", "view", "1"]) == payload
+
+
+def test_github_transport_keeps_json_and_process_failures(monkeypatch):
+    import json
+    import subprocess
+    import sys
+    from types import SimpleNamespace
+
+    import pytest
+
+    run = subprocess.run
+    source = "import sys; sys.stdout.buffer.write(b'not-json')"
+
+    def child(_args, **kwargs):
+        return run([sys.executable, "-c", source], **kwargs)
+
+    monkeypatch.setattr(subprocess, "_text_encoding", lambda: "gbk")
+    monkeypatch.setattr(
+        pr_review_module, "subprocess", SimpleNamespace(run=child, PIPE=subprocess.PIPE)
+    )
+    with pytest.raises(json.JSONDecodeError):
+        pr_review_module._run_gh_json(["pr", "view", "1"])
+    source = (
+        "import sys; sys.stderr.buffer.write('请求失败'.encode('utf-8')); sys.exit(2)"
+    )
+    with pytest.raises(subprocess.CalledProcessError) as raised:
+        pr_review_module._run_gh_json(["pr", "view", "1"])
+    assert raised.value.returncode == 2
+    assert raised.value.stderr == "请求失败"
+
+
+def test_github_transport_replaces_malformed_utf8(monkeypatch):
+    import subprocess
+    import sys
+    from types import SimpleNamespace
+
+    run = subprocess.run
+
+    def child(_args, **kwargs):
+        return run(
+            [
+                sys.executable,
+                "-c",
+                r"""import sys; sys.stdout.buffer.write(b'{"title":"broken\xff"}')""",
+            ],
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        pr_review_module, "subprocess", SimpleNamespace(run=child, PIPE=subprocess.PIPE)
+    )
+    assert pr_review_module._run_gh_json(["pr", "view", "1"]) == {
+        "title": "broken\ufffd"
+    }


### PR DESCRIPTION
## Summary

Pin UTF-8 decoding with replacement at the PR review scanner's existing `gh` JSON transport. On Windows with a GBK default codec, Unicode PR metadata can otherwise fail during subprocess decoding. This changes two production lines and preserves the existing JSON parsing and nonzero-exit failure paths.

Related to #4155. This covers `loopx/pr_review.py`; the `issue_fix` paths covered by #4158 and #4160 are separate. It does not close the wider subprocess survey.

## Validation

- 41 tests passed: `tests/test_pr_review_github_scan.py` and `tests/capabilities/test_pr_review_queue.py`.
- All three new regressions failed before the fix and passed afterward. They use real Python child stdout/stderr bytes, with the default decoder forced to GBK, to check Chinese/emoji/accented text, malformed UTF-8 replacement, invalid JSON and nonzero command exits.
- Read-only live `gh` transport check against the issue's public fixture preserved its exact Chinese title with the simulated GBK default.
- Ruff, compilation, diff hygiene and the two-file public-boundary scan passed. Standard premerge passed its one selected maintainability canary plus direct checks.
- Local validation used macOS/Python 3.12; native Windows/PyInstaller execution remains for Windows CI or reporter confirmation.

## Boundaries

The existing PR review transport owns the fix. No generic subprocess abstraction, binary-mode change, network write behavior or scheduler/authority change is introduced. No private data, credentials or raw traces are included. Every commit has a DCO sign-off.
