### PR TITLE
fix(install): handle large GitHub commit responses on Linux

### DIFF
--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -20,6 +20,12 @@ need curl
 need tar
 need "$python_bin"
 
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/loopx-install.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
 if [[ -n "${LOOPX_RESOLVED_SOURCE_GIT_COMMIT:-}" \
   && ! "$LOOPX_RESOLVED_SOURCE_GIT_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
   echo "loopx installer error: LOOPX_RESOLVED_SOURCE_GIT_COMMIT must be a full Git commit SHA" >&2
@@ -43,15 +49,16 @@ print(
 )
 PY
 )"
-  commit_json="$(curl -fsSL \
+  curl -fsSL \
     -H 'Accept: application/vnd.github+json' \
     -H 'User-Agent: LoopX-installer' \
-    "$commit_api_url")"
-  resolved_commit="$(LOOPX_COMMIT_JSON="$commit_json" "$python_bin" - <<'PY'
+    "$commit_api_url" -o "$tmp_dir/commit.json"
+  resolved_commit="$("$python_bin" - "$tmp_dir/commit.json" <<'PY'
 import json
-import os
+import sys
 
-payload = json.loads(os.environ["LOOPX_COMMIT_JSON"])
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
 sha = payload.get("sha")
 if not isinstance(sha, str) or len(sha) != 40:
     raise SystemExit("GitHub commit response did not include a full SHA")
@@ -62,12 +69,6 @@ PY
   archive_url="https://codeload.github.com/$repo/tar.gz/$resolved_commit"
 fi
 export LOOPX_ARCHIVE_URL="$archive_url"
-
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/loopx-install.XXXXXX")"
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT
 
 archive_path="$tmp_dir/loopx.tar.gz"
 extract_dir="$tmp_dir/extract"

--- a/tests/test_archive_installer_commit_response.py
+++ b/tests/test_archive_installer_commit_response.py
@@ -1,0 +1,78 @@
+"""Exercise the shipped shell installer with a large GitHub commit response."""
+
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX archive installer")
+@pytest.mark.parametrize("valid", [True, False])
+def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
+    source = Path(__file__).resolve().parents[1]
+    sha = "a" * 40
+    fixture = tmp_path / "response.json"
+    fixture.write_text(
+        json.dumps({"sha": sha if valid else None, "patch": "x" * 524288})
+    )
+    package = tmp_path / "package" / "scripts"
+    package.mkdir(parents=True)
+    installer = package / "install-local.sh"
+    installer.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$LOOPX_RESOLVED_SOURCE_GIT_COMMIT" > "$TEST_RECEIPT"\n'
+    )
+    installer.chmod(0o755)
+    archive = tmp_path / "package.tar.gz"
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(package.parent, arcname="package")
+    binary = tmp_path / "bin"
+    binary.mkdir()
+    curl = binary / "curl"
+    curl.write_text(
+        "#!/bin/sh\nexec "
+        + shlex.quote(sys.executable)
+        + " -c "
+        + shlex.quote(
+            "import os,sys,shutil; "
+            "args=sys.argv[1:]; "
+            "source=os.environ['TEST_RESPONSE'] if any('api.github.com' in a for a in args) "
+            "else os.environ['TEST_ARCHIVE']; "
+            "target=args[args.index('-o')+1] if '-o' in args else None; "
+            "shutil.copyfile(source,target) if target else sys.stdout.write(open(source).read())"
+        )
+        + ' "$@"\n'
+    )
+    curl.chmod(0o755)
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    receipt = tmp_path / "receipt"
+    env = {k: v for k, v in os.environ.items() if not k.startswith("LOOPX_")}
+    env.update(
+        PATH=f"{binary}{os.pathsep}{env['PATH']}",
+        TMPDIR=str(scratch),
+        LOOPX_PYTHON=sys.executable,
+        LOOPX_REF=sha,
+        TEST_RESPONSE=str(fixture),
+        TEST_ARCHIVE=str(archive),
+        TEST_RECEIPT=str(receipt),
+    )
+    result = subprocess.run(
+        ["bash", str(source / "scripts/install-from-github.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if valid:
+        assert result.returncode == 0, result.stderr
+        assert receipt.read_text().strip() == sha
+    else:
+        assert result.returncode != 0
+        assert "did not include a full SHA" in result.stderr
+        assert not receipt.exists()
+    assert list(scratch.iterdir()) == []


### PR DESCRIPTION
Linux archive upgrades can fail with `Argument list too long` when GitHub returns a commit response containing large patches. The installer passed the entire response as one environment variable to Python, exceeding Linux's per-string limit before parsing the commit SHA.

Download the response into the installer's temporary directory and pass only its filename to Python. Register cleanup before the API request so failure and success both remove the response. Commit resolution, archive selection and SHA checks are unchanged.

Validation: two shell-installer integration tests with a 512 KiB response verify successful installation/SHA propagation and rejection of a missing SHA, including temporary-file cleanup. Ruff, shell syntax and diff checks pass. The fix was discovered while upgrading a Linux host after #4147; no machine configuration or private evidence is included.
