### PR TITLE
fix(lark): show manager received emoji and preserve sender identity

### DIFF
--- a/docs/reference/protocols/manager-evidence-and-continuity-v0.md
+++ b/docs/reference/protocols/manager-evidence-and-continuity-v0.md
@@ -307,3 +307,19 @@ by text similarity. Different independent frontend and Lark requests remain
 different requests: this implementation does not claim automatic cross-entry
 origin correlation. A delivered request remains deduplicated after worker
 acknowledgment and service restart. Full three-Goal live acceptance remains open.
+
+
+### Lark receipt feedback
+
+After a routed manager message is durably captured, the synchronous ingress
+uses the existing inbox reaction ledger to add the configured received emoji
+(default `Get`) before waiting for the model. Replayed source messages reuse the
+same receipt. Emoji failure is diagnostic and does not suppress the answer;
+verified final reply performs the existing reaction cleanup and message ACK.
+This received indicator is distinct from internal processed-message ACK and
+from downstream work completion. Provider sender identity is preserved through
+canonical event conversion into the manager handoff provenance record.
+
+Listener registration alone cannot prove upstream message delivery. If provider
+history contains an addressed message but the bus received count stays zero,
+record that gap explicitly; do not report a missing event as successful intake.

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -33,6 +33,9 @@ from .goal_channel_contracts import LarkTopicEventDecisionReason, bindings_for_g
 from .goal_channel_targets import goal_channel_target_for_name
 from .goal_topic_connections import decide_lark_topic_event
 from .inbox_reply import CommandRunner, reply_lark_event_inbox
+from .inbox_reactions import (
+    _create_reaction, _delete_reaction, ensure_lark_event_inbox_received_reaction,
+)
 
 Answer = Callable[[Mapping[str, Any], str], str | Mapping[str, Any]]
 SnapshotProvider = Callable[[], Mapping[str, Any]]
@@ -969,6 +972,7 @@ def process_lark_goal_topic_event(
         "create_time": str(event.get("create_time") or ""),
         "content": str(event.get("content") or ""),
         "sender_type": str(event.get("sender_type") or ""),
+        "sender_id": str(event.get("sender_id") or ""),
         "root_id": str(event.get("root_id") or ""),
         "parent_id": str(event.get("parent_id") or ""),
         "mentions": event.get("mentions")
@@ -1005,6 +1009,24 @@ def process_lark_goal_topic_event(
             "agent_id": route.get("agent_id"),
             "inbox_config_ref": config_ref,
         }
+    # Receipt ACK is visible while the synchronous manager is reasoning. The
+    # private reaction ledger makes retries idempotent; final reply owns cleanup.
+    # A cosmetic reaction failure must not suppress the actual answer.
+    received_reaction = None
+    if route.get("conversation_kind") == "manager":
+        profile = str(route.get("app_ref") or "")
+        try:
+            received_reaction = ensure_lark_event_inbox_received_reaction(
+                project=root, config_path=config_path, event=canonical,
+                create_reaction=lambda mid, emoji: _create_reaction(
+                    runner=reply_runner, profile=profile, message_id=mid, emoji_type=emoji),
+                delete_reaction=lambda mid, rid: _delete_reaction(
+                    runner=reply_runner, profile=profile, message_id=mid, reaction_id=rid),
+            )
+        except (OSError, ValueError):
+            received_reaction = {"ok": False, "status": "reaction_state_unavailable"}
+        if not received_reaction.get("ok"):
+            logging.getLogger(__name__).warning("Lark manager received reaction was not verified")
     # Sender provenance comes from the provider event, never the model response.
     route = {**route, "source_sender_id": str(canonical.get("sender_id") or "")}
     answer_result = answer(route, canonical["content"])
@@ -1090,6 +1112,7 @@ def process_lark_goal_topic_event(
     return {
         "ok": True,
         "status": "replied_and_acknowledged",
+        "received_reaction_status": (received_reaction or {}).get("status"),
         "goal_id": route["goal_id"],
         "inbox_config_ref": config_ref,
     }

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -1372,3 +1372,51 @@ def test_profile_poll_does_not_reply_or_invoke_agent_when_message_mentions_other
     assert result_all["replied_count"] == 0
     assert result_all["event_statuses"] == ["ignored"]
     assert not answer_called
+
+
+@pytest.mark.parametrize("reaction_ok", [True, False, None])
+def test_manager_receives_reaction_before_answer_and_preserves_sender(tmp_path, monkeypatch, reaction_ok):
+    from loopx.extensions.lark import goal_topic_runtime as runtime
+    target_path, binding_path = tmp_path / "targets.json", tmp_path / "bindings.json"
+    _seed_legacy_topic(target_path, binding_path)
+    original_decide = runtime.decide_lark_topic_event
+    def manager_decision(**kw):
+        result = original_decide(**kw)
+        result["route"] = {**result["route"], "conversation_kind": "manager", "ingress_mode": "session_queue"}
+        return result
+    monkeypatch.setattr(runtime, "decide_lark_topic_event", manager_decision)
+    state = {}
+    runner = _reply_runner(state)
+    stages = []
+    if reaction_ok is None:
+        def unavailable(**kw):
+            raise OSError("private receipt unavailable")
+        monkeypatch.setattr(runtime, "ensure_lark_event_inbox_received_reaction", unavailable)
+    def with_reactions(args):
+        if args[3:6] == ["im", "reactions", "create"]:
+            stages.append("received")
+            assert args[args.index("--message-id") + 1] == "om_incoming"
+            assert json.loads(args[args.index("--data") + 1])["reaction_type"]["emoji_type"] == "Get"
+            return {"returncode": 0 if reaction_ok else 1, "stdout": json.dumps({"ok": reaction_ok, "data": {"reaction_id": "reaction_fixture"}})}
+        if args[3:6] == ["im", "reactions", "delete"]:
+            stages.append("cleanup")
+            return {"returncode": 0, "stdout": json.dumps({"ok": True})}
+        return runner(args)
+    def answer(route, text):
+        stages.append("answer")
+        assert stages == (["answer"] if reaction_ok is None else ["received", "answer"])
+        assert route["source_sender_id"] == "ou_owner_fixture"
+        return "Received the original intent."
+    kwargs = dict(target_payload=read_goal_channel_targets(target_path),
+                  binding_payloads={"goal-alpha": read_goal_channel_binding(binding_path)},
+                  event={"event_id": "evt_incoming", "message_id": "om_incoming", "chat_id": "oc_public_fixture",
+                         "root_id": "om_topic_alpha", "create_time": "2026-08-14T21:00:00Z",
+                         "content": "@linkmacbot forward this", "mentioned": True, "sender_type": "user", "sender_id": "ou_owner_fixture"},
+                  runtime_root=tmp_path / "runtime", answer=answer, reply_runner=with_reactions)
+    result = runtime.process_lark_goal_topic_event(**kwargs)
+    assert result["ok"], result
+    assert result["status"] == "replied_and_acknowledged"
+    assert ("cleanup" in stages) == bool(reaction_ok)
+    before = list(stages)
+    assert runtime.process_lark_goal_topic_event(**kwargs)["status"] == "already_acknowledged"
+    assert stages == before


### PR DESCRIPTION
A synchronous manager could receive a Lark message without displaying the configured receipt emoji. Its event canonicalization also dropped sender_id, leaving the new context-delegation path without provider provenance.

Preserve sender identity and reuse the existing inbox received-reaction ledger immediately after durable capture, before waiting for the manager answer. Duplicate processing reuses the receipt; final verified reply retains the existing reaction cleanup. Reaction/provider ledger failures do not prevent answering. Ordinary worker ingress behavior is unchanged.

Validation: 132 focused tests passed (received-before-answer, sender preservation, retry deduplication, reaction API failure, ledger failure, existing inbox cleanup, manager handoff, turn-start sync and Chat API); Chat HTTP smoke, Ruff and diff/privacy checks passed. A real addressed message was recovered from provider history, its receipt emoji read back, and the original manager session produced a verified intent handoff and final Lark reply/ACK. This is recovery validation, not proof of fresh websocket delivery.

Architecture/risk: reuses the capability-owned reaction lifecycle and preserves provider identity at the conversion boundary. No new scheduler, permission grant, task mutation or parallel progress ledger. The separate upstream websocket delivery gap remains unqualified; listener registration is not delivery evidence.
