### PR TITLE
test(dashboard): align Lark readiness contract

### DIFF
--- a/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
+++ b/apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs
@@ -467,8 +467,8 @@ assert.match(
 );
 assert.match(
   larkSettings,
-  /targetAppsReady\s*=\s*targetAgentBindings\.length\s*>\s*0\s*&&\s*targetAgentBindings\.every/,
-  "Connect readiness requires every selected Agent App to be reply-ready",
+  /targetAppsReady\s*=\s*Boolean\(editingConnection\)\s*\|\|\s*targetAgentBindings\.length\s*>\s*0\s*&&\s*targetAgentBindings\.every/,
+  "New connections require every selected Agent App to be reply-ready while edits preserve their stored identity",
 );
 assert.match(
   larkSettings,


### PR DESCRIPTION
## Summary

- align the Personal Workspace static contract with the existing edit-connection compatibility branch
- keep new Lark connection readiness strict: every selected Agent App must still be reply-ready
- make no runtime or UI behavior change

## Validation

- `node apps/presentation/dashboard/src/features/personal-workspace/personal-workspace-contract.test.mjs`
- `uv run python examples/lark-goal-topic-connection-smoke.py`
- `uv run python examples/project/global-manager-command-protocol-smoke.py`
- 43 focused chat/Lark pytest cases passed using the existing project test environment
- `git diff --check`

## Scope and future-facing pass

This is a focused validation repair for the already-shipped Lark connection owner. The production expression intentionally allows edits to preserve a stored App identity while new connections remain fail-closed on reply readiness. No broader refactor is needed.