### PR TITLE
fix(extensions): preserve provider environments across desktop upgrades

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -902,6 +902,31 @@ clean source checkout and a local LoopX release activate bundled providers
 without separately installing a console script; catalog discovery remains
 declarative and does not import the module.
 
+### Local executable locations
+
+Successful executable install/upgrade and doctor operations save the resolved
+absolute entrypoint in the host-local revision state, separately from the
+portable manifest. Enable, rollback, update-time revalidation and invocation use
+that revision's saved location instead of rediscovering a same-named executable
+on the current shell PATH. File-identity checks remain mandatory; a missing
+saved executable does not fall back to another PATH entry. Package upgrades
+resolve and verify the new revision's executable through the explicit upgrade
+workflow. Bundled `python_module` providers continue using the current LoopX
+interpreter and retain their existing identity checks.
+
+For executable providers, only the child process prepends the executable's
+directory to PATH, so tools installed in the same environment remain available.
+No complete environment, credentials, package contents, or local path is added
+to the public manifest or doctor result. An explicitly supplied execution
+environment remains the base environment; only this PATH prefix is added.
+
+Legacy installations without a saved location require one successful
+`loopx extension doctor <extension-id> --execute` with the provider environment
+available on PATH. Read-only doctor calls do not migrate state. Subsequent
+revalidation can run from the desktop's minimal PATH. If an executable is moved,
+restore its registered location or explicitly upgrade its local manifest to
+point to the new executable; do not hide the failure by disabling the extension.
+
 ## Scope Boundaries
 
 The executable v0 runtime intentionally does not:

--- a/loopx/extensions/readiness.py
+++ b/loopx/extensions/readiness.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -19,6 +20,19 @@ RUNTIME_ENTRYPOINT_IDENTITY_SCHEMA_VERSION = "loopx_runtime_entrypoint_identity_
 class ResolvedRuntimeEntrypoint:
     argv_prefix: tuple[str, ...]
     identity: str
+    path_prefix: str | None = None
+
+
+def runtime_process_environment(
+    path_prefix: str | None, base: Mapping[str, str] | None = None,
+) -> Mapping[str, str] | None:
+    if path_prefix is None:
+        return base
+    if not isinstance(path_prefix, str) or not Path(path_prefix).is_absolute():
+        raise ValueError("extension runtime search directory must be absolute")
+    environment = dict(os.environ if base is None else base)
+    environment["PATH"] = path_prefix + os.pathsep + environment.get("PATH", os.defpath)
+    return environment
 
 
 def extension_runtime(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -71,6 +85,7 @@ def resolve_runtime_entrypoint(
         return ResolvedRuntimeEntrypoint(
             argv_prefix=(str(resolved[0]),),
             identity=resolved[1],
+            path_prefix=str(resolved[0].parent),
         )
 
     interpreter_path = Path(sys.executable).expanduser()
@@ -133,6 +148,7 @@ def extension_doctor(
                 stderr=subprocess.DEVNULL,
                 timeout=int(runtime["timeout_seconds"]),
                 check=False,
+                env=runtime_process_environment(identity_before.path_prefix),
             )
         except (OSError, subprocess.TimeoutExpired):
             completed = None

--- a/loopx/extensions/runtime.py
+++ b/loopx/extensions/runtime.py
@@ -14,12 +14,13 @@ from typing import Any
 from ..file_lock import exclusive_file_lock
 from .manifest import load_extension_manifest
 from .process_runtime import run_capped_process
+from .runtime_location import located_runtime, probe_runtime_location, record_runtime_location
 from .readiness import (
     EXTENSION_DOCTOR_SCHEMA_VERSION,
     ResolvedRuntimeEntrypoint,
-    extension_doctor,
     extension_runtime,
     resolve_runtime_entrypoint,
+    runtime_process_environment,
 )
 
 EXTENSION_STATE_SCHEMA_VERSION = "loopx_extension_state_v0"
@@ -176,7 +177,7 @@ def install_extension(
     provider = manifest["provider"]
     extension_id = str(provider["id"])
     revision = _revision(manifest)
-    doctor = extension_doctor(manifest, execute=execute)
+    doctor, location = probe_runtime_location(manifest, execute=execute)
     if execute and not doctor["verified"]:
         raise ValueError(
             f"extension `{extension_id}` doctor is not ready: {doctor['status']}"
@@ -209,6 +210,7 @@ def install_extension(
                     "revision": revision,
                     "version": provider["version"],
                     "manifest": _manifest_snapshot(manifest),
+                    **({"entrypoint_path": location} if location is not None else {}),
                 },
                 required_revision=previous_revision,
             )
@@ -256,7 +258,9 @@ def enable_extension(
     if not isinstance(manifest, Mapping):
         raise ValueError("extension active manifest is invalid")
     already_enabled = bool(entry.get("enabled"))
-    doctor = extension_doctor(manifest, execute=execute)
+    doctor, location = probe_runtime_location(
+        manifest, location=snapshot.get("entrypoint_path"), execute=execute,
+    )
     if execute and not doctor["verified"]:
         with exclusive_file_lock(path):
             current_state = _read_state(path)
@@ -284,6 +288,10 @@ def enable_extension(
                 or bool(current_entry.get("enabled")) != already_enabled
             ):
                 raise ValueError("extension state changed during enable; retry")
+            record_runtime_location(
+                _entry_for_revision(current_entry, active_revision),
+                location=location, expected=snapshot.get("entrypoint_path"),
+            )
             current_entry["enabled"] = True
             current_entry["doctor_verified_revision"] = active_revision
             current_entry["doctor_verified_entrypoint_identity"] = doctor[
@@ -353,7 +361,9 @@ def rollback_extension(
     manifest = target.get("manifest")
     if not isinstance(manifest, dict):
         raise ValueError("extension rollback manifest is invalid")
-    doctor = extension_doctor(manifest, execute=execute)
+    doctor, location = probe_runtime_location(
+        manifest, location=target.get("entrypoint_path"), execute=execute,
+    )
     if execute and not doctor["verified"]:
         raise ValueError(
             f"extension `{extension_id}` rollback doctor is not ready: {doctor['status']}"
@@ -370,6 +380,10 @@ def rollback_extension(
                 or current_entry.get("rollback_revision") != target_revision
             ):
                 raise ValueError("extension state changed during rollback; retry")
+            record_runtime_location(
+                _entry_for_revision(current_entry, target_revision),
+                location=location, expected=target.get("entrypoint_path"),
+            )
             current_entry["active_revision"] = target_revision
             current_entry["rollback_revision"] = previous_revision
             current_entry["doctor_verified_revision"] = target_revision
@@ -453,7 +467,9 @@ def doctor_installed_extension(
     manifest = snapshot.get("manifest")
     if not isinstance(manifest, Mapping):
         raise ValueError("extension active manifest is invalid")
-    doctor = extension_doctor(manifest, execute=execute)
+    doctor, location = probe_runtime_location(
+        manifest, location=snapshot.get("entrypoint_path"), execute=execute,
+    )
     if execute:
         with exclusive_file_lock(path):
             current_state = _read_state(path)
@@ -465,6 +481,10 @@ def doctor_installed_extension(
             ):
                 raise ValueError("extension state changed during doctor; retry")
             if doctor["verified"]:
+                record_runtime_location(
+                    _entry_for_revision(current_entry, active_revision),
+                    location=location, expected=snapshot.get("entrypoint_path"),
+                )
                 current_entry["doctor_verified_revision"] = active_revision
                 current_entry["doctor_verified_entrypoint_identity"] = doctor[
                     "entrypoint_identity"
@@ -540,7 +560,7 @@ def _verified_entrypoint(
     manifest = snapshot.get("manifest")
     if not isinstance(manifest, Mapping):
         return None
-    runtime = _runtime(manifest)
+    runtime = located_runtime(manifest, snapshot.get("entrypoint_path"))
     identity = resolve_runtime_entrypoint(runtime)
     if identity is None or identity.identity != entry.get(
         "doctor_verified_entrypoint_identity"
@@ -773,6 +793,7 @@ def _capability_binding_from_entry(
         "revision": active_revision,
         "protocol": protocol,
         "argv": [*verified_entrypoint.argv_prefix, *(runtime.get("args") or [])],
+        "environment_path_prefix": verified_entrypoint.path_prefix,
         "doctor_argv": [
             *verified_entrypoint.argv_prefix,
             *(runtime.get("args") or []),
@@ -1025,6 +1046,7 @@ def resolve_extension_runtime_binding(
         "revision": active_revision,
         "protocol": protocol,
         "argv": [*verified_entrypoint.argv_prefix, *(runtime.get("args") or [])],
+        "environment_path_prefix": verified_entrypoint.path_prefix,
         "doctor_argv": [
             *verified_entrypoint.argv_prefix,
             *(runtime.get("args") or []),
@@ -1132,6 +1154,7 @@ def run_standalone_extension(
             stdin=request_bytes,
             timeout_seconds=int(runtime["timeout_seconds"]),
             output_limit_bytes=MAX_EXTENSION_RESPONSE_BYTES,
+            env=runtime_process_environment(verified_entrypoint.path_prefix),
         )
     except OSError:
         return {
@@ -1238,7 +1261,7 @@ def execute_extension_runtime_binding(
             stdin=request_bytes,
             timeout_seconds=timeout_seconds,
             output_limit_bytes=MAX_EXTENSION_RESPONSE_BYTES,
-            env=environment,
+            env=runtime_process_environment(binding.get("environment_path_prefix"), environment),
         )
     except OSError as exc:
         raise RuntimeError("extension provider execution failed") from exc

--- a/loopx/extensions/runtime_location.py
+++ b/loopx/extensions/runtime_location.py
@@ -1,0 +1,42 @@
+"""Host-local launch locations; package manifests remain portable and unchanged."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .readiness import extension_doctor, extension_runtime, resolve_runtime_entrypoint
+
+
+def located_runtime(manifest: Mapping[str, Any], location: Any = None) -> Mapping[str, Any]:
+    runtime = extension_runtime(manifest)
+    if location is None:
+        return runtime
+    if (
+        not isinstance(location, str) or not Path(location).is_absolute()
+        or "python_module" in runtime
+    ):
+        raise ValueError("extension local executable location is invalid")
+    return {**runtime, "entrypoint": location}
+
+
+def probe_runtime_location(
+    manifest: Mapping[str, Any], *, location: Any = None, execute: bool = False,
+) -> tuple[dict[str, Any], str | None]:
+    runtime = located_runtime(manifest, location)
+    resolved = resolve_runtime_entrypoint(runtime)
+    # Resolve once before probing so the saved location is the one actually
+    # checked, even if the parent process changes PATH during the probe.
+    if resolved is not None and "python_module" not in runtime:
+        location = resolved.argv_prefix[0]
+        runtime = {**runtime, "entrypoint": location}
+    return extension_doctor({**manifest, "runtime": runtime}, execute=execute), location
+
+
+def record_runtime_location(
+    snapshot: dict[str, Any], *, location: str | None, expected: Any,
+) -> None:
+    if snapshot.get("entrypoint_path") != expected:
+        raise ValueError("extension runtime location changed during doctor; retry")
+    if location is not None:
+        snapshot["entrypoint_path"] = location

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -1904,3 +1904,88 @@ def test_legacy_openviking_alias_matches_provider_argument_contract() -> None:
     assert options(_register_legacy_openviking_provider_arguments) == options(
         register_openviking_provider_arguments
     )
+
+
+def test_executable_location_survives_path_changes_upgrade_and_rollback(tmp_path, monkeypatch):
+    first_bin, second_bin, unrelated = [tmp_path / name for name in ("first", "second", "unrelated")]
+    for directory in (first_bin, second_bin, unrelated):
+        directory.mkdir()
+    first = _provider(first_bin / "provider")
+    second = _provider(second_bin / "provider")
+    _provider(unrelated / "provider", doctor_exit=42)
+    helper = _provider(first_bin / "companion")
+    first.write_text(first.read_text().replace(
+        "import json", f"import shutil\nassert shutil.which('companion') == {str(helper)!r}\nimport json",
+    ))
+    one = _standalone_manifest(tmp_path / "one.toml", entrypoint=Path("provider"))
+    two = _standalone_manifest(tmp_path / "two.toml", entrypoint=Path("provider"), version="2.0.0")
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("PATH", str(first_bin))
+    installed = install_extension(one, state_file=state_file, execute=True)
+    monkeypatch.setenv("PATH", str(unrelated))
+    assert doctor_enabled_extensions(state_file=state_file, execute=True)["ok"]
+    result = run_standalone_extension(
+        "test-standalone-extension", state_file=state_file,
+        request={"schema_version": "test_extension_request_v0"}, execute=True,
+    )
+    assert result["status"] == "succeeded"
+    assert str(first_bin) not in json.dumps(installed)
+    assert os.environ["PATH"] == str(unrelated)
+    monkeypatch.setenv("PATH", str(second_bin))
+    install_extension(two, state_file=state_file, operation="upgrade", execute=True)
+    monkeypatch.setenv("PATH", str(unrelated))
+    assert rollback_extension("test-standalone-extension", state_file=state_file, execute=True)["doctor"]["verified"]
+    state = json.loads(state_file.read_text())
+    entry = state["extensions"]["test-standalone-extension"]
+    assert {r["entrypoint_path"] for r in entry["revisions"]} == {str(first), str(second)}
+    assert all(r["manifest"]["runtime"]["entrypoint"] == "provider" for r in entry["revisions"])
+    first.unlink()
+    missing = doctor_installed_extension("test-standalone-extension", state_file=state_file, execute=True)
+    assert missing["status"] == "entrypoint_missing"  # Never switch to the unrelated PATH copy.
+
+
+def test_legacy_doctor_captures_location_only_after_success(tmp_path, monkeypatch):
+    provider = _provider(tmp_path / "provider")
+    manifest = _standalone_manifest(tmp_path / "manifest.toml", entrypoint=Path("provider"))
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("PATH", str(tmp_path))
+    install_extension(manifest, state_file=state_file, execute=True)
+    state = json.loads(state_file.read_text())
+    state["extensions"]["test-standalone-extension"]["revisions"][0].pop("entrypoint_path")
+    state_file.write_text(json.dumps(state))
+    preview = doctor_installed_extension("test-standalone-extension", state_file=state_file)
+    assert preview["status"] == "probe_required"
+    assert json.loads(state_file.read_text()) == state
+    assert doctor_installed_extension("test-standalone-extension", state_file=state_file, execute=True)["verified"]
+    monkeypatch.setenv("PATH", "")
+    assert doctor_installed_extension("test-standalone-extension", state_file=state_file, execute=True)["verified"]
+    provider.write_text(provider.read_text() + "\n# changed artifact\n")
+    with pytest.raises(ValueError, match="doctor readiness is stale"):
+        resolve_extension_activation("test-standalone-extension", state_file=state_file)
+
+
+def test_bound_execution_preserves_explicit_environment_and_sibling_tools(tmp_path, monkeypatch):
+    provider = _provider(tmp_path / "provider")
+    helper = _provider(tmp_path / "companion")
+    provider.write_text(provider.read_text().replace(
+        "request = json.load(sys.stdin)",
+        f"import os, shutil\nassert os.environ.get('EXPLICIT_BASE') == 'fixture'\n"
+        f"assert shutil.which('companion') == {str(helper)!r}\nrequest = json.load(sys.stdin)",
+    ))
+    manifest = _standalone_manifest(
+        tmp_path / "manifest.toml", entrypoint=Path("provider"), permission="semantic_preference.read",
+    )
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("PATH", str(tmp_path))
+    install_extension(manifest, state_file=state_file, execute=True)
+    monkeypatch.setenv("PATH", "")
+    binding = resolve_extension_runtime_binding(
+        "test-standalone-extension", state_file=state_file,
+        protocol="semantic_preference_provider_v0", permission="semantic_preference.read",
+    )
+    environment = {"EXPLICIT_BASE": "fixture", "PATH": ""}
+    result = execute_extension_runtime_binding(
+        binding, request={"schema_version": "test_extension_request_v0"}, environment=environment,
+    )
+    assert result["schema_version"] == "semantic_preference_provider_response_v0"
+    assert environment == {"EXPLICIT_BASE": "fixture", "PATH": ""}


### PR DESCRIPTION
An executable extension installed from a virtual environment could pass admission and later become unavailable when a desktop upgrade rechecked it with a different PATH. Invocation also rediscovered the command, so a same-named executable could replace the original lookup target.

Persist the verified absolute executable location in host-local revision state, separately from the portable manifest. Doctor, enable, rollback and invocation use that location; missing or changed files retain the existing readiness fence. Executable provider subprocesses prepend their own directory to PATH so sibling tools remain available, without persisting an environment or changing the parent process. Python-module providers keep the current LoopX interpreter behavior. Legacy activations acquire their location through one successful explicit doctor run in the provider environment.

Validation: 122 extension runtime, envelope, registry, presentation and scaffold tests passed; Ruff and diff checks passed. Regression cases cover PATH replacement, sibling dependencies, explicit environment preservation, revision upgrade/rollback, legacy migration, removed executables and modified-file rejection. Two preinstalled providers also passed read-only qualification under a minimal PATH; an existing managed capability completed its offline example with no external writes. No account or market qualification is claimed.

Placement: existing built-in extension lifecycle/runtime boundary, with a small host-local location helper shared by lifecycle operations. No new capability, package installer, global PATH change or provider-specific rule. Default executable resolution/search behavior changes are documented in the extension guide.
