### PR TITLE
fix(lark): preserve active inbox routing when connecting topics

### DIFF
--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -42,6 +42,24 @@ for eligibility, source verification, write/readback and default-off behavior.
 
 ### Optional turn-start Agent reading hook
 
+Collector health does not prove that an Agent consumes every collected route.
+Verify the canonical project registry's Agent inbox pointer and the normal
+`lark-inbox drain --goal-id ... --agent-id ...` path together. For multiple
+configured chats, bind the collector configuration rather than one child inbox.
+An empty child inbox is not evidence that other routes have no updates.
+
+Connecting an async Goal Topic now fails with `agent_inbox_binding_conflict`
+before provider calls when it would replace a different enabled Agent inbox
+(including an inherited Goal inbox). Reconnecting the same inbox is unchanged.
+Reconcile route ownership explicitly through the canonical project registry;
+do not clear a multi-route binding just to make topic setup pass. This guard
+prevents silent replacement; it does not automatically merge Topic routes.
+
+Before continuing fallback work, review fresh dependency messages and write any
+resolved wait or priority change to the existing Todo/vision state. Settle the
+message after that durable effect; collection alone is not interpretation or
+permission to reply, deploy, or run work.
+
 Realtime collection is the preferred ingress, but a long-running Agent may also
 need a bounded provider-history tail at the beginning of every LoopX turn. The
 collector config can opt into `turn_start_sync`. This is not a background-only

--- a/loopx/extensions/lark/goal_topic_connections.py
+++ b/loopx/extensions/lark/goal_topic_connections.py
@@ -450,6 +450,32 @@ def connect_lark_goal_topic(
             bot_display_name=profile,
             capture_scope=effective_capture_scope,
         )
+        control_plane = goal.get("control_plane")
+        control_plane = control_plane if isinstance(control_plane, Mapping) else {}
+        agent_inboxes = control_plane.get("lark_event_inboxes")
+        agent_inboxes = agent_inboxes if isinstance(agent_inboxes, Mapping) else {}
+        current_inbox = agent_inboxes.get(normalized_agent_id)
+        if not isinstance(current_inbox, Mapping):
+            current_inbox = control_plane.get("lark_event_inbox")
+        if isinstance(current_inbox, Mapping) and current_inbox.get("enabled") is True:
+            current_ref = str(current_inbox.get("config_path") or "").strip()
+            project = Path(str(goal["repo"])).expanduser().resolve()
+            # A Topic is not authority to replace an existing read route. In
+            # particular, a collector may cover several independent chats.
+            # Reject before provider calls or local configuration writes.
+            if current_ref and (project / current_ref).resolve() != inbox_config[0].resolve():
+                return operation_packet(
+                    ok=False,
+                    goal_id=goal_id,
+                    operation="connect_topic",
+                    execute=execute,
+                    status="blocked",
+                    blocker="agent_inbox_binding_conflict",
+                    public_summary=(
+                        "the Agent already consumes a different inbox; reconcile its "
+                        "routes explicitly before connecting this Topic"
+                    ),
+                )
 
     target_payload = read_goal_channel_targets(target_path)
     matched = _target_for_connection(

--- a/tests/extensions/test_lark_goal_topic_connections.py
+++ b/tests/extensions/test_lark_goal_topic_connections.py
@@ -678,6 +678,60 @@ def test_async_inbox_preflights_local_state_before_provider_write(
     assert not any("+messages-send" in call for call in state.get("calls", []))
 
 
+@pytest.mark.parametrize("execute", [False, True])
+@pytest.mark.parametrize("scope", ["agent", "goal"])
+def test_connect_preserves_existing_inbox_before_any_effect(
+    tmp_path: Path, execute: bool, scope: str
+) -> None:
+    registry = _registry(tmp_path)
+    inbox = {"enabled": True, "config_path": ".loopx/config/team-collector.json"}
+    registry["goals"][0]["control_plane"] = (
+        {"lark_event_inboxes": {"agent-alpha": inbox}}
+        if scope == "agent"
+        else {"lark_event_inbox": inbox}
+    )
+    state: dict[str, Any] = {}
+    result = _connect_registered_agent(
+        registry=registry,
+        goal_id="goal-alpha",
+        target_path=tmp_path / "targets.json",
+        binding_path=tmp_path / "binding.json",
+        app_ref="mew",
+        chat_id=CHAT_ID,
+        execute=execute,
+        runner=_runner(state),
+        cli_bin="fake-lark",
+    )
+    assert result["ok"] is False
+    assert result["blocker"] == "agent_inbox_binding_conflict"
+    assert state.get("calls", []) == []
+    assert not (tmp_path / "targets.json").exists()
+    assert not (tmp_path / "binding.json").exists()
+    assert not (tmp_path / ".loopx/config/lark-goal-topics").exists()
+    saved = json.loads((tmp_path / ".loopx/registry.json").read_text())
+    assert saved["goals"][0]["control_plane"] == registry["goals"][0]["control_plane"]
+
+
+def test_reconnect_same_inbox_keeps_registration(tmp_path: Path) -> None:
+    state: dict[str, Any] = {}
+    kwargs = dict(
+        goal_id="goal-alpha",
+        target_path=tmp_path / "targets.json",
+        binding_path=tmp_path / "binding.json",
+        app_ref="mew",
+        chat_id=CHAT_ID,
+        runner=_runner(state),
+        cli_bin="fake-lark",
+    )
+    assert _connect_registered_agent(registry=_registry(tmp_path), **kwargs)["ok"]
+    registry_path = tmp_path / ".loopx/registry.json"
+    registry = json.loads(registry_path.read_text())
+    before = registry["goals"][0]["control_plane"]["lark_event_inboxes"]
+    assert _connect_registered_agent(registry=registry, **kwargs)["ok"]
+    after = json.loads(registry_path.read_text())["goals"][0]["control_plane"]
+    assert after["lark_event_inboxes"] == before
+
+
 def test_two_goals_share_one_connection_with_distinct_topics(tmp_path: Path) -> None:
     state: dict[str, Any] = {}
     runner = _runner(state)


### PR DESCRIPTION
## Summary
- Reject async Goal Topic setup before any provider call when it would silently replace a different enabled Agent inbox, including an inherited Goal inbox or collector.
- Preserve same-inbox reconnect behavior. Route conflicts require explicit reconciliation; this patch does not automatically merge routes.
- Document collector-versus-consumer coverage and the message → durable Todo/vision update → settlement ordering.

## Validation
- 152 tests passed: Goal Topic connections, runtime, and inbox reactions.
- git diff --check passed.
- loopx check: public boundary scan clean for all 3 changed files; 3 unrelated existing local registry warnings.
- Tests use synthetic identities and local state; no live provider writes, production experiments, private evidence or credentials.

## Scope and behavior change
Owner: bundled Lark extension connection lifecycle; no new capability, protocol or scheduler keyword policy. Existing conflicting setup now returns agent_inbox_binding_conflict instead of replacing a working read route. First-time setup and same-route reconnect remain supported.
Future-facing review: kept the preflight in the existing connection owner; automatic multi-route composition and cross-process registry concurrency are not claimed by this guard.