### PR TITLE
feat(finance): derive query coverage gates from frozen receipts

### DIFF
--- a/packages/loopx-finance-value-discovery/CONTRACT.md
+++ b/packages/loopx-finance-value-discovery/CONTRACT.md
@@ -82,6 +82,64 @@ method promotion, investment advice, or permission to trade.
 
 ## Replay
 
+### Source query coverage (extension 0.5.0)
+
+A gate can opt into receipt-derived source coverage with a `source_coverage`
+requirement. It must use `boolean eq true`. The requirement freezes
+`request_identity` (`market`, `universe_id`, `query_id`) and
+`collection_started_at`; its universe must match the case contract. `query_id`
+identifies immutable query parameters in the adapter's evidence catalog; a
+reused label cannot prove that those parameters actually stayed unchanged.
+
+The matching observation contains **only** `gate_id` and `source_pages`.
+Callers cannot also supply a value, state, reason, or computed coverage result.
+The engine derives the observation and includes a `finance_source_coverage_v1`
+report in that gate's result. A coverage gate after an earlier blocker instead
+uses the existing `not_run` observation. Unbound gates reject receipt fields.
+The complete runnable input is
+[`finance-source-coverage-v1.json`](examples/finance-source-coverage-v1.json).
+
+Each normalized page contains its request identity, positive `page_number`,
+`source_status`, `started_at`, `observed_at`, `rows`, `total_count`, `has_more`,
+`snapshot_id`, and `snapshot_evidence_ref`. Row metadata consists of `id`,
+`market`, `content_sha256`, and optional `publication_at`. Bodies and unmodeled
+fields are rejected. Receipts require timezone-aware timestamps ordered inside
+the frozen collection window. A date-only case evaluation cutoff is midnight
+UTC; use a timestamp for intraday or end-of-day collection. The collection start
+must lie inside the case window. Collection time does not prove availability at
+the case's earlier historical `point_in_time`.
+
+| Coverage state | Evidence condition | Gate / case result |
+| --- | --- | --- |
+| `complete` | Contiguous pages from 1, a unique terminal page, one reported total matching unique IDs, consistent versions, common nonempty snapshot identity and evidence reference | `passed`; later gates still determine the case |
+| `partial` | Missing pages, unknown total/end/snapshot assertion, or no observations | `missing` / `insufficient_evidence` |
+| `unstable` | Cross-page overlap, changed repeated page, conflicting record versions, totals, terminal pages, or snapshots | `missing` / `insufficient_evidence`, with explicit instability reasons |
+| `source_error` | Source failure, missing rows, mismatched query/market, or invalid row metadata | `missing` / `insufficient_evidence`, with explicit error reasons |
+
+Source errors take precedence over instability, then gaps; all reason lists
+remain visible. Instability is not an economic hypothesis failure. The engine
+uses `missing` rather than inventing multiple independent evidence references
+to satisfy the existing `conflict` observation contract. A complete query may
+contain zero records; an empty error response or absent receipt never proves
+that. Identical retries preserve unique IDs; changed versions remain recorded.
+
+Completeness is **conditional on adapter assertions**. The engine does not fetch
+or authenticate snapshot evidence, establish source truth, prove historical
+publication time, discover new economic events, or validate an investment edge.
+`snapshot_evidence_state=adapter_asserted` makes that limit explicit. The
+coverage digest identifies computed evidence, not independent corroboration.
+Only normalized, authorized public metadata should enter this public reducer.
+
+Inputs are bounded to 128 receipts, 500 rows per receipt and 5,000 rows including
+retries. Exceeding a bound is an explicit error; no truncation is called complete.
+Page-number validation does not allocate memory proportional to a reported last
+page. Freeze a narrower query or use a domain adapter with its own explicit
+partition coverage contract for larger collections.
+
+No new collector, scheduler, builtin capability, or CLI command is added.
+Existing `evaluate`, `replay`, and the managed extension entrypoint consume the
+same input. Replay binds the requirement, receipt metadata and computed report.
+
 The replay receipt binds three SHA-256 values:
 
 - the normalized contract;
@@ -101,3 +159,13 @@ The existing `finance_value_discovery_input_v0` reducer and
 subject, so a gate input packet must declare the subject it evaluates; this
 binds the case identity end to end. The `finance_value_discovery_input_v0`
 packets are not reclassified and gain no new fields.
+
+The 0.5.0 coverage gate is opt-in. Inputs without `source_coverage` retain their
+existing normalized contract, result fields and replay bytes. Older extension
+versions reject the new fields; install 0.5.0 before invoking this form. To stop
+using it, choose a separately frozen contract revision without that gate, rather
+than removing evidence from an already evaluated contract. Prior evaluations
+must be replayed with their original contract and implementation version. To
+disable the entire optional workflow, use `loopx extension disable
+loopx-finance-value-discovery --execute`; this does not authorize any financial
+operation or remove evidence already stored by its owner.

--- a/packages/loopx-finance-value-discovery/README.md
+++ b/packages/loopx-finance-value-discovery/README.md
@@ -186,6 +186,25 @@ loopx-finance-value-discovery evaluate-pack \
   --input-json packages/loopx-finance-value-discovery/examples/software-metric-pack-v1.json
 ```
 
+In extension 0.5.0, a frozen gate can require source-query coverage computed from
+normalized page receipts. Matching totals alone cannot pass it: missing pages or
+snapshot assertions remain insufficient evidence. This does not verify source
+truth or historical publication time. See the [coverage contract](CONTRACT.md#source-query-coverage-extension-050).
+
+```bash
+loopx extension run loopx-finance-value-discovery \
+  --input-json packages/loopx-finance-value-discovery/examples/finance-source-coverage-v1.json \
+  --execute --format json
+loopx-finance-value-discovery evaluate \
+  --input-json packages/loopx-finance-value-discovery/examples/finance-source-coverage-v1.json > evaluation.json
+loopx-finance-value-discovery replay \
+  --input-json packages/loopx-finance-value-discovery/examples/finance-source-coverage-v1.json \
+  --expected-json evaluation.json
+```
+
+The synthetic example passes query coverage but still lacks economic evidence.
+Existing inputs without the optional gate retain their result and replay bytes.
+
 The manifest declares no permissions: this workflow is a deterministic reducer
 over caller-supplied frozen public evidence. It performs no collection or other
 effectful operation. Permissioned Finance work must use a capability or domain

--- a/packages/loopx-finance-value-discovery/examples/finance-source-coverage-v1.json
+++ b/packages/loopx-finance-value-discovery/examples/finance-source-coverage-v1.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "finance_case_gate_input_v1",
+  "case_id": "synthetic-disclosure-coverage",
+  "subject_ref": "synthetic-universe",
+  "contract": {
+    "schema_version": "finance_case_contract_v1",
+    "contract_id": "synthetic-coverage-contract",
+    "method_revision": "coverage-example-v1",
+    "point_in_time": "2026-01-02T00:00:00Z",
+    "evaluation_as_of": "2026-01-02T03:00:00Z",
+    "universe_id": "synthetic-universe",
+    "universe_frozen": true,
+    "identities_frozen": true,
+    "thresholds_frozen": true,
+    "outcome_blind": true,
+    "public_evidence_only": true,
+    "investment_advice_allowed": false,
+    "trading_allowed": false,
+    "automatic_promotion_allowed": false,
+    "gates": [
+      {
+        "gate_id": "disclosure_coverage",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": true,
+        "source_coverage": {
+          "request_identity": {
+            "market": "TEST",
+            "universe_id": "synthetic-universe",
+            "query_id": "synthetic-filings-window-v1"
+          },
+          "collection_started_at": "2026-01-02T00:00:00Z"
+        }
+      },
+      {
+        "gate_id": "economic_evidence",
+        "value_type": "boolean",
+        "operator": "eq",
+        "reference_value": true
+      }
+    ]
+  },
+  "observations": [
+    {
+      "gate_id": "disclosure_coverage",
+      "source_pages": [
+        {
+          "request_identity": {
+            "market": "TEST",
+            "universe_id": "synthetic-universe",
+            "query_id": "synthetic-filings-window-v1"
+          },
+          "page_number": 1,
+          "source_status": "ok",
+          "started_at": "2026-01-02T01:00:00Z",
+          "observed_at": "2026-01-02T01:01:00Z",
+          "total_count": 1,
+          "has_more": false,
+          "snapshot_id": "synthetic-immutable-snapshot",
+          "snapshot_evidence_ref": "synthetic-snapshot-assertion",
+          "rows": [
+            {
+              "id": "synthetic-filing-a",
+              "market": "TEST",
+              "content_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "gate_id": "economic_evidence",
+      "observation_state": "missing",
+      "value": null,
+      "evidence_refs": [],
+      "reason": "Query coverage does not supply economic evidence."
+    }
+  ]
+}

--- a/packages/loopx-finance-value-discovery/extension.toml
+++ b/packages/loopx-finance-value-discovery/extension.toml
@@ -1,6 +1,6 @@
 schema_version = "loopx_extension_manifest_v0"
 id = "loopx-finance-value-discovery"
-version = "0.4.0"
+version = "0.5.0"
 requires_loopx_api = ">=1,<2"
 permissions = []
 

--- a/packages/loopx-finance-value-discovery/pyproject.toml
+++ b/packages/loopx-finance-value-discovery/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx-finance-value-discovery"
-version = "0.4.0"
+version = "0.5.0"
 description = "Public-safe finance value-discovery extension for LoopX."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/contract.py
@@ -6,6 +6,7 @@ from math import isfinite
 from typing import Any
 
 from .boundary import reject_forbidden_material
+from .source_coverage import validate_coverage_requirement
 
 FINANCE_CASE_CONTRACT_SCHEMA_VERSION = "finance_case_contract_v1"
 FINANCE_CASE_INPUT_SCHEMA_VERSION = "finance_case_gate_input_v1"
@@ -66,7 +67,7 @@ def _gate_rule(value: object, *, index: int) -> dict[str, Any]:
     field = f"contract.gates[{index}]"
     if not isinstance(value, Mapping):
         raise ValueError(f"{field} must be an object")
-    allowed = {"gate_id", "value_type", "operator", "reference_value"}
+    allowed = {"gate_id", "value_type", "operator", "reference_value", "source_coverage"}
     if set(value) - allowed:
         raise ValueError(f"{field} has unsupported fields")
     value_type = _text(
@@ -92,12 +93,17 @@ def _gate_rule(value: object, *, index: int) -> dict[str, Any]:
         reference = _text(
             reference, field=f"{field}.reference_value", limit=120
         )
-    return {
+    rule = {
         "gate_id": _text(value.get("gate_id"), field=f"{field}.gate_id", limit=80),
         "value_type": value_type,
         "operator": operator,
         "reference_value": reference,
     }
+    if "source_coverage" in value:
+        if value_type != "boolean" or operator != "eq" or reference is not True:
+            raise ValueError("source_coverage requires a boolean eq true gate")
+        rule["source_coverage"] = validate_coverage_requirement(value["source_coverage"])
+    return rule
 
 
 def validate_finance_case_contract(value: object) -> dict[str, Any]:
@@ -154,6 +160,21 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
         raise ValueError(
             "contract.point_in_time must not be after contract.evaluation_as_of"
         )
+    universe_id = _text(value.get("universe_id"), field="contract.universe_id", limit=96)
+    for rule in gates:
+        requirement = rule.get("source_coverage")
+        if requirement is None:
+            continue
+        if requirement["request_identity"]["universe_id"] != universe_id:
+            raise ValueError("source_coverage universe_id must match contract.universe_id")
+        if not (
+            iso_comparable_datetime(point_in_time)
+            <= iso_comparable_datetime(requirement["collection_started_at"])
+            <= iso_comparable_datetime(evaluation_as_of)
+        ):
+            raise ValueError(
+                "source_coverage collection start must be inside the case window"
+            )
     return {
         "schema_version": FINANCE_CASE_CONTRACT_SCHEMA_VERSION,
         "contract_id": _text(
@@ -166,9 +187,7 @@ def validate_finance_case_contract(value: object) -> dict[str, Any]:
         ),
         "point_in_time": point_in_time,
         "evaluation_as_of": evaluation_as_of,
-        "universe_id": _text(
-            value.get("universe_id"), field="contract.universe_id", limit=96
-        ),
+        "universe_id": universe_id,
         "universe_frozen": _required_boolean(
             value, "universe_frozen", expected=True
         ),

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/gates.py
@@ -9,6 +9,7 @@ from .contract import (
     FINANCE_CASE_EVALUATION_SCHEMA_VERSION,
     validate_finance_case_input,
 )
+from .source_coverage import coverage_observation
 
 OBSERVATION_STATES = {"observed", "missing", "conflict", "not_run"}
 BLOCKING_GATE_STATES = {"failed", "missing", "conflict"}
@@ -120,10 +121,23 @@ def _observed_value_matches(rule: Mapping[str, Any], value: object) -> bool:
 def evaluate_finance_case_gates(value: object) -> dict[str, Any]:
     payload = validate_finance_case_input(value)
     contract = payload["contract"]
-    observations = [
-        _observation(item, index=index)
-        for index, item in enumerate(payload["observations"])
-    ]
+    if len(payload["observations"]) != len(contract["gates"]):
+        raise ValueError("observations must exactly match contract.gates order")
+    observations = []
+    for index, (rule, item) in enumerate(
+        zip(contract["gates"], payload["observations"], strict=True)
+    ):
+        if (
+            "source_coverage" in rule
+            and isinstance(item, Mapping)
+            and item.get("observation_state") != "not_run"
+        ):
+            observation = coverage_observation(
+                item, rule=rule, evaluation_as_of=contract["evaluation_as_of"]
+            )
+        else:
+            observation = _observation(item, index=index)
+        observations.append(observation)
     gate_order = [item["gate_id"] for item in contract["gates"]]
     observed_order = [item["gate_id"] for item in observations]
     if observed_order != gate_order:

--- a/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/source_coverage.py
+++ b/packages/loopx-finance-value-discovery/src/loopx_finance_value_discovery/source_coverage.py
@@ -1,0 +1,330 @@
+"""Offline coverage assessment of normalized, read-only source receipts.
+
+Transport adapters own source decoding, market identity and snapshot assertions.
+A complete result covers only the supplied query and asserted snapshot. It does
+not establish source truth, publication time, new economic events or alpha.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+from .boundary import reject_forbidden_material
+
+MAX_PAGES = 128
+MAX_ROWS_PER_PAGE = 500
+MAX_ROWS = 5000
+PAGE_FIELDS = {
+    "request_identity",
+    "page_number",
+    "source_status",
+    "started_at",
+    "observed_at",
+    "rows",
+    "total_count",
+    "has_more",
+    "snapshot_id",
+    "snapshot_evidence_ref",
+}
+ROW_FIELDS = {"id", "market", "content_sha256", "publication_at"}
+
+
+class CoverageState(StrEnum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    UNSTABLE = "unstable"
+    SOURCE_ERROR = "source_error"
+
+
+def timestamp(value: object) -> datetime:
+    if not isinstance(value, str) or len(value) > 40 or "T" not in value:
+        raise ValueError("coverage timestamps require ISO datetime with timezone")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(
+            "coverage timestamps require ISO datetime with timezone"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise ValueError("coverage timestamps require ISO datetime with timezone")
+    return parsed.astimezone(UTC)
+
+
+def _label(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > 120:
+        raise ValueError(
+            f"{field} requires a nonempty string of at most 120 characters"
+        )
+    reject_forbidden_material(value, path=field)
+    return value
+
+
+def validate_coverage_requirement(value: object) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != {
+        "request_identity",
+        "collection_started_at",
+    }:
+        raise ValueError(
+            "source_coverage requires request_identity and collection_started_at"
+        )
+    identity = value["request_identity"]
+    if not isinstance(identity, Mapping) or set(identity) != {
+        "market",
+        "universe_id",
+        "query_id",
+    }:
+        raise ValueError("coverage identity requires market, universe_id, query_id")
+    return {
+        "request_identity": {
+            key: _label(identity[key], key) for key in sorted(identity)
+        },
+        "collection_started_at": timestamp(value["collection_started_at"]).isoformat(),
+    }
+
+
+def assess_pages(
+    pages: object,
+    *,
+    request_identity: Mapping[str, Any],
+    frozen_at: str,
+    evaluated_at: str,
+) -> dict[str, Any]:
+    """Assess normalized pages while preserving observed IDs and versions.
+
+    Each page has request_identity (excluding page number), page_number,
+    source_status, started_at, observed_at, rows, total_count and has_more.
+    Rows have id, market and content_sha256, with optional publication_at.
+    Completeness additionally requires a common nonempty snapshot_id and
+    snapshot_evidence_ref asserted by the adapter. No such evidence
+    means partial even when counts match. Missing/error payloads are not empty
+    successes. Caller contract violations raise ValueError.
+    """
+    requirement = validate_coverage_requirement(
+        {
+            "request_identity": request_identity,
+            "collection_started_at": frozen_at,
+        }
+    )
+    request_identity = requirement["request_identity"]
+    if not isinstance(pages, list) or len(pages) > MAX_PAGES:
+        raise ValueError(f"source_pages requires at most {MAX_PAGES} receipts")
+    reject_forbidden_material(pages, path="source_pages")
+    for page in pages:
+        if not isinstance(page, dict) or set(page) - PAGE_FIELDS:
+            raise ValueError("coverage pages accept only normalized receipt metadata")
+        rows = page.get("rows")
+        if isinstance(rows, list):
+            if len(rows) > MAX_ROWS_PER_PAGE:
+                raise ValueError("source_pages exceeds normalized row budget")
+            for row in rows:
+                if not isinstance(row, dict) or set(row) - ROW_FIELDS:
+                    raise ValueError(
+                        "coverage rows accept only identity and version metadata"
+                    )
+    if sum(len(p["rows"]) for p in pages if isinstance(p.get("rows"), list)) > MAX_ROWS:
+        raise ValueError("source_pages exceeds normalized row budget")
+    frozen, evaluated = timestamp(frozen_at), timestamp(evaluated_at)
+    if frozen > evaluated:
+        raise ValueError("invalid_evaluation_clock")
+    errors, instability, gaps = set(), set(), set()
+    observations, page_versions, page_ids = {}, {}, {}
+    totals, terminals, snapshots, snapshot_refs = set(), set(), set(), set()
+    raw_count = 0
+    for page in pages:
+        start, observed = (
+            timestamp(page.get("started_at")),
+            timestamp(page.get("observed_at")),
+        )
+        if not frozen <= start <= observed <= evaluated:
+            raise ValueError("invalid_observation_clock")
+        number = page.get("page_number")
+        if type(number) is not int or number < 1:
+            raise ValueError("positive_page_number_required")
+        if page.get("request_identity") != request_identity:
+            errors.add("request_identity_mismatch")
+        if page.get("source_status") != "ok":
+            errors.add("source_error_or_unknown")
+            continue
+        rows = page.get("rows")
+        if not isinstance(rows, list):
+            errors.add("missing_rows")
+            continue
+        total = page.get("total_count")
+        if total is None:
+            gaps.add("total_unknown")
+        elif type(total) is not int or total < 0:
+            errors.add("invalid_total")
+        else:
+            totals.add(total)
+        more = page.get("has_more")
+        if more is False:
+            terminals.add(number)
+        elif more is not True:
+            gaps.add("terminal_unknown")
+        snapshot, snapshot_ref = (
+            page.get("snapshot_id"),
+            page.get("snapshot_evidence_ref"),
+        )
+        if (
+            snapshot is None
+            or snapshot == ""
+            or snapshot_ref is None
+            or snapshot_ref == ""
+        ):
+            gaps.add("snapshot_unattested")
+        else:
+            snapshots.add(_label(snapshot, "snapshot_id"))
+            snapshot_refs.add(_label(snapshot_ref, "snapshot_evidence_ref"))
+        raw_count += len(rows)
+        signature, ids = [], set()
+        for row in rows:
+            key, digest = row.get("id"), row.get("content_sha256")
+            if (
+                not isinstance(key, str)
+                or not key.strip()
+                or len(key) > 120
+                or not isinstance(digest, str)
+                or len(digest) != 64
+                or any(c not in "0123456789abcdef" for c in digest)
+            ):
+                errors.add("row_identity_or_digest_missing")
+                continue
+            if row.get("market") != request_identity["market"]:
+                errors.add("row_market_mismatch")
+            pub = row.get("publication_at")
+            if pub is not None:
+                try:
+                    if timestamp(pub) > observed:
+                        errors.add("publication_after_observation")
+                except (ValueError, AttributeError, TypeError):
+                    errors.add("invalid_publication_time")
+                    pub = None
+            if key in ids:
+                instability.add("duplicate_within_page")
+            ids.add(key)
+            signature.append((key, digest, pub))
+            seen = observed.isoformat()
+            item = observations.setdefault(
+                key, {"id": key, "versions": {}, "first_observed_at": seen}
+            )
+            if observed < timestamp(item["first_observed_at"]):
+                item["first_observed_at"] = seen
+            version = item["versions"].setdefault(
+                digest,
+                {
+                    "content_sha256": digest,
+                    "first_observed_at": seen,
+                    "publication_at_values": [],
+                },
+            )
+            if observed < timestamp(version["first_observed_at"]):
+                version["first_observed_at"] = seen
+            if pub not in version["publication_at_values"]:
+                version["publication_at_values"].append(pub)
+                version["publication_at_values"].sort(
+                    key=lambda p: (p is not None, p or "")
+                )
+            if len(item["versions"]) > 1 or len(version["publication_at_values"]) > 1:
+                instability.add("record_version_conflict")
+        encoded = json.dumps(
+            {
+                "rows": signature,
+                "has_more": more,
+                "total_count": total,
+                "snapshot_id": snapshot,
+                "snapshot_evidence_ref": snapshot_ref,
+            },
+            ensure_ascii=False,
+        )
+        if number in page_versions and encoded != page_versions[number]:
+            instability.add("repeated_page_changed")
+        page_versions.setdefault(number, encoded)
+        page_ids.setdefault(number, set()).update(ids)
+    seen_ids = set()
+    for number in sorted(page_ids):
+        if seen_ids & page_ids[number]:
+            instability.add("cross_page_overlap")
+        seen_ids.update(page_ids[number])
+    if len(totals) > 1:
+        instability.add("reported_total_changed")
+    if len(snapshots) > 1 or len(snapshot_refs) > 1:
+        instability.add("snapshot_changed")
+    if len(terminals) > 1:
+        instability.add("inconsistent_terminal")
+    if len(terminals) != 1:
+        gaps.add("terminal_not_established")
+    elif next(iter(terminals)) != len(page_ids) or any(
+        number != index for index, number in enumerate(sorted(page_ids), 1)
+    ):
+        gaps.add("noncontiguous_pages_or_pages_after_terminal")
+    if len(totals) != 1 or len(observations) != next(iter(totals), None):
+        gaps.add("reported_count_not_covered")
+    if not pages:
+        gaps.add("no_observations")
+    state = (
+        CoverageState.SOURCE_ERROR
+        if errors
+        else CoverageState.UNSTABLE
+        if instability
+        else CoverageState.PARTIAL
+        if gaps
+        else CoverageState.COMPLETE
+    )
+    return {
+        "schema_version": "finance_source_coverage_v1",
+        "state": state.value,
+        "requirement": requirement,
+        "evaluated_at": evaluated.isoformat(),
+        "row_count_including_replays": raw_count,
+        "receipt_count": len(pages),
+        "unique_ids": len(observations),
+        "reported_totals": sorted(totals),
+        "observed_page_numbers": sorted(page_ids),
+        "errors": sorted(errors),
+        "instability": sorted(instability),
+        "gaps": sorted(gaps),
+        "records": [observations[k] for k in sorted(observations)],
+        "snapshot_evidence_state": "adapter_asserted" if snapshots else "missing",
+        "publication_time_verified": False,
+        "event_novelty_verified": False,
+        "limitation": "Conditional on adapter identities and snapshot assertions; query coverage does not prove source truth, historical availability, or an investment edge.",
+    }
+
+
+def coverage_observation(
+    value: Mapping[str, Any],
+    *,
+    rule: Mapping[str, Any],
+    evaluation_as_of: str,
+) -> dict[str, Any]:
+    if set(value) != {"gate_id", "source_pages"} or value["gate_id"] != rule["gate_id"]:
+        raise ValueError(
+            "a source-coverage observation requires only the bound gate_id and source_pages"
+        )
+    # Case dates mean midnight UTC. Datetimes in coverage-enabled cases must
+    # carry an offset; do not infer the host timezone for receipt verification.
+    if "T" not in evaluation_as_of:
+        evaluation_as_of += "T00:00:00+00:00"
+    requirement = rule["source_coverage"]
+    report = assess_pages(
+        value["source_pages"],
+        request_identity=requirement["request_identity"],
+        frozen_at=requirement["collection_started_at"],
+        evaluated_at=evaluation_as_of,
+    )
+    complete = report["state"] == CoverageState.COMPLETE
+    encoded = json.dumps(report, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    return {
+        "gate_id": rule["gate_id"],
+        "observation_state": "observed" if complete else "missing",
+        "value": True if complete else None,
+        "evidence_refs": [f"coverage:{digest}"],
+        "reason": f"Source query coverage is {report['state']}; snapshot evidence remains adapter-asserted.",
+        "source_coverage": report,
+    }

--- a/tests/extensions/test_finance_source_coverage.py
+++ b/tests/extensions/test_finance_source_coverage.py
@@ -1,0 +1,416 @@
+"""Public source coverage must gate real evaluation, without inventing truth."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+PACKAGE = ROOT / "packages" / "loopx-finance-value-discovery"
+sys.path.insert(0, str(PACKAGE / "src"))
+
+from loopx_finance_value_discovery.replay import (  # noqa: E402
+    build_finance_case_evaluation,
+    canonical_json_bytes,
+    replay_finance_case_evaluation,
+)
+from loopx_finance_value_discovery.source_coverage import (  # noqa: E402
+    MAX_PAGES,
+    MAX_ROWS,
+    MAX_ROWS_PER_PAGE,
+)
+
+
+def example():
+    return json.loads(
+        (PACKAGE / "examples/finance-source-coverage-v1.json").read_text()
+    )
+
+
+def pages(payload):
+    return payload["observations"][0]["source_pages"]
+
+
+def skip_later(payload):
+    payload["observations"][1] = {
+        "gate_id": "economic_evidence",
+        "observation_state": "not_run",
+        "value": None,
+        "evidence_refs": [],
+        "reason": "Coverage prevents downstream evaluation.",
+    }
+
+
+def result(payload):
+    return build_finance_case_evaluation(payload)
+
+
+def coverage(evaluation):
+    return evaluation["gate_results"][0]["source_coverage"]
+
+
+def two_pages(payload):
+    first = pages(payload)[0]
+    first.update(total_count=2, has_more=True)
+    second = deepcopy(first)
+    second.update(page_number=2, has_more=False)
+    second["rows"][0]["id"] = "synthetic-filing-b"
+    pages(payload).append(second)
+
+
+def test_complete_coverage_only_passes_its_own_gate():
+    evaluation = result(example())
+    report = coverage(evaluation)
+    assert report["state"] == "complete"
+    assert report["unique_ids"] == 1
+    assert report["snapshot_evidence_state"] == "adapter_asserted"
+    assert report["publication_time_verified"] is False
+    assert report["event_novelty_verified"] is False
+    assert report["records"][0]["versions"]["a" * 64]["publication_at_values"] == [None]
+    assert evaluation["gate_results"][0]["state"] == "passed"
+    assert evaluation["first_blocking_gate"]["gate_id"] == "economic_evidence"
+    assert evaluation["disposition"] == "insufficient_evidence"
+    assert evaluation["boundary"]["trading_allowed"] is False
+
+
+@pytest.mark.parametrize(
+    "missing",
+    ["snapshot_id", "snapshot_evidence_ref", "total_count", "has_more", "rows"],
+)
+def test_counts_are_not_proof_and_missing_payload_is_not_empty_success(missing):
+    payload = example()
+    pages(payload)[0].pop(missing)
+    skip_later(payload)
+    evaluation = result(payload)
+    assert coverage(evaluation)["state"] == (
+        "source_error" if missing == "rows" else "partial"
+    )
+    assert evaluation["disposition"] == "insufficient_evidence"
+    assert evaluation["first_blocking_gate"]["state"] == "missing"
+    assert evaluation["gate_results"][1]["state"] == "not_run"
+
+
+@pytest.mark.parametrize("source_status", ["error", "unknown", None])
+def test_error_empty_is_not_complete_empty(source_status):
+    payload = example()
+    pages(payload)[0].update(source_status=source_status, rows=[], total_count=0)
+    skip_later(payload)
+    assert coverage(result(payload))["state"] == "source_error"
+
+
+def test_no_receipts_and_attested_empty_have_different_meanings():
+    payload = example()
+    payload["observations"][0]["source_pages"] = []
+    skip_later(payload)
+    assert coverage(result(payload))["state"] == "partial"
+    payload = example()
+    pages(payload)[0].update(rows=[], total_count=0)
+    assert coverage(result(payload))["state"] == "complete"
+
+
+@pytest.mark.parametrize(
+    "change,reason",
+    [
+        ("overlap", "cross_page_overlap"),
+        ("snapshot", "snapshot_changed"),
+        ("count", "reported_total_changed"),
+        ("terminal", "inconsistent_terminal"),
+    ],
+)
+def test_cross_page_instability_blocks_without_rejecting_hypothesis(change, reason):
+    payload = example()
+    two_pages(payload)
+    if change == "overlap":
+        pages(payload)[1]["rows"][0]["id"] = pages(payload)[0]["rows"][0]["id"]
+    elif change == "snapshot":
+        pages(payload)[1]["snapshot_id"] = "another-snapshot"
+    elif change == "count":
+        pages(payload)[1]["total_count"] = 3
+    else:
+        pages(payload)[0]["has_more"] = False
+    skip_later(payload)
+    evaluation = result(payload)
+    assert coverage(evaluation)["state"] == "unstable"
+    assert reason in coverage(evaluation)["instability"]
+    assert evaluation["disposition"] == "insufficient_evidence"
+
+
+@pytest.mark.parametrize("number", [3, 10**12])
+def test_missing_pages_do_not_allocate_a_range_of_claimed_page_numbers(number):
+    payload = example()
+    two_pages(payload)
+    pages(payload)[1]["page_number"] = number
+    skip_later(payload)
+    assert coverage(result(payload))["state"] == "partial"
+
+
+def test_two_pages_and_exact_replay_are_complete_but_do_not_create_new_records():
+    payload = example()
+    two_pages(payload)
+    pages(payload).append(deepcopy(pages(payload)[0]))
+    report = coverage(result(payload))
+    assert report["state"] == "complete"
+    assert report["unique_ids"] == 2
+    assert report["row_count_including_replays"] == 3
+
+
+def test_changed_replay_retains_versions_and_first_observation():
+    payload = example()
+    later = deepcopy(pages(payload)[0])
+    later.update(started_at="2026-01-02T02:00:00Z", observed_at="2026-01-02T02:01:00Z")
+    later["rows"][0]["content_sha256"] = "b" * 64
+    pages(payload).insert(0, later)
+    skip_later(payload)
+    report = coverage(result(payload))
+    assert report["state"] == "unstable"
+    assert "repeated_page_changed" in report["instability"]
+    assert "record_version_conflict" in report["instability"]
+    assert report["records"][0]["first_observed_at"] == "2026-01-02T01:01:00+00:00"
+    assert set(report["records"][0]["versions"]) == {"a" * 64, "b" * 64}
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("started_at", "2026-01-01T00:00:00Z"),
+        ("started_at", "2026-01-02T02:00:00Z"),
+        ("observed_at", "2026-01-02T04:00:00Z"),
+        ("observed_at", "2026-01-02T01:01:00"),
+        ("observed_at", "not-a-clock"),
+        ("page_number", True),
+        ("page_number", 0),
+    ],
+)
+def test_malformed_or_outside_window_receipts_fail_closed(field, value):
+    payload = example()
+    pages(payload)[0][field] = value
+    with pytest.raises(ValueError):
+        result(payload)
+
+
+@pytest.mark.parametrize("field", ["market", "query_id", "universe_id"])
+def test_adapter_cannot_substitute_the_frozen_query(field):
+    payload = example()
+    pages(payload)[0]["request_identity"][field] = "another-scope"
+    skip_later(payload)
+    assert "request_identity_mismatch" in coverage(result(payload))["errors"]
+
+
+def test_contract_cannot_bind_coverage_to_another_universe_or_weaken_rule():
+    for patch in (
+        {"reference_value": False},
+        {"value_type": "string", "reference_value": "complete"},
+    ):
+        payload = example()
+        payload["contract"]["gates"][0].update(patch)
+        with pytest.raises(ValueError, match="boolean eq true"):
+            result(payload)
+    payload = example()
+    payload["contract"]["universe_id"] = "another-universe"
+    with pytest.raises(ValueError, match="universe_id"):
+        result(payload)
+
+
+def test_provider_cannot_self_assert_coverage_or_smuggle_rows_into_an_unbound_gate():
+    payload = example()
+    payload["observations"][0] = {
+        "gate_id": "disclosure_coverage",
+        "observation_state": "observed",
+        "value": True,
+        "evidence_refs": ["trust-me"],
+        "reason": "Caller asserts success.",
+    }
+    with pytest.raises(ValueError, match="requires only"):
+        result(payload)
+    payload = example()
+    payload["contract"]["gates"][0].pop("source_coverage")
+    with pytest.raises(ValueError, match="unsupported fields"):
+        result(payload)
+
+
+def test_later_gates_still_must_not_run_after_coverage_gap():
+    payload = example()
+    pages(payload)[0].pop("snapshot_evidence_ref")
+    with pytest.raises(ValueError, match="after the first blocking gate"):
+        result(payload)
+
+
+@pytest.mark.parametrize(
+    "patch,reason",
+    [
+        ({"market": "OTHER"}, "row_market_mismatch"),
+        ({"content_sha256": "invalid"}, "row_identity_or_digest_missing"),
+        ({"publication_at": "2026-01-02T02:00:00Z"}, "publication_after_observation"),
+        ({"publication_at": {"invalid": True}}, "invalid_publication_time"),
+    ],
+)
+def test_invalid_record_metadata_cannot_pass(patch, reason):
+    payload = example()
+    pages(payload)[0]["rows"][0].update(patch)
+    skip_later(payload)
+    assert reason in coverage(result(payload))["errors"]
+
+
+@pytest.mark.parametrize("value", [True, -1, 1.5, "1"])
+def test_total_requires_a_nonnegative_integer(value):
+    payload = example()
+    pages(payload)[0]["total_count"] = value
+    skip_later(payload)
+    assert coverage(result(payload))["state"] == "source_error"
+
+
+@pytest.mark.parametrize(
+    "target,key,value",
+    [
+        ("page", "body", "not accepted"),
+        ("row", "extra", "unmodeled content"),
+        ("page", "snapshot_evidence_ref", "/Users/example/source.json"),
+    ],
+)
+def test_raw_or_private_material_is_rejected(target, key, value):
+    payload = example()
+    item = pages(payload)[0] if target == "page" else pages(payload)[0]["rows"][0]
+    item[key] = value
+    with pytest.raises(ValueError):
+        result(payload)
+
+
+def test_receipt_and_row_budgets():
+    payload = example()
+    payload["observations"][0]["source_pages"] *= MAX_PAGES + 1
+    with pytest.raises(ValueError, match="at most"):
+        result(payload)
+    payload = example()
+    pages(payload)[0]["rows"] *= MAX_ROWS_PER_PAGE + 1
+    with pytest.raises(ValueError, match="row budget"):
+        result(payload)
+    payload = example()
+    pages(payload)[0]["rows"] *= MAX_ROWS_PER_PAGE
+    payload["observations"][0]["source_pages"] *= MAX_ROWS // MAX_ROWS_PER_PAGE + 1
+    with pytest.raises(ValueError, match="row budget"):
+        result(payload)
+
+
+def test_replay_binds_query_receipts_and_computed_coverage():
+    payload = example()
+    expected = result(payload)
+    assert replay_finance_case_evaluation(payload, expected)["replay_verified"] is True
+    mutated = deepcopy(payload)
+    pages(mutated)[0]["rows"][0]["content_sha256"] = "b" * 64
+    with pytest.raises(ValueError, match="mismatch"):
+        replay_finance_case_evaluation(mutated, expected)
+    altered = deepcopy(expected)
+    coverage(altered)["state"] = "partial"
+    with pytest.raises(ValueError, match="mismatch"):
+        replay_finance_case_evaluation(payload, altered)
+
+
+def test_real_cli_evaluate_replay_and_managed_stdin(tmp_path):
+    env = dict(
+        os.environ, PYTHONPATH=os.pathsep.join((str(PACKAGE / "src"), str(ROOT)))
+    )
+    command = [sys.executable, "-m", "loopx_finance_value_discovery.cli"]
+    input_path = PACKAGE / "examples/finance-source-coverage-v1.json"
+    evaluated = subprocess.run(
+        command + ["evaluate", "--input-json", str(input_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    evaluation = json.loads(evaluated.stdout)
+    assert coverage(evaluation)["state"] == "complete"
+    expected_path = tmp_path / "evaluation.json"
+    expected_path.write_text(evaluated.stdout)
+    replay = subprocess.run(
+        command
+        + [
+            "replay",
+            "--input-json",
+            str(input_path),
+            "--expected-json",
+            str(expected_path),
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert json.loads(replay.stdout)["replay_verified"] is True
+    managed = subprocess.run(
+        command,
+        input=input_path.read_text(),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert canonical_json_bytes(json.loads(managed.stdout)) == canonical_json_bytes(
+        evaluation
+    )
+    invalid = example()
+    pages(invalid)[0]["observed_at"] = "invalid"
+    failed = subprocess.run(
+        command, input=json.dumps(invalid), env=env, capture_output=True, text=True
+    )
+    assert failed.returncode == 1
+    assert json.loads(failed.stdout)["ok"] is False
+
+
+def test_opt_out_preserves_the_pre_coverage_replay_hash():
+    legacy = json.loads((PACKAGE / "examples/finance-case-gates-v1.json").read_text())
+    evaluation = result(legacy)
+    # Captured from the shipped 0.4.0 implementation before this change.
+    assert evaluation["replay"]["evaluation_sha256"] == (
+        "8ff7517fe0e8d285d8144bae9b7d52f02d7ae2e397860bef25f83d2c8ea92015"
+    )
+    assert all("source_coverage" not in item for item in evaluation["gate_results"])
+
+
+def test_coverage_gate_can_remain_not_run_after_an_earlier_blocker():
+    payload = example()
+    payload["contract"]["gates"].reverse()
+    payload["observations"].reverse()
+    payload["observations"][1] = {
+        "gate_id": "disclosure_coverage",
+        "observation_state": "not_run",
+        "value": None,
+        "evidence_refs": [],
+        "reason": "Earlier evidence is missing.",
+    }
+    evaluation = result(payload)
+    assert evaluation["gate_results"][1]["state"] == "not_run"
+    assert "source_coverage" not in evaluation["gate_results"][1]
+
+
+def test_duplicate_rows_and_terminal_flip_are_not_complete():
+    for kind in ("duplicate", "terminal_flip"):
+        payload = example()
+        if kind == "duplicate":
+            pages(payload)[0]["rows"] *= 2
+        else:
+            repeated = deepcopy(pages(payload)[0])
+            repeated["has_more"] = True
+            pages(payload).append(repeated)
+        skip_later(payload)
+        assert coverage(result(payload))["state"] == "unstable"
+
+
+def test_offsets_compare_as_instants_and_date_only_cutoff_is_midnight():
+    payload = example()
+    pages(payload)[0].update(
+        started_at="2026-01-02T09:00:00+08:00", observed_at="2026-01-02T09:01:00+08:00"
+    )
+    assert (
+        coverage(result(payload))["records"][0]["first_observed_at"]
+        == "2026-01-02T01:01:00+00:00"
+    )
+    payload["contract"]["evaluation_as_of"] = "2026-01-02"
+    with pytest.raises(ValueError, match="observation_clock"):
+        result(payload)

--- a/tests/extensions/test_finance_value_discovery_extension.py
+++ b/tests/extensions/test_finance_value_discovery_extension.py
@@ -936,7 +936,12 @@ def test_standalone_extension_runs_through_verified_runtime(
     assert packet["projection"]["next_targets"] == ["PYPL"]
 
 
+@pytest.mark.parametrize(
+    "case_example",
+    [CASE_EXAMPLE, EXTENSION_ROOT / "examples" / "finance-source-coverage-v1.json"],
+)
 def test_unified_gate_contract_runs_through_verified_runtime(
+    case_example: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -953,7 +958,7 @@ def test_unified_gate_contract_runs_through_verified_runtime(
                 "run",
                 "loopx-finance-value-discovery",
                 "--input-json",
-                str(CASE_EXAMPLE),
+                str(case_example),
                 "--execute",
             ]
         )
@@ -965,6 +970,9 @@ def test_unified_gate_contract_runs_through_verified_runtime(
     assert evaluation["schema_version"] == "finance_case_gate_evaluation_v1"
     assert evaluation["disposition"] == "insufficient_evidence"
     assert evaluation["replay"]["evaluation_sha256"]
+    if case_example.name == "finance-source-coverage-v1.json":
+        assert evaluation["gate_results"][0]["source_coverage"]["state"] == "complete"
+        assert evaluation["first_blocking_gate"]["gate_id"] == "economic_evidence"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Source-query completeness previously depended on caller-supplied gate values. Finance extension 0.5.0 adds an opt-in receipt-derived coverage gate: the contract freezes the query identity and collection start, and the existing evaluator computes coverage from bounded normalized page receipts.

Missing pages, absent snapshot assertions, source errors, duplicate pages/records, or changing totals/versions stop the case as insufficient evidence. Complete coverage passes only that gate. Existing evaluate/replay commands and the managed extension runtime consume the same input; no new builtin capability, collector, or scheduler is introduced.

Inputs without the optional field retain their prior evaluation bytes and replay hashes. Completeness remains conditional on adapter-supplied query and snapshot assertions; it does not authenticate source truth or historical availability. The contract documents limits and a synthetic example, and package/manifest versions advance together to 0.5.0.

Validation:

- 172 finance tests passed, including actual CLI evaluate/replay, managed extension execution, input limits, scope/clock failures, and legacy byte parity.
- 8 maintainability checks passed; Ruff and diff checks passed.
- Public boundary scan passed. Only synthetic fixtures are included.

Scope review: coverage belongs to the existing finance extension. Its state classification is typed, receipt counts are bounded, and page continuity avoids allocation proportional to an untrusted terminal page. Core lifecycle and finance presentation behavior are unchanged. This PR does not install or publish a runtime release.

CI readback: the non-blocking Node 26 forward-compatibility job reproduces the existing EISDIR error-message parity failures described in #4146. This branch does not change those control-plane surfaces. Required CI is still running.
