### PR TITLE
test(todos): repair fence oracles for canonical planning

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2563,9 +2563,13 @@ as storage readiness. Its T0 checkpoint is the entry condition for these cards.
 Lifecycle admission and the preauthorized terminal fence now share the TS
 owner across legacy writers and native terminal transactions; the replaced
 Python rules are removed without changing provider defaults or promotion.
-This is not full native field-edit support: retain the strict text/note
-transaction boundary until update's fields, ownership, validation and
-monitor/resume effects close together. Neither an admission result nor a
+This is not full native field-edit support. The raw text/note patch remains
+strict; a separate bounded planning intent now composes the public TS update
+owner over the same canonical head before CAS. Resume clearing removes its
+generation fence atomically; retries retain intent identity. Active-lease status
+changes and Monitor planning/effects remain unsupported. The Python synthetic
+Markdown editor and pre-transaction target read are retired, not the unpromoted
+writer or permanent renderer. Neither an admission result nor a
 lease-fence result is a commit receipt. Keep provider CAS/replay and existing
 writer lock lifetimes unchanged while collecting this deletion payoff.
 Waiting/resume lane selection is now one TS read-policy owner shared by quota,

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -2035,8 +2035,11 @@ D1–D3 资格化和 T1/T2 条件保持不变。
 
 Lifecycle 准入及预授权 terminal fence 现由 legacy writer 与 native terminal
 transaction 共用 TS owner；删除对应 Python 规则，不改变 provider 默认或 promotion。
-这不是完整 native 字段编辑：在 update 的字段、ownership、validation 和 monitor/resume
-effect 一起闭合前，保留严格 text/note 事务边界。准入结果和 lease-fence 结果都不是
+这不是完整 native 字段编辑：原 text/note patch 仍严格受限，另有有界 planning intent
+在同一 canonical head 上组合公共 TS update owner 后进行 CAS。清除 resume 时原子
+删除 generation fence，重试保持 intent identity。Active lease 下的状态变化及 Monitor
+规划/effect 仍不支持。删除的是 Python 合成 Markdown editor 和事务前目标读取，
+不是未 promotion writer 或永久 renderer。准入结果和 lease-fence 结果都不是
 commit receipt；兑现删除收益时，provider CAS/replay 与既有 writer 持锁生命周期不变。
 等待/恢复 lane 选择现由 quota、vision-wait、agent-scope、replan 共用一个 TS 读取
 策略 owner，删除旧 Python selector 模块。适配层在 promotion 后消费同一 canonical

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -3,7 +3,7 @@
 - Status: Accepted, transaction-payoff phase in progress
 - Proposed by: LoopX maintainers
 - Date: 2026-08-15
-- Last revised: 2026-09-09
+- Last revised: 2026-09-10
 - Scope: an incremental, replacement-first migration of the LoopX control-plane
   core from Python to TypeScript without maintaining two semantic
   implementations
@@ -15,6 +15,19 @@
 ---
 
 ## Current implementation checkpoint
+
+Native update now composes `todos/public_update.ts` for a bounded nonterminal
+planning intent (status, evidence/reason, resume/clear and successor links),
+against the same complete canonical head used for authority checks and CAS.
+The separate intent namespace leaves the raw text/note patch allowlist and old
+receipt fingerprints unchanged. Planning uses the v1 request envelope, so older
+runtimes reject the entire request rather than apply only its text/note part.
+Python's synthetic Markdown round-trip and
+pre-transaction target lookup are retired; its adapter only normalizes CLI
+text, transports intent and drains the committed display projection.
+Active-lease status changes, Monitor planning/observations, ownership/routing/
+capability edits and terminal transitions remain held. This is a T1 stage,
+not full update closure, a provider-default change or permission to promote.
 
 Provider-first text/note updates now accept the active execution key and lease
 version through the existing terminal fence, with automatic acquisition and
@@ -42,7 +55,7 @@ ordering without rewriting history. Lifecycle/ownership admission now precedes p
 diagnostics, so an unauthorized request cannot use malformed metadata to avoid
 its authority rejection. Exact replay, same-second unkeyed polls, explicit
 clears and legacy boundedness exemptions remain. The plan grants no permission,
-receipt or promotion; native update still owns only text/note.
+receipt or promotion; Monitor planning is not added to native update by this slice.
 
 Public Todo add/update now resolve role, continuation binding, gate scope and
 deferred-condition requirements through `todos/authoring_scope.ts`. Python's
@@ -55,8 +68,8 @@ are never inferred from actor identity or `goal_bound`. Existing omitted scope,
 completed-history repair and lifecycle/lease permission boundaries remain.
 
 This closes T1's authoring-scope prerequisite, not the whole update transaction.
-Public metadata expansion, validation/effect closure and provider CAS/replay
-integration remain T1/T2 work. Native update retains its text/note allowlist;
+Remaining metadata expansion and validation/effect closure are T1/T2 work.
+Native update retains its raw text/note allowlist alongside bounded planning intent;
 legacy codecs/locks/writers still have active callers and are not retired here.
 
 A checked-in generator validates the language-neutral contract and emits
@@ -284,8 +297,8 @@ RPC/facade are removed, not kept as a fallback.
 This is a pure plan, not admission or a provider commit. Python still owns
 Markdown lookup/encoding, byte-level no-op detection, locking and external
 effects. Public role/binding admission and the event writer are not declared
-migrated by this slice. Promoted update remains text/note-only; no unsupported
-field gains authority, no goal is promoted, and no third storage path appears.
+migrated by that slice. Native planning now composes this owner as described in
+T1; unsupported fields gain no authority, no goal is promoted, and no third storage path appears.
 Rejected plans now leave even the caller's in-memory line buffer unchanged;
 public rejected transactions were already non-committing.
 
@@ -374,7 +387,7 @@ the shared plan, not another per-agent checklist database.
   merged/not-merged status. Compare code, not just PR titles. If a dependency
   is open, use an explicitly selected stacked base or stop that dependent unit.
 - Start from `coordination/todo_update.ts`, `todos/field_update.ts`,
-  `todos/provider_compatibility_edit.py`, `todos/line_update.py`,
+  `todos/provider_update.py`, `todos/native_update_plan.ts`, `todos/line_update.py`,
   `scheduler/monitor_poll_writeback.py` and their public callers. These paths
   are under `loopx/control_plane/`. Re-resolve moved symbols instead of
   restoring removed compatibility wrappers.
@@ -402,8 +415,9 @@ This deletes orchestration, not persistence: lifecycle/lease admission, completi
 effects, writer lock, capture and provider CAS/replay remain with their existing
 owners. The internal terminal/import field codec still has actual callers and
 does not acquire the public update policy. Native metadata expansion and T2
-atomic follow-up remain held. Reconcile the separate lease-edit PR #4152 before
-changing the provider transaction; do not infer it is merged from this checkpoint.
+atomic follow-up are not fully closed. Lease-edit PR #4152 is merged; bounded
+planning updates now reuse that fence and the existing CAS/receipt transaction.
+Continue with the remaining field/effect inventory, not another update engine.
 
 - Reuse the current provider text/note transaction, lifecycle admission,
   field-plan and completion rules. Enumerate actual public metadata edits and

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -3,7 +3,7 @@
 - Status：Accepted，transaction-payoff 阶段进行中
 - Proposed by：LoopX maintainers
 - Date：2026-08-15
-- Last revised：2026-09-09
+- Last revised：2026-09-10
 - Scope：LoopX 控制面核心从 Python 到 TypeScript 的增量、replacement-first
   迁移；不长期维护两份语义实现
 - Tracking issue：[#3225](https://github.com/huangruiteng/loopx/issues/3225)
@@ -14,6 +14,16 @@
 ---
 
 ## 当前实现检查点
+
+Native update 现通过 `todos/public_update.ts` 组合有界的非终态 planning intent
+（status、evidence/reason、resume/clear、successor links），使用权限检查与 CAS
+同一份完整 canonical head。独立 intent 命名空间不扩大原 text/note patch allowlist，
+不改变旧回执指纹。规划使用 v1 请求 envelope，让旧 runtime 拒绝整个请求，避免只
+提交其中的 text/note。删除 Python 的合成 Markdown 编解码与事务前目标查询；adapter
+只规范化 CLI 文本、传递意图并排空已提交的展示投影。
+Active lease 下的状态改变、Monitor 规划/观察、ownership/routing/capability 编辑及
+terminal transition 仍未开放。这是 T1 的一个阶段，不是完整 update 闭合，不改变
+provider 默认，也不授予 promotion 权限。
 
 Provider-first text/note 更新现可携带当前执行 key 和租约版本，复用 terminal fence，
 禁用自动获取及委托覆盖。修改和回执受同一个 provider revision 保护，租约不变。
@@ -34,7 +44,7 @@ T1 事务，也不是 T2 的 Monitor 与 successor 原子提交。
 周日期、时区偏移秒数及微秒排序，不改写历史。
 Lifecycle/ownership 准入现在先于 poll 诊断，未授权请求不能靠非法 metadata 回避
 权限拒绝。精确 replay、同秒无 ID 轮询、显式清空及 legacy boundedness 豁免保持。
-Plan 不授予权限、receipt 或 promotion；native update 仍只拥有 text/note。
+Plan 不授予权限、receipt 或 promotion；该切片不开放 native Monitor 规划更新。
 
 公开 Todo add/update 现通过 `todos/authoring_scope.ts` 统一解析角色、continuation
 绑定、gate 作用域与 deferred 条件要求。删除 Python `write_policy.py` 及 `todos.py`
@@ -44,9 +54,9 @@ successor 共用最终 scope 不变量，不执行草稿默认值推断。
 不得从 actor 或 `goal_bound` 推断全局 gate。省略 scope 的更新、历史已完成记录修复、
 lifecycle／lease 权限边界保持。
 
-这是 T1 的 authoring-scope 前置闭合，不是整个 update 事务完成。公开 metadata 扩展、
-validation／effect 闭合和 provider CAS/replay 汇合仍属于 T1/T2。Native update 继续
-保留 text/note allowlist；legacy codec／lock／writer 仍有实际 caller，本批不退役。
+这是 T1 的 authoring-scope 前置闭合，不是整个 update 事务完成。其余 metadata 扩展及
+validation／effect 闭合仍属于 T1/T2。Native update 保留原 text/note patch allowlist，
+另接有界 planning intent；legacy codec／lock／writer 仍有实际 caller，本批不退役。
 
 受检入的 generator 校验语言中立 contract，并生成深度不可变的 Python/TypeScript
 binding，覆盖原生 domain 与 projection section。两端 runtime 直接 import 生成物；
@@ -221,8 +231,8 @@ metadata。它直接组合已有 TS completion rule。被替代的 Python decisi
 
 这是一份纯 plan，不是 admission 或 provider commit。Python 仍保留 Markdown 定位／
 编码、字节级 no-op 检查、锁与外部 effect；本批不宣称迁完公共 role/binding admission
-或 event writer。Promoted update 仍只支持 text/note：不扩权、不 promotion goal、
-不增加第三条存储路径。plan 拒绝时，现在连调用方的内存行缓冲也保持不变；公共
+或 event writer。Native planning 现按 T1 所述组合此 owner；不支持的字段不扩权、
+不 promotion goal、不增加第三条存储路径。plan 拒绝时，现在连调用方的内存行缓冲也保持不变；公共
 事务在拒绝时原本就不会提交。
 
 每次 legacy line write 有一次 field-plan crossing：普通编辑替代原 metadata RPC；
@@ -289,7 +299,7 @@ commit。#4121（SQLite 候选）和 #4101（投影 receipt 保留）是独立�
 - Fetch 目标 remote base，记录 SHA 和每项依赖的实际合并状态。核对代码而非 PR
   标题；依赖未合并时，使用明确选定的 stacked base，或暂停该依赖单元。
 - 从 `loopx/control_plane/` 下的 `coordination/todo_update.ts`、
-  `todos/field_update.ts`、`todos/provider_compatibility_edit.py`、
+  `todos/field_update.ts`、`todos/provider_update.py`、`todos/native_update_plan.ts`、
   `todos/line_update.py`、`scheduler/monitor_poll_writeback.py` 及公开 caller
   入手。符号移动后重新定位，不恢复已删除 wrapper。
 - 形成紧凑 caller 表：公开操作、promotion 前后来源、TS owner、外部 effect、
@@ -311,8 +321,8 @@ active/archive 事实，不使用受展示条数限制的 inventory。局部拓�
 这里删除的是编排而非持久化：lifecycle/lease 准入、completion effect、writer
 lock、capture、provider CAS/replay 仍由既有 owner 负责。内部 terminal/import
 field codec 仍有真实 caller，不引入公开 update 限制。Native metadata 扩展和
-T2 原子后续动作仍未闭合。修改 provider 事务前先核对独立 lease-edit PR #4152，
-不能从本检查点推断它已经合入。
+T2 原子后续动作尚未全部闭合。Lease-edit PR #4152 已合入；有界规划更新复用该
+fence 及既有 CAS/receipt 事务。下一步继续剩余字段/effect 清单，不另建 update engine。
 
 - 复用现有 provider text/note 事务、lifecycle 准入、field-plan 和 completion
   规则。先枚举公开 metadata 编辑与显式 clear，不把 `UPDATE_FIELDS` 扩成所有存储

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -923,7 +923,7 @@ candidate selection, bridge repair, and owner-gated capability misses.
 ### Lease-fenced canonical text/note updates
 
 After explicit canonical-authority promotion, the active lease holder can edit
-only `text` and `note` using the existing execution key and current lease version:
+`text` and `note` using the existing execution key and current lease version:
 
 ```bash
 loopx todo update --goal-id <goal> --todo-id <todo> --agent-id <agent> \
@@ -947,3 +947,50 @@ legacy updates without the new options retain their existing behavior.
 内容会冲突；省略 ID 则每次 CLI 调用生成新 ID。Preview 不写入、不消耗 ID。
 更新不获取、续期、释放或转交租约；缺失、陈旧或过期凭证拒绝。此入口不自动
 promotion，也不回退 Markdown；不带新选项的 legacy 更新保持原行为。
+
+### Canonical nonterminal planning updates
+
+An explicitly promoted agent Todo also accepts a bounded planning update through
+the same transaction: `--status open|blocked|deferred`, `--evidence`, `--reason`,
+`--resume-when` / `--clear-resume-when`, `--unblocks-todo-id`, successor links and
+`--no-follow-up`. Text/note may be supplied in the same atomic operation.
+
+```bash
+loopx todo update --goal-id <goal> --todo-id <todo> --agent-id <agent> \
+  --status deferred --resume-when 'pr_merged:#123' --reason 'Await upstream' \
+  --update-operation-id <wait-attempt-id>
+loopx todo update --goal-id <goal> --todo-id <todo> --agent-id <agent> \
+  --status open --clear-resume-when --update-operation-id <resume-attempt-id>
+loopx todo list --goal-id <goal>
+```
+
+Preview with `--dry-run` before the real attempt. A cleared resume condition also
+clears its generation fence; an omitted condition is retained. Empty successor
+arrays and explicit `no_followup=false` in API intent remain meaningful values.
+Dependency validation sees the complete canonical inventory, not a hot-path
+summary or a Markdown buffer. A satisfied Monitor wait is not silently re-armed
+by an evidence edit; changing its topology requires clearing that old condition.
+Planning is transported in the v1 request envelope: an older runtime rejects the
+whole request instead of silently applying only an accompanying text/note patch.
+
+Authority is unchanged: registered, non-excluded peers may edit unclaimed work
+without claiming it; another owner's claim is not writable. A lease-bearing edit
+requires current execution proof and preserves the entire lease. **Changing a
+leased Todo's status is unsupported** until status and lease effects can commit
+together. Monitor planning/observations, ownership, routing, capability fields
+and terminal operations are outside this update intent. Use the existing
+dedicated lifecycle operations where supported; no unsupported update falls
+back to Markdown. Missing display files do not block a canonical update; normal
+post-commit projection delivery restores the managed Todo display.
+
+显式 promotion 后，agent Todo 可在同一事务中修改上述非终态规划字段，并与 text/note
+合并提交。使用 `--dry-run` 预览，重试沿用相同 operation id 与意图；新的修改使用新 ID。
+清除 resume 时一起清除 generation fence，省略则保留。校验读取完整 canonical
+inventory，不依赖摘要条数或 Markdown。补 evidence 不会重新设置已满足的 Monitor
+等待；更改其拓扑需要先清除旧条件。API 中空 successor 数组和 `no_followup=false`
+不是省略值。规划使用 v1 请求，旧 runtime 必须拒绝整次请求，不能只提交 text/note。
+权限不扩大：未 claim 的工作仍可由未被排除的注册 agent 修改，不能改写
+其他 owner 的工作。带租约的编辑须提供当前 proof，保持租约不变；**暂不支持改变
+带租约 Todo 的 status**。Monitor 规划/观察、ownership、routing、capability 与终态
+操作不在此 intent 内。缺失 display 不阻止 canonical 更新；提交后的正常投影恢复
+托管 Todo 展示。不支持的操作不会回退 Markdown，也不自动切换 provider 或 promotion。

--- a/examples/shared-goal-authority-e2e/mutants.py
+++ b/examples/shared-goal-authority-e2e/mutants.py
@@ -307,7 +307,7 @@ CASES.append(Case("python_fence_remediation_truncated", (
     (COORDINATION + "legacy_writer_fence.py", replacement(
         'LEGACY_WRITER_FENCED_REMEDIATION = (\n    "legacy coordination writer is fenced; use the promoted canonical authority "\n    "({authority_mode}) for goal {goal_id}; fence {fence_id}; "\n    "the primary record was not changed"\n)',
         'LEGACY_WRITER_FENCED_REMEDIATION = "legacy coordination writer is fenced"')),
-), "tests/control_plane/test_shadow_fence_caller_parity_e2e.py::test_fence_caller_parity[cli-todo_update_status-engaged]"))
+), "tests/control_plane/test_shadow_fence_caller_parity_e2e.py::test_fence_caller_parity[cli-todo_update_task_class-engaged]"))
 CASES.append(Case("fence_envelope_schema_leak", (
     (COORDINATION + "legacy_writer_fence.ts", replacement(
         "    this.payload = { write_check: writeCheck };",

--- a/loopx/cli_commands/todo_registration.py
+++ b/loopx/cli_commands/todo_registration.py
@@ -65,7 +65,9 @@ def register_todo_command(
     todo_parser.add_argument("--todo-id", help="Structured todo id from status/quota, such as todo_ab12cd34ef56.")
     todo_parser.add_argument(
         "--update-operation-id",
-        help="For promoted text/note update, reuse this operation id after a lost response; changed intent is rejected.",
+        help=("For promoted text/note or nonterminal planning update, reuse this operation id after a lost response; "
+              "changed intent is rejected. Planning supports status, evidence, reason, resume conditions and successor links; "
+              "leased status changes and Monitor planning remain unsupported."),
     )
     todo_parser.add_argument(
         "--claim-operation-id",
@@ -283,7 +285,7 @@ def register_todo_command(
         "--task-lease-idempotency-key",
         help=(
             "For todo claim on promoted hard-lease authority, atomically acquire "
-            "the canonical lease and claim; for promoted text/note update, complete and supersede, prove the "
+            "the canonical lease and claim; for promoted text/note or planning update, complete and supersede, prove the "
             "execution instance that owns the active lease."
         ),
     )
@@ -292,7 +294,7 @@ def register_todo_command(
         type=int,
         help=(
             "For promoted todo claim, optionally compare-and-set the canonical "
-            "lease version; for promoted text/note update, complete and supersede, supply the active lease "
+            "lease version; for promoted text/note or planning update, complete and supersede, supply the active lease "
             "version when it is effective."
         ),
     )

--- a/loopx/control_plane/coordination/local_authority_runtime.ts
+++ b/loopx/control_plane/coordination/local_authority_runtime.ts
@@ -49,6 +49,7 @@ import {
 } from "./todo_create.ts";
 import {
   COORDINATION_TODO_UPDATE_REQUEST_SCHEMA,
+  COORDINATION_TODO_PLANNING_UPDATE_REQUEST_SCHEMA,
   COORDINATION_TODO_UPDATE_RESULT_SCHEMA,
   executeCoordinationTodoUpdate,
 } from "./todo_update.ts";
@@ -740,8 +741,15 @@ export async function updateLocalCoordinationTodo(
     decision_read_from_provider: true, legacy_fallback_used: false};
   try {
     const input = requireJsonObject(value, "local coordination Todo update request");
-    if (input.schema_version !== COORDINATION_TODO_UPDATE_REQUEST_SCHEMA) {
+    if (input.schema_version !== COORDINATION_TODO_UPDATE_REQUEST_SCHEMA &&
+        input.schema_version !== COORDINATION_TODO_PLANNING_UPDATE_REQUEST_SCHEMA) {
       throw new TypeError("local coordination Todo update request schema mismatch");
+    }
+    const planningIntent = input.planning_intent == null ? undefined :
+      requireJsonObject(input.planning_intent, "Todo planning intent");
+    if (planningIntent && Object.keys(planningIntent).length &&
+        input.schema_version !== COORDINATION_TODO_PLANNING_UPDATE_REQUEST_SCHEMA) {
+      throw new TypeError("planning_intent requires the v1 Todo update request");
     }
     const root = runtimeRoot(input.runtime_root);
     const goalId = requireAuthorityStoreId(input.goal_id, "goal id");
@@ -764,6 +772,7 @@ export async function updateLocalCoordinationTodo(
           requireAuthorityStoreId(input.lease_idempotency_key, "lease_idempotency_key"),
         lease_expected_version: optionalNonNegativeSafeInteger(input.lease_expected_version, "lease_expected_version"),
         patch: requireJsonObject(input.patch, "Todo update patch"),
+        planning_intent: planningIntent,
         clear_fields: input.clear_fields.map((field) => claimAgentValue(field, "clear field")),
         dry_run: input.dry_run as boolean,
         now: claimObservedAt(input.observed_at),

--- a/loopx/control_plane/coordination/todo_update.ts
+++ b/loopx/control_plane/coordination/todo_update.ts
@@ -23,9 +23,13 @@ import { evaluateCoordinationTerminalFence, COORDINATION_TERMINAL_FENCE_REQUEST_
   from "./todo_lifecycle_decision.ts";
 import { leaseEpoch } from "../work_items/task_lease_acquire.ts";
 import { parseIsoTimestamp } from "../runtime_timestamp.ts";
+import { normalizeNativePlanningIntent, planNativeTodoUpdate } from "../todos/native_update_plan.ts";
 
 export const COORDINATION_TODO_UPDATE_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_update_request_v0";
+// Older runtimes must reject planning requests rather than commit only their copy patch.
+export const COORDINATION_TODO_PLANNING_UPDATE_REQUEST_SCHEMA =
+  "loopx_local_coordination_todo_update_request_v1";
 export const COORDINATION_TODO_UPDATE_RESULT_SCHEMA =
   "loopx_coordination_todo_update_result_v0";
 export const COORDINATION_TODO_UPDATE_RECEIPT_SCHEMA =
@@ -46,6 +50,7 @@ export interface CoordinationTodoUpdateInput {
   readonly now: Date;
   readonly lease_idempotency_key?: string | null;
   readonly lease_expected_version?: number | null;
+  readonly planning_intent?: JsonObject;
 }
 
 export type CoordinationTodoUpdateResult = JsonObject & {
@@ -63,6 +68,7 @@ function isFailure(value: JsonObject): value is CoordinationTodoUpdateResult {
 }
 
 function normalizeInput(raw: CoordinationTodoUpdateInput): CoordinationTodoUpdateInput {
+  const planningIntent = normalizeNativePlanningIntent(raw.planning_intent);
   const key = raw.lease_idempotency_key ?? null;
   const version = raw.lease_expected_version ?? null;
   if (key !== null && (typeof key !== "string" || !key.trim() || key !== key.trim())) {
@@ -74,7 +80,7 @@ function normalizeInput(raw: CoordinationTodoUpdateInput): CoordinationTodoUpdat
   const patch = canonicalAuthorityObject(raw.patch, "Todo update patch");
   const clearFields = raw.clear_fields.map((field, index) =>
     requireAuthorityStoreId(field, `clear_fields[${index}]`));
-  if (Object.keys(patch).length + clearFields.length === 0) {
+  if (Object.keys(patch).length + clearFields.length + Object.keys(planningIntent).length === 0) {
     throw new AuthorityStoreProtocolError("Todo update requires a non-empty patch");
   }
   if (new Set(clearFields).size !== clearFields.length) {
@@ -97,7 +103,7 @@ function normalizeInput(raw: CoordinationTodoUpdateInput): CoordinationTodoUpdat
   if (!(raw.now instanceof Date) || Number.isNaN(raw.now.valueOf())) {
     throw new AuthorityStoreProtocolError("now must be a valid Date");
   }
-  return {...raw, lease_idempotency_key: key, lease_expected_version: version,
+  return {...raw, planning_intent: planningIntent, lease_idempotency_key: key, lease_expected_version: version,
     goal_id: requireAuthorityStoreId(raw.goal_id, "goal id"),
     todo_id: requireAuthorityStoreId(raw.todo_id, "todo id"),
     operation_id: requireAuthorityStoreId(raw.operation_id, "operation id"),
@@ -138,6 +144,7 @@ function updateRequestSha(input: CoordinationTodoUpdateInput): string {
     todo_id: input.todo_id, expected_role: input.expected_role,
     actor_agent_id: input.actor_agent_id, patch: input.patch,
     clear_fields: input.clear_fields, dry_run: input.dry_run,
+    ...(Object.keys(input.planning_intent ?? {}).length ? {planning_intent: input.planning_intent} : {}),
     // Preserve receipt identity for pre-proof requests already persisted in v0.
     ...(input.lease_idempotency_key != null || input.lease_expected_version != null ? {
       lease_idempotency_key: input.lease_idempotency_key,
@@ -219,6 +226,11 @@ function targetRejection(
       if (lease !== undefined && todo.claimed_by !== input.actor_agent_id) {
         return failure("update_owner_mismatch", "Leased Todo update requires the current claim owner");
       }
+      const status = input.planning_intent?.status;
+      if (lease !== undefined && typeof status === "string" && status.toLowerCase() !== todo.status) {
+        return failure("update_lease_status_transition_unsupported",
+          "Changing a leased Todo status requires an atomic lifecycle operation; planning update leaves the lease unchanged");
+      }
     } catch (error) {
       return failure("invalid_coordination_projection",
         error instanceof Error ? error.message : "invalid lease facts");
@@ -228,13 +240,23 @@ function targetRejection(
 }
 
 function prepareUpdatedTodo(
-  todo: JsonObject, input: CoordinationTodoUpdateInput,
-): {next: JsonObject; changed: boolean} | CoordinationTodoUpdateResult {
+  todo: JsonObject, input: CoordinationTodoUpdateInput, head: JsonObject,
+): {next: JsonObject; changed: boolean; clearFields: string[]} | CoordinationTodoUpdateResult {
   const next: JsonObject = {...todo, ...input.patch};
   for (const field of input.clear_fields) delete next[field];
   next.last_actor_agent_id = input.actor_agent_id;
   next.updated_at = input.now.toISOString().replace(/\.\d{3}Z$/u, "Z");
+  const clearFields = new Set(input.clear_fields);
   try {
+    if (Object.keys(input.planning_intent ?? {}).length) {
+      const updates = planNativeTodoUpdate(todo, input.planning_intent!, head,
+        input.actor_agent_id, input.registered_agents, String(next.updated_at));
+      for (const [field, value] of Object.entries(updates)) {
+        if (value === null) { delete next[field]; clearFields.add(field); }
+        else next[field] = value;
+      }
+      next.done = next.status === "done" || next.status === "deferred";
+    }
     if (todo.schema_version === TODO_DOMAIN_ITEM_SCHEMA) {
       canonicalTodoDomainRecord(next, "updated Todo");
     } else {
@@ -256,7 +278,7 @@ function prepareUpdatedTodo(
     next.last_actor_agent_id = todo.last_actor_agent_id;
     next.updated_at = todo.updated_at;
   }
-  return {next, changed};
+  return {next, changed, clearFields: [...clearFields]};
 }
 
 /** Update mutable Todo metadata from the canonical provider head. */
@@ -282,16 +304,16 @@ export async function executeCoordinationTodoUpdate(
   if (isFailure(target)) return target;
   const rejected = targetRejection(head.head, target.todo, target.leases, input);
   if (rejected !== null) return rejected;
-  const prepared = prepareUpdatedTodo(target.todo, input);
+  const prepared = prepareUpdatedTodo(target.todo, input, head.head);
   if (isFailure(prepared)) return prepared;
-  const {next, changed} = prepared;
+  const {next, changed, clearFields} = prepared;
   if (input.dry_run) return {schema_version: COORDINATION_TODO_UPDATE_RESULT_SCHEMA,
     status: changed ? "planned" : "no_change", changed, todo_id: input.todo_id,
     provider_revision: head.provider_revision, cursor: head.cursor, dry_run: true};
   const commit: AuthorityStoreCommit = changed ? prepareCoordinationProjectionCommit({
     goal_id: input.goal_id, operation_id: input.operation_id,
     expected_provider_revision: head.provider_revision, projection: head.head,
-    mutations: [{kind: "todo_upsert", todo: next, clear_fields: input.clear_fields}],
+    mutations: [{kind: "todo_upsert", todo: next, clear_fields: clearFields}],
   }) : {operation_id: input.operation_id,
     expected_provider_revision: head.provider_revision, next_projection: head.head,
     events: [], receipts: []};

--- a/loopx/control_plane/todos/native_update_plan.ts
+++ b/loopx/control_plane/todos/native_update_plan.ts
@@ -1,0 +1,52 @@
+/** Bounded native planning edits. Compose the public rule owner in-process;
+ * this plan never grants authority, reads storage, or emits a lease effect. */
+import type { JsonObject } from "../effect_program.ts";
+import { requireJsonObject } from "../runtime_decode.ts";
+import { AuthorityStoreProtocolError } from "../coordination/authority_store_codec.ts";
+import { compactPythonWhitespace } from "../coordination/todo_agents.ts";
+import { normalizeTodoId } from "../work_items/task_lease_acquire.ts";
+import { planPublicTodoUpdate, TODO_PUBLIC_UPDATE_REQUEST_SCHEMA } from "./public_update.ts";
+
+const STRINGS = new Set(["status", "evidence", "reason", "resume_when", "unblocks_todo_id"]);
+const BOOLEANS = new Set(["clear_resume_when", "no_followup"]);
+const FIELDS = new Set([...STRINGS, ...BOOLEANS, "successor_todo_ids"]);
+
+/** A separate intent namespace preserves the shipped text/note patch and its
+ * historical receipt encoding. Raw field patches do not gain new authority. */
+export function normalizeNativePlanningIntent(value: unknown): JsonObject {
+  if (value === undefined || value === null) return {};
+  const raw = requireJsonObject(value, "Todo planning intent");
+  const intent: JsonObject = {};
+  for (const [field, value] of Object.entries(raw)) {
+    if (!FIELDS.has(field)) throw new AuthorityStoreProtocolError(`Todo planning update does not own ${field}`);
+    if (value === null) continue;
+    if (STRINGS.has(field)) {
+      if (typeof value !== "string") throw new AuthorityStoreProtocolError(`${field} must be a string`);
+      const text = compactPythonWhitespace(value);
+      if (text) intent[field] = field === "unblocks_todo_id" ? normalizeTodoId(text, field) : text;
+    } else if (BOOLEANS.has(field)) {
+      if (typeof value !== "boolean") throw new AuthorityStoreProtocolError(`${field} must be a boolean`);
+      if (field !== "clear_resume_when" || value) intent[field] = value;
+    } else {
+      if (!Array.isArray(value)) throw new AuthorityStoreProtocolError("successor_todo_ids must be an array");
+      intent[field] = [...new Set(value.map(item => normalizeTodoId(item, "successor_todo_id")))];
+    }
+  }
+  return intent;
+}
+
+export function planNativeTodoUpdate(todo: JsonObject, intent: JsonObject,
+  head: JsonObject, actor: string | null, agents: readonly string[], updatedAt: string): JsonObject {
+  if (todo.task_class === "continuous_monitor") {
+    throw new AuthorityStoreProtocolError("native Monitor planning updates require the atomic monitor writer; text/note correction remains supported");
+  }
+  const planned = planPublicTodoUpdate({schema_version: TODO_PUBLIC_UPDATE_REQUEST_SCHEMA,
+    todo, intent, updated_at: updatedAt,
+    context: {goal_id: head.goal_id, role: todo.role, actor_agent_id: actor,
+      registered_agents: [...agents], items: head.todos,
+      monitor_observation: null, enforce_monitor_boundedness: true}});
+  if (planned.target_status === "done" || planned.monitor_poll_transition != null) {
+    throw new AuthorityStoreProtocolError("native planning update cannot complete work or commit a Monitor observation");
+  }
+  return requireJsonObject(planned.metadata_updates, "Todo planning metadata updates");
+}

--- a/loopx/control_plane/todos/provider_update.py
+++ b/loopx/control_plane/todos/provider_update.py
@@ -1,8 +1,7 @@
-"""In-memory Markdown editing adapter; the TS provider owns the commit.
+"""Input transport for the native update transaction, never a Markdown editor.
 
-Only the explicitly requested text/note fields cross back. Unrepresented
-canonical fields, section/index provenance and lease records never round-trip
-through Markdown. The on-disk projection is not an input or a commit target.
+The provider owns target lookup, planning, authority and CAS at one revision.
+This adapter preserves CLI text encoding and drains the committed projection.
 """
 
 from __future__ import annotations
@@ -15,50 +14,33 @@ from ...agent_registry import registered_agent_ids_from_registry
 from ...state_refresh import now_local
 from ..coordination.local_authority import (
     LocalCoordinationAuthorityUnavailable,
-    read_canonical_todos_if_promoted,
+    local_authority_is_promoted,
 )
 from ..effect_runtime import effect_runtime_result
-from .active_state_editing import find_todo_block, set_todo_text
-from .contract import format_todo_metadata_line, metadata_line_for_todo_block
-from .line_update import upsert_todo_metadata
+from .contract import compact_todo_text
 from .provider_projection import settle_canonical_todo_projection
+from .text import normalize_new_todo
 
 
-def edit_canonical_todo_if_promoted(
+def update_canonical_todo_if_promoted(
     *, registry_path: Path, runtime_root: Path, goal_id: str, todo_id: str,
     actor_agent_id: str | None, role: str | None, text: str | None,
     note: str | None, dry_run: bool,
     project: Path | None = None, state_file: Path | None = None,
     operation_id: str | None = None, task_lease_idempotency_key: str | None = None,
     task_lease_expected_version: int | None = None,
+    planning_intent: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
-    canonical = read_canonical_todos_if_promoted(runtime_root=runtime_root, goal_id=goal_id)
-    if canonical is None:
+    if not local_authority_is_promoted(runtime_root=runtime_root, goal_id=goal_id):
         return None
-    todo = next((item for item in canonical["todos"] if item["todo_id"] == todo_id), None)
-    if todo is None:
-        raise ValueError("Todo is missing from canonical authority")
-    if role is not None and role != todo["role"]:
-        raise ValueError("Todo does not have the requested role")
-    # Reuse the existing Markdown text/metadata editor as a codec, not an
-    # authorization engine. This buffer is synthetic and is never persisted.
-    lines = ["## Agent Todo", "", f"- [ ] {todo['text']}",
-             format_todo_metadata_line(todo_id=todo_id, note=todo.get("note"))]
-    found = find_todo_block(lines, todo_id=todo_id, role="agent")
-    if found is None:
-        raise ValueError("canonical Todo cannot be represented by the compatibility editor")
-    block = found[4]
+    patch: dict[str, Any] = {}
     if text is not None:
-        set_todo_text(lines, block, text, status="open")
+        patch["text"] = normalize_new_todo(text)
     if note is not None:
-        upsert_todo_metadata(lines, block, metadata_line_for_todo_block(block, {"note": note}))
-    edited = find_todo_block(lines, todo_id=todo_id, role="agent")
-    if edited is None:
-        raise ValueError("compatibility editor lost Todo identity")
-    patch = {field: edited[4].get(field) for field, requested in
-             (("text", text), ("note", note)) if requested is not None}
+        patch["note"] = compact_todo_text(note) or None
     result = effect_runtime_result("coordination.local_authority.todo_update", {
-        "schema_version": "loopx_local_coordination_todo_update_request_v0",
+        "schema_version": ("loopx_local_coordination_todo_update_request_v1" if planning_intent
+                           else "loopx_local_coordination_todo_update_request_v0"),
         "runtime_root": str(runtime_root.resolve()), "goal_id": goal_id,
         "todo_id": todo_id, "role": role, "actor_agent_id": actor_agent_id,
         "registered_agents": registered_agent_ids_from_registry(registry_path, goal_id),
@@ -66,8 +48,15 @@ def edit_canonical_todo_if_promoted(
         "lease_idempotency_key": task_lease_idempotency_key,
         "lease_expected_version": task_lease_expected_version,
         "patch": patch, "clear_fields": [], "dry_run": dry_run,
+        "planning_intent": planning_intent or {},
         "observed_at": now_local(),
     })
+    # Keep the public lookup-error contract, without a second pre-transaction read.
+    if isinstance(result, dict) and result.get("status") == "failed":
+        if result.get("reason_code") == "todo_not_found":
+            raise ValueError("Todo is missing from canonical authority")
+        if result.get("reason_code") == "todo_role_mismatch":
+            raise ValueError("Todo does not have the requested role")
     if not isinstance(result, dict) or result.get("status") not in {
         "applied", "recovered", "replayed", "no_change", "planned",
     } or result.get("source_authority") != "file_v0" or (
@@ -82,7 +71,7 @@ def edit_canonical_todo_if_promoted(
         )
     return settle_canonical_todo_projection(
         {"ok": True, "goal_id": goal_id, "todo_id": todo_id,
-         "role": todo["role"], "dry_run": dry_run, **result},
+         "role": "agent", "dry_run": dry_run, **result},
         registry_path=registry_path, runtime_root=runtime_root, goal_id=goal_id,
         project=project, state_file=state_file,
     )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -120,7 +120,7 @@ from .control_plane.coordination.local_authority import (
     local_authority_is_promoted,
     read_canonical_todos_if_promoted,
 )
-from .control_plane.todos.provider_compatibility_edit import edit_canonical_todo_if_promoted
+from .control_plane.todos.provider_update import update_canonical_todo_if_promoted
 from .control_plane.todos.provider_create import create_canonical_todo_if_promoted
 from .control_plane.todos.path_resolution import resolve_todo_state_path
 from .control_plane.todos.provider_terminal_lifecycle import provider_first_terminal_lifecycle
@@ -1112,21 +1112,26 @@ def update_goal_todo(
         )
         if canonical_claim is not None:
             return canonical_claim
-    # A narrow compatibility editor is admitted through provider CAS. All
-    # other legacy writes still encounter the existing promotion fence.
-    if not claim_only and (text is not None or note is not None) and not any((
+    # Transport explicit planning intent; TS owns its meaning at the canonical
+    # commit revision. Unsupported fields still encounter the promotion fence.
+    planning_intent = {key: value for key, value in {
+        "status": status, "evidence": evidence, "reason": reason,
+        "resume_when": resume_when, "clear_resume_when": clear_resume_when or None,
+        "unblocks_todo_id": unblocks_todo_id, "successor_todo_ids": successor_todo_ids,
+        "no_followup": no_followup,
+    }.items() if value is not None}
+    if not claim_only and (text is not None or note is not None or planning_intent) and not any((
         monitor_metadata,
         goal_bound, clear_blocks_agent, clear_excluded_agents, global_gate,
-        clear_global_gate, clear_resume_when, clear_claim, authority_reason,
+        clear_global_gate, clear_claim, authority_reason,
     )) and all(value is None for value in (
-        status, evidence, reason, task_class, action_kind, task_domain,
+        task_class, action_kind, task_domain,
         task_repository, continuation_policy, required_write_scopes,
         required_capabilities, target_capabilities, explore_result_node_refs,
         decision_scope, required_decision_scopes, claimed_by, bound_agent,
-        blocks_agent, excluded_agents, unblocks_todo_id, successor_todo_ids,
-        resume_when, no_followup, authority_reason,
+        blocks_agent, excluded_agents, authority_reason,
     )):
-        canonical_edit = edit_canonical_todo_if_promoted(
+        canonical_edit = update_canonical_todo_if_promoted(
             registry_path=registry_path, runtime_root=shadow_runtime_root,
             goal_id=goal_id, todo_id=normalize_todo_id(todo_id) or todo_id,
             actor_agent_id=agent_id, role=role, text=text, note=note, dry_run=dry_run,
@@ -1134,13 +1139,14 @@ def update_goal_todo(
             operation_id=update_operation_id,
             task_lease_idempotency_key=task_lease_idempotency_key,
             task_lease_expected_version=task_lease_expected_version,
+            planning_intent=planning_intent,
         )
         if canonical_edit is not None:
             return canonical_edit
     if update_operation_id is not None or (not claim_only and (
         task_lease_idempotency_key is not None or task_lease_expected_version is not None
     )):
-        raise ValueError("update operation id and lease proof require promoted text/note-only update; no legacy write attempted")
+        raise ValueError("update operation id and lease proof require a supported promoted update; no legacy write attempted")
     resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
         goal_id=goal_id,

--- a/tests/control_plane/test_native_todo_planning_update.py
+++ b/tests/control_plane/test_native_todo_planning_update.py
@@ -1,0 +1,118 @@
+"""Real CLI and canonical FileAuthorityStore; no production registry or promotion."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from canonical_authority_fixture import initialize_canonical_authority
+
+from loopx.control_plane.coordination.runtime_shadow import build_todo_runtime_shadow_projection
+from loopx.control_plane.todos.contract import format_todo_metadata_line
+from loopx.todos import list_goal_todos, update_goal_todo
+
+
+def fixture(tmp_path: Path, promoted: bool) -> tuple[Path, Path]:
+    project = tmp_path / "project"
+    state = project / ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md"
+    state.parent.mkdir(parents=True)
+    rows = "\n".join(
+        "- [ ] " + text + "\n" + format_todo_metadata_line(
+            todo_id=todo_id, status="open", task_class="advancement_task",
+            claimed_by=owner, note="Preserved note",
+        ) for todo_id, text, owner in [
+            ("todo_target", "Synthetic task", "agent-a"),
+            ("todo_other", "Independent task", "agent-b"),
+        ]
+    )
+    state.write_text("# Goal\n\n## User Todo / Owner Review Reading Queue\n\n"
+                     "## Agent Todo\n\n" + rows + "\n\n## Completed Work Archive\n", encoding="utf-8")
+    registry = tmp_path / "registry.json"
+    runtime = tmp_path / "runtime"
+    registry.write_text(json.dumps({"schema_version": 1, "common_runtime_root": str(runtime), "goals": [{
+        "id": "goal-a", "status": "active", "repo": str(project),
+        "state_file": ".codex/goals/goal-a/ACTIVE_GOAL_STATE.md",
+        "coordination": {"registered_agents": ["agent-a", "agent-b"]},
+    }]}), encoding="utf-8")
+    if promoted:
+        todos = list_goal_todos(registry_path=registry, goal_id="goal-a")["todos"]
+        projection = build_todo_runtime_shadow_projection(goal_id="goal-a", todos=todos, handoff_mode="soft_claim")
+        initialize_canonical_authority(runtime, "goal-a", projection, state_path=state)
+        state.unlink()  # The update must neither require nor import a Markdown authority source.
+    return registry, state
+
+
+def update(registry: Path, *args: str, ok: bool = True) -> dict:
+    process = subprocess.run([
+        sys.executable, "-m", "loopx.cli", "--format", "json", "--registry", str(registry),
+        "todo", "update", "--goal-id", "goal-a", "--todo-id", "todo_target", "--agent-id", "agent-a", *args,
+    ], capture_output=True, text=True, timeout=45)
+    result = json.loads(process.stdout)
+    assert (process.returncode == 0) is ok, (result, process.stderr)
+    return result
+
+
+def records(registry: Path) -> dict[str, dict]:
+    return {item["todo_id"]: item for item in list_goal_todos(registry_path=registry, goal_id="goal-a")["todos"]}
+
+
+@pytest.mark.parametrize("promoted", [False, True])
+def test_public_cli_nonterminal_wait_update_and_clear(tmp_path: Path, promoted: bool) -> None:
+    registry, state = fixture(tmp_path, promoted)
+    before = records(registry)
+    args = ["--status", "deferred", "--resume-when", "pr_merged:#123", "--reason", "Await upstream",
+            "--evidence", "Synthetic evidence", "--text", "  Corrected\u2003task  "]
+    if promoted:
+        args += ["--update-operation-id", "planning-attempt"]
+    update(registry, *args, "--dry-run")
+    assert records(registry) == before
+    if promoted:
+        assert not state.exists()
+    update(registry, *args)
+    waiting = records(registry)
+    todo = waiting["todo_target"]
+    assert todo["status"] == "deferred" and todo["done"] is True
+    assert todo["resume_when"] == "pr_merged:#123"
+    assert todo["reason"] == "Await upstream"
+    assert todo["text"] == "Corrected task"
+    assert todo["note"] == "Preserved note"
+    assert todo["claimed_by"] == "agent-a"
+    assert waiting["todo_other"] == before["todo_other"]
+    if promoted:
+        assert update(registry, *args)["status"] == "replayed"
+        update(registry, *args, "--note", "Changed retry", ok=False)
+        assert records(registry) == waiting
+        assert state.exists(), "accepted commit should drain its independent display projection"
+    update(registry, "--status", "open", "--clear-resume-when")
+    resumed = records(registry)["todo_target"]
+    assert resumed["status"] == "open" and resumed["done"] is False
+    assert not resumed.get("resume_when")
+    assert not resumed.get("resume_monitor_generation")
+
+
+@pytest.mark.parametrize("args", [
+    ["--status", "done"], ["--status", "deferred"], ["--claimed-by", "agent-b"],
+    ["--task-class", "continuous_monitor"], ["--status", "blocked", "--agent-id", "agent-b"],
+])
+def test_promoted_unsupported_or_unauthorized_update_never_falls_back(tmp_path: Path, args: list[str]) -> None:
+    registry, state = fixture(tmp_path, True)
+    before = records(registry)
+    update(registry, *args, ok=False)
+    assert records(registry) == before
+    assert not state.exists()
+
+
+@pytest.mark.parametrize("todo_id,role,reason", [
+    ("todo_missing", "agent", "Todo is missing from canonical authority"),
+    ("todo_target", "user", "Todo does not have the requested role"),
+])
+def test_native_target_lookup_keeps_public_value_error(tmp_path: Path, todo_id: str, role: str, reason: str) -> None:
+    registry, state = fixture(tmp_path, True)
+    before = records(registry)
+    with pytest.raises(ValueError, match=reason):
+        update_goal_todo(registry_path=registry, goal_id="goal-a", todo_id=todo_id,
+                         role=role, agent_id="agent-a", text="Correction")
+    assert records(registry) == before
+    assert not state.exists()

--- a/tests/control_plane/test_shadow_fence_caller_parity_e2e.py
+++ b/tests/control_plane/test_shadow_fence_caller_parity_e2e.py
@@ -167,7 +167,7 @@ def row_args(ws: Workspace, caller: str) -> tuple[str, ...]:
         "task_lease_release": lease_args(ws, "release"),
         "todo_complete": ("todo", "complete", "--todo-id", a, "--agent-id", "agent-a",
                           "--evidence", "validation://parity", "--no-follow-up"),
-        "todo_update_status": ("todo", "update", "--todo-id", a, "--agent-id", "agent-a", "--status", "deferred"),
+        "todo_update_task_class": ("todo", "update", "--todo-id", a, "--agent-id", "agent-a", "--task-class", "advancement_task"),
         "todo_supersede": ("todo", "supersede", "--todo-id", a, "--agent-id", "agent-a",
                            "--text", "Parity successor", "--evidence", "validation://parity"),
         "todo_archive_completed_execute": ("todo", "archive-completed", "--execute"),
@@ -248,3 +248,20 @@ def test_baseline_annotations_are_not_stale() -> None:
             if revision == "note":
                 continue
             assert delta != row["expect"], row["id"]
+
+
+def test_promoted_planning_status_requires_execution_proof(tmp_path: Path) -> None:
+    """Supported planning reaches canonical fencing, not the retired writer."""
+    ws = build_seeded(tmp_path, "absent", "planning-proof-parity", gate=False)
+    before = {key: value for key, value in ws.w.files().items() if key.startswith("runtime/authority/")}
+    assert before, "fixture must contain a real canonical store"
+    observed = ws.observe(("todo", "update", "--todo-id", ws.ids["todo_a"],
+                           "--agent-id", "agent-a", "--status", "deferred"))
+    assert observed["exit"] == 1
+    assert observed["envelope"]["error_code"] == "handoff_mode_requires_lease"
+    assert observed["envelope"]["decision_read_from_provider"] is True
+    assert observed["envelope"]["legacy_fallback_used"] is False
+    assert observed["effect"] == {"added": [], "removed": [], "changed": []}
+    assert observed["outbox_added"] == []
+    after = {key: value for key, value in ws.w.files().items() if key.startswith("runtime/authority/")}
+    assert after == before

--- a/tests/control_plane/test_split_root_todo_writeback_fence.py
+++ b/tests/control_plane/test_split_root_todo_writeback_fence.py
@@ -335,16 +335,15 @@ def test_read_only_quota_still_collects_promoted_state(
 
 
 def test_turn_repair_update_blocked_when_override_root_is_fenced(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    registry, _state, _runtime_registry, runtime_override = (
+    registry, state, runtime_registry, runtime_override = (
         _write_split_root_goal(tmp_path)
     )
     _engage_fence_at(runtime_override)
-    _fence_check_blocks(monkeypatch)
 
-    with pytest.raises(LegacyCoordinationWriterFenced):
+    before = state.read_bytes()
+    with pytest.raises(LocalCoordinationAuthorityUnavailable) as error:
         write_turn_repair_update(
             registry_path=registry,
             runtime_root_arg=str(runtime_override),
@@ -354,6 +353,21 @@ def test_turn_repair_update_blocked_when_override_root_is_fenced(
             evidence="LoopX Turn repair_required: rerun the slice",
             agent_id=AGENT_ID,
         )
+
+    # Planning updates now use the promoted transaction. An engaged marker with
+    # no canonical store must remain unavailable, never fall back to Markdown.
+    assert error.value.code == "compatibility_edit_failed"
+    assert error.value.payload == {
+        "schema_version": "loopx_coordination_todo_update_result_v0",
+        "status": "missing",
+        "changed": False,
+        "source_authority": "file_v0",
+        "decision_read_from_provider": True,
+        "legacy_fallback_used": False,
+    }
+    assert state.read_bytes() == before
+    assert not (runtime_override / "authority").exists()
+    assert not (runtime_registry / "authority").exists()
 
 
 def test_turn_validated_completion_blocked_when_override_root_is_fenced(

--- a/tests/control_plane_ts/authority_store_conformance.ts
+++ b/tests/control_plane_ts/authority_store_conformance.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import test from "node:test";
+import {registerNativePlanningUpdateConformance} from "./native_planning_update_conformance.ts";
 
 import type {
   AuthorityStore,
@@ -215,6 +216,7 @@ export function registerAuthorityStoreConformance(
   providerName: string,
   factory: AuthorityStoreConformanceFactory,
 ): void {
+  registerNativePlanningUpdateConformance(providerName, factory);
   for (const native of [false, true]) test(`${providerName} conformance: governance reads one full Todo/lease snapshot (${native ? "native" : "legacy"})`, async (t) => {
     const {store} = await factory(t);
     const goal = "goal-governance";

--- a/tests/control_plane_ts/native_planning_update_conformance.ts
+++ b/tests/control_plane_ts/native_planning_update_conformance.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {AuthorityStore} from "../../loopx/control_plane/coordination/authority_store.ts";
+import type {JsonObject} from "../../loopx/control_plane/effect_program.ts";
+import {canonicalAuthoritySha256} from "../../loopx/control_plane/coordination/authority_store_codec.ts";
+import {executeCoordinationTodoUpdate} from "../../loopx/control_plane/coordination/todo_update.ts";
+import {TODO_DOMAIN_ITEM_SCHEMA, TODO_DOMAIN_READ_RECORD_SCHEMA, TODO_DOMAIN_RECORD_CONTRACT,
+  TODO_ITEM_SCHEMA, TODO_CANONICAL_READ_RECORD_SCHEMA, TODO_CANONICAL_READ_RECORD_FIELDS}
+  from "../../loopx/control_plane/coordination/coordination_state_contract.ts";
+import type {AuthorityStoreConformanceFactory} from "./authority_store_conformance.ts";
+import {productionScaleCoordinationFixture} from "./production_scale_coordination_fixture.ts";
+
+async function head(store: AuthorityStore) {
+  const loaded = await store.loadAuthority();
+  assert.equal(loaded.status, "loaded");
+  if (loaded.status !== "loaded") throw new Error("fixture head missing");
+  return loaded;
+}
+
+export function registerNativePlanningUpdateConformance(provider: string, factory: AuthorityStoreConformanceFactory) {
+  for (const native of [false, true]) {
+    test(`${provider}: planning transaction uses complete ${native ? "native" : "legacy"} records and keeps wait generation`, async t => {
+      const {store, contender} = await factory(t);
+      const goal = "planning-goal";
+      const todos: JsonObject[] = [
+        {todo_id: "todo_aaa_target", task_class: "advancement_task", claimed_by: "agent-a", note: "retained",
+          successor_todo_ids: ["todo_bbb_successor"]},
+        {todo_id: "todo_bbb_successor", task_class: "advancement_task"},
+        // Deliberately beyond the hot read-model limit: authoring uses the head, not its summary.
+        ...Array.from({length: 40}, (_, i) => ({todo_id: `todo_other_${String(i).padStart(2, "0")}`, task_class: "advancement_task"})),
+        {todo_id: "todo_zzz_monitor", task_class: "continuous_monitor", material_change_generation: 7},
+      ].map(record => ({schema_version: native ? TODO_DOMAIN_ITEM_SCHEMA : TODO_ITEM_SCHEMA,
+        role: "agent", status: "open", done: false, text: "Synthetic planning record", archive_state: "active",
+        ...(!native ? {source_section: "Agent Todo"} : {}), ...record}));
+      const seed = await store.commitAuthority({operation_id: "seed", expected_provider_revision: null,
+        events: [], receipts: [], next_projection: {goal_id: goal, handoff_mode: "soft_claim", todos, leases: [],
+          todo_read_model: {schema_version: native ? TODO_DOMAIN_READ_RECORD_SCHEMA : TODO_CANONICAL_READ_RECORD_SCHEMA,
+            todo_count: todos.length, records_sha256: canonicalAuthoritySha256(todos),
+            contract_fields: native ? [...TODO_DOMAIN_RECORD_CONTRACT.fields] : [...TODO_CANONICAL_READ_RECORD_FIELDS]}}});
+      assert.equal(seed.status, "applied");
+      const request = {goal_id: goal, todo_id: "todo_aaa_target", expected_role: "agent", actor_agent_id: "agent-a",
+        registered_agents: ["agent-a", "agent-b"], operation_id: "wait", patch: {}, clear_fields: [],
+        planning_intent: {resume_when: "monitor_changed:todo_zzz_monitor", reason: "Await material change"},
+        dry_run: false, now: new Date("2026-09-10T00:00:00Z")};
+      const before = await head(store);
+      const preview = await executeCoordinationTodoUpdate(store, {...request, dry_run: true});
+      assert.equal(preview.status, "planned", JSON.stringify(preview));
+      assert.deepEqual(await head(store), before);
+      const applied = await executeCoordinationTodoUpdate(store, request);
+      assert.equal(applied.status, "applied", JSON.stringify(applied));
+      let current = await head(store);
+      let target = (current.head.todos as JsonObject[])[0]!;
+      assert.equal(target.resume_monitor_generation, 7);
+      assert.deepEqual((current.head.todos as JsonObject[]).slice(1), todos.slice(1));
+      // Simulate an independent observation at a new canonical revision.
+      const observed = structuredClone(current.head);
+      (observed.todos as JsonObject[]).at(-1)!.material_change_generation = 8;
+      (observed.todo_read_model as JsonObject).records_sha256 = canonicalAuthoritySha256(observed.todos);
+      assert.equal((await contender.commitAuthority({operation_id: "observe", expected_provider_revision: current.provider_revision,
+        next_projection: observed, events: [], receipts: []})).status, "applied");
+      const topology = await executeCoordinationTodoUpdate(store, {...request, operation_id: "topology",
+        planning_intent: {successor_todo_ids: ["todo_bbb_successor"], evidence: "Checked dependency"}});
+      assert.equal(topology.status, "failed", JSON.stringify(topology));
+      assert.match(String(topology.reason), /clear the satisfied resume_when/);
+      assert.equal((await store.readReceipt("topology")).status, "missing");
+      const evidenceOnly = await executeCoordinationTodoUpdate(store, {...request, operation_id: "evidence",
+        planning_intent: {evidence: "Checked dependency"}});
+      assert.equal(evidenceOnly.status, "applied", JSON.stringify(evidenceOnly));
+      current = await head(store);
+      target = (current.head.todos as JsonObject[])[0]!;
+      assert.equal(target.resume_monitor_generation, 7, "retained wait must not silently re-arm");
+      assert.equal((await executeCoordinationTodoUpdate(store, request)).status, "replayed");
+      assert.deepEqual(await head(store), current);
+      assert.equal((await executeCoordinationTodoUpdate(store, {...request,
+        planning_intent: {reason: "Different request"}})).reason_code, "coordination_operation_identity_mismatch");
+      // Lost commit response is recovered from the same durable receipt.
+      const lostResponse: AuthorityStore = {storeIdentity: () => store.storeIdentity(),
+        loadAuthority: () => store.loadAuthority(), readReceipt: id => store.readReceipt(id),
+        scanCommitted: (cursor, limit) => store.scanCommitted(cursor, limit),
+        commitAuthority: async input => {await store.commitAuthority(input); return {
+          status: "ambiguous", reason_code: "lost_response", reason: "Synthetic lost response"};}};
+      const cleared = await executeCoordinationTodoUpdate(lostResponse, {...request, operation_id: "clear",
+        planning_intent: {clear_resume_when: true, successor_todo_ids: [], no_followup: false}});
+      assert.equal(cleared.status, "recovered", JSON.stringify(cleared));
+      target = ((await head(store)).head.todos as JsonObject[])[0]!;
+      assert.equal(target.resume_when, undefined);
+      assert.equal(target.resume_monitor_generation, undefined);
+      assert.deepEqual(target.successor_todo_ids, []);
+      assert.equal(target.no_followup, false);
+      assert.equal(target.claimed_by, "agent-a");
+      assert.equal(target.note, "retained");
+
+      // Force a canonical-head race between plan and CAS; do not recompute against a stale dependency.
+      const racing: AuthorityStore = {...lostResponse, commitAuthority: async input => {
+        const fresh = await head(contender);
+        await contender.commitAuthority({operation_id: "race-winner", expected_provider_revision: fresh.provider_revision,
+          next_projection: fresh.head, events: [], receipts: []});
+        return store.commitAuthority(input);
+      }};
+      const conflict = await executeCoordinationTodoUpdate(racing, {...request, operation_id: "race-loser",
+        planning_intent: {...request.planning_intent, successor_todo_ids: ["todo_bbb_successor"]}});
+      assert.equal(conflict.status, "conflict", JSON.stringify(conflict));
+      assert.equal((await store.readReceipt("race-loser")).status, "missing");
+      assert.deepEqual(((await head(store)).head.todos as JsonObject[])[0], target);
+    });
+  }
+
+  test(`${provider}: production-scale planning edit preserves unrelated state and active lease`, async t => {
+    const {store} = await factory(t);
+    const fixture = productionScaleCoordinationFixture("planning-scale");
+    assert.equal((await store.commitAuthority({operation_id: "seed", expected_provider_revision: null,
+      next_projection: fixture.projection, events: [], receipts: []})).status, "applied");
+    const request = {goal_id: "planning-scale", todo_id: fixture.completion_todo_id, expected_role: "agent",
+      actor_agent_id: "agent-a", registered_agents: fixture.registered_agents, operation_id: "scale-edit",
+      patch: {}, clear_fields: [], planning_intent: {reason: "Bounded planning update", evidence: "Synthetic readback"},
+      lease_idempotency_key: fixture.completion_lease_idempotency_key,
+      lease_expected_version: fixture.completion_lease_expected_version,
+      dry_run: false, now: new Date("2026-09-07T06:00:00Z")};
+    const before = await head(store);
+    const applied = await executeCoordinationTodoUpdate(store, request);
+    assert.equal(applied.status, "applied", JSON.stringify(applied));
+    const after = await head(store);
+    assert.deepEqual(after.head.leases, before.head.leases);
+    const records = after.head.todos as JsonObject[];
+    const original = before.head.todos as JsonObject[];
+    assert.equal(records.length, fixture.expected_initial_todo_count);
+    assert.deepEqual(records.filter(t => t.todo_id !== request.todo_id), original.filter(t => t.todo_id !== request.todo_id));
+    for (const [operation_id, change] of [
+      ["no-proof", {lease_idempotency_key: null, lease_expected_version: null}],
+      ["status-change", {planning_intent: {status: "deferred", resume_when: "pr_merged:#123"}}],
+      ["wrong-owner", {actor_agent_id: "agent-b"}],
+    ] as const) {
+      const result = await executeCoordinationTodoUpdate(store, {...request, operation_id, ...change});
+      assert.equal(result.status, "failed", JSON.stringify(result));
+      if (operation_id === "status-change") assert.equal(result.reason_code, "update_lease_status_transition_unsupported");
+      assert.deepEqual(await head(store), after);
+      assert.equal((await store.readReceipt(operation_id)).status, "missing");
+    }
+  });
+}

--- a/tests/control_plane_ts/todo_update.test.ts
+++ b/tests/control_plane_ts/todo_update.test.ts
@@ -10,6 +10,66 @@ import {
   TODO_DOMAIN_ITEM_SCHEMA, TODO_DOMAIN_READ_RECORD_SCHEMA, TODO_DOMAIN_RECORD_CONTRACT,
 } from "../../loopx/control_plane/coordination/coordination_state_contract.ts";
 import { executeCoordinationTodoUpdate } from "../../loopx/control_plane/coordination/todo_update.ts";
+import {updateLocalCoordinationTodo} from "../../loopx/control_plane/coordination/local_authority_runtime.ts";
+
+test("planning transport is explicitly versioned before any provider access", async () => {
+  const result = await updateLocalCoordinationTodo({
+    schema_version: "loopx_local_coordination_todo_update_request_v0",
+    patch: {text: "Must not partially commit"}, planning_intent: {status: "blocked"},
+  }, {createStore: () => {throw new Error("must not open a store");}});
+  assert.equal(result.status, "failed");
+  assert.match(String(result.reason), /requires the v1/);
+});
+
+test("native planning edit commits nonterminal state and clears its wait atomically", async () => {
+  const {store, request} = await seeded({task_class: "advancement_task"});
+  const edit = {...request, patch: {}, clear_fields: [], planning_intent: {
+    status: "deferred", resume_when: "pr_merged:#123", reason: "Waiting for upstream",
+  }};
+  const before = await store.loadAuthority();
+  assert.equal((await executeCoordinationTodoUpdate(store, {...edit, dry_run: true})).status, "planned");
+  assert.deepEqual(await store.loadAuthority(), before);
+  assert.equal((await executeCoordinationTodoUpdate(store, edit)).status, "applied");
+  const deferred = await store.loadAuthority();
+  assert.equal(deferred.status, "loaded");
+  if (deferred.status !== "loaded") return;
+  const record = (deferred.head.todos as Record<string, unknown>[])[0]!;
+  assert.equal(record.status, "deferred");
+  assert.equal(record.done, true);
+  assert.equal(record.resume_when, "pr_merged:#123");
+  assert.equal(record.claimed_by, "agent-a");
+  assert.equal(record.note, "old note");
+  assert.equal((await executeCoordinationTodoUpdate(store, edit)).status, "replayed");
+  assert.equal((await executeCoordinationTodoUpdate(store, {...edit,
+    planning_intent: {...edit.planning_intent, reason: "Different intent"}})).reason_code,
+    "coordination_operation_identity_mismatch");
+  assert.equal((await executeCoordinationTodoUpdate(store, {...edit, operation_id: "resume-a",
+    planning_intent: {status: "open", clear_resume_when: true}})).status, "applied");
+  const resumed = await store.loadAuthority();
+  assert.equal(resumed.status, "loaded");
+  if (resumed.status !== "loaded") return;
+  const next = (resumed.head.todos as Record<string, unknown>[])[0]!;
+  assert.equal(next.status, "open");
+  assert.equal(next.done, false);
+  assert.equal(next.resume_when, undefined);
+  assert.equal(next.resume_monitor_generation, undefined);
+});
+
+test("planning intent cannot smuggle terminal, ownership or observation writes", async () => {
+  const {store, request} = await seeded({task_class: "advancement_task"});
+  for (const planning_intent of [
+    {status: "done"}, {claimed_by: "agent-b"}, {clear_claim: true},
+    {global_gate: true}, {monitor_metadata: {material_change: "true"}},
+    {completion_metadata_updates_override: {completion_continuation: "no_followup"}},
+    {status: "deferred"}, {successor_todo_ids: "todo_other"},
+  ]) {
+    const before = await store.loadAuthority();
+    const result = await executeCoordinationTodoUpdate(store, {...request, planning_intent});
+    assert.equal(result.status, "failed", JSON.stringify(planning_intent));
+    assert.deepEqual(await store.loadAuthority(), before);
+    assert.equal((await store.readReceipt(request.operation_id)).status, "missing");
+  }
+});
 
 function todo(overrides: Record<string, unknown> = {}) {
   return {schema_version: TODO_DOMAIN_ITEM_SCHEMA, todo_id: "todo_a", role: "agent",
@@ -40,6 +100,11 @@ test("provider-first update commits complete record and replays by intent", asyn
   assert.equal(preview.status, "planned");
   const applied = await executeCoordinationTodoUpdate(store, request);
   assert.equal(applied.status, "applied");
+  assert.equal((applied.original_receipt as Record<string, unknown>).request_sha256,
+    canonicalAuthoritySha256({goal_id: request.goal_id, todo_id: request.todo_id,
+      expected_role: request.expected_role, actor_agent_id: request.actor_agent_id,
+      patch: request.patch, clear_fields: request.clear_fields, dry_run: request.dry_run}));
+  assert.equal((await executeCoordinationTodoUpdate(store, {...request, planning_intent: {}})).status, "replayed");
   const head = await store.loadAuthority();
   assert.equal(head.status, "loaded");
   if (head.status !== "loaded") return;
@@ -51,6 +116,24 @@ test("provider-first update commits complete record and replays by intent", asyn
   assert.equal((await executeCoordinationTodoUpdate(store, request)).status, "replayed");
   assert.equal((await executeCoordinationTodoUpdate(store, {...request,
     patch: {text: "Different"}})).reason_code, "coordination_operation_identity_mismatch");
+});
+
+test("planning no-op consumes its identity but never claims unclaimed work", async () => {
+  const {store, request} = await seeded({claimed_by: null, task_class: "advancement_task", reason: "Same"});
+  const edit = {...request, patch: {}, clear_fields: [], planning_intent: {reason: "Same"}};
+  const before = await store.loadAuthority();
+  assert.equal((await executeCoordinationTodoUpdate(store, edit)).status, "no_change");
+  const after = await store.loadAuthority();
+  assert.equal(before.status, "loaded");
+  assert.equal(after.status, "loaded");
+  if (before.status !== "loaded" || after.status !== "loaded") return;
+  assert.deepEqual(after.head, before.head);
+  assert.equal((await store.readReceipt(edit.operation_id)).status, "found");
+  assert.equal((await executeCoordinationTodoUpdate(store, {...edit, operation_id: "later",
+    planning_intent: {reason: "Later"}})).status, "applied");
+  const latest = await store.loadAuthority();
+  assert.equal((await executeCoordinationTodoUpdate(store, edit)).status, "replayed");
+  assert.deepEqual(await store.loadAuthority(), latest);
 });
 
 test("unclaimed text edits are claim-neutral, including preview and replay", async () => {

--- a/tests/fixtures/control_plane/legacy_writer_fence_caller_parity_v0.json
+++ b/tests/fixtures/control_plane/legacy_writer_fence_caller_parity_v0.json
@@ -1310,10 +1310,10 @@
       }
     },
     {
-      "id": "cli-todo_update_status-engaged",
+      "id": "cli-todo_update_task_class-engaged",
       "surface": "cli",
       "workspace": "w1",
-      "caller": "todo_update_status",
+      "caller": "todo_update_task_class",
       "fence_state": "engaged",
       "exit": 1,
       "expect": {


### PR DESCRIPTION
## Summary

Repair two stale fence oracles exposed by #4178's admitted canonical planning path. This PR targets `codex/native-todo-update-closure` at `95ff4bca329aa38a1450dbdaa4eb83180dd585cd`, not main, and contains only the test follow-up.

- Exercise unsupported task-class editing in the legacy Python fence/remediation parity row; status planning now reaches the canonical transaction. Update the matching mutation selector without relaxing the exact legacy error envelope.
- For Turn repair planning against a promoted override root with no canonical store, require the actual provider-unavailable result and prove no Markdown fallback or writes in either runtime root. Remove the irrelevant legacy-fence mock.
- Add a separate real-CLI negative case for supported status planning in hard-lease mode: missing execution proof rejects, with unchanged canonical files, primary state and outbox.

Production permissions and planning behavior are unchanged. No tests are skipped and the existing exact envelope assertions are retained for the still-fenced operation.

## Validation

- Reproduced the two deterministic CI failures on #4178's head before editing.
- 45 focused tests passed across the full fence-caller parity module, split-root writeback module and native planning update module. The two adjusted no-write cases were rerun after strengthening the nonempty canonical-store assertion.
- Both `python_fence_remediation_truncated` and `native_fence_remediation_truncated` controls pass, and both intentional mutants are killed by assertions.
- Standard premerge against the target PR head: five selected checks passed, plus diff hygiene and compilation. Ruff and four-file public-boundary scan passed without findings.
- Real CLI, TypeScript runtime and FileAuthorityStore ran against isolated synthetic state; no production goal or external provider was mutated.

## Remaining CI evidence

The separately reported `test_product_cli_loses_capture_between_commit_and_observer_then_refreshes_snapshot` passed on the original PR head locally and in five additional consecutive isolated runs. This patch does not claim to fix that intermittent Linux CI failure. Its recovery path is unchanged and needs confirmation in the next CI run. This is not a claim that every check on #4178 is now green.

## Scope

Related to #4178; no tracking issue is closed. The future-facing adjustment keeps separate oracles for legacy writer fencing and newly admitted canonical planning instead of reverting the feature or weakening authority checks. Synthetic fixtures only, no private logs or credentials. All commits carry a DCO sign-off.
