### PR TITLE
fix(pr-review): enforce structured review evidence

### DIFF
--- a/loopx/capabilities/pr_review_queue/README.md
+++ b/loopx/capabilities/pr_review_queue/README.md
@@ -607,8 +607,12 @@ Keeping a legacy storage writer does not justify keeping its independent
 eligibility, retention, ordering or successor rules. Name actual retired rules
 and justified compatibility/effect code, not a net-deletion quota. A positive
 twin with shared decisions and necessary extra adapter code must remain
-approvable. Verified evidence rows must fill their declared fields; the checker
-validates this completeness only, never the truth of their contents.
+approvable. Verified evidence rows must fill their declared fields and structured
+shapes. `symbol_map.items` obeys the declared count and item fields;
+`walkthroughs.positive` plus any applicable `walkthroughs.negative` fill their
+declared fields; `validation_matrix.items[].case_id` proves coverage of the
+packet's typed required cases. The checker validates this completeness only,
+never the truth of their contents.
 
 Behavioral qualification lives in `tests/capabilities/test_pr_review_behavior.py`:
 paired synthetic cases include valid designs as well as counterexamples. The optional

--- a/loopx/capabilities/pr_review_queue/result_check.py
+++ b/loopx/capabilities/pr_review_queue/result_check.py
@@ -6,6 +6,89 @@ from typing import Any
 from .review_contract import build_review_execution_contract, build_review_plan
 
 
+def _missing(value: object) -> bool:
+    return value is None or value == "" or value == [] or value == {}
+
+
+def _require_fields(
+    blockers: list[str],
+    *,
+    evidence_id: str,
+    value: object,
+    fields: object,
+    location: str = "",
+) -> None:
+    if not isinstance(fields, list):
+        return
+    if not isinstance(value, Mapping):
+        blockers.append(f"{evidence_id}:{location or 'value'}_not_object")
+        return
+    for field in fields:
+        if not isinstance(field, str) or _missing(value.get(field)):
+            prefix = f"{location}:" if location else ""
+            blockers.append(f"{evidence_id}:{prefix}missing_field:{field}")
+
+
+def _require_items(
+    blockers: list[str],
+    *,
+    evidence_id: str,
+    row: Mapping[str, Any],
+    requirement: Mapping[str, Any],
+) -> list[Mapping[str, Any]]:
+    items_field = requirement.get("items_field")
+    if not isinstance(items_field, str):
+        return []
+    raw_items = row.get(items_field)
+    if not isinstance(raw_items, list):
+        blockers.append(f"{evidence_id}:missing_or_invalid_items")
+        return []
+    count = requirement.get("item_count")
+    if isinstance(count, Mapping):
+        minimum = count.get("minimum")
+        maximum = count.get("maximum")
+        if type(minimum) is int and len(raw_items) < minimum:
+            blockers.append(f"{evidence_id}:too_few_items")
+        if type(maximum) is int and len(raw_items) > maximum:
+            blockers.append(f"{evidence_id}:too_many_items")
+    items: list[Mapping[str, Any]] = []
+    for index, item in enumerate(raw_items):
+        if not isinstance(item, Mapping):
+            blockers.append(f"{evidence_id}:items[{index}]_not_object")
+            continue
+        items.append(item)
+        _require_fields(
+            blockers,
+            evidence_id=evidence_id,
+            value=item,
+            fields=requirement.get("item_fields"),
+            location=f"items[{index}]",
+        )
+    return items
+
+
+def _required_validation_case_ids(
+    requirement: Mapping[str, Any],
+    applicability: Mapping[str, Any],
+) -> set[str]:
+    required: set[str] = set()
+    cases = requirement.get("required_cases")
+    if not isinstance(cases, list):
+        return required
+    for case in cases:
+        if not isinstance(case, Mapping):
+            continue
+        case_id = case.get("case_id")
+        condition = case.get("required_when")
+        if not isinstance(case_id, str):
+            continue
+        if condition == "always" or (
+            isinstance(condition, str) and applicability.get(condition) is True
+        ):
+            required.add(case_id)
+    return required
+
+
 def check_review_result(
     packet: Mapping[str, Any],
     result: Mapping[str, Any],
@@ -30,6 +113,9 @@ def check_review_result(
         )
     # Rebuild policy from this installed capability, not caller-supplied plans.
     plan = build_review_plan(matches[0])
+    applicability = plan.get("applicability")
+    if not isinstance(applicability, Mapping):
+        applicability = {}
     contract = build_review_execution_contract()
     requirements = {
         row["evidence_id"]: row for row in contract["evidence_requirements"]
@@ -59,9 +145,49 @@ def check_review_result(
         if not any(v not in (None, "", [], {}) for v in detail.values()):
             blockers.append(f"{key}:missing_evidence_detail")
         if status == "verified":
-            for field in requirements[key].get("fields", []):
-                if row.get(field) in (None, "", [], {}):
-                    blockers.append(f"{key}:missing_field:{field}")
+            requirement = requirements[key]
+            _require_fields(
+                blockers,
+                evidence_id=key,
+                value=row,
+                fields=requirement.get("fields"),
+            )
+            items = _require_items(
+                blockers,
+                evidence_id=key,
+                row=row,
+                requirement=requirement,
+            )
+            positive_field = requirement.get("positive_field")
+            if isinstance(positive_field, str):
+                _require_fields(
+                    blockers,
+                    evidence_id=key,
+                    value=row.get(positive_field),
+                    fields=requirement.get("positive_fields"),
+                    location=positive_field,
+                )
+            negative_field = requirement.get("negative_field")
+            if (
+                isinstance(negative_field, str)
+                and applicability.get("negative_walkthrough_required") is True
+            ):
+                _require_fields(
+                    blockers,
+                    evidence_id=key,
+                    value=row.get(negative_field),
+                    fields=requirement.get("negative_fields"),
+                    location=negative_field,
+                )
+            required_cases = _required_validation_case_ids(requirement, applicability)
+            if required_cases:
+                observed_cases = {
+                    str(item.get("case_id"))
+                    for item in items
+                    if isinstance(item.get("case_id"), str)
+                }
+                for case_id in sorted(required_cases - observed_cases):
+                    blockers.append(f"{key}:missing_required_case:{case_id}")
         allowed = requirements[key].get("verdict_values")
         if allowed and row.get("verdict") not in allowed:
             blockers.append(f"{key}:missing_or_invalid_verdict")

--- a/loopx/capabilities/pr_review_queue/review_contract.py
+++ b/loopx/capabilities/pr_review_queue/review_contract.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 # Increment when review requirements change without changing the packet shape.
-REVIEW_POLICY_REVISION = 2
+REVIEW_POLICY_REVISION = 3
 
 REQUIRED_FINAL_SECTIONS = [
     "动机",
@@ -115,7 +115,12 @@ def build_review_execution_contract() -> dict[str, Any]:
         ),
         "evidence_status_values": ["verified", "unverified", "not_applicable"],
         "decision_procedure": {
-            "order": ["challenge_design", "falsify_claims", "inspect_implementation", "reconcile_verdict"],
+            "order": [
+                "challenge_design",
+                "falsify_claims",
+                "inspect_implementation",
+                "reconcile_verdict",
+            ],
             "challenge_design": (
                 "Before explaining how the patch works, make the strongest evidence-backed "
                 "case for not shipping it. Compare doing nothing, a smaller fix in the existing "
@@ -186,25 +191,40 @@ def build_review_execution_contract() -> dict[str, Any]:
                 "evidence_id": "repository_reuse",
                 "required_when": "behavior_bearing_change",
                 "verdict_values": [
-                    "reused", "separation_justified", "no_existing_candidate",
-                    "unjustified_duplication", "not_yet_proven",
+                    "reused",
+                    "separation_justified",
+                    "no_existing_candidate",
+                    "unjustified_duplication",
+                    "not_yet_proven",
                 ],
                 "fields": [
-                    "searched_revisions", "queries_and_paths", "existing_candidates",
-                    "semantic_comparison", "reuse_or_separation_reason",
-                    "state_model_assessment", "rule_ownership", "validation_evidence", "verdict",
+                    "searched_revisions",
+                    "queries_and_paths",
+                    "existing_candidates",
+                    "semantic_comparison",
+                    "reuse_or_separation_reason",
+                    "state_model_assessment",
+                    "rule_ownership",
+                    "validation_evidence",
+                    "verdict",
                 ],
                 "comparison_dimensions": [
-                    "resource_and_caller", "data_scope_and_filters",
-                    "ordering_and_pagination", "authority_and_sanitization",
+                    "resource_and_caller",
+                    "data_scope_and_filters",
+                    "ordering_and_pagination",
+                    "authority_and_sanitization",
                     "state_retry_and_failure_owner",
                 ],
                 "rule_ownership": {
                     "required_when": "retained_or_parallel_implementations",
                     "row_fields": [
-                        "business_rule", "baseline_owner", "head_owner",
-                        "retained_path_and_caller", "retention_reason",
-                        "deleted_rule_or_exit_condition", "validation",
+                        "business_rule",
+                        "baseline_owner",
+                        "head_owner",
+                        "retained_path_and_caller",
+                        "retention_reason",
+                        "deleted_rule_or_exit_condition",
+                        "validation",
                     ],
                     "rule": (
                         "For migrations, fallback paths, dual providers or old/new entrypoints, "
@@ -225,15 +245,23 @@ def build_review_execution_contract() -> dict[str, Any]:
                 "state_model_assessment": {
                     "required_when": "introduced_or_newly_enforced_state",
                     "classification_values": [
-                        "authoritative_fact", "irreducible_intent",
-                        "derived_projection", "diagnostic_hint",
+                        "authoritative_fact",
+                        "irreducible_intent",
+                        "derived_projection",
+                        "diagnostic_hint",
                     ],
                     "item_fields": [
-                        "field_or_relation", "classification", "existing_canonical_sources",
-                        "derivation_or_irreducibility_evidence", "producer_and_trigger",
-                        "authoring_discovery_path", "update_retire_and_replay_owner",
-                        "missing_stale_or_conflicting_value_behavior", "source_completeness",
-                        "counterfactual_validation", "decision",
+                        "field_or_relation",
+                        "classification",
+                        "existing_canonical_sources",
+                        "derivation_or_irreducibility_evidence",
+                        "producer_and_trigger",
+                        "authoring_discovery_path",
+                        "update_retire_and_replay_owner",
+                        "missing_stale_or_conflicting_value_behavior",
+                        "source_completeness",
+                        "counterfactual_validation",
+                        "decision",
                     ],
                     "rule": (
                         "Before accepting each added or newly enforced declaration, flag, "
@@ -437,6 +465,7 @@ def build_review_execution_contract() -> dict[str, Any]:
             {
                 "evidence_id": "symbol_map",
                 "required_when": "code_change",
+                "items_field": "items",
                 "item_count": {"minimum": 2, "maximum": 5},
                 "item_fields": [
                     "path",
@@ -459,6 +488,8 @@ def build_review_execution_contract() -> dict[str, Any]:
             {
                 "evidence_id": "walkthroughs",
                 "required_when": "always",
+                "positive_field": "positive",
+                "negative_field": "negative",
                 "positive_fields": [
                     "trigger",
                     "ordered_symbols_or_steps",
@@ -479,7 +510,9 @@ def build_review_execution_contract() -> dict[str, Any]:
             {
                 "evidence_id": "validation_matrix",
                 "required_when": "always",
+                "items_field": "items",
                 "item_fields": [
+                    "case_id",
                     "invariant_or_case",
                     "command_or_check",
                     "status",
@@ -488,9 +521,18 @@ def build_review_execution_contract() -> dict[str, Any]:
                     "skip_or_failure_reason",
                 ],
                 "required_cases": [
-                    "changed invariant positive case",
-                    "material negative or failure case when applicable",
-                    "repository-required checks",
+                    {
+                        "case_id": "changed_invariant_positive",
+                        "required_when": "always",
+                    },
+                    {
+                        "case_id": "material_negative_or_failure",
+                        "required_when": "negative_walkthrough_required",
+                    },
+                    {
+                        "case_id": "repository_required_checks",
+                        "required_when": "always",
+                    },
                 ],
             },
             {
@@ -874,7 +916,11 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
             required_evidence.append("scope_fit")
         required_evidence.append("default_off_isolation")
         required_evidence.append("behavior_change_disclosure")
-    if areas & {"product_runtime", "public_entry_or_policy", "agent_instruction_surface"}:
+    if areas & {
+        "product_runtime",
+        "public_entry_or_policy",
+        "agent_instruction_surface",
+    }:
         required_evidence.append("domain_neutrality")
         required_evidence.append("guidance_vs_obligation")
     if smoke_or_example_only:
@@ -909,11 +955,19 @@ def build_review_plan(item: Mapping[str, Any]) -> dict[str, Any]:
             "behavior_change_disclosure_required": behavior_bearing_change,
             "domain_neutrality_required": bool(
                 areas
-                & {"product_runtime", "public_entry_or_policy", "agent_instruction_surface"}
+                & {
+                    "product_runtime",
+                    "public_entry_or_policy",
+                    "agent_instruction_surface",
+                }
             ),
             "guidance_vs_obligation_required": bool(
                 areas
-                & {"product_runtime", "public_entry_or_policy", "agent_instruction_surface"}
+                & {
+                    "product_runtime",
+                    "public_entry_or_policy",
+                    "agent_instruction_surface",
+                }
             ),
             "smoke_or_example_only": smoke_or_example_only,
             "durable_smoke_value_required": smoke_or_example_only,

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -50,7 +50,7 @@ Do not pipe the only copy through `jq`. When an exhaustive request has
 `result_completeness.complete=false`, rerun with its `recommended_limit` before
 reviewing.
 
-Require execution `policy_revision == 2`; a schema name alone is insufficient.
+Require execution `policy_revision == 3`; a schema name alone is insufficient.
 If missing or unequal, do not publish APPROVE. A conservative REQUEST_CHANGES
 may be published only when it explicitly names the incompatible-policy evidence
 gap; regenerate with current installed LoopX before any later approval. Do not retain
@@ -81,7 +81,7 @@ When `review_action_kind` is null, the row stays in `pull_requests` inventory bu
    check cannot verify evidence truth, architecture judgment, or remote freshness.
    Preserve the template's `review_policy_revision`; do not relabel an old result
    without executing the current evidence plan. Verified rows must fill their
-   declared fields; a single generic “reviewed” note is insufficient.
+   declared structured fields; validation rows bind typed `case_id` coverage, and a generic “reviewed” note is insufficient.
    Missing material evidence needs a concrete hold/request-changes explanation,
    not an invented bug or approval inherited from the previous round.
 4. Render the verified result through `review_template`. The five sections are

--- a/tests/capabilities/test_pr_review_result_check.py
+++ b/tests/capabilities/test_pr_review_result_check.py
@@ -27,16 +27,44 @@ def _review():
         for row in build_review_execution_contract()["evidence_requirements"]
     }
     for key, row in result["evidence"].items():
+        requirement = requirements[key]
         row.update(
             status="verified",
             evidence="Synthetic consistency fixture, not a real review.",
             **{
                 field: "Synthetic consistency fixture, not a real review."
-                for field in requirements[key].get("fields", [])
+                for field in requirement.get("fields", [])
             },
         )
-        if "verdict_values" in requirements[key]:
-            row["verdict"] = requirements[key]["verdict_values"][0]
+        if "verdict_values" in requirement:
+            row["verdict"] = requirement["verdict_values"][0]
+        if "items_field" in requirement:
+            item_fields = requirement.get("item_fields", [])
+            if "required_cases" in requirement:
+                case_ids = [case["case_id"] for case in requirement["required_cases"]]
+            else:
+                count = requirement.get("item_count", {}).get("minimum", 1)
+                case_ids = [f"synthetic_{index}" for index in range(count)]
+            row[requirement["items_field"]] = [
+                {
+                    field: (
+                        case_id
+                        if field == "case_id"
+                        else True
+                        if field == "required"
+                        else "Synthetic consistency fixture, not a real review."
+                    )
+                    for field in item_fields
+                }
+                for case_id in case_ids
+            ]
+        for shape in ("positive", "negative"):
+            fields = requirement.get(f"{shape}_fields")
+            if fields:
+                row[shape] = {
+                    field: "Synthetic consistency fixture, not a real review."
+                    for field in fields
+                }
     result["verdict"] = "APPROVE"
     return {"pull_requests": [item]}, result
 
@@ -119,10 +147,59 @@ def test_verified_label_and_generic_prose_do_not_replace_rule_ownership():
     del result["evidence"]["repository_reuse"]["rule_ownership"]
     result["evidence"]["repository_reuse"]["evidence"] = "All providers passed."
     checked = check_review_result(packet, result)
-    assert "repository_reuse:missing_field:rule_ownership" in checked["approval_blockers"]
+    assert (
+        "repository_reuse:missing_field:rule_ownership" in checked["approval_blockers"]
+    )
     assert not checked["ok"]
     result["verdict"] = "REQUEST_CHANGES"
     assert check_review_result(packet, result)["ok"]
+
+
+@pytest.mark.parametrize(
+    "evidence_id", ["symbol_map", "walkthroughs", "validation_matrix"]
+)
+def test_generic_prose_cannot_replace_structured_evidence(evidence_id):
+    packet, result = _review()
+    result["evidence"][evidence_id] = {
+        "status": "verified",
+        "evidence": "Generic prose only.",
+    }
+
+    checked = check_review_result(packet, result)
+
+    assert not checked["approval_consistent"]
+    assert any(
+        blocker.startswith(f"{evidence_id}:")
+        for blocker in checked["approval_blockers"]
+    )
+    assert "approval_contradicts_evidence" in checked["errors"]
+    result["verdict"] = "REQUEST_CHANGES"
+    assert check_review_result(packet, result)["ok"]
+
+
+def test_structured_evidence_enforces_count_fields_and_required_cases():
+    packet, result = _review()
+    result["evidence"]["symbol_map"]["items"] = [
+        result["evidence"]["symbol_map"]["items"][0]
+    ]
+    del result["evidence"]["walkthroughs"]["negative"]["error_or_retry_owner"]
+    result["evidence"]["validation_matrix"]["items"] = [
+        item
+        for item in result["evidence"]["validation_matrix"]["items"]
+        if item["case_id"] != "repository_required_checks"
+    ]
+
+    checked = check_review_result(packet, result)
+
+    assert "symbol_map:too_few_items" in checked["approval_blockers"]
+    assert (
+        "walkthroughs:negative:missing_field:error_or_retry_owner"
+        in checked["approval_blockers"]
+    )
+    assert (
+        "validation_matrix:missing_required_case:repository_required_checks"
+        in checked["approval_blockers"]
+    )
 
 
 @pytest.mark.parametrize("mutation", ["head", "duplicate", "shape"])


### PR DESCRIPTION
## Summary

- make `symbol_map`, `walkthroughs`, and `validation_matrix` structural review evidence instead of prose-only declarations;
- bind required validation coverage to typed `case_id` values and bump the review policy revision to 3 so stale result templates cannot certify an approval;
- keep the rule in the capability-owned contract/checker and update the installed skill and capability reference.

This closes the post-merge audit gap identified on #4065: a generic `evidence` string can no longer stand in for the declared nested evidence shapes.

## Validation

| Check | Result | Scope |
| --- | --- | --- |
| PR-review pytest suite | 93 passed, 8 skipped | behavior, contract, queue, result checker, and GitHub scan |
| `examples/pr-review-command-smoke.py` | passed | public CLI packet and contract wiring |
| Ruff check / format check | passed | changed Python implementation and tests |
| skill quick validation | passed | updated `loopx-pr-review` skill |
| `loopx check` | passed | changed public capability, tests, skill, and docs |
| `loopx canary premerge --from-git-diff` | passed | 16/16 selected canaries plus compile, diff, and public-boundary checks |

Mypy was not run because the repository-declared mypy file list excludes the changed modules. TypeScript control-plane checks were not run because no TypeScript or control-plane path changed. There are no manual holds.

Change-quality receipt: `cqr_26f6f5a804bc6fd9f27e` (exact current base and diff, passing).

## Coverage rationale

The negative regressions remove each nested evidence shape, violate the symbol count, remove a walkthrough field, and omit a required typed validation case. The command smoke proves that policy revision 3 is emitted through the public entrypoint. The bounded future-facing pass kept one generic contract-driven validator rather than introducing a second review engine or a host-side policy copy.

## Public/private boundary

The diff contains only public capability code, tests, skill text, and reference documentation; the boundary scan passed and no local evidence or credentials are included.
