### PR TITLE
test(control-plane): stabilize lease-timeout contention

### DIFF
--- a/tests/control_plane/test_post_writeback_capability_hooks.py
+++ b/tests/control_plane/test_post_writeback_capability_hooks.py
@@ -2309,6 +2309,7 @@ def test_post_writeback_concurrent_exact_dispatch_lease_timeout_isolated(
     calls = 0
     lock = threading.Lock()
     started = threading.Event()
+    release = threading.Event()
     base = _hook()
 
     def producer(value: object) -> dict[str, object]:
@@ -2316,7 +2317,7 @@ def test_post_writeback_concurrent_exact_dispatch_lease_timeout_isolated(
         with lock:
             calls += 1
         started.set()
-        time.sleep(0.3)
+        assert release.wait(timeout=5.0)
         return dict(base.producer(value))  # type: ignore[arg-type]
 
     hook = PostWritebackHookRegistration(
@@ -2340,14 +2341,18 @@ def test_post_writeback_concurrent_exact_dispatch_lease_timeout_isolated(
     assert started.wait(timeout=5.0)
 
     # Second caller attempts exact dispatch with small lease timeout while producer is holding lease
-    result_timeout = dispatch_post_writeback_hooks(
-        [hook],
-        hook_input=_input(),
-        runtime_root=tmp_path,
-        lease_timeout_seconds=0.05,
-    )
+    try:
+        result_timeout = dispatch_post_writeback_hooks(
+            [hook],
+            hook_input=_input(),
+            runtime_root=tmp_path,
+            lease_timeout_seconds=0.05,
+        )
+    finally:
+        release.set()
 
     t_slow.join(timeout=5.0)
+    assert not t_slow.is_alive()
     result_slow = results["slow"]
 
     # Contention timeout is isolated: does not raise, preserves primary writeback, returns typed failure


### PR DESCRIPTION
## Summary

Make the post-writeback lease-timeout contention test deterministic after it failed in the #4197 Python shard.

- Replace a 300ms sleep with an explicit release event so the first producer holds the lease until the second dispatch has returned.
- Release the producer in `finally` and assert the worker terminates.
- Leave production locking, timeout, retry, and post-writeback behavior unchanged.

## Root cause

The test used wall-clock sleep as synchronization. Under CI load, the main test thread could be descheduled for longer than 300ms after observing `started`; the first worker then released the lease before the supposed timeout dispatch ran, so a valid successful dispatch contradicted the test's intended interleaving.

## Validation

- Exact contention test: 30 consecutive passes.
- `test_post_writeback_capability_hooks.py`: 60 passed.
- Ruff and diff checks passed.
- Change Quality: `cqr_2930f30161717c234ed7`, exact scope verified.
- Premerge canary passed with zero failures, warnings, or holds.

## Scope and future-facing pass

One test changes. Events are the smallest direct representation of the required happens-before relation; no production hooks or timing multipliers are added.

