### PR TITLE
fix(desktop): speed up runtime installation and expose startup progress

### DIFF
--- a/apps/desktop/loopx-control-plane/README.md
+++ b/apps/desktop/loopx-control-plane/README.md
@@ -18,6 +18,10 @@ update, select **Install update**, then **Restart to finish**. The App verifies
 the archive signature before replacing itself; the restarted App installs its
 bundled runtime and verifies the selected CLI revision before reconnecting.
 This updates both layers without asking the operator to run a terminal command.
+The boot screen shows runtime installation separately from status/chat service
+connection, and reports elapsed startup time across WebView reloads. Slow
+startup exposes recovery guidance in the first screen instead of hiding all
+progress in the collapsed update panel.
 Existing desktop builds without this updater need a one-time App replacement.
 Windows preview installers retain the manual CLI installation path; they are
 not advertised in the signed update feed until their runtime installer is

--- a/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/maintenance.rs
@@ -21,6 +21,8 @@ pub struct Maintenance {
     runtime_retry: Mutex<RuntimeRetry>,
     install_journal_discarded: AtomicBool,
     environment_cache: Mutex<Option<(Instant, Value)>>,
+    startup_started: std::sync::OnceLock<Instant>,
+    phase_started: Mutex<Option<Instant>>,
 }
 
 #[derive(Default)]
@@ -55,8 +57,31 @@ impl Maintenance {
         if matches!(phase, "error" | "runtime_required" | "service_error") {
             *self.last_failure.lock().unwrap() = value.clone();
         }
-        *self.snapshot.lock().unwrap() = value.clone();
+        let mut snapshot = self.snapshot.lock().unwrap();
+        if snapshot["phase"] != phase || snapshot["details"] != value["details"] {
+            *self.phase_started.lock().unwrap() = Some(Instant::now());
+            if let Some(started) = self.startup_started.get() {
+                eprintln!(
+                    "LoopX startup phase={phase} elapsed_ms={}",
+                    started.elapsed().as_millis()
+                );
+            }
+        }
+        *snapshot = value.clone();
         value
+    }
+
+    fn startup_timing(&self) -> Value {
+        let elapsed = self
+            .startup_started
+            .get()
+            .map(|at| at.elapsed().as_millis());
+        let phase_elapsed = self
+            .phase_started
+            .lock()
+            .unwrap()
+            .map(|at| at.elapsed().as_millis());
+        json!({"elapsed_ms": elapsed, "phase_elapsed_ms": phase_elapsed})
     }
 
     fn prepare_runtime(
@@ -232,7 +257,7 @@ pub fn desktop_update_status(app: AppHandle, state: State<'_, Maintenance>) -> V
         }
         cache.as_ref().expect("refreshed above").1.clone()
     };
-    json!({"state": snapshot, "last_failure": last_failure, "app_version": app.package_info().version.to_string(), "runtime": bundled_runtime::identity(&app).ok(), "rollback_available": crate::update_backup::available(&app), "environment": environment})
+    json!({"state": snapshot, "startup": state.startup_timing(), "last_failure": last_failure, "app_version": app.package_info().version.to_string(), "runtime": bundled_runtime::identity(&app).ok(), "rollback_available": crate::update_backup::available(&app), "environment": environment})
 }
 #[tauri::command]
 pub async fn desktop_update(
@@ -596,6 +621,9 @@ fn resume_runtime(app: &AppHandle) -> Result<(), String> {
     Ok(())
 }
 pub fn start_services(app: &AppHandle) -> Result<Option<crate::services::ServiceSet>, String> {
+    app.state::<Maintenance>()
+        .startup_started
+        .get_or_init(Instant::now);
     app.state::<Maintenance>().reconcile_services(|| {
         if let Err(error) = resume_runtime(app) {
             if error != "runtime_setup_required" {
@@ -604,7 +632,11 @@ pub fn start_services(app: &AppHandle) -> Result<Option<crate::services::Service
             }
             return Err(error);
         }
-        crate::services::ServiceSet::start().map_err(|e| e.to_string())
+        crate::services::ServiceSet::start(|kind| {
+            app.state::<Maintenance>()
+                .publish("connecting", json!({"service":kind.label()}));
+        })
+        .map_err(|e| e.to_string())
     })
 }
 
@@ -615,6 +647,23 @@ pub fn reconnect_requested(app: &AppHandle) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn startup_clock_survives_status_reads_and_repeated_phase_publication() {
+        let state = Maintenance::default();
+        assert!(state.startup_timing()["elapsed_ms"].is_null());
+        state
+            .startup_started
+            .set(Instant::now() - Duration::from_secs(35))
+            .unwrap();
+        state.publish("installing_runtime", json!({}));
+        let first = *state.phase_started.lock().unwrap();
+        state.publish("installing_runtime", json!({}));
+        assert_eq!(*state.phase_started.lock().unwrap(), first);
+        assert!(state.startup_timing()["elapsed_ms"].as_u64().unwrap() >= 35000);
+        state.publish("connecting", json!({"service":"chat"}));
+        assert!(state.phase_started.lock().unwrap().unwrap() >= first.unwrap());
+        assert!(state.startup_timing()["elapsed_ms"].as_u64().unwrap() >= 35000);
+    }
     #[test]
     fn runtime_failure_can_recover_without_restarting_the_supervisor() {
         let state = Maintenance::default();

--- a/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
+++ b/apps/desktop/loopx-control-plane/src-tauri/src/services.rs
@@ -22,7 +22,7 @@ pub enum ServiceKind {
 }
 
 impl ServiceKind {
-    fn label(self) -> &'static str {
+    pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Status => "status",
             Self::Chat => "chat",
@@ -118,12 +118,13 @@ pub struct ServiceSet {
 }
 
 impl ServiceSet {
-    pub fn start() -> Result<Self, ServiceError> {
+    pub fn start(mut progress: impl FnMut(ServiceKind)) -> Result<Self, ServiceError> {
         let mut services = Self {
             owned: Vec::new(),
             healed: false,
         };
         for kind in [ServiceKind::Status, ServiceKind::Chat] {
+            progress(kind);
             if let Err(error) = services.ensure(kind) {
                 services.stop();
                 return Err(error);

--- a/apps/desktop/loopx-control-plane/static/boot.js
+++ b/apps/desktop/loopx-control-plane/static/boot.js
@@ -1,5 +1,44 @@
 const panel = document.querySelector("main");
 const status = document.querySelector("#status");
+const bootElapsed = document.querySelector("#boot-elapsed");
+const bootDetail = document.querySelector("#boot-detail");
+const pageStarted = performance.now();
+let lastTiming = null;
+let timingObservedAt = pageStarted;
+let bootState = null;
+function renderStartup(result) {
+  const state = result?.state;
+  bootState = state;
+  if (Number.isFinite(result?.startup?.elapsed_ms) && result.startup.elapsed_ms >= 0) {
+    lastTiming = result.startup.elapsed_ms;
+    timingObservedAt = performance.now();
+  }
+  const titles = {
+    installing_runtime: "正在安装 App 配套运行时",
+    connecting: state?.details?.service === "status" ? "正在连接状态服务" : state?.details?.service === "chat" ? "正在连接管家对话服务" : "正在连接本地服务",
+    ready: "本地服务已就绪，正在打开工作区",
+    service_error: "本地服务连接失败，正在等待重试",
+  };
+  if (Object.hasOwn(titles, state?.phase)) {
+    status.textContent = titles[state.phase];
+    panel.dataset.state = "loading";
+    panel.setAttribute("aria-busy", "true");
+  }
+  updateStartupElapsed();
+}
+function updateStartupElapsed() {
+  const elapsed = lastTiming === null ? performance.now() - pageStarted : lastTiming + performance.now() - timingObservedAt;
+  const seconds = Math.floor(elapsed / 1000);
+  bootElapsed.textContent = `${lastTiming === null ? "此页面已等待" : "启动已用时"} ${seconds} 秒`;
+  bootDetail.textContent = bootState?.phase === "installing_runtime"
+    ? "正在安装此 App 随附的组件，并切换本机运行时；无需重复打开 App。"
+    : bootState?.phase === "service_error"
+      ? "启动器会自动重试；可展开「恢复与更新」查看诊断。"
+      : seconds >= 15
+        ? "启动用时较长。当前步骤尚未完成，可展开「恢复与更新」查看诊断。"
+        : "正在检查 App 配套组件和本地服务。";
+}
+setInterval(updateStartupElapsed, 1000);
 window.loopxBootFailed = (message) => {
   panel.dataset.state = "error";
   panel.setAttribute("aria-busy", "false");
@@ -155,6 +194,7 @@ async function refresh() {
     rollback.hidden = !result.rollback_available;
     renderDiagnostics(result);
     render(result.state);
+    renderStartup(result);
     escalateFromSnapshot(result.state);
   } catch { renderDiagnostics({state:{phase:"error",details:{code:"desktop_status_unavailable"}}}); }
 }

--- a/apps/desktop/loopx-control-plane/static/index.html
+++ b/apps/desktop/loopx-control-plane/static/index.html
@@ -18,7 +18,8 @@
           <span aria-hidden="true" class="status-dots"><i></i><i></i><i></i></span>
         </p>
         <div aria-hidden="true" class="progress"></div>
-        <p class="boot-note">启动较慢时仍会自动重试；不会自动升级安装包。</p>
+        <p id="boot-elapsed" class="boot-note" aria-live="off">正在读取启动进度…</p>
+        <p id="boot-detail" class="boot-note">正在检查 App 配套组件和本地服务。</p>
       </section>
       <details class="recovery">
         <summary>恢复与更新 / Recovery & updates</summary>

--- a/examples/desktop-update-browser-smoke.mjs
+++ b/examples/desktop-update-browser-smoke.mjs
@@ -28,6 +28,7 @@ try {
   const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
   const calls = [];
   let nativeState = null;
+  let startupTiming = null;
   let failUpdate = false;
   let checkFailure = null;
   let statusFailure = false;
@@ -35,7 +36,7 @@ try {
   await page.exposeFunction("nativeInvoke", async (command, args) => {
     if (command === "desktop_update_status") {
       if (statusFailure) throw new Error("Command desktop_update_status not allowed by ACL");
-      return { state: nativeState, app_version: "0.5.4", rollback_available: true, environment: environmentTelemetry };
+      return { state: nativeState, startup: startupTiming, app_version: "0.5.4", rollback_available: true, environment: environmentTelemetry };
     }
     calls.push({ command, args });
     if (checkFailure && args.action === "check") return { phase: "error", details: { code: checkFailure } };
@@ -231,6 +232,23 @@ try {
   nativeState = { phase: "runtime_required", details: { code: "runtime_setup_required" } };
   await page.waitForFunction(() => document.querySelector("main").dataset.state === "error" && document.querySelector("#status").innerText.includes("请修复当前版本，成功后重启"));
   environmentTelemetry = null;
+  // Production boot surface must expose native installation and service
+  // stages even while recovery is collapsed; reload keeps native elapsed time.
+  nativeState = { phase: "installing_runtime", details: {} };
+  startupTiming = { elapsed_ms: 35000, phase_elapsed_ms: 32000 };
+  await page.reload();
+  await page.getByText("正在安装 App 配套运行时", { exact: true }).waitFor();
+  assert.ok((await page.locator("#boot-elapsed").innerText()).includes("35 秒"));
+  assert.equal(await page.locator("details.recovery").getAttribute("open"), null);
+  await page.screenshot({ path: resolve(output, "startup-installing-progress.png") });
+  await page.reload();
+  await page.getByText("正在安装 App 配套运行时", { exact: true }).waitFor();
+  assert.ok((await page.locator("#boot-elapsed").innerText()).includes("35 秒"));
+  nativeState = { phase: "connecting", details: { service: "chat" } };
+  await page.getByText("正在连接管家对话服务", { exact: true }).waitFor();
+  await page.getByText(/启动用时较长/).waitFor();
+  nativeState = { phase: "service_error", details: { code: "service_start_failed" } };
+  await page.getByText("本地服务连接失败，正在等待重试", { exact: true }).waitFor();
   console.log("desktop-update-browser-smoke: passed (confirmation, failure redaction, mobile, missing assets + reload, startup motion states, startup recovery, startup error escalation)");
 } finally {
   await browser.close();

--- a/loopx/desktop_installation.py
+++ b/loopx/desktop_installation.py
@@ -1,0 +1,86 @@
+"""Read-only App/runtime pairing evidence; CLI health does not qualify the App."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import plistlib
+import re
+import sys
+from typing import Any
+
+
+def desktop_installation_status(
+    installed_revision: Any,
+    *,
+    applications: tuple[Path, ...] | None = None,
+) -> dict[str, Any]:
+    if applications is None:
+        applications = (
+            (Path("/Applications/LoopX.app"), Path.home() / "Applications/LoopX.app")
+            if sys.platform == "darwin"
+            else ()
+        )
+    rows = []
+    for app in applications:
+        if not app.exists():
+            continue
+        version = revision = None
+        try:
+            info = plistlib.loads((app / "Contents/Info.plist").read_bytes())
+            identity = json.loads(
+                (app / "Contents/Resources/runtime/identity.json").read_text()
+            )
+            if isinstance(info, dict):
+                value = info.get("CFBundleShortVersionString")
+                if isinstance(value, str) and re.fullmatch(
+                    r"[0-9A-Za-z.+-]{1,80}", value
+                ):
+                    version = value
+            if (
+                isinstance(identity, dict)
+                and identity.get("schema_version") == "desktop_runtime_bundle_v1"
+            ):
+                value = identity.get("source_revision")
+                if isinstance(value, str) and re.fullmatch(r"[0-9a-f]{40}", value):
+                    revision = value
+        except (OSError, ValueError, plistlib.InvalidFileException):
+            pass
+        valid_installed = isinstance(installed_revision, str) and re.fullmatch(
+            r"[0-9a-f]{40}", installed_revision
+        )
+        pairing = (
+            "unknown"
+            if not revision or not valid_installed
+            else "paired"
+            if revision == installed_revision
+            else "mismatch"
+        )
+        rows.append(
+            {
+                "app_version": version,
+                "bundled_source_revision": revision,
+                "pairing": pairing,
+            }
+        )
+    status = (
+        "not_detected"
+        if not rows
+        else "mismatch"
+        if any(r["pairing"] == "mismatch" for r in rows)
+        else "unknown"
+        if any(r["pairing"] == "unknown" for r in rows)
+        else "paired"
+    )
+    return {
+        "schema_version": "loopx_desktop_installation_v0",
+        "status": status,
+        "apps": rows,
+        "scope": "standard_macos_install_locations",
+        "running_app_verified": False,
+        "recommended_action": (
+            "Update the desktop App and its bundled runtime together; opening a mismatched App may replace the CLI runtime. Verify running services after restarting the App."
+            if status in {"mismatch", "unknown"}
+            else None
+        ),
+    }

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -28,6 +28,7 @@ from .skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
     configured_host_skills_dir,
     inspect_skill_install_readback,
+    skill_install_doctor_checks,
 )
 
 
@@ -1213,19 +1214,7 @@ def collect_doctor(
                 else ",".join(globally_visible_project_skills)
             ),
         },
-        *(
-            [
-                {
-                    "id": "host_skill_installation_readback",
-                    "required": False,
-                    "ok": bool(host_skill_install_readback.get("ready")),
-                    "applicable": True,
-                    "detail": str(host_skill_install_readback.get("reason")),
-                }
-            ]
-            if host_skill_install_readback
-            else []
-        ),
+        *skill_install_doctor_checks(host_skill_install_readback),
         {
             "id": "global_registry_writable",
             "required": True,

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -1251,6 +1251,16 @@ def collect_doctor(
             "detail": str(typescript_control_plane.get("status")),
         },
     ]
+    from .desktop_installation import desktop_installation_status
+
+    desktop_installation = desktop_installation_status(release_manifest_source.get("git_commit"))
+    if desktop_installation["apps"]:
+        checks.append({
+            "id": "desktop_app_runtime_pairing",
+            "required": False,
+            "ok": desktop_installation["status"] == "paired",
+            "detail": desktop_installation["recommended_action"] or "App bundle and CLI source revisions match; running App not verified",
+        })
     if deep_validation:
         checks.extend(deep_validation["checks"])
     payload = {
@@ -1289,6 +1299,7 @@ def collect_doctor(
             "python_distribution": python_distribution,
         },
         "release_manifest": release_manifest,
+        "desktop_installation": desktop_installation,
         "release_provenance": release_provenance,
         "global_registry_writability": global_registry_writability,
         "runtime_projection_routes": runtime_projection_routes,

--- a/loopx/release_candidate.py
+++ b/loopx/release_candidate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from concurrent.futures import ThreadPoolExecutor
 import os
 from importlib.metadata import PackageNotFoundError, distribution
 import subprocess
@@ -60,8 +61,8 @@ def _command_summary(command_path: Path | None) -> dict[str, Any]:
     if command_path is None:
         return {"ok": False, "results": {}, "failed": ["command_missing"]}
 
-    results: dict[str, dict[str, Any]] = {}
-    for probe_name, args in REPRESENTATIVE_CLI_COMMANDS:
+    def probe(item: tuple[str, tuple[str, ...]]) -> tuple[str, dict[str, Any]]:
+        probe_name, args = item
         try:
             result = subprocess.run(
                 command_argv(command_path, args),
@@ -71,15 +72,13 @@ def _command_summary(command_path: Path | None) -> dict[str, Any]:
                 timeout=30,
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
-            results[probe_name] = {
-                "ok": False,
-                "detail": f"{type(exc).__name__}: {exc}",
-            }
-            continue
-        results[probe_name] = {
-            "ok": result.returncode == 0,
-            "returncode": result.returncode,
-        }
+            return probe_name, {"ok": False, "detail": f"{type(exc).__name__}: {exc}"}
+        return probe_name, {"ok": result.returncode == 0, "returncode": result.returncode}
+
+    # These are read-only version/catalog/help probes. Preserve every result
+    # and its timeout while avoiding serial interpreter startup costs.
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = dict(executor.map(probe, REPRESENTATIVE_CLI_COMMANDS))
     failed = sorted(name for name, result in results.items() if not result.get("ok"))
     return {
         "ok": not failed,

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -679,3 +679,16 @@ def inspect_skill_install_readback(
         "source_dirty": source.get("git_dirty"),
         "reason": reason,
     }
+
+
+def skill_install_doctor_checks(readback: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Expose an optional host installation check only when readback applies."""
+    if not readback:
+        return []
+    return [{
+        "id": "host_skill_installation_readback",
+        "required": False,
+        "ok": bool(readback.get("ready")),
+        "applicable": True,
+        "detail": str(readback.get("reason")),
+    }]

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -218,35 +218,47 @@ acquire_install_lock() {
 warn_stale_promotion_readiness() {
   local python_bin="${LOOPX_PYTHON:-python3}"
   local runtime_root="${LOOPX_RUNTIME_ROOT:-$codex_home/loopx}"
-  local gate_json
-  gate_json="$(PYTHONSAFEPATH=1 PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}" "$python_bin" -m loopx.cli --runtime-root "$runtime_root" --format json promotion-gate 2>/dev/null || true)"
-  if [[ -z "$gate_json" ]]; then
-    return 0
-  fi
-  LOOPX_PROMOTION_GATE_JSON="$gate_json" "$python_bin" - <<'PY' || true
-import json
+  # Reuse the same collector and registry resolution without importing every CLI.
+  LOOPX_PROMOTION_WARNING_RUNTIME_ROOT="$runtime_root" \
+    PYTHONSAFEPATH=1 PYTHONPATH="$repo_root${PYTHONPATH:+:$PYTHONPATH}" \
+    "$python_bin" - <<'PY_WARNING' || true
+import argparse
 import os
 import sys
 
+from loopx.cli_runtime import resolve_cli_registry
+from loopx.paths import default_registry_path
+from loopx.promotion_gate import build_promotion_gate
+
+runtime_root = os.environ["LOOPX_PROMOTION_WARNING_RUNTIME_ROOT"]
+args = argparse.Namespace(command="promotion-gate", registry=str(default_registry_path()), runtime_root=runtime_root)
+registry_path, _ = resolve_cli_registry(args, [])
 try:
-    payload = json.loads(os.environ.get("LOOPX_PROMOTION_GATE_JSON") or "{}")
-except json.JSONDecodeError:
-    sys.exit(0)
-
-if not payload.get("should_warn"):
-    sys.exit(0)
-
-message = payload.get("warning_message")
-if not message:
-    message = "promotion-readiness evidence requires a canary readiness run before promotion."
-print(f"loopx install warning: {message}", file=sys.stderr)
-PY
+    payload = build_promotion_gate(registry_path=registry_path, runtime_root_override=runtime_root)
+except Exception:
+    print("loopx install warning: promotion readiness could not be checked", file=sys.stderr)
+else:
+    if payload.get("should_warn"):
+        message = payload.get("warning_message") or "promotion-readiness evidence requires a canary readiness run before promotion."
+        print(f"loopx install warning: {message}", file=sys.stderr)
+PY_WARNING
 }
 
+copy_platform="$(uname -s)"
 copy_path() {
   local src="$1"
   local dst="$2"
   if [[ -e "$src" ]]; then
+    # A release owns independent files. APFS clones avoid recopying their data;
+    # copy-on-write keeps later cleanup or edits separate from the checkout.
+    if [[ "$copy_platform" == "Darwin" ]]; then
+      if cp -cR "$src" "$dst" 2>/dev/null; then
+        return 0
+      fi
+      # Cloning may be unsupported across filesystems. Discard only this fresh
+      # staging target before ordinary copy, so a partial directory cannot nest.
+      rm -rf "$dst"
+    fi
     cp -R "$src" "$dst"
   fi
 }

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -25,6 +25,15 @@ automatically.
 
 ## Slash Command Fallback
 
+When asked to upgrade LoopX on a machine with the desktop App, inspect the App
+bundle and its runtime as well as the CLI. `loopx doctor` exposes
+`desktop_installation` for standard macOS install locations; a paired bundle
+still does not prove which App process is running. Upgrade the App and its
+bundled runtime together, then restart and verify the App, CLI and service
+source revisions. Never claim a desktop upgrade from CLI/HTTP checks alone:
+opening an older App can replace a separately upgraded CLI with its bundle.
+Keep SSH host verification separate; a host without an App needs no App install.
+
 When the visible user message is exactly a LoopX slash command or starts with a
 LoopX slash command plus arguments, do not treat it as ordinary chat.
 

--- a/tests/test_desktop_installation.py
+++ b/tests/test_desktop_installation.py
@@ -1,0 +1,47 @@
+import json
+import plistlib
+
+from loopx.desktop_installation import desktop_installation_status
+
+
+def test_same_version_different_commit_is_not_a_desktop_upgrade(tmp_path):
+    app = tmp_path / "LoopX.app"
+    contents = app / "Contents"
+    runtime = contents / "Resources/runtime"
+    runtime.mkdir(parents=True)
+    (contents / "Info.plist").write_bytes(
+        plistlib.dumps({"CFBundleShortVersionString": "1.0.2"})
+    )
+    identity = runtime / "identity.json"
+    identity.write_text(
+        json.dumps(
+            {"schema_version": "desktop_runtime_bundle_v1", "source_revision": "a" * 40}
+        )
+    )
+    mismatch = desktop_installation_status("b" * 40, applications=(app,))
+    assert mismatch["status"] == "mismatch"
+    assert "replace the CLI" in mismatch["recommended_action"]
+    assert str(tmp_path) not in json.dumps(mismatch)
+    paired = desktop_installation_status("a" * 40, applications=(app,))
+    assert paired["status"] == "paired"
+    assert paired["running_app_verified"] is False
+    assert desktop_installation_status(None, applications=(app,))["status"] == "unknown"
+    identity.write_text("[]")
+    assert (
+        desktop_installation_status("a" * 40, applications=(app,))["status"]
+        == "unknown"
+    )
+    identity.write_text("{broken")
+    assert (
+        desktop_installation_status("a" * 40, applications=(app,))["status"]
+        == "unknown"
+    )
+
+
+def test_cli_only_host_does_not_require_desktop_installation(tmp_path):
+    result = desktop_installation_status(
+        "a" * 40, applications=(tmp_path / "missing.app",)
+    )
+    assert result["status"] == "not_detected"
+    assert result["recommended_action"] is None
+    assert result["apps"] == []

--- a/tests/test_install_copy_fallback.py
+++ b/tests/test_install_copy_fallback.py
@@ -1,0 +1,37 @@
+import os
+from pathlib import Path
+import subprocess
+
+
+def test_clone_failure_discards_only_partial_staging_target(tmp_path):
+    script = (Path(__file__).parents[1] / "scripts/install-local.sh").read_text()
+    function = script.split("copy_path() {", 1)[1].split("\n}\n", 1)[0]
+    source, destination = tmp_path / "source tree", tmp_path / "staged tree"
+    source.mkdir()
+    (source / "keep.txt").write_text("original")
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    copier = binaries / "cp"
+    copier.write_text(
+        '#!/bin/sh\nif [ "$1" = "-cR" ]; then mkdir -p "$3"; touch "$3/partial"; exit 1; fi\nexec /bin/cp "$@"\n'
+    )
+    copier.chmod(0o755)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "set -eu\ncopy_platform=Darwin\ncopy_path() {"
+            + function
+            + '\n}\ncopy_path "$1" "$2"',
+            "copy-test",
+            str(source),
+            str(destination),
+        ],
+        env={**os.environ, "PATH": f"{binaries}:{os.environ['PATH']}"},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert sorted(p.name for p in destination.iterdir()) == ["keep.txt"]
+    (destination / "keep.txt").write_text("changed")
+    assert (source / "keep.txt").read_text() == "original"

--- a/tests/test_release_candidate.py
+++ b/tests/test_release_candidate.py
@@ -148,3 +148,27 @@ def test_python_distribution_checks_reject_command_from_another_install(
     checks = {check["id"]: check for check in payload["checks"]}
     assert payload["ok"] is False
     assert checks["command_package_same_distribution"]["ok"] is False
+
+
+def test_command_probes_overlap_but_keep_each_failure(monkeypatch):
+    import subprocess
+    import threading
+    from loopx.release_candidate import _command_summary
+
+    rendezvous = threading.Barrier(4)
+
+    def run(argv, **kwargs):
+        rendezvous.wait(timeout=5)
+        if "commands" in argv:
+            return subprocess.CompletedProcess(argv, 3)
+        if "quota" in argv:
+            raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr("loopx.release_candidate.subprocess.run", run)
+    result = _command_summary(Path("/fixture/loopx"))
+    assert not result["ok"]
+    assert result["failed"] == ["commands", "quota_help"]
+    assert list(result["results"]) == ["version", "commands", "status_help", "quota_help"]
+    assert result["results"]["commands"]["returncode"] == 3
+    assert "TimeoutExpired" in result["results"]["quota_help"]["detail"]


### PR DESCRIPTION
Opening a desktop App with a different bundled runtime can spend tens of seconds installing it while the boot screen only says “starting.” CLI-only upgrades leave the App unchanged and may be replaced when that App opens.

This change displays native installation, status/chat connection and retry phases with elapsed time that survives page reloads. Doctor reports App/CLI source pairing, and the upgrade skill requires App, bundle and running-service verification.

It also reduces installation work: collect the existing promotion warning without importing the entire CLI, use APFS copy-on-write clones on macOS with an ordinary-copy fallback, and run four independent read-only command probes concurrently while retaining every failure and timeout. Complete candidate validation and source-identity checks remain mandatory. An isolated macOS install measured27.65s before and14.65s after; this is a local measurement, not a cross-platform guarantee.

Validation:64 Rust tests passed(2 existing ignored);37 targeted Python and maintainability tests passed;production browser smoke passed, including installation visibility and reload timing. Complete installer smoke passed. The installed App measured runtime installation28.95s→19.73s and service readiness34.72s→22.81s; warm reopening skipped installation. These timings exclude window paint.

App detection covers standard macOS install locations and explicitly does not attest the running process. CLI-only hosts remain supported. Native phase logs contain no local paths or installer output.
