### PR TITLE
fix(todos): reject lossy decision scope projections

### DIFF
--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -153,6 +153,9 @@ The projection command has four safety properties:
 - it preserves every segment outside those spans byte-for-byte;
 - it fails closed when a canonical field cannot be represented by the current
   Markdown metadata grammar, rather than dropping that field;
+- it defaults an optional nested schema field only when the key is absent;
+  explicitly incompatible, malformed or unrepresentable nested values fail
+  before normalization;
 - it parses the rendered sections back and requires deterministic parity and
   idempotent second rendering before an `--execute` write.
 

--- a/loopx/control_plane/todos/machine_section_projection.py
+++ b/loopx/control_plane/todos/machine_section_projection.py
@@ -38,9 +38,11 @@ from .completion_validation_projection import (
 )
 from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
+    TODO_DECISION_SCOPE_SCHEMA_VERSION,
     TODO_METADATA_FIELDS,
     TODO_STATUS_OPEN,
     format_todo_metadata_line,
+    normalize_todo_id,
     normalize_todo_status,
     require_todo_decision_scope,
     todo_marker_for_status,
@@ -118,6 +120,7 @@ def _canonical_records(records: Sequence[Mapping[str, object]]) -> list[dict[str
             raise TodoSectionProjectionError(
                 f"Todo {todo_id!r} has an unsupported archive state"
             )
+        _validate_projection_decision_scope(record, todo_id=todo_id)
         canonical_todo_read_record(
             {
                 **record,
@@ -133,6 +136,63 @@ def _canonical_records(records: Sequence[Mapping[str, object]]) -> list[dict[str
         )
         canonical.append(record)
     return canonical
+
+
+def _validate_projection_decision_scope(
+    record: Mapping[str, object],
+    *,
+    todo_id: str,
+) -> None:
+    """Reject explicit scope data that the Markdown projection cannot preserve."""
+
+    if "decision_scope" not in record:
+        return
+    value = record["decision_scope"]
+    if not isinstance(value, Mapping):
+        raise TodoSectionProjectionError(
+            f"Todo {todo_id!r} decision_scope must be an object"
+        )
+    allowed_fields = {
+        "schema_version",
+        "kind",
+        "granularity",
+        "scope_key",
+        "decision_id",
+    }
+    unknown_fields = sorted(str(field) for field in set(value) - allowed_fields)
+    if unknown_fields:
+        raise TodoSectionProjectionError(
+            f"Todo {todo_id!r} decision_scope has unsupported fields: "
+            + ", ".join(unknown_fields)
+        )
+    if (
+        "schema_version" in value
+        and value["schema_version"] != TODO_DECISION_SCOPE_SCHEMA_VERSION
+    ):
+        raise TodoSectionProjectionError(
+            f"Todo {todo_id!r} decision_scope.schema_version must be "
+            f"{TODO_DECISION_SCOPE_SCHEMA_VERSION!r} when present"
+        )
+    if "decision_id" in value:
+        decision_id = value["decision_id"]
+        if (
+            not isinstance(decision_id, str)
+            or normalize_todo_id(decision_id) != decision_id
+        ):
+            raise TodoSectionProjectionError(
+                f"Todo {todo_id!r} decision_scope.decision_id must be a "
+                "public-safe Todo id"
+            )
+        raise TodoSectionProjectionError(
+            f"Todo {todo_id!r} decision_scope.decision_id cannot be represented "
+            "by the current Markdown projection"
+        )
+    try:
+        require_todo_decision_scope(value)
+    except ValueError as exc:
+        raise TodoSectionProjectionError(
+            f"Todo {todo_id!r} has invalid decision_scope: {exc}"
+        ) from exc
 
 
 def _record_sort_key(record: Mapping[str, object]) -> tuple[int, str]:

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -277,6 +277,77 @@ def test_optional_scope_version_is_display_only_not_permission_to_change_scope(m
     assert records == before
 
 
+@pytest.mark.parametrize("schema_version", ["decision_scope_v1", "", None, 7])
+def test_projection_rejects_explicit_invalid_scope_version_without_mutation(
+    schema_version: object,
+) -> None:
+    records = _records()
+    records[1]["decision_scope"]["schema_version"] = schema_version
+    before = deepcopy(records)
+
+    with pytest.raises(
+        TodoSectionProjectionError,
+        match=r"decision_scope\.schema_version must be 'decision_scope_v0'",
+    ):
+        render_canonical_todo_sections(
+            SOURCE,
+            records,
+            provider_revision="scope-version",
+        )
+
+    assert records == before
+
+
+@pytest.mark.parametrize(
+    ("decision_id", "message"),
+    [
+        ("todo_bad!", "must be a public-safe Todo id"),
+        ("", "must be a public-safe Todo id"),
+        (None, "must be a public-safe Todo id"),
+        (7, "must be a public-safe Todo id"),
+        ("todo_decision", "cannot be represented by the current Markdown projection"),
+    ],
+)
+def test_projection_rejects_unrepresentable_decision_id_without_mutation(
+    decision_id: object,
+    message: str,
+) -> None:
+    records = _records()
+    records[1]["decision_scope"]["decision_id"] = decision_id
+    before = deepcopy(records)
+
+    with pytest.raises(TodoSectionProjectionError, match=message):
+        render_canonical_todo_sections(
+            SOURCE,
+            records,
+            provider_revision="scope-decision-id",
+        )
+
+    assert records == before
+
+
+def test_projection_rejects_non_object_or_unknown_scope_shape() -> None:
+    for value, message in (
+        ("direction:action:authority_cutover", "must be an object"),
+        (
+            {**_records()[1]["decision_scope"], "future_field": "value"},
+            "unsupported fields",
+        ),
+    ):
+        records = _records()
+        records[1]["decision_scope"] = value
+        before = deepcopy(records)
+
+        with pytest.raises(TodoSectionProjectionError, match=message):
+            render_canonical_todo_sections(
+                SOURCE,
+                records,
+                provider_revision="scope-shape",
+            )
+
+        assert records == before
+
+
 def test_projection_rejects_duplicate_sections_and_unsafe_revision() -> None:
     duplicate = SOURCE + "\n## Agent Todo\n\n- [ ] duplicate\n"
     with pytest.raises(TodoSectionProjectionError, match="multiple agent"):


### PR DESCRIPTION
## Summary

- validate canonical `decision_scope` objects before the Markdown parity path can normalize away explicit data;
- preserve the intended compatibility rule only for an omitted `schema_version`, while rejecting future, empty, null, non-string, unknown, and otherwise malformed nested values;
- fail closed with an actionable error when a valid `decision_id` is present but the current Markdown codec cannot represent it.

This closes both post-merge findings on #4097. Invalid `schema_version` and `decision_id` values can no longer be erased before `parse_render_parity` is evaluated.

## Validation

| Check | Result | Scope |
| --- | --- | --- |
| Todo projection/recovery pytest suite | 68 passed | machine-section projection, recovery, provider projection, native E2E, and real FileAuthorityStore-to-CLI path |
| TypeScript control-plane typecheck | passed | repository `tsconfig.control-plane.json` |
| TypeScript projection/authority tests | 19 passed | coordination projection and local authority readback |
| Ruff check | passed | changed Python implementation and test |
| `loopx check` | passed | all three public changed files |
| `loopx canary premerge --from-git-diff` | passed | 16/16 selected canaries plus compile, diff, and public-boundary checks |

Ruff format check was not retained because formatting these pre-existing files rewrites many unrelated baseline lines; that mechanical churn was removed from the final diff. PostgreSQL integration was not run because no authority-store transaction or provider behavior changed. There are no manual holds.

Change-quality receipt: `cqr_94f789bb8a666cc5303e` (passing, exact current base and diff).

## Coverage rationale

The regression matrix distinguishes omitted and exact-v0 schema versions from future, empty, null, and non-string values; it also covers invalid, empty, null, non-string, and valid-but-unrepresentable `decision_id` values, non-object scopes, and unknown nested fields. Every case asserts that the canonical input remains unchanged. The real-path test exercises a promoted isolated FileAuthorityStore, the TypeScript bridge, the public CLI process, publication, readback, and idempotent replay.

The bounded future-facing pass keeps validation at the existing canonical projection boundary. It does not add a second state authority or a speculative Markdown codec extension.

## Public/private boundary

Only provider-neutral public control-plane code, its regression tests, and the public projection protocol are changed. The public boundary scan passed; no local state, private evidence, credentials, or machine paths are included.
