### PR TITLE
fix(install): preserve commit validation precedence

### DIFF
--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -20,17 +20,17 @@ need curl
 need tar
 need "$python_bin"
 
-tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/loopx-install.XXXXXX")"
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT
-
 if [[ -n "${LOOPX_RESOLVED_SOURCE_GIT_COMMIT:-}" \
   && ! "$LOOPX_RESOLVED_SOURCE_GIT_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
   echo "loopx installer error: LOOPX_RESOLVED_SOURCE_GIT_COMMIT must be a full Git commit SHA" >&2
   exit 2
 fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/loopx-install.XXXXXX")"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
 
 if [[ -z "$archive_url" ]]; then
   if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then

--- a/tests/test_archive_installer_commit_response.py
+++ b/tests/test_archive_installer_commit_response.py
@@ -12,6 +12,32 @@ import pytest
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX archive installer")
+def test_invalid_commit_override_precedes_temp_directory_failure(tmp_path):
+    source = Path(__file__).resolve().parents[1]
+    env = {k: v for k, v in os.environ.items() if not k.startswith("LOOPX_")}
+    env.update(
+        TMPDIR=str(tmp_path / "missing"),
+        LOOPX_PYTHON=sys.executable,
+        LOOPX_RESOLVED_SOURCE_GIT_COMMIT="not-a-full-sha",
+    )
+
+    result = subprocess.run(
+        ["bash", str(source / "scripts/install-from-github.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 2
+    assert (
+        "LOOPX_RESOLVED_SOURCE_GIT_COMMIT must be a full Git commit SHA"
+        in result.stderr
+    )
+    assert "mktemp" not in result.stderr
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX archive installer")
 @pytest.mark.parametrize("valid", [True, False])
 def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
     source = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

- restore the public installer's input-validation order after #4164
- validate an invalid resolved commit before allocating the temporary workspace
- add a real shell regression for invalid commit plus unavailable `TMPDIR`

## Product and architecture judgment

The file-backed GitHub response transport from #4164 remains the right owner and design. The follow-up only restores the previously observable fail-fast boundary: invalid caller input must produce its actionable full-SHA diagnosis even when a later filesystem resource is also unavailable. No new installer abstraction, option, authority, or persistent state is introduced.

## Validation

- focused pytest: 3 passed
- Ruff: passed
- `bash -n scripts/install-from-github.sh`: passed
- diff check: passed
- packaged install smoke: passed twice
- update, overwrite, uninstall, desktop release, and related install risk smokes: passed
- premerge catalog: one first-run `install-local-smoke.py` invocation reached the 120s per-check timeout; the identical smoke passed in the same premerge run's risk profile in 116.384s. No assertion failure or tracked side effect occurred.

## Scope and safety

- changed surfaces: public GitHub archive installer and focused regression test
- private/local state, credentials, generated logs, and unrelated artifacts excluded
- future-facing pass: no broader framework is warranted; the existing temporary-directory lifecycle remains sufficient

Fixes the P2 follow-up recorded in #4164.
