### PR TITLE
fix(change-window): accept empty Git reference transactions

### DIFF
--- a/loopx/capabilities/repository_change_window/git_hook.py
+++ b/loopx/capabilities/repository_change_window/git_hook.py
@@ -992,6 +992,11 @@ def _reference_transaction_introduces_commit(
         ReferenceTransactionPhase.PREPARED,
     }:
         return False
+    # Git can invoke admission hooks for a zero-update transaction (including
+    # Git 2.55's pull path). No refs means no new commit to guard; provider
+    # integrity and previous-hook delegation remain owned by the caller.
+    if not hook_stdin:
+        return False
     if not hook_stdin.strip():
         raise RepositoryChangeWindowError(
             f"reference-transaction {phase.value} phase requires at least one ref update"

--- a/tests/capabilities/test_change_window_git_fast_path.py
+++ b/tests/capabilities/test_change_window_git_fast_path.py
@@ -35,9 +35,12 @@ def installed(tmp_path, monkeypatch):
     )
 
     def git(repo, *args, check=True):
-        return subprocess.run(
-            ["git", "-C", str(repo), *args], check=check, capture_output=True, text=True
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args], check=False, capture_output=True, text=True
         )
+        if check:
+            assert result.returncode == 0, result.stdout + result.stderr
+        return result
 
     git(remote, "config", "user.name", "Synthetic User")
     git(remote, "config", "user.email", "user@example.invalid")
@@ -161,6 +164,41 @@ def test_selected_cli_does_not_import_full_cli(installed):
         [sys.executable, "-c", program], capture_output=True, text=True
     )
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("phase", ["preparing", "prepared"])
+def test_empty_transaction_is_noop_but_keeps_hook_guards(
+    installed, tmp_path, monkeypatch, phase
+):
+    repo, _remote, _git, _policy = installed
+
+    def unexpected(*args, **kwargs):
+        raise AssertionError("empty transaction evaluated the time policy")
+
+    monkeypatch.setattr(owner, "evaluate_policy", unexpected)
+    args = {
+        "repo_path": repo,
+        "runtime_root": tmp_path / "runtime",
+        "event": "reference-transaction",
+        "hook_args": [phase],
+        "hook_stdin": b"",
+    }
+    result = owner.run_git_hook_provider(**args)
+    assert result["ok"] and result["previous_hook_invoked"]
+    assert not result["guarded_change"] and not result["policy_evaluated"]
+    assert result["decision"] is None
+    assert (tmp_path / "phases").read_text().splitlines() == [phase]
+    assert (tmp_path / "payloads").read_bytes() == b""
+    # An empty batch is legal; a nonempty malformed row is not.
+    with pytest.raises(ValueError, match="at least one ref update"):
+        owner.run_git_hook_provider(**{**args, "hook_stdin": b" \n"})
+    previous = tmp_path / "previous" / "reference-transaction"
+    previous.write_text("#!/bin/sh\nexit 7\n")
+    result = owner.run_git_hook_provider(**args)
+    assert result["status"] == "previous_hook_failed" and result["exit_code"] == 7
+    managed = repo / ".git/loopx/repository-change-window/hooks/reference-transaction"
+    managed.write_text(managed.read_text() + "# modified\n")
+    assert owner.run_git_hook_provider(**args)["status"] == "provider_drift"
 
 
 def test_old_valid_hook_generation_requires_explicit_refresh(installed):


### PR DESCRIPTION
## Summary

Treat empty Git reference transactions as no change rather than malformed input. Git 2.55 emits an empty `preparing` callback during a normal `pull --ff-only`; the prior hook rejects it and prevents the pull.

Keep phase validation, malformed nonempty-row rejection, provider integrity checks, previous-hook delegation, and new-commit blocking unchanged. Improve the synthetic Git test helper to expose captured errors on failure.

## Issue Or Task

Follow-up to the inherited CI failure diagnosed in #4101. No archive or provider-authority changes.

## Validation

- Tested revision: `76246ee22` (same two changed files as the previously qualified `4c4abe89b`).
- Run state: completed
- Input classes: synthetic

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| regression_parity | passed | Git 2.55.0 real fetch/pull fails before the fix and passes afterward; new local commits still rejected. Older Git 2.39 and isolated Linux Git 2.47 pass the original scenario. |
| unit | passed | Both empty preparing/prepared regressions fail before the fix; 23 change-window tests pass after it, including prior-hook failure and provider drift. |
| integration | passed | Fresh 23-test run on the main-based patch passed; earlier 154 Python and 979 TS tests including isolated PostgreSQL 16.15 passed on the identical patch atop the pre-merge source. |
| static | passed | Supported Ruff, diff check, DCO and public-boundary scan. |

Coverage and gaps: no production Goal, live registry, external model or release change. This is a reference-transaction classifier correction, not a time-policy bypass. Hosted Python Tests run 34462222257 completed successfully, including both test shards, all three stage2c lanes and compatibility checks. The change remains in the existing built-in repository-change-window Git-hook owner; no additional abstraction or new authority is needed.

## Type of Change

- [x] Bug fix
- [x] Test update

## LoopX Area

- [x] Capability or extension (providers, adapters, skills)

## Technical Direction

- [x] Core control-plane hardening
- Target base branch: main

## Shared-authority RFC fixture impact

N/A: no Todo/provider/promotion change.

## Boundary Checklist

- [x] No private state, credentials, raw traces, internal links or local machine paths.
- [x] No benchmark work.
- [x] Scoped to empty reference-transaction compatibility.
- [x] Every commit includes DCO sign-off.
