### PR TITLE
fix(change-window): make Git fetch/pull hooks lightweight and quiet

### DIFF
--- a/loopx/capabilities/repository_change_window/README.md
+++ b/loopx/capabilities/repository_change_window/README.md
@@ -61,11 +61,27 @@ the repository-local `core.sshCommand` route. In a blocked window it rejects a
 `git commit --no-verify`. The `pre-push` hook covers ordinary pushes, while the
 SSH route also rejects an SSH push that uses `--no-verify`. Checkout,
 linked-worktree creation, branch deletion, SSH fetches, and local branch
-creation at a commit already reachable from another local branch or the current
-`HEAD` stays available. Tags, notes, and custom refs do not make a new commit
+creation at a commit already reachable from another local branch, a remote-tracking
+branch, or the current `HEAD` stays available. This includes fast-forward pulls
+after fetch; a pull that creates a new merge/rebase commit still faces the gate.
+Tags, notes, and custom refs do not make a new commit
 eligible for a local-branch update during the blocked window.
 Unknown SSH service commands fail closed. `status` and `verify` report the
 typed enforcement level, exact managed hook set, and SSH-route health.
+
+Managed hooks use the selected-command CLI loader rather than loading every
+capability. Reference updates outside `HEAD`/local branches and post-transaction
+phases do not evaluate the time policy. Provider integrity checks and the prior
+hook's phase, input, output and exit status remain in force. Successful managed
+hooks are quiet; failures remain visible. Direct `change-window hook` diagnostics
+remain structured unless `LOOPX_GIT_HOOK_QUIET_SUCCESS=1` is set. This flag only
+controls output, never admission, and is harmless with older runtimes.
+
+After upgrading the runtime, preview `change-window install` with the existing
+policy and enforcement settings plus `--replace`, then add `--execute` to refresh
+older generated hooks. Preserve the existing window; do not accidentally use
+installation defaults as a new policy. Status/verify still recognize an intact
+older installation; install detects that its hook generation needs refresh.
 
 Customize one typed v0 window with repeatable weekdays and IANA timezone data:
 
@@ -226,7 +242,8 @@ This is local workflow enforcement, not branch protection. `hook_only` can be
 bypassed with `--no-verify`; `reference_guard` closes that commit path and the
 repository's SSH transport path. HTTPS pushes that both skip `pre-push` and
 avoid SSH, replacing `core.hooksPath` or `core.sshCommand`, using an alternate
-Git configuration or binary, directly editing ref files, writing from another
+Git configuration or binary, staging fabricated remote-tracking refs, directly
+editing ref files, writing from another
 machine, or calling a hosting API remain outside its authority. Use OS policy
 plus remote branch protection or server-side controls for a security boundary.
 The capability does not push, merge, create a PR, modify protected branches,

--- a/loopx/capabilities/repository_change_window/cli.py
+++ b/loopx/capabilities/repository_change_window/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -379,9 +380,12 @@ def handle_repository_change_window_command(
             "status": "error",
             "error": str(exc),
         }
-    print_payload(
-        payload, output_format(args), render_repository_change_window_markdown
-    )
+    if not (args.change_window_command == "hook"
+            and os.environ.get("LOOPX_GIT_HOOK_QUIET_SUCCESS") == "1"
+            and payload.get("ok")):
+        print_payload(
+            payload, output_format(args), render_repository_change_window_markdown
+        )
     if args.change_window_command == "hook" and isinstance(
         payload.get("exit_code"), int
     ):

--- a/loopx/capabilities/repository_change_window/git_hook.py
+++ b/loopx/capabilities/repository_change_window/git_hook.py
@@ -19,6 +19,9 @@ from .repository import (
     RepositoryChangeWindowError,
     git,
     git_text,
+    repository_root,
+    repository_common_dir,
+    repository_identity,
     resolve_repository_context,
 )
 
@@ -182,6 +185,7 @@ def _hook_script(event: str) -> str:
         (
             "#!/bin/sh",
             "set -u",
+            "export LOOPX_GIT_HOOK_QUIET_SUCCESS=1",
             (
                 "exec loopx --format json change-window hook "
                 f'--repo-path . --event {event} -- "$@"'
@@ -471,9 +475,7 @@ def _provider_checks(
     include_runtime: bool = True,
 ) -> list[dict[str, object]]:
     hooks_dir = _hooks_dir(common_dir)
-    repository_matches = (
-        state.get("repository_id") == resolve_repository_context(repo).repository_id
-    )
+    repository_matches = state.get("repository_id") == repository_identity(repo, common_dir)
     configured = git_text(
         repo, "config", "--local", "--get", "core.hooksPath", check=False
     )
@@ -648,6 +650,10 @@ def install_git_hook_provider(
             and existing_policy == policy
             and _state_enforcement_level(existing) is enforcement
             and all(bool(item["ok"]) for item in checks)
+            and existing.get("hook_digests") == {
+                event: _digest_text(_hook_script(event))
+                for event in _managed_hook_names(enforcement)
+            }
         ):
             installation_mode = str(
                 existing.get("installation_mode") or "fresh_repository_provider"
@@ -953,6 +959,7 @@ def _commit_reachable_from_existing_branch_or_head(repo: Path, oid: str) -> bool
         f"--contains={oid}",
         "--format=%(refname)",
         "refs/heads",
+        "refs/remotes",
         check=False,
     )
     if containing_branches:
@@ -1060,16 +1067,19 @@ def run_git_hook_provider(
             "reason": "read_only_ssh_transport",
         }
 
-    context = resolve_repository_context(repo_path)
-    state = _read_state(_state_path(context.common_dir))
+    # Hook admission needs repository identity, not a checkout snapshot. In
+    # particular, reference hooks can run before HEAD exists in a new worktree.
+    root = repository_root(repo_path)
+    common_dir = repository_common_dir(root)
+    state = _read_state(_state_path(common_dir))
     enforcement = _state_enforcement_level(state)
     if event not in _managed_events(enforcement):
         raise RepositoryChangeWindowError(
             f"hook event `{event}` is not managed by enforcement level `{enforcement.value}`"
         )
     checks = _provider_checks(
-        repo=context.root,
-        common_dir=context.common_dir,
+        repo=root,
+        common_dir=common_dir,
         state=state,
         include_runtime=False,
     )
@@ -1083,21 +1093,23 @@ def run_git_hook_provider(
             "exit_code": 1,
             "checks": checks,
         }
-    policy = ChangeWindowPolicy.from_dict(state["policy"])
-    decision = evaluate_policy(policy, now=now)
     if event == REFERENCE_GUARD_HOOK_NAME:
         guarded_change = _reference_transaction_introduces_commit(
-            repo=context.root,
+            repo=root,
             hook_args=hook_args,
             hook_stdin=hook_stdin,
         )
     else:
         guarded_change = True
-    if guarded_change and not decision["allowed"]:
+    decision = (
+        evaluate_policy(ChangeWindowPolicy.from_dict(state["policy"]), now=now)
+        if guarded_change else None
+    )
+    if decision is not None and not decision["allowed"]:
         try:
             ledger_record: dict[str, Any] = record_pending_change(
                 runtime_root=runtime_root,
-                repo_path=context.root,
+                repo_path=root,
                 decision=decision,
                 source=f"git_hook:{event}",
                 execute=True,
@@ -1132,7 +1144,7 @@ def run_git_hook_provider(
     if previous_hook_invoked:
         result = subprocess.run(
             [str(previous_hook), *hook_args],
-            cwd=context.root,
+            cwd=root,
             input=hook_stdin,
             check=False,
         )
@@ -1144,6 +1156,7 @@ def run_git_hook_provider(
         "event": event,
         "exit_code": previous_exit_code,
         "decision": decision,
+        "policy_evaluated": guarded_change,
         "enforcement_level": enforcement.value,
         "guarded_change": guarded_change,
         "previous_hook_invoked": previous_hook_invoked,

--- a/loopx/cli_runtime.py
+++ b/loopx/cli_runtime.py
@@ -57,7 +57,7 @@ _REGISTRY_OPTIONAL_COMMANDS = frozenset(
 )
 
 _STATUS_COMMANDS = frozenset({"check", "status", "diagnose", "review-packet"})
-_SELECTED_COMMANDS = _STATUS_COMMANDS | {"todo", "quota"}
+_SELECTED_COMMANDS = _STATUS_COMMANDS | {"todo", "quota", "change-window"}
 
 
 class LoopXArgumentParser(argparse.ArgumentParser):
@@ -212,6 +212,10 @@ def _build_selected_parser(command: str) -> LoopXArgumentParser:
 		from .cli_commands.quota_registration import register_quota_command
 
 		register_quota_command(subparsers)
+	elif command == "change-window":
+		from .capabilities.repository_change_window.cli import register_repository_change_window_commands
+
+		register_repository_change_window_commands(subparsers, add_subcommand_format)
 	else:  # pragma: no cover - caller guards the private interface
 		raise ValueError(f"unsupported selected command: {command}")
 	return parser
@@ -225,6 +229,13 @@ def dispatch_common_command(
 ) -> int | None:
 	"""Dispatch one selected command through the shared canonical wiring."""
 
+	if args.command == "change-window":
+		from .capabilities.repository_change_window.cli import handle_repository_change_window_command
+
+		return handle_repository_change_window_command(
+			args, registry_path=registry_path, runtime_root_arg=args.runtime_root,
+			output_format=output_format, print_payload=print_payload,
+		)
 	if args.command in _STATUS_COMMANDS:
 		from .cli_commands.status import (
 			handle_check_command,

--- a/tests/capabilities/test_change_window_git_fast_path.py
+++ b/tests/capabilities/test_change_window_git_fast_path.py
@@ -1,0 +1,191 @@
+"""Real Git hooks: fast read paths must not weaken write or delegation fences."""
+
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+
+import pytest
+
+from loopx.capabilities.repository_change_window import git_hook as owner
+from loopx.capabilities.repository_change_window.policy import build_policy
+
+
+@pytest.fixture
+def installed(tmp_path, monkeypatch):
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "empty-config"))
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("LOOPX_RUNTIME_ROOT", str(tmp_path / "runtime"))
+    monkeypatch.setenv("LOOPX_REGISTRY", str(tmp_path / "registry.json"))
+    source = Path(__file__).resolve().parents[2]
+    monkeypatch.setenv("PYTHONPATH", str(source))
+    binary = tmp_path / "bin"
+    binary.mkdir()
+    launcher = binary / "loopx"
+    launcher.write_text(
+        f'#!/bin/sh\nexec {shlex.quote(sys.executable)} -m loopx.entrypoint "$@"\n'
+    )
+    launcher.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{binary}:/usr/bin:/bin:" + os.environ["PATH"])
+    remote = tmp_path / "remote"
+    subprocess.run(
+        ["git", "init", "-b", "main", str(remote)], check=True, capture_output=True
+    )
+
+    def git(repo, *args, check=True):
+        return subprocess.run(
+            ["git", "-C", str(repo), *args], check=check, capture_output=True, text=True
+        )
+
+    git(remote, "config", "user.name", "Synthetic User")
+    git(remote, "config", "user.email", "user@example.invalid")
+    (remote / "file").write_text("base\n")
+    git(remote, "add", "file")
+    git(remote, "commit", "-m", "base")
+    repo = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", str(remote), str(repo)], check=True, capture_output=True
+    )
+    git(repo, "config", "user.name", "Synthetic User")
+    git(repo, "config", "user.email", "user@example.invalid")
+    previous = tmp_path / "previous"
+    previous.mkdir()
+    hook = previous / "reference-transaction"
+    hook.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$1" >> "'
+        + str(tmp_path / "phases")
+        + '"\ncat >> "'
+        + str(tmp_path / "payloads")
+        + '"\n'
+    )
+    hook.chmod(0o755)
+    git(repo, "config", "core.hooksPath", str(previous))
+    policy = build_policy(
+        timezone_name="UTC",
+        weekdays=["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+        blocked_start="00:00",
+        blocked_end="23:59",
+    )
+    owner.install_git_hook_provider(
+        repo_path=repo, policy=policy, enforcement_level="reference_guard", execute=True
+    )
+    return repo, remote, git, policy
+
+
+def test_real_fetch_pull_quiet_and_new_commit_still_denied(installed, tmp_path):
+    repo, remote, git, _policy = installed
+    (remote / "file").write_text("remote advancement\n")
+    git(remote, "commit", "-am", "advance")
+    fetched = git(repo, "fetch", "origin")
+    assert fetched.stdout == ""
+    pulled = git(repo, "pull", "--ff-only")
+    assert "repository_change_window" not in pulled.stdout + pulled.stderr
+    assert (
+        git(repo, "rev-parse", "HEAD").stdout == git(remote, "rev-parse", "HEAD").stdout
+    )
+    assert "prepared" in (tmp_path / "phases").read_text()
+    assert "committed" in (tmp_path / "phases").read_text()
+    assert "refs/remotes/origin/main" in (tmp_path / "payloads").read_text()
+    # Actual detached worktree initialization must not require an existing HEAD.
+    git(repo, "worktree", "add", "--detach", str(tmp_path / "linked"), "origin/main")
+    head = git(repo, "rev-parse", "HEAD").stdout.strip()
+    tree = git(repo, "rev-parse", "HEAD^{tree}").stdout.strip()
+    candidate = git(
+        repo, "commit-tree", tree, "-p", head, "-m", "new local commit"
+    ).stdout.strip()
+    denied = git(repo, "update-ref", "refs/heads/main", candidate, check=False)
+    assert denied.returncode != 0
+    assert "blocked_by_policy" in denied.stdout + denied.stderr
+    assert git(repo, "rev-parse", "HEAD").stdout.strip() == head
+    denied_commit = git(
+        repo,
+        "commit",
+        "--allow-empty",
+        "--no-verify",
+        "-m",
+        "must be denied",
+        check=False,
+    )
+    assert denied_commit.returncode != 0
+    assert git(repo, "rev-parse", "HEAD").stdout.strip() == head
+
+
+def test_read_phases_skip_policy_but_preserve_drift_and_previous_hook(
+    installed, tmp_path, monkeypatch
+):
+    repo, _remote, _git, _policy = installed
+
+    def unexpected(*args, **kwargs):
+        raise AssertionError("read-only hook evaluated the time policy")
+
+    monkeypatch.setattr(owner, "evaluate_policy", unexpected)
+    row = ("0" * 40 + " " + "1" * 40 + " refs/remotes/origin/example\n").encode()
+    for phase in ("prepared", "committed", "aborted"):
+        result = owner.run_git_hook_provider(
+            repo_path=repo,
+            runtime_root=tmp_path / "runtime",
+            event="reference-transaction",
+            hook_args=[phase],
+            hook_stdin=row,
+        )
+        assert result["ok"] and not result["policy_evaluated"]
+        assert result["decision"] is None
+    previous = tmp_path / "previous" / "reference-transaction"
+    previous.write_text("#!/bin/sh\necho previous-failure >&2\nexit 7\n")
+    result = owner.run_git_hook_provider(
+        repo_path=repo,
+        runtime_root=tmp_path / "runtime",
+        event="reference-transaction",
+        hook_args=["prepared"],
+        hook_stdin=row,
+    )
+    assert result["exit_code"] == 7 and result["status"] == "previous_hook_failed"
+    managed = repo / ".git/loopx/repository-change-window/hooks/pre-push"
+    managed.write_text("#!/bin/sh\nexit 0\n")
+    result = owner.run_git_hook_provider(
+        repo_path=repo,
+        runtime_root=tmp_path / "runtime",
+        event="reference-transaction",
+        hook_args=["prepared"],
+        hook_stdin=row,
+    )
+    assert result["status"] == "provider_drift"
+
+
+def test_selected_cli_does_not_import_full_cli(installed):
+    _repo, _remote, _git, _policy = installed
+    program = 'import sys; from loopx.entrypoint import main; assert main(["--format","json","change-window","hook-runtime"]) == 0; assert "loopx.cli" not in sys.modules'
+    result = subprocess.run(
+        [sys.executable, "-c", program], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_old_valid_hook_generation_requires_explicit_refresh(installed):
+    repo, _remote, _git, policy = installed
+    state_path = repo / ".git/loopx/repository-change-window/provider.json"
+    state = json.loads(state_path.read_text())
+    for event in state["hook_digests"]:
+        hook = state_path.parent / "hooks" / event
+        old = hook.read_text().replace("export LOOPX_GIT_HOOK_QUIET_SUCCESS=1\n", "")
+        hook.write_text(old)
+        state["hook_digests"][event] = owner._digest_text(old)
+    state_path.write_text(json.dumps(state))
+    with pytest.raises(ValueError, match="--replace"):
+        owner.install_git_hook_provider(
+            repo_path=repo, policy=policy, enforcement_level="reference_guard"
+        )
+    refreshed = owner.install_git_hook_provider(
+        repo_path=repo,
+        policy=policy,
+        enforcement_level="reference_guard",
+        replace=True,
+        execute=True,
+    )
+    assert refreshed["changed"]
+    assert (
+        "LOOPX_GIT_HOOK_QUIET_SUCCESS=1"
+        in (state_path.parent / "hooks/reference-transaction").read_text()
+    )


### PR DESCRIPTION
## Summary

Fix slow, noisy `git fetch` / fast-forward `git pull` under the existing repository change-window provider.

- Route `change-window` through the existing selected-command CLI parser/dispatcher; keep the same command grammar and capability handler, without importing the whole CLI.
- Stop resolving checkout/HEAD facts twice for every hook. Retain repository identity, managed asset integrity and configured-route checks; detached worktree initialization no longer requires a pre-existing HEAD.
- Classify reference changes before evaluating time policy. Non-local refs and completed/aborted phases report `policy_evaluated=false`, `decision=null` rather than an unrelated blocked-window decision.
- Generated hooks suppress only their successful result. Failure diagnostics and prior-hook input, phases, output and exit status remain intact. The output-only environment marker is compatible with older runtimes.
- Detect older generated-hook content during explicit reinstall, even if it still matches its stored digest. Preserve the existing policy and prior-hook route when refreshing.

## Intentional behavior and authority boundary

Existing remote-tracking branches now count as already-known commits, so fetch followed by a fast-forward pull (or worktree creation from that commit) is admitted. New merge/rebase/local commits still face the time gate. Tags, notes and custom refs still cannot launder new commits into local branches. This local workflow guard does **not** prove remote provenance against a user deliberately fabricating remote-tracking refs; the README explicitly records this alongside existing local-configuration/ref-file bypass limitations. It is not a security sandbox or remote-write grant.

The owning capability remains `repository-change-window`, built-in `git-hook` provider. No new capability, provider, policy cache, alternate rule engine or persistent gate bypass is introduced.

## Issue Or Task

Owner-reported Git pull latency and noisy reference-transaction results. Owner explicitly authorized a temporary per-command Git-gate bypass and self-merge for this repair.

## Validation

- Tested revision: `8cfc94b999d8a7453524a426dc6e0ac0c3b554e5`
- Run state: finished
- Input classes: synthetic

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| integration | passed | 38 tests across `test_change_window_git_fast_path.py`, `test_repository_change_window.py`, `test_cli_entrypoint.py`. Final test formatting was mechanical. |
| real_entrypoint | passed | Isolated local Git remote/clone: fetch, fast-forward pull, detached worktree, hook chaining, explicit hook-generation refresh. Tests run the candidate `loopx.entrypoint` in fresh processes. |
| real_backend | passed | Actual Git refs, hook processes and configuration; no mock Git backend. Unreferenced `update-ref` and `commit --no-verify` remain denied during the blocked window. Existing tests cover pre-push/SSH denial and tags/notes/custom-ref negative cases. |
| regression_parity | passed | Assert selected command execution never imports `loopx.cli`; read-only phases never evaluate time policy; provider drift and prior-hook failure remain errors. |
| manual | passed | Same-machine read-only two-phase hook probe: approximately 4.31s before, 1.06s after; successful output 1,086 bytes to zero. Host-specific samples, not a universal latency SLA or network timing claim. |
| static | passed | Changed Python Ruff/compile checks, diff whitespace and public/private scan. |
| integration | passed | `python examples/capability-extension-registry-smoke.py`. |

Coverage and gaps: focused risk-based premerge coverage exercises the changed loader, real Git/provider path, policy negatives, upgrade behavior and delegation boundary. Initial run exposed the risk of generated hooks passing a new option to an old runtime; replaced that design with a backward-compatible output-only environment marker, then reran all 38 tests successfully. No whole-repository test claim, PostgreSQL changes, live Goal writes or network push test are included. Hosted CI runs separately.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Test update

## LoopX Area

- [x] Capability or extension (providers, adapters, skills)
- [x] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- Target base branch: main
- Direction tracker or promotion unit: existing Git-hook provider; no shared-authority promotion claim.

## Shared-authority RFC fixture impact

N/A: no Todo authority/provider-state migration or shared transaction changes.

## Boundary Checklist

- [x] No private state, credentials, raw traces, internal links or local machine paths in public artifacts.
- [x] No duplicated benchmark work.
- [x] Single-purpose repair; unrelated worktrees untouched.
- [x] DCO signed commit.

Future-facing pass applied: reuse the canonical selected CLI loader and narrow hook fact collection instead of introducing a second policy implementation. On local deployment, refresh only the affected repository provider with its exact existing policy; keep prior hooks and a recoverable prior runtime snapshot.
