### PR TITLE
fix(pr-review): require exact-head readiness before merge

### DIFF
--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -69,6 +69,8 @@ def main() -> int:
         "formal `REQUEST_CHANGES`",
         "Read the published review back",
         "Route approval, merge, self-merge, and admin bypass to `loopx-pr-merge`",
+        "--check-merge-readiness NUMBER@HEAD_OID",
+        "admin bypass never overrides this gate",
         "Full PR Review And Bilingual Format",
         "findings-only or blocker-only body is incomplete",
         "Cover every changed surface and key symbols",
@@ -245,6 +247,100 @@ def main() -> int:
     assert any(
         item["number"] == 770 and item["state"] == "MERGED" for item in sequence
     ), sequence
+
+    merge_head = "e" * 40
+    with tempfile.TemporaryDirectory() as temp_dir:
+        merge_fixture_path = Path(temp_dir) / "merge-readiness.json"
+        merge_fixture = {
+            "repository": "owner/repo",
+            "pull_requests": [
+                {
+                    "number": 4110,
+                    "title": "Exact-head merge gate fixture",
+                    "url": "https://github.com/owner/repo/pull/4110",
+                    "state": "OPEN",
+                    "author": {"login": "contributor"},
+                    "headRefOid": merge_head,
+                    "baseRefName": "main",
+                    "isDraft": False,
+                    "reviewDecision": "APPROVED",
+                    "mergeStateStatus": "CLEAN",
+                    "files": [
+                        {"path": "src/runtime.py", "additions": 1, "deletions": 1}
+                    ],
+                    "reviews": [
+                        {
+                            "state": "APPROVED",
+                            "body": (
+                                "## 动机\n动机。\n\n## 改动思路\n思路。\n\n"
+                                "## 具体改动\n改动。\n\n## 对主干的风险\n风险。\n\n"
+                                "## 我的整体评价\n通过。\n\n"
+                                f"English verdict: APPROVE at exact head {merge_head}."
+                            ),
+                            "author": {"login": "maintainer"},
+                            "commit": {"oid": merge_head},
+                            "submittedAt": "2026-09-09T11:14:01Z",
+                        }
+                    ],
+                    "statusCheckRollup": [
+                        {
+                            "name": "Sign-off",
+                            "status": "COMPLETED",
+                            "conclusion": "SUCCESS",
+                        },
+                        {
+                            "name": "merge-gate",
+                            "status": "COMPLETED",
+                            "conclusion": "SUCCESS",
+                        },
+                    ],
+                    "review_thread_summary": {
+                        "schema_version": "github_review_thread_summary_v0",
+                        "complete": True,
+                        "total_count": 0,
+                        "unresolved_count": 0,
+                    },
+                }
+            ],
+        }
+        merge_fixture_path.write_text(json.dumps(merge_fixture), encoding="utf-8")
+        ready = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "pr-review",
+                "--fixture",
+                str(merge_fixture_path),
+                "--check-merge-readiness",
+                f"4110@{merge_head}",
+            ).stdout
+        )
+        assert ready["ready"] is True, ready
+        assert ready["blocking_reasons"] == [], ready
+
+        merge_fixture["pull_requests"][0]["reviews"][0]["body"] = merge_fixture[
+            "pull_requests"
+        ][0]["reviews"][0]["body"].replace(merge_head, "d" * 40)
+        merge_fixture["pull_requests"][0]["statusCheckRollup"][0]["conclusion"] = (
+            "FAILURE"
+        )
+        merge_fixture_path.write_text(json.dumps(merge_fixture), encoding="utf-8")
+        blocked_run = run_cli(
+            "--format",
+            "json",
+            "pr-review",
+            "--fixture",
+            str(merge_fixture_path),
+            "--check-merge-readiness",
+            f"4110@{merge_head}",
+            check=False,
+        )
+        assert blocked_run.returncode == 1, blocked_run
+        blocked = json.loads(blocked_run.stdout)
+        assert (
+            "current_head_review_missing_or_invalid" in blocked["blocking_reasons"]
+        ), blocked
+        assert "status_checks_failed" in blocked["blocking_reasons"], blocked
     assert sequence[0]["risk_hint_level"] == "medium", sequence[0]
     assert sequence[0]["main_risk_level"] == "medium", sequence[0]
     merged_sequence = next(item for item in sequence if item["number"] == 770)

--- a/loopx/capabilities/pr_review_queue/README.md
+++ b/loopx/capabilities/pr_review_queue/README.md
@@ -37,6 +37,7 @@ workflow or the merge-focused `loopx-pr-merge` skill.
 | Command | CLI reference | Intent |
 | --- | --- | --- |
 | `/loopx-pr-review` | `loopx pr-review [--repo owner/repo] [--state open\|merged\|all] [--since ISO] [--fresh-audit-exact-head NUMBER@HEAD_OID]` | List open and merged PRs for the current project or explicit repository, provide concrete main-regression analysis for each actionable PR, and include a blank five-block template that agentloop fills after reading the selected PR body/diff. A typed exact-head option is required to re-audit an unchanged concluded head. |
+| pre-merge readback | `loopx pr-review --repo owner/repo --check-merge-readiness NUMBER@HEAD_OID` | Immediately before merge, fail closed unless the remote PR is still open at the reviewed head, its standalone conclusion approves that head, all checks are successful or skipped, review-thread pagination is complete with no unresolved thread, and merge state is compatible. This read grants no merge authority. |
 
 The slash command must run the CLI first. Agentloop must not reconstruct the
 review window by manually calling `gh pr view` / `gh pr list` for every PR. The
@@ -349,7 +350,16 @@ state transition, author-owned conclusions use `COMMENTED` plus one exact title:
 `Approval conclusion (author-owned PR; GitHub blocks formal self-approval)` or
 `Request changes conclusion (author-owned PR; GitHub blocks formal self-review)`.
 The compact result is versioned as `pull_request_review_conclusion_v0` and
-reports typed invalid-reason codes.
+reports a typed verdict and invalid-reason codes.
+
+`pull_request_merge_readiness_v0` is a separate, read-only last-mile gate. It
+re-reads the named PR instead of trusting a saved review packet. In particular,
+GitHub may retain or reassociate an approval after an update-from-base commit;
+the gate still requires the public review body to name the observed exact head.
+It also rejects missing, pending, failed, or unknown checks and incomplete or
+unresolved review threads. An admin bypass may satisfy GitHub's author-owned
+self-review limitation, but it never overrides this capability gate or supplies
+user merge authority.
 
 They must not include raw logs, private connector payloads, credentials, local
 absolute paths, private source bodies, or hidden CI artifacts.
@@ -650,7 +660,8 @@ The packet should let a reviewer move through PRs in order:
 7. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
    copied as the final risk judgement.
 8. Recheck the exact head, then decide `approve`, `request changes`, `defer`, or
-   `merge after checks`.
+   `merge after checks`. Immediately before merge, require
+   `--check-merge-readiness NUMBER@HEAD_OID` to return `ready=true`.
 
 A response that only lists `Open` and `Merged` PRs, scale, and recommended next
 order is incomplete for `/loopx-pr-review`; it should continue into the
@@ -680,6 +691,9 @@ A first implementation is acceptable when:
 - `--fresh-audit-exact-head NUMBER@HEAD_OID` is the only packet-level way to
   turn an unchanged valid conclusion into an actionable fresh audit, and
   malformed, absent, or already-actionable targets fail closed;
+- `--check-merge-readiness NUMBER@HEAD_OID` rejects head drift, stale review
+  prose, non-approval conclusions, red/pending/unknown checks, incomplete or
+  unresolved review-thread evidence, and incompatible merge state;
 - the default limit is 100, and exhaustive requests only proceed when
   `result_completeness.complete=true`; truncated packets provide a larger
   `recommended_limit` for the next read;

--- a/loopx/capabilities/pr_review_queue/__init__.py
+++ b/loopx/capabilities/pr_review_queue/__init__.py
@@ -1,6 +1,7 @@
 """Deterministic observation and review contracts for pull-request queues."""
 
 from .core import build_pull_request_review_queue_observation
+from .merge_readiness import build_merge_readiness
 from .review_contract import (
     build_agent_response_contract,
     build_review_execution_contract,
@@ -23,6 +24,7 @@ from .scheduling import (
 
 __all__ = [
     "build_agent_response_contract",
+    "build_merge_readiness",
     "build_pull_request_review_queue_observation",
     "build_review_execution_contract",
     "build_review_plan",

--- a/loopx/capabilities/pr_review_queue/catalog_entry.py
+++ b/loopx/capabilities/pr_review_queue/catalog_entry.py
@@ -32,6 +32,11 @@ PR_REVIEW_CATALOG_ENTRY: dict[str, Any] = {
     ),
     "commands": [
         {
+            "command": "loopx pr-review --repo <owner/repo> --check-merge-readiness NUMBER@HEAD_OID --format json",
+            "purpose": "Fail closed on exact-head, approval-body, check, thread, or merge-state drift immediately before merge.",
+            "write_boundary": "live public GitHub read only; does not approve, merge, bypass policy, or grant merge authority",
+        },
+        {
             "command": "loopx pr-review --check-result <result.json> --packet <packet.json> --format json",
             "purpose": "Reject a declared approval inconsistent with the saved exact head and required evidence.",
             "write_boundary": "local read-only consistency check; does not verify evidence truth, remote freshness or grant publication/merge authority",
@@ -68,6 +73,11 @@ PR_REVIEW_CATALOG_ENTRY: dict[str, Any] = {
         },
     ],
     "implemented_protocols": [
+        {
+            "schema_version": "pull_request_merge_readiness_v0",
+            "module": "loopx.capabilities.pr_review_queue.merge_readiness",
+            "doc": "loopx/capabilities/pr_review_queue/README.md",
+        },
         {
             "schema_version": "pull_request_review_result_check_v0",
             "module": "loopx.capabilities.pr_review_queue.result_check",
@@ -132,6 +142,7 @@ PR_REVIEW_CATALOG_ENTRY: dict[str, Any] = {
         "Only rows with a non-null review_action_kind enter review_sequence and carry review plans, templates, or evidence commands; valid exact-head conclusions remain artifact-free inventory-only rows, and only --fresh-audit-exact-head NUMBER@HEAD_OID can explicitly reopen one.",
         "Todo prose, monitor notes, and one-off author filters are not scheduling authority.",
         "A complete exact-head conclusion requires the five Chinese sections, a state-aligned English verdict, and formal state or the verdict-specific titled author-owned fallback.",
+        "Every merge must rerun the read-only merge-readiness gate for the reviewed exact head; admin bypass cannot override stale review text, red or pending checks, incomplete thread evidence, or head drift.",
         "One observation emits at most one exact-head advancement Todo preview; unchanged observations replay it until explicit durable Todo-projection ACK, then rotate across acknowledged exact heads.",
         "The capability reuses the existing pr-review GitHub scan and normalized packet; review bodies are inspected for format but never emitted or checkpointed.",
         "Candidate selection grants no GitHub review, comment, push, merge, quota, or Todo-write authority; those remain with their existing policy surfaces.",

--- a/loopx/capabilities/pr_review_queue/merge_readiness.py
+++ b/loopx/capabilities/pr_review_queue/merge_readiness.py
@@ -1,0 +1,116 @@
+"""Fail-closed merge readiness for one already-reviewed exact PR head."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+SCHEMA_VERSION = "pull_request_merge_readiness_v0"
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def build_merge_readiness(
+    *,
+    repository: str,
+    expected_exact_head: str,
+    item: Mapping[str, Any],
+    review_threads: Mapping[str, Any],
+    source: str,
+) -> dict[str, Any]:
+    """Return a read-only pre-merge gate without granting merge authority."""
+
+    number = item.get("number")
+    head_oid = _text(item.get("head_oid"))
+    observed_exact_head = f"{number}@{head_oid}" if number and head_oid else None
+    conclusion = _mapping(item.get("review_conclusion"))
+    checks = _mapping(item.get("checks"))
+    check_counts = _mapping(checks.get("counts"))
+    thread_complete = review_threads.get("complete") is True
+    unresolved_threads = review_threads.get("unresolved_count")
+    blockers: list[str] = []
+
+    if _text(item.get("state")).upper() != "OPEN":
+        blockers.append("pull_request_not_open")
+    if item.get("is_draft") is True:
+        blockers.append("draft_pull_request")
+    if observed_exact_head != expected_exact_head:
+        blockers.append("remote_head_mismatch")
+
+    if conclusion.get("valid") is not True:
+        blockers.append("current_head_review_missing_or_invalid")
+    elif _text(conclusion.get("verdict")).upper() != "APPROVE":
+        blockers.append("current_head_conclusion_not_approval")
+
+    author_owned_fallback = bool(
+        item.get("author_owned") is True
+        and conclusion.get("valid") is True
+        and _text(conclusion.get("state")).upper() == "COMMENTED"
+        and _text(conclusion.get("verdict")).upper() == "APPROVE"
+    )
+    review_decision = _text(item.get("review_decision")).upper()
+    if review_decision != "APPROVED" and not author_owned_fallback:
+        blockers.append("github_review_decision_not_approved")
+
+    total_checks = checks.get("total")
+    successful_checks = check_counts.get("success", 0)
+    if type(total_checks) is not int or total_checks <= 0:
+        blockers.append("status_checks_missing")
+    else:
+        if check_counts.get("failure", 0):
+            blockers.append("status_checks_failed")
+        if check_counts.get("pending", 0):
+            blockers.append("status_checks_pending")
+        if successful_checks != total_checks:
+            blockers.append("status_checks_incomplete")
+
+    if not thread_complete:
+        blockers.append("review_threads_incomplete")
+    elif type(unresolved_threads) is not int:
+        blockers.append("review_threads_incomplete")
+    elif unresolved_threads > 0:
+        blockers.append("unresolved_review_threads")
+
+    merge_state = _text(item.get("merge_state")).upper()
+    if merge_state in {"BEHIND", "DIRTY", "DRAFT"}:
+        blockers.append("merge_state_requires_update")
+    elif merge_state in {"", "UNKNOWN"}:
+        blockers.append("merge_state_unverified")
+    elif merge_state == "BLOCKED" and not author_owned_fallback:
+        blockers.append("repository_merge_state_blocked")
+
+    blockers = list(dict.fromkeys(blockers))
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "ready": not blockers,
+        "repository": repository,
+        "source": source,
+        "expected_exact_head": expected_exact_head,
+        "observed_exact_head": observed_exact_head,
+        "url": item.get("url"),
+        "state": item.get("state"),
+        "merge_state": item.get("merge_state"),
+        "review_decision": item.get("review_decision"),
+        "review_conclusion": dict(conclusion),
+        "checks": dict(checks),
+        "review_threads": dict(review_threads),
+        "author_owned_commented_approval": author_owned_fallback,
+        "admin_bypass_required": bool(
+            author_owned_fallback and merge_state == "BLOCKED"
+        ),
+        "blocking_reasons": blockers,
+        "authority": {
+            "grants_merge_authority": False,
+            "admin_bypass_overrides_this_gate": False,
+            "required_timing": "immediately_before_merge",
+            "head_change_action": "restart_review_and_rerun_gate",
+        },
+    }

--- a/loopx/cli_commands/pr_review.py
+++ b/loopx/cli_commands/pr_review.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from ..capabilities.pr_review_queue import (
     build_pull_request_review_queue_observation,
+    normalize_fresh_audit_exact_heads,
 )
 from ..capabilities.pr_review_queue.result_check import check_review_result
 from ..file_lock import exclusive_file_lock
@@ -20,6 +21,11 @@ from ..pr_review import (
     resolve_current_github_login,
     resolve_current_github_repository,
     scan_github_pull_requests,
+)
+from ..pr_review_merge_readiness import (
+    build_pr_merge_readiness_packet,
+    fetch_github_pull_request,
+    fetch_github_review_thread_summary,
 )
 from ..registry import atomic_write_json
 
@@ -87,6 +93,14 @@ def register_pr_review_command(
     parser.add_argument(
         "--check-result",
         help="Check a saved review result for verdict/evidence consistency; no GitHub writes.",
+    )
+    parser.add_argument(
+        "--check-merge-readiness",
+        metavar="NUMBER@HEAD_OID",
+        help=(
+            "Re-read one open PR and fail closed unless this exact reviewed head, "
+            "its checks, and review threads are ready immediately before merge."
+        ),
     )
     parser.add_argument(
         "--packet",
@@ -187,6 +201,7 @@ def handle_pr_review_command(
                 or args.repo
                 or args.since
                 or args.fresh_audit_exact_head
+                or args.check_merge_readiness
             ):
                 raise ValueError(
                     "result checking cannot be combined with scan or observation options"
@@ -207,6 +222,82 @@ def handle_pr_review_command(
                 payload, output_format(args), lambda value: json.dumps(value, indent=2)
             )
             return 0 if payload["ok"] else 1
+        if args.check_merge_readiness:
+            if (
+                args.autonomous_observation
+                or args.observation_state_file
+                or args.previous_observation_json
+                or args.handled_exact_head
+                or args.projected_exact_head
+                or args.since
+                or args.fresh_audit_exact_head
+            ):
+                raise ValueError(
+                    "merge readiness cannot be combined with queue or observation options"
+                )
+            expected = normalize_fresh_audit_exact_heads([args.check_merge_readiness])
+            if len(expected) != 1:
+                raise ValueError("merge readiness requires one exact NUMBER@HEAD_OID")
+            expected_exact_head = next(iter(expected))
+            number = int(expected_exact_head.split("@", 1)[0])
+            repository = args.repo
+            reviewer_login = None
+            if args.fixture:
+                fixture_repository, pull_requests = load_pr_fixture(
+                    Path(args.fixture).expanduser()
+                )
+                repository = repository or fixture_repository
+                matches = [
+                    item for item in pull_requests if item.get("number") == number
+                ]
+                if len(matches) != 1:
+                    raise ValueError(
+                        "merge readiness target must match exactly one fixture PR"
+                    )
+                pull_request = matches[0]
+                raw_threads = pull_request.get("review_thread_summary")
+                review_threads = (
+                    raw_threads
+                    if isinstance(raw_threads, dict)
+                    else {
+                        "schema_version": "github_review_thread_summary_v0",
+                        "complete": False,
+                        "total_count": 0,
+                        "unresolved_count": 0,
+                        "failure_code": "fixture_review_thread_summary_missing",
+                    }
+                )
+                source = "fixture"
+            else:
+                repository = repository or resolve_current_github_repository()
+                if not repository:
+                    raise RuntimeError("GitHub repository could not be resolved")
+                reviewer_login = resolve_current_github_login()
+                pull_request = fetch_github_pull_request(
+                    repo=repository,
+                    number=number,
+                )
+                review_threads = fetch_github_review_thread_summary(
+                    repo=repository,
+                    number=number,
+                )
+                source = "github_cli"
+            if not repository:
+                raise ValueError("repository is required for merge readiness")
+            payload = build_pr_merge_readiness_packet(
+                pull_request=pull_request,
+                repository=repository,
+                expected_exact_head=expected_exact_head,
+                reviewer_login=reviewer_login,
+                review_threads=review_threads,
+                source=source,
+            )
+            print_payload(
+                payload,
+                output_format(args),
+                lambda value: json.dumps(value, indent=2),
+            )
+            return 0 if payload["ready"] else 1
         if args.previous_observation_json and not args.autonomous_observation:
             raise ValueError(
                 "--previous-observation-json requires --autonomous-observation"

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -196,6 +196,7 @@ def resolve_current_github_login(*, cwd: Path | None = None) -> str | None:
         return None
     return str(payload.get("login") or "").strip() or None
 
+
 def _parse_timestamp(value: object) -> datetime | None:
     text = str(value or "").strip()
     if not text:
@@ -871,6 +872,7 @@ def _review_conclusion(
             "status": "missing",
             "valid": False,
             "state": None,
+            "verdict": None,
             "reviewer": None,
             "submitted_at": None,
             "invalid_reasons": ["no_review_conclusion_available"],
@@ -915,6 +917,7 @@ def _review_conclusion(
             "status": "valid" if not reasons else "invalid",
             "valid": not reasons,
             "state": state or None,
+            "verdict": english_verdict,
             "reviewer": review_author or reviewer_login,
             "submitted_at": review.get("submittedAt"),
             "invalid_reasons": reasons,

--- a/loopx/pr_review_merge_readiness.py
+++ b/loopx/pr_review_merge_readiness.py
@@ -1,0 +1,150 @@
+"""GitHub readback adapter for exact-head pull-request merge readiness."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .capabilities.pr_review_queue import build_merge_readiness
+from .pr_review import (
+    _as_dict,
+    _as_list,
+    _normalize_pr,
+    _now_iso,
+    _parse_timestamp,
+    _run_gh_json,
+)
+
+
+def fetch_github_pull_request(
+    *,
+    repo: str,
+    number: int,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    fields = (
+        "number,title,url,state,isDraft,reviewDecision,mergeStateStatus,"
+        "headRefName,headRefOid,baseRefName,author,createdAt,updatedAt,"
+        "closedAt,mergedAt,mergeCommit,body,files,changedFiles,additions,"
+        "deletions,commits,reviews,statusCheckRollup"
+    )
+    payload = _run_gh_json(
+        ["pr", "view", str(number), "--json", fields, "--repo", repo],
+        cwd=cwd,
+    )
+    if not isinstance(payload, dict) or payload.get("number") != number:
+        raise RuntimeError("GitHub returned an invalid pull-request readback")
+    return payload
+
+
+def fetch_github_review_thread_summary(
+    *,
+    repo: str,
+    number: int,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    owner, separator, name = repo.partition("/")
+    if not separator or not owner or not name:
+        raise ValueError("repository must use owner/name form")
+    query = """
+query($owner:String!,$name:String!,$number:Int!,$cursor:String) {
+  repository(owner:$owner,name:$name) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100,after:$cursor) {
+        nodes { isResolved }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+""".strip()
+    cursor: str | None = None
+    total_count = 0
+    unresolved_count = 0
+    try:
+        for _ in range(10):
+            args = [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={number}",
+            ]
+            if cursor:
+                args.extend(["-F", f"cursor={cursor}"])
+            payload = _run_gh_json(args, cwd=cwd)
+            threads = _as_dict(
+                _as_dict(_as_dict(_as_dict(payload).get("data")).get("repository")).get(
+                    "pullRequest"
+                )
+            ).get("reviewThreads")
+            if not isinstance(threads, dict):
+                raise RuntimeError("review-thread readback is incomplete")
+            nodes = _as_list(threads.get("nodes"))
+            if any(not isinstance(item, dict) for item in nodes):
+                raise RuntimeError("review-thread readback is malformed")
+            total_count += len(nodes)
+            unresolved_count += sum(
+                1 for item in nodes if item.get("isResolved") is not True
+            )
+            page_info = _as_dict(threads.get("pageInfo"))
+            if page_info.get("hasNextPage") is not True:
+                return {
+                    "schema_version": "github_review_thread_summary_v0",
+                    "complete": True,
+                    "total_count": total_count,
+                    "unresolved_count": unresolved_count,
+                }
+            cursor = str(page_info.get("endCursor") or "").strip() or None
+            if cursor is None:
+                raise RuntimeError("review-thread cursor is missing")
+    except Exception:
+        return {
+            "schema_version": "github_review_thread_summary_v0",
+            "complete": False,
+            "total_count": total_count,
+            "unresolved_count": unresolved_count,
+            "failure_code": "github_review_thread_read_failed",
+        }
+    return {
+        "schema_version": "github_review_thread_summary_v0",
+        "complete": False,
+        "total_count": total_count,
+        "unresolved_count": unresolved_count,
+        "failure_code": "github_review_thread_pagination_limit",
+    }
+
+
+def build_pr_merge_readiness_packet(
+    *,
+    pull_request: dict[str, Any],
+    repository: str,
+    expected_exact_head: str,
+    reviewer_login: str | None,
+    review_threads: Mapping[str, Any],
+    source: str,
+) -> dict[str, Any]:
+    generated_at_text = _now_iso()
+    generated_at = _parse_timestamp(generated_at_text) or datetime.now(timezone.utc)
+    item = _normalize_pr(
+        pull_request,
+        reviewer_login=reviewer_login,
+        generated_at=generated_at,
+        fresh_audit_exact_heads=set(),
+    )
+    payload = build_merge_readiness(
+        repository=repository,
+        expected_exact_head=expected_exact_head,
+        item=item,
+        review_threads=review_threads,
+        source=source,
+    )
+    payload["generated_at"] = generated_at_text
+    return payload

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -16,11 +16,7 @@ Use this skill for `/loopx-pr-review`, explicit PR reviews, or review queues by
 state or time window. Route approval, merge, self-merge, and admin bypass to
 `loopx-pr-merge` after the evidence review is complete.
 
-Run the LoopX CLI before ad hoc GitHub reads:
-
-```bash
-loopx --format json pr-review --state all
-```
+Run `loopx --format json pr-review --state all` before ad hoc GitHub reads.
 
 Translate only explicit filters:
 
@@ -116,6 +112,12 @@ review back, verify its state and rendered body, and return its URL. Merge
 still routes through `loopx-pr-merge`; an `APPROVE` is not merge authority.
 Do not leave a public blocker only in chat.
 
+Immediately before every merge, run `loopx --format json pr-review --repo
+OWNER/REPO --check-merge-readiness NUMBER@HEAD_OID`. Merge only when it returns
+`ready=true` for that unchanged head. A rebase/update restarts review; admin
+bypass never overrides this gate. Author-owned fallback still needs explicit
+user merge authority.
+
 ## Full PR Review And Bilingual Format
 
 Every review must cover the whole PR, not only the top finding. Read the full
@@ -159,13 +161,10 @@ necessary but not enough.
 
 ## Autonomous Queue
 
-For recurring observation, keep one ignored checkpoint and use the same capability:
-
-```bash
-loopx --format json pr-review --repo owner/repo --state open \
-  --autonomous-observation --observation-state-file .local/pr-review-monitor.json \
-  [--projected-exact-head NUMBER@HEAD_OID] [--handled-exact-head NUMBER@HEAD_OID]
-```
+For recurring observation, keep one ignored checkpoint and use `loopx --format
+json pr-review --repo owner/repo --state open --autonomous-observation
+--observation-state-file .local/pr-review-monitor.json` with the projected or
+handled exact-head flags when their corresponding durable receipts exist.
 
 Treat `candidate` as a preview, not a durable projection. Follow this order: durable
 Todo target-key readback -> `--projected-exact-head` -> exact-head review/comment

--- a/tests/test_pr_review_github_scan.py
+++ b/tests/test_pr_review_github_scan.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
+import loopx.cli_commands.pr_review as pr_review_cli_module
 import loopx.pr_review as pr_review_module
+import loopx.pr_review_merge_readiness as merge_readiness_module
 import pytest
 
 HEAD_1 = "a" * 40
@@ -218,6 +222,334 @@ def _full_review_body(
         "## 我的整体评价\n整体通过。\n\n"
         f"**English verdict:** {verdict} at exact head {head}."
     )
+
+
+def _merge_ready_pr(
+    *,
+    head: str = HEAD_1,
+    body_head: str | None = None,
+    review_commit: str | None = None,
+    review_state: str = "APPROVED",
+    review_decision: str = "APPROVED",
+    author: str = "contributor",
+    reviewer: str = "maintainer",
+    author_fallback: bool = False,
+) -> dict[str, object]:
+    return {
+        "number": 4110,
+        "title": "Fix persisted lease validation",
+        "url": "https://github.com/owner/repo/pull/4110",
+        "state": "OPEN",
+        "headRefOid": head,
+        "baseRefName": "main",
+        "author": {"login": author},
+        "isDraft": False,
+        "reviewDecision": review_decision,
+        "mergeStateStatus": "BLOCKED" if author_fallback else "CLEAN",
+        "files": [{"path": "src/runtime.py", "additions": 2, "deletions": 1}],
+        "reviews": [
+            {
+                "state": review_state,
+                "body": _full_review_body(
+                    body_head or head,
+                    author_fallback=author_fallback,
+                ),
+                "author": {"login": reviewer},
+                "commit": {"oid": review_commit or head},
+                "submittedAt": "2026-09-09T11:14:01Z",
+            }
+        ],
+        "statusCheckRollup": [
+            {
+                "name": "Sign-off",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+            {
+                "name": "merge-gate",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+            },
+        ],
+    }
+
+
+def _complete_review_threads(unresolved: int = 0) -> dict[str, object]:
+    return {
+        "schema_version": "github_review_thread_summary_v0",
+        "complete": True,
+        "total_count": unresolved,
+        "unresolved_count": unresolved,
+    }
+
+
+def _merge_readiness_args(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "command": "pr-review",
+        "check_result": None,
+        "packet": None,
+        "check_merge_readiness": f"4110@{HEAD_1}",
+        "autonomous_observation": False,
+        "observation_state_file": None,
+        "previous_observation_json": None,
+        "handled_exact_head": [],
+        "projected_exact_head": [],
+        "fixture": None,
+        "repo": "owner/repo",
+        "since": None,
+        "fresh_audit_exact_head": [],
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _capture_payload(out: list[dict[str, object]]):
+    def capture(
+        payload: dict[str, object],
+        _output_format: str,
+        _markdown_renderer,
+    ) -> None:
+        out.append(payload)
+
+    return capture
+
+
+def test_merge_readiness_cli_qualifies_one_fixture_exact_head(
+    tmp_path: Path,
+) -> None:
+    fixture_path = tmp_path / "pull-request.json"
+    pull_request = _merge_ready_pr()
+    pull_request["review_thread_summary"] = _complete_review_threads()
+    fixture_path.write_text(
+        json.dumps(
+            {
+                "repository": "owner/repo",
+                "pull_requests": [pull_request],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out: list[dict[str, object]] = []
+
+    result = pr_review_cli_module.handle_pr_review_command(
+        _merge_readiness_args(fixture=str(fixture_path), repo=None),
+        output_format=lambda _args: "json",
+        print_payload=_capture_payload(out),
+    )
+
+    assert result == 0
+    assert out[0]["ready"] is True
+    assert out[0]["source"] == "fixture"
+    assert out[0]["expected_exact_head"] == f"4110@{HEAD_1}"
+
+
+def test_merge_readiness_cli_reads_live_pr_and_threads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pr_review_cli_module,
+        "resolve_current_github_login",
+        lambda: "maintainer",
+    )
+    monkeypatch.setattr(
+        pr_review_cli_module,
+        "fetch_github_pull_request",
+        lambda *, repo, number: _merge_ready_pr(),
+    )
+    monkeypatch.setattr(
+        pr_review_cli_module,
+        "fetch_github_review_thread_summary",
+        lambda *, repo, number: _complete_review_threads(),
+    )
+    out: list[dict[str, object]] = []
+
+    result = pr_review_cli_module.handle_pr_review_command(
+        _merge_readiness_args(),
+        output_format=lambda _args: "json",
+        print_payload=_capture_payload(out),
+    )
+
+    assert result == 0
+    assert out[0]["ready"] is True
+    assert out[0]["source"] == "github_cli"
+    assert out[0]["review_conclusion"]["reviewer"] == "maintainer"
+
+
+def test_review_thread_summary_paginates_and_counts_unresolved(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    pages = iter(
+        [
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [
+                                    {"isResolved": True},
+                                    {"isResolved": False},
+                                ],
+                                "pageInfo": {
+                                    "hasNextPage": True,
+                                    "endCursor": "page-2",
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [{"isResolved": True}],
+                                "pageInfo": {
+                                    "hasNextPage": False,
+                                    "endCursor": None,
+                                },
+                            }
+                        }
+                    }
+                }
+            },
+        ]
+    )
+
+    def fake(args: list[str], *, cwd: Path | None = None):
+        calls.append(args)
+        return next(pages)
+
+    monkeypatch.setattr(merge_readiness_module, "_run_gh_json", fake)
+    summary = merge_readiness_module.fetch_github_review_thread_summary(
+        repo="owner/repo",
+        number=4110,
+    )
+
+    assert summary == {
+        "schema_version": "github_review_thread_summary_v0",
+        "complete": True,
+        "total_count": 3,
+        "unresolved_count": 1,
+    }
+    assert len(calls) == 2
+    assert "cursor=page-2" not in calls[0]
+    assert "cursor=page-2" in calls[1]
+
+
+def test_review_thread_summary_fails_closed_on_incomplete_readback(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        merge_readiness_module,
+        "_run_gh_json",
+        lambda args, cwd=None: {
+            "data": {"repository": {"pullRequest": {}}},
+        },
+    )
+
+    summary = merge_readiness_module.fetch_github_review_thread_summary(
+        repo="owner/repo",
+        number=4110,
+    )
+
+    assert summary["complete"] is False
+    assert summary["failure_code"] == "github_review_thread_read_failed"
+
+
+def test_merge_readiness_binds_review_body_checks_and_threads_to_exact_head() -> None:
+    ready = merge_readiness_module.build_pr_merge_readiness_packet(
+        pull_request=_merge_ready_pr(),
+        repository="owner/repo",
+        expected_exact_head=f"4110@{HEAD_1}",
+        reviewer_login="maintainer",
+        review_threads=_complete_review_threads(),
+        source="fixture",
+    )
+
+    assert ready["ready"] is True, ready
+    assert ready["blocking_reasons"] == [], ready
+    assert ready["authority"]["grants_merge_authority"] is False, ready
+    assert ready["review_conclusion"]["verdict"] == "APPROVE", ready
+
+
+def test_merge_readiness_rejects_review_text_for_pre_update_head() -> None:
+    # GitHub may associate a preserved review with the merge-from-main commit even
+    # though its public evidence still names the earlier reviewed head.
+    stale = merge_readiness_module.build_pr_merge_readiness_packet(
+        pull_request=_merge_ready_pr(
+            head=HEAD_2,
+            body_head=HEAD_1,
+            review_commit=HEAD_2,
+        ),
+        repository="owner/repo",
+        expected_exact_head=f"4110@{HEAD_2}",
+        reviewer_login="maintainer",
+        review_threads=_complete_review_threads(),
+        source="fixture",
+    )
+
+    assert stale["ready"] is False, stale
+    assert "current_head_review_missing_or_invalid" in stale["blocking_reasons"]
+    assert (
+        "review_body_missing_standalone_bilingual_format"
+        in (stale["review_conclusion"]["invalid_reasons"])
+    )
+
+
+def test_merge_readiness_rejects_red_pending_and_unresolved_remote_gates() -> None:
+    pr = _merge_ready_pr()
+    pr["statusCheckRollup"] = [
+        {
+            "name": "Sign-off",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+        },
+        {
+            "name": "merge-gate",
+            "status": "IN_PROGRESS",
+            "conclusion": "",
+        },
+    ]
+    blocked = merge_readiness_module.build_pr_merge_readiness_packet(
+        pull_request=pr,
+        repository="owner/repo",
+        expected_exact_head=f"4110@{HEAD_1}",
+        reviewer_login="maintainer",
+        review_threads=_complete_review_threads(unresolved=1),
+        source="fixture",
+    )
+
+    assert blocked["ready"] is False, blocked
+    assert {
+        "status_checks_failed",
+        "status_checks_pending",
+        "status_checks_incomplete",
+        "unresolved_review_threads",
+    }.issubset(blocked["blocking_reasons"]), blocked
+
+
+def test_merge_readiness_accepts_titled_author_owned_approval_only_with_bypass() -> (
+    None
+):
+    pr = _merge_ready_pr(
+        author="maintainer",
+        reviewer="maintainer",
+        review_state="COMMENTED",
+        review_decision="REVIEW_REQUIRED",
+        author_fallback=True,
+    )
+    ready = merge_readiness_module.build_pr_merge_readiness_packet(
+        pull_request=pr,
+        repository="owner/repo",
+        expected_exact_head=f"4110@{HEAD_1}",
+        reviewer_login="maintainer",
+        review_threads=_complete_review_threads(),
+        source="fixture",
+    )
+
+    assert ready["ready"] is True, ready
+    assert ready["author_owned_commented_approval"] is True, ready
+    assert ready["admin_bypass_required"] is True, ready
 
 
 def test_queue_prioritizes_authenticated_developer_owned_heads(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- add a fail-closed `pull_request_merge_readiness_v0` read model for `NUMBER@HEAD_OID`
- require the PR to be open, non-draft, still on the reviewed exact head, fully qualified, free of unresolved review threads, and in a verified merge state
- preserve the documented author-owned `COMMENTED` approval fallback while making admin bypass explicitly unable to override this evidence gate
- make the installed PR-review skill rerun the gate immediately before every merge and restart review after any head change

## Post-merge audit root cause

PR #4110 was merged after its final head no longer had valid current-head review evidence and while four checks were failing. GitHub also reassociated the stored review record with the updated commit, so reading only the review record's commit association could incorrectly look current. The workflow lacked one mandatory, fail-closed remote read immediately before the merge write.

The new gate binds the caller's expected `NUMBER@HEAD_OID` to the remote head, validates the standalone bilingual conclusion body, reads every status check, drains all review-thread pages, and refuses to grant merge authority itself. A live readback of #4110's real final head is now rejected for the invalid current conclusion, failed checks, closed state, and unverifiable merge state.

## Changed surfaces

- PR-review queue capability contract, catalog entry, and README
- GitHub CLI adapter and `loopx pr-review --check-merge-readiness`
- PR-review conclusion packet (`verdict` field)
- installed `loopx-pr-review` skill merge procedure
- focused unit and CLI smoke coverage

## Validation

- `199 passed, 8 skipped` in the focused PR-review and CLI suites; the skips are explicitly optional no-tools live-qualification cases
- direct fixture and live-adapter CLI tests now execute the merge-readiness command branch; changed decision and adapter modules report 81% and 82% line coverage
- `examples/pr-review-command-smoke.py`: passed
- live GitHub readback of #4110's exact final head: correctly rejected with four failed checks and invalid current-head review evidence
- independently built and installed wheel: new CLI option present
- Ruff: passed
- mypy: passed
- maintainability ratchet: passed with zero unreviewed or stale debt
- public/private boundary scan and `git diff --check`: passed
- full `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 18/18 checks passed, zero failures, warnings, or manual holds

One alternate local `python -m build --no-isolation` invocation could not resolve the repository's exact setuptools pin from the available environment; the independently installed wheel was instead built and validated through the repository-compatible no-build-isolation path. No required qualification was skipped.

## Change-quality qualification

- receipt: `cqr_725f3527b55253e0e952`
- exact scope fingerprint: `725f3527b55253e0e95248f663d85b8464dfffc4972f3304f289d2f2641420db`
- decision: pass

## Future-facing pass

Applied a bounded behavior-preserving extraction: live GitHub reads now live in `loopx/pr_review_merge_readiness.py`, while the pure merge decision remains in the PR-review capability boundary. This keeps the existing hot PR-review module below its maintainability budget without adding a merge executor, a second review authority, or a speculative bypass framework.

## Merge decision

No manual holds remain. The exact diff is single-purpose, reversible, fully qualified, and approved for owner-authorized self-merge after the remote exact-head gate passes.
