### PR TITLE
fix(dsh): restore GoalBar on DSH 0.1.5

### DIFF
--- a/packages/dsh-loopx-plugin/README.md
+++ b/packages/dsh-loopx-plugin/README.md
@@ -53,7 +53,7 @@ Install the prebuilt release into the web profile:
 
 ```bash
 dsh plugin --profile web add \
-  "https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.4/dsh-loopx-plugin-0.1.1-beta.4.tgz"
+  "https://github.com/huangruiteng/loopx/releases/download/dsh-loopx-plugin-v0.1.1-beta.5/dsh-loopx-plugin-0.1.1-beta.5.tgz"
 ```
 
 For a source checkout, the equivalent build-and-install path is:
@@ -124,9 +124,10 @@ Start/Pause. Focused Client tests cover Session-generation replacement and old
 request cancellation without duplicating that matrix in the packed smoke.
 The Docker smoke packs the current plugin and builds the current LoopX
 release-candidate wheel, then starts both in a clean Debian container with the
-supported DSH release. It proves PEP 668-compatible private installation, the
-managed launcher, startup readiness, and first-session `loopx` skill
-discovery. It requires Docker, `uv`, and network access for base images and
+DSH 0.1.5 release candidate. It proves PEP 668-compatible private installation,
+the managed launcher, startup readiness, installed `loopx` skill files, launch-
+token authentication, and an authenticated GoalBar read through DSH's shared
+API carrier. It requires Docker, `uv`, and network access for base images and
 never opens a browser or configures a model provider.
 
 ## Shadow observer (default off)

--- a/packages/dsh-loopx-plugin/package.json
+++ b/packages/dsh-loopx-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-loopx-plugin",
-  "version": "0.1.1-beta.4",
+  "version": "0.1.1-beta.5",
   "description": "One-step LoopX bootstrap, same-session driver, and local GoalBar for DeepSeek Harness",
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/dsh-loopx-plugin/smoke/Dockerfile.clean
+++ b/packages/dsh-loopx-plugin/smoke/Dockerfile.clean
@@ -8,7 +8,7 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 RUN --mount=type=cache,target=/root/.npm \
     npm install --global --silent --ignore-scripts \
-      pnpm@10.33.0 @deepseek-ai/dsh@0.1.1-rc.2
+      pnpm@10.33.0 @deepseek-ai/dsh@0.1.5-rc.1
 RUN useradd --create-home --uid 10001 --shell /bin/bash loopx-smoke \
     && externally_managed="$(python3 -c \
       'import sysconfig; print(sysconfig.get_path("stdlib") + "/EXTERNALLY-MANAGED")')" \

--- a/packages/dsh-loopx-plugin/smoke/dsh-clean-docker-probe.mjs
+++ b/packages/dsh-loopx-plugin/smoke/dsh-clean-docker-probe.mjs
@@ -9,11 +9,23 @@ if (endpoint.protocol !== 'http:' || endpoint.hostname !== '127.0.0.1') {
   throw new Error('DSH smoke endpoint must use container-local loopback')
 }
 
-async function rpc(method, payload) {
+const exchange = await fetch(endpoint, {
+  redirect: 'manual',
+  signal: AbortSignal.timeout(10_000),
+})
+if (exchange.status !== 303) {
+  throw new Error(`DSH launch-token exchange returned HTTP ${exchange.status}`)
+}
+const cookie = exchange.headers.get('set-cookie')?.split(';', 1)[0]
+if (!cookie) throw new Error('DSH launch-token exchange omitted its session cookie')
+const cleanEndpoint = new URL(exchange.headers.get('location') ?? '/', endpoint)
+
+async function rpc(payload) {
   const rpcId = randomUUID()
-  const response = await fetch(new URL(`/api/${method}`, endpoint), {
+  const method = 'loopx.goalbar'
+  const response = await fetch(new URL(`/api/${method}`, cleanEndpoint), {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', cookie },
     body: JSON.stringify({ type: 'client-request', rpcId, method, payload }),
     signal: AbortSignal.timeout(10_000),
   })
@@ -27,16 +39,18 @@ async function rpc(method, payload) {
   return body.result.value
 }
 
-const sessionId = 'clean-docker-loopx-bootstrap'
-await rpc('session.create', { sessionId, cwd: workspace })
-const catalog = await rpc('skill.list', { sessionId })
-const names = catalog.skills.map(skill => skill.name).sort()
-if (!names.includes('loopx')) {
-  throw new Error(`first skill catalog omitted loopx: ${JSON.stringify(names)}`)
+const sessionId = 'clean-docker-no-agent'
+const result = await rpc({
+  v: 'loopx_goalbar_request_v2',
+  op: 'read',
+  sessionId,
+})
+if (result.result?.kind !== 'fault' || result.result.code !== 'session_unavailable') {
+  throw new Error('DSH 0.1.5 GoalBar shared-API route returned an unexpected result')
 }
 process.stdout.write(JSON.stringify({
   ok: true,
   sessionId,
-  skillCount: names.length,
+  carrier: 'shared-api',
   loopx: true,
 }))

--- a/packages/dsh-loopx-plugin/smoke/dsh-clean-docker-smoke.sh
+++ b/packages/dsh-loopx-plugin/smoke/dsh-clean-docker-smoke.sh
@@ -20,6 +20,11 @@ container_smoke() {
   local dsh_log="$smoke_root/dsh.log"
   local pep668_log="$smoke_root/pep668.log"
 
+  print_dsh_log() {
+    sed -n "$LOG_PREVIEW_RANGE" "$dsh_log" \
+      | sed -E 's/([?&][A-Za-z0-9_-]+=)[A-Za-z0-9_-]+/\1<redacted>/g'
+  }
+
   if python3 -m pip install --dry-run --no-index loopx >"$pep668_log" 2>&1; then
     echo 'clean Docker smoke: PEP 668 guard was not active' >&2
     return 1
@@ -34,6 +39,10 @@ container_smoke() {
   mkdir -p "$workspace"
   timeout 180 dsh plugin --profile web add \
     /artifact/dsh-loopx-plugin.tgz --ignore-scripts
+  [[ "$(dsh --version)" == '0.1.5-rc.1' ]] || {
+    echo 'clean Docker smoke: unexpected DSH regression version' >&2
+    return 1
+  }
 
   dsh --profile web --port 0 --no-open >"$dsh_log" 2>&1 &
   DSH_SMOKE_PID=$!
@@ -49,14 +58,14 @@ container_smoke() {
     base_url="$(awk '/dsh web: / { value = $NF } END { print value }' "$dsh_log")"
     [[ -n "$base_url" ]] && break
     if ! kill -0 "$DSH_SMOKE_PID" 2>/dev/null; then
-      sed -n "$LOG_PREVIEW_RANGE" "$dsh_log"
+      print_dsh_log
       return 1
     fi
     sleep 1
   done
 
   if [[ -z "$base_url" ]]; then
-    sed -n "$LOG_PREVIEW_RANGE" "$dsh_log"
+    print_dsh_log
     echo 'clean Docker smoke: DSH did not publish a URL' >&2
     return 1
   fi
@@ -67,7 +76,7 @@ container_smoke() {
     "$runtime_dir/site-packages/loopx" \
     "$DSH_AGENTS_HOME/skills/loopx/SKILL.md"; do
     if [[ ! -e "$expected" ]]; then
-      sed -n "$LOG_PREVIEW_RANGE" "$dsh_log"
+      print_dsh_log
       find "$DSH_AGENTS_HOME" "$HOME/.agents" \
         -maxdepth 4 -type f -print 2>/dev/null | sort || true
       if [[ -f "$runtime_dir/loopx_cli.py" ]]; then
@@ -81,7 +90,7 @@ container_smoke() {
     fi
   done
   python3 "$runtime_dir/loopx_cli.py" --version | grep -E '^loopx '
-  node /smoke/dsh-clean-docker-probe.mjs "$base_url" "$workspace"
+  node "$SCRIPT_DIR/dsh-clean-docker-probe.mjs" "$base_url" "$workspace"
   printf '\nclean Docker smoke passed\n'
 }
 
@@ -99,7 +108,16 @@ for command in docker pnpm uv; do
   }
 done
 
-artifact_parent="${TMPDIR:-/tmp}"
+if [[ -n "${DSH_DOCKER_SMOKE_TMPDIR:-}" ]]; then
+  artifact_parent="$DSH_DOCKER_SMOKE_TMPDIR"
+elif [[ "$(uname -s)" == 'Darwin' ]]; then
+  # Docker Desktop and Colima share the user's home by default, but not every
+  # per-user macOS TMPDIR under /var/folders.
+  artifact_parent="$HOME/.cache/loopx-dsh-smoke"
+else
+  artifact_parent="${TMPDIR:-/tmp}"
+fi
+mkdir -p "$artifact_parent"
 artifact_dir="$(mktemp -d "$artifact_parent/dsh-loopx-clean-docker.XXXXXX")"
 image_id=''
 cleanup_artifact() {
@@ -129,6 +147,10 @@ wheel_count="$(find "$artifact_dir" -maxdepth 1 -name 'loopx-*.whl' -print | wc 
 }
 chmod 755 "$artifact_dir"
 chmod 644 "$artifact_dir/dsh-loopx-plugin.tgz" "$artifact_dir"/loopx-*.whl
+install -m 755 "$SCRIPT_DIR/dsh-clean-docker-smoke.sh" \
+  "$artifact_dir/dsh-clean-docker-smoke.sh"
+install -m 644 "$SCRIPT_DIR/dsh-clean-docker-probe.mjs" \
+  "$artifact_dir/dsh-clean-docker-probe.mjs"
 docker build \
   --file "$SCRIPT_DIR/Dockerfile.clean" \
   --iidfile "$artifact_dir/image-id" \
@@ -140,6 +162,5 @@ image_id="$(tr -d '[:space:]' <"$artifact_dir/image-id")"
 }
 docker run --rm \
   --mount "type=bind,src=$artifact_dir,dst=/artifact,readonly" \
-  --mount "type=bind,src=$SCRIPT_DIR,dst=/smoke,readonly" \
   "$image_id" \
-  bash /smoke/dsh-clean-docker-smoke.sh --container
+  bash /artifact/dsh-clean-docker-smoke.sh --container

--- a/packages/dsh-loopx-plugin/smoke/dsh-goalbar-runtime-smoke.mjs
+++ b/packages/dsh-loopx-plugin/smoke/dsh-goalbar-runtime-smoke.mjs
@@ -338,13 +338,13 @@ function coordinatorHarness() {
   }
 }
 
-async function openPackedConnection(installed, host, service) {
-  const installedRequire = createRequire(join(installed, 'package.json'))
-  const dshRequire = createRequire(installedRequire.resolve('@deepseek-ai/dsh/package.json'))
+async function openPackedConnection(host, service) {
+  const harnessRequire = createRequire(join(packageRoot, 'package.json'))
+  const dshRequire = createRequire(harnessRequire.resolve('@deepseek-ai/dsh/package.json'))
   const appRequire = createRequire(dshRequire.resolve('@deepseek-ai/dsh-web-app/package.json'))
   const [{ Context }, { HostConnectionService }, { WebServer }] = await Promise.all([
-    import(pathToFileURL(installedRequire.resolve('@deepseek-ai/cordis')).href),
-    import(pathToFileURL(installedRequire.resolve('@deepseek-ai/dsh-client-connection')).href),
+    import(pathToFileURL(harnessRequire.resolve('@deepseek-ai/cordis')).href),
+    import(pathToFileURL(harnessRequire.resolve('@deepseek-ai/dsh-client-connection')).href),
     import(pathToFileURL(appRequire.resolve('@deepseek-ai/dsh-host-webserver')).href),
   ])
   const ctx = new Context()
@@ -353,6 +353,7 @@ async function openPackedConnection(installed, host, service) {
   const disposeRpc = host.registerGoalBarConnectionRpc(ctx.connection, service)
   return {
     baseUrl: `http://127.0.0.1:${String(ctx.webServer.port)}`,
+    sharedApi: Reflect.has(HostConnectionService.prototype, 'fetch'),
     disposeRpc,
     close: () => ctx.fiber.dispose(),
   }
@@ -417,9 +418,16 @@ async function exercisePackedService(installed) {
     retryDelaysMs: [0, 0],
     watchTimeoutMs: 50,
   })
-  const connection = await openPackedConnection(installed, host, service)
+  const connection = await openPackedConnection(host, service)
   const call = async (endpoint, payload, signal) => {
-    const result = await rpc(connection.baseUrl, endpoint, payload, {}, signal)
+    const result = await rpc(
+      connection.baseUrl,
+      endpoint,
+      payload,
+      {},
+      signal,
+      connection.sharedApi,
+    )
     assert.equal(result.response.status, 200)
     assert.equal(result.body.rpcId, result.rpcId)
     return result.body.result
@@ -750,10 +758,14 @@ async function materializeServedClient(source) {
 
 async function waitForWebUrl(child, output) {
   return await new Promise((resolveUrl, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`DSH URL timeout\n${output.text}`)), 20_000)
+    const timeout = setTimeout(() => reject(new Error(
+      `DSH URL timeout\n${redactWebOutput(output.text)}`,
+    )), 20_000)
     const inspect = chunk => {
       output.text += chunk.toString()
-      const match = output.text.match(/dsh web: (http:\/\/127\.0\.0\.1:\d+)/u)
+      const match = output.text.match(
+        /dsh web: (http:\/\/127\.0\.0\.1:\d+(?:\/\?[A-Za-z0-9_-]+=[A-Za-z0-9_-]+)?)/u,
+      )
       if (match) {
         clearTimeout(timeout)
         resolveUrl(match[1])
@@ -763,9 +775,43 @@ async function waitForWebUrl(child, output) {
     child.stderr.on('data', inspect)
     child.once('exit', (code, signal) => {
       clearTimeout(timeout)
-      reject(new Error(`DSH exited before URL (code=${code}, signal=${signal})\n${output.text}`))
+      reject(new Error(
+        `DSH exited before URL (code=${code}, signal=${signal})\n${redactWebOutput(output.text)}`,
+      ))
     })
   })
+}
+
+function redactWebOutput(value) {
+  return value.replace(/([?&][A-Za-z0-9_-]+=)[A-Za-z0-9_-]+/gu, '$1<redacted>')
+}
+
+async function openAuthenticatedWeb(launchUrl) {
+  const url = new URL(launchUrl)
+  if (!url.searchParams.has('token')) {
+    return {
+      baseUrl: url.origin,
+      headers: {},
+      index: await fetch(url, { signal: AbortSignal.timeout(5_000) }),
+    }
+  }
+  const exchange = await fetch(url, {
+    redirect: 'manual',
+    signal: AbortSignal.timeout(5_000),
+  })
+  assert.equal(exchange.status, 303)
+  const cookie = exchange.headers.get('set-cookie')?.split(';', 1)[0]
+  assert(cookie, 'DSH launch-token exchange omitted its browser session cookie')
+  const cleanUrl = new URL(exchange.headers.get('location') ?? '/', url)
+  const headers = { cookie }
+  return {
+    baseUrl: cleanUrl.origin,
+    headers,
+    index: await fetch(cleanUrl, {
+      headers,
+      signal: AbortSignal.timeout(5_000),
+    }),
+  }
 }
 
 async function stopChild(child) {
@@ -786,13 +832,22 @@ async function stopChild(child) {
   await closed
 }
 
-async function rpc(baseUrl, endpoint, payload, extraHeaders = {}, signal) {
+async function rpc(
+  baseUrl,
+  endpoint,
+  payload,
+  extraHeaders = {},
+  signal,
+  sharedApi = false,
+) {
   const rpcId = randomUUID()
   const requestSignal = signal ?? AbortSignal.timeout(5_000)
-  const response = await fetch(`${baseUrl}/loopx/${endpoint}`, {
+  const wireEndpoint = sharedApi ? 'loopx.goalbar' : endpoint
+  const channel = sharedApi ? 'api' : 'loopx'
+  const response = await fetch(`${baseUrl}/${channel}/${wireEndpoint}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json', ...extraHeaders },
-    body: JSON.stringify({ type: 'client-request', rpcId, method: endpoint, payload }),
+    body: JSON.stringify({ type: 'client-request', rpcId, method: wireEndpoint, payload }),
     signal: requestSignal,
   })
   const body = response.headers.get('content-type')?.includes('json')
@@ -801,11 +856,11 @@ async function rpc(baseUrl, endpoint, payload, extraHeaders = {}, signal) {
   return { response, body, rpcId }
 }
 
-async function hostRpc(baseUrl, method, payload) {
+async function hostRpc(baseUrl, method, payload, extraHeaders = {}) {
   const rpcId = randomUUID()
   const response = await fetch(`${baseUrl}/api/${method}`, {
     method: 'POST',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...extraHeaders },
     body: JSON.stringify({ type: 'client-request', rpcId, method, payload }),
     signal: AbortSignal.timeout(5_000),
   })
@@ -851,7 +906,13 @@ function disconnectableRpc(baseUrl, endpoint, payload) {
   }
 }
 
-async function exerciseRealDshWeb(home, env, cliLog) {
+async function exerciseRealDshWeb(
+  home,
+  env,
+  cliLog,
+  skipSessionFixture,
+  sharedApi,
+) {
   const output = { text: '' }
   const child = spawn(dshBin, ['--profile', 'web', '--port', '0', '--no-open'], {
     cwd: packageRoot,
@@ -860,8 +921,11 @@ async function exerciseRealDshWeb(home, env, cliLog) {
   })
   let baseUrl
   try {
-    baseUrl = await waitForWebUrl(child, output)
-    const index = await fetch(baseUrl, { signal: AbortSignal.timeout(5_000) })
+    const launchUrl = await waitForWebUrl(child, output)
+    const authenticated = await openAuthenticatedWeb(launchUrl)
+    baseUrl = authenticated.baseUrl
+    const index = authenticated.index
+    const authHeaders = authenticated.headers
     assert.equal(index.status, 200)
     const html = await index.text()
     const bootText = /(?:window\.__DSH_BOOT__|globalThis\["__DSH_BOOT__"\])\s*=\s*(\{.*?\})<\/script>/su
@@ -877,6 +941,7 @@ async function exerciseRealDshWeb(home, env, cliLog) {
       '@deepseek-ai/dsh-client-ui-conversation',
     ])
     const bundle = await fetch(new URL(row.url, baseUrl), {
+      headers: authHeaders,
       signal: AbortSignal.timeout(5_000),
     })
     assert.equal(bundle.status, 200)
@@ -889,14 +954,16 @@ async function exerciseRealDshWeb(home, env, cliLog) {
     assert(
       await stat(join(env.DSH_AGENTS_HOME, 'skills', 'loopx', 'SKILL.md'))
         .then(() => true, () => false),
-      `automatic initialization did not create the isolated loopx skill: ${initializationLog}\n${output.text}`,
+      `automatic initialization did not create the isolated loopx skill: ${initializationLog}\n${redactWebOutput(output.text)}`,
     )
-    await hostRpc(baseUrl, 'session.create', { sessionId, cwd: packageRoot })
-    const skillCatalog = await hostRpc(baseUrl, 'skill.list', { sessionId })
-    assert(
-      skillCatalog.skills.some(skill => skill.name === 'loopx'),
-      `automatic initialization did not expose the loopx skill before DSH readiness: ${JSON.stringify(skillCatalog)}\n${output.text}`,
-    )
+    if (!skipSessionFixture) {
+      await hostRpc(baseUrl, 'session.create', { sessionId, cwd: packageRoot }, authHeaders)
+      const skillCatalog = await hostRpc(baseUrl, 'skill.list', { sessionId }, authHeaders)
+      assert(
+        skillCatalog.skills.some(skill => skill.name === 'loopx'),
+        `automatic initialization did not expose the loopx skill before DSH readiness: ${JSON.stringify(skillCatalog)}\n${redactWebOutput(output.text)}`,
+      )
+    }
 
     const startupCalls = (await readFile(cliLog, 'utf8')).trim().split('\n')
     assert.equal(startupCalls.length, 4, `unexpected automatic initialization calls: ${startupCalls.join(' | ')}`)
@@ -905,8 +972,19 @@ async function exerciseRealDshWeb(home, env, cliLog) {
     assert(startupCalls[2].includes('--install'))
     assert(startupCalls[3].includes('workflow-skills'))
 
-    const malformed = await rpc(baseUrl, 'goalbar/read', { reflected: 'must-not-return' })
-    assert.equal(malformed.response.status, 200)
+    const malformed = await rpc(
+      baseUrl,
+      'goalbar/read',
+      { reflected: 'must-not-return' },
+      authHeaders,
+      undefined,
+      sharedApi,
+    )
+    assert.equal(
+      malformed.response.status,
+      200,
+      `GoalBar route unavailable: ${JSON.stringify(malformed.body)}\n${redactWebOutput(output.text)}`,
+    )
     assert.equal(malformed.body.rpcId, malformed.rpcId)
     assert.equal(malformed.body.result.ok, false)
     assert.equal(malformed.body.result.error.code, 'bad-request')
@@ -914,7 +992,7 @@ async function exerciseRealDshWeb(home, env, cliLog) {
 
     const read = await rpc(baseUrl, 'goalbar/read', {
       v: requestVersion, op: 'read', sessionId: 'runtime-no-agent',
-    })
+    }, authHeaders, undefined, sharedApi)
     const unavailable = read.body.result.value.result
     assert.equal(unavailable.kind, 'fault')
     assert.equal(unavailable.code, 'session_unavailable')
@@ -923,7 +1001,7 @@ async function exerciseRealDshWeb(home, env, cliLog) {
 
     const rejected = await rpc(baseUrl, 'goalbar/read', {
       v: requestVersion, op: 'read', sessionId: 'runtime-no-agent',
-    }, { origin: 'http://non-loopback.invalid' })
+    }, { ...authHeaders, origin: 'http://non-loopback.invalid' }, undefined, sharedApi)
     assert.equal(rejected.response.status, 403)
     assert.equal(rejected.body, 'forbidden')
     await new Promise(resolveWait => setTimeout(resolveWait, 150))
@@ -939,6 +1017,10 @@ async function exerciseRealDshWeb(home, env, cliLog) {
 
 async function main() {
   const suppliedTarball = parseArgs(process.argv.slice(2))
+  const dshVersion = run(dshBin, ['--version']).trim()
+  const expectedDshVersion = process.env.DSH_EXPECTED_VERSION
+  if (expectedDshVersion) assert.equal(dshVersion, expectedDshVersion)
+  const skipSessionFixture = process.env.DSH_RUNTIME_SKIP_SESSION_FIXTURE === '1'
   const temp = await mkdtemp(join(tmpdir(), 'dsh-loopx-goalbar-runtime-'))
   const home = join(temp, 'dsh-home')
   const tarball = suppliedTarball ?? join(temp, 'dsh-loopx-plugin.tgz')
@@ -1000,7 +1082,17 @@ esac
       '--prefer-offline', '--ignore-scripts',
     ], env)
     installed = await realpath(join(home, 'profiles', 'web', 'node_modules', packageId))
-    await exerciseRealDshWeb(home, env, cliLog)
+    const dshInstallRequire = createRequire(
+      join(dirname(dirname(dshBin)), '..', 'package.json'),
+    )
+    const installedDshRequire = createRequire(
+      dshInstallRequire.resolve('@deepseek-ai/dsh/package.json'),
+    )
+    const installedConnection = await import(pathToFileURL(
+      installedDshRequire.resolve('@deepseek-ai/dsh-client-connection'),
+    ).href)
+    const sharedApi = Reflect.has(installedConnection.HostConnectionService.prototype, 'fetch')
+    await exerciseRealDshWeb(home, env, cliLog, skipSessionFixture, sharedApi)
     await exercisePackedService(installed)
     const installedDump = run(dshBin, ['--profile', 'web', '--dump-config'], env)
     let previousRow = -1
@@ -1027,7 +1119,7 @@ esac
   }
   process.stdout.write([
     'dsh-loopx GoalBar runtime smoke passed',
-    '  real-profile: packed install, awaited automatic initialization, immediate /loopx skill readback, boot graph, served/materialized Client, loopback fence, process teardown, idle no-extra-CLI',
+    `  real-profile: DSH ${dshVersion}, packed install, awaited automatic initialization, immediate /loopx skill readback, boot graph, served/materialized Client, loopback fence, process teardown, idle no-extra-CLI`,
     '  packed-rc7-connection: live mid-turn binding, lease revision reconciliation, runtime-only update, pending-watch abort, successful Start/Pause, handler disposal',
     '  client-lifecycle: slot coexistence/session injection plus ordinary-unload and cached-reapply CSS cleanup',
     '  manual-evidence: mounted Client-to-carrier Start/Pause stays in the owner-reviewed packed-browser gate',

--- a/packages/dsh-loopx-plugin/src/client/index.tsx
+++ b/packages/dsh-loopx-plugin/src/client/index.tsx
@@ -41,7 +41,10 @@ export function apply(ctx: GoalBarClientContext): void {
     'dsh-loopx-plugin GoalBar locale',
   )
 
-  const rpc = createGoalBarRpc(ctx.connection.rpc)
+  const rpc = createGoalBarRpc(
+    ctx.connection.rpc,
+    Reflect.has(ctx.connection, 'generation'),
+  )
   ctx.slots.inject('conversation.input.dock', () => ctx.slots.register({
     name: 'conversation.input.dock',
     id: 'loopx-goal',

--- a/packages/dsh-loopx-plugin/src/client/rpc.ts
+++ b/packages/dsh-loopx-plugin/src/client/rpc.ts
@@ -14,6 +14,8 @@ import type {
 } from '../goalbar/protocol.ts'
 
 const GOALBAR_CHANNEL = '/loopx'
+const GOALBAR_SHARED_API_CHANNEL = '/api'
+const GOALBAR_SHARED_API_ENDPOINT = 'loopx.goalbar'
 
 export type GoalBarRpcOutcome<T> =
   | { readonly ok: true; readonly response: T }
@@ -75,11 +77,13 @@ async function callGoalBar<T extends GoalBarRequestV1>(
   caller: ConnectionRpcCaller,
   request: T,
   signal: AbortSignal,
+  sharedApi: boolean,
 ): Promise<GoalBarRpcOutcome<GoalBarResponseFor<T>>> {
   try {
+    const endpoint = endpointForGoalBarOp(request.op)
     const carrier = await caller.call(
-      GOALBAR_CHANNEL,
-      endpointForGoalBarOp(request.op),
+      sharedApi ? GOALBAR_SHARED_API_CHANNEL : GOALBAR_CHANNEL,
+      sharedApi ? GOALBAR_SHARED_API_ENDPOINT : endpoint,
       request,
       signal,
     )
@@ -97,7 +101,10 @@ async function callGoalBar<T extends GoalBarRequestV1>(
  * Wrap DSH's generic Connection caller with the closed GoalBar V2 wire.
  * Carrier errors and thrown values are deliberately discarded at this boundary.
  */
-export function createGoalBarRpc(caller: ConnectionRpcCaller): GoalBarRpc {
+export function createGoalBarRpc(
+  caller: ConnectionRpcCaller,
+  sharedApi = false,
+): GoalBarRpc {
   return {
     read(sessionId, signal) {
       const request = {
@@ -105,7 +112,7 @@ export function createGoalBarRpc(caller: ConnectionRpcCaller): GoalBarRpc {
         op: 'read',
         sessionId,
       } as const
-      return callGoalBar(caller, request, signal)
+      return callGoalBar(caller, request, signal, sharedApi)
     },
     watch(sessionId, anchor, signal) {
       const request = {
@@ -114,7 +121,7 @@ export function createGoalBarRpc(caller: ConnectionRpcCaller): GoalBarRpc {
         sessionId,
         ...anchor,
       } as const
-      return callGoalBar(caller, request, signal)
+      return callGoalBar(caller, request, signal, sharedApi)
     },
     start(sessionId, expected, signal) {
       const request = {
@@ -123,7 +130,7 @@ export function createGoalBarRpc(caller: ConnectionRpcCaller): GoalBarRpc {
         sessionId,
         expected,
       } as const
-      return callGoalBar(caller, request, signal)
+      return callGoalBar(caller, request, signal, sharedApi)
     },
     pause(sessionId, expected, signal) {
       const request = {
@@ -132,7 +139,7 @@ export function createGoalBarRpc(caller: ConnectionRpcCaller): GoalBarRpc {
         sessionId,
         expected,
       } as const
-      return callGoalBar(caller, request, signal)
+      return callGoalBar(caller, request, signal, sharedApi)
     },
   }
 }

--- a/packages/dsh-loopx-plugin/src/goalbar/connection-rpc.ts
+++ b/packages/dsh-loopx-plugin/src/goalbar/connection-rpc.ts
@@ -4,6 +4,7 @@ import type {
 } from '@deepseek-ai/dsh-client-connection'
 import {
   decodeGoalBarRequestV1,
+  endpointForGoalBarOp,
 } from './protocol.ts'
 import type {
   GoalBarRequestV1,
@@ -15,6 +16,21 @@ import {
 import type { GoalBarServiceHandle } from './service.ts'
 
 export const GOALBAR_RPC_CHANNEL = '/loopx' as const
+export const GOALBAR_SHARED_API_CHANNEL = '/api' as const
+const GOALBAR_SHARED_API_ENDPOINT = 'loopx.goalbar' as const
+
+interface ConnectionFetchRoute {
+  readonly path: string
+  readonly methods: readonly ['POST']
+  readonly requestBody: 'buffered'
+  readonly fetch: (request: Request) => Promise<Response>
+}
+
+interface SharedApiConnection extends HostConnectionHandle {
+  readonly fetch: {
+    register(route: ConnectionFetchRoute): () => Promise<void>
+  }
+}
 
 type ConnectionRpcResult = Awaited<ReturnType<ConnectionRpcHandler>>
 
@@ -31,6 +47,77 @@ function badRequestCarrier(): ConnectionRpcResult {
 
 function successCarrier(value: GoalBarResponseV1): ConnectionRpcResult {
   return { ok: true, value }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function hasSharedApiFetch(
+  connection: HostConnectionHandle,
+): connection is SharedApiConnection {
+  return Reflect.has(connection, 'fetch')
+}
+
+function responseEnvelope(rpcId: string, result: ConnectionRpcResult): Response {
+  return Response.json({ type: 'server-response', rpcId, result })
+}
+
+function invalidEnvelope(rpcId = 'invalid-request'): Response {
+  return responseEnvelope(rpcId, {
+    ok: false,
+    error: {
+      code: 'bad-request',
+      message: 'invalid client-request message',
+      details: { issues: [] },
+    },
+  })
+}
+
+async function handleSharedApiRequest(
+  request: Request,
+  handler: ConnectionRpcHandler,
+): Promise<Response> {
+  if (request.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase()
+    !== 'application/json') {
+    return new Response('content type must be application/json', { status: 415 })
+  }
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return new Response('body is not JSON', { status: 400 })
+  }
+  const rpcId = isRecord(body) && typeof body.rpcId === 'string'
+    ? body.rpcId
+    : 'invalid-request'
+  if (!isRecord(body)
+    || body.type !== 'client-request'
+    || typeof body.rpcId !== 'string'
+    || body.method !== GOALBAR_SHARED_API_ENDPOINT
+    || !Object.hasOwn(body, 'payload')) {
+    return invalidEnvelope(rpcId)
+  }
+  const op = isRecord(body.payload) ? body.payload.op : undefined
+  if (op !== 'read' && op !== 'watch' && op !== 'start' && op !== 'pause') {
+    return responseEnvelope(rpcId, badRequestCarrier())
+  }
+  const endpoint = endpointForGoalBarOp(op)
+  try {
+    return responseEnvelope(
+      rpcId,
+      await handler(endpoint, body.payload, request.signal),
+    )
+  } catch {
+    return responseEnvelope(rpcId, {
+      ok: false,
+      error: {
+        code: 'internal',
+        message: 'GoalBar handler failed',
+        details: {},
+      },
+    })
+  }
 }
 
 /**
@@ -67,4 +154,25 @@ export function registerGoalBarConnectionRpc(
     createGoalBarConnectionHandler(service),
     { authority: 'loopback' },
   )
+}
+
+/**
+ * Register GoalBar on the carrier supported by the installed DSH generation.
+ * DSH 0.1.5 owns extension routes inside its authenticated shared `/api`
+ * bridge; earlier compatible releases expose the legacy standalone channel.
+ */
+export function registerGoalBarConnectionTransport(
+  connection: HostConnectionHandle,
+  service: GoalBarServiceHandle,
+): () => Promise<void> {
+  if (!hasSharedApiFetch(connection)) {
+    return registerGoalBarConnectionRpc(connection, service)
+  }
+  const handler = createGoalBarConnectionHandler(service)
+  return connection.fetch.register({
+    path: `${GOALBAR_SHARED_API_CHANNEL}/${GOALBAR_SHARED_API_ENDPOINT}`,
+    methods: ['POST'],
+    requestBody: 'buffered',
+    fetch: request => handleSharedApiRequest(request, handler),
+  })
 }

--- a/packages/dsh-loopx-plugin/src/index.ts
+++ b/packages/dsh-loopx-plugin/src/index.ts
@@ -1,7 +1,7 @@
 import type { Context } from '@deepseek-ai/cordis'
 import type { Agent } from '@deepseek-ai/dsh-agent'
 import {
-  registerGoalBarConnectionRpc,
+  registerGoalBarConnectionTransport,
 } from './goalbar/connection-rpc.ts'
 import { goalBarCoordinator } from './goalbar/events.ts'
 import { createGoalBarService } from './goalbar/service.ts'
@@ -19,7 +19,7 @@ export function apply(ctx: Context): void {
       resolveCommand: signal => resolvePluginLoopXCommand({ signal }),
       warn: message => { ctx.logger.warn(message) },
     })
-    const disposeRpc = registerGoalBarConnectionRpc(ctx.connection, service)
+    const disposeRpc = registerGoalBarConnectionTransport(ctx.connection, service)
     return async () => {
       await service.dispose()
       await disposeRpc()
@@ -46,6 +46,8 @@ export type {
 export {
   createGoalBarConnectionHandler,
   GOALBAR_RPC_CHANNEL,
+  GOALBAR_SHARED_API_CHANNEL,
+  registerGoalBarConnectionTransport,
   registerGoalBarConnectionRpc,
 } from './goalbar/connection-rpc.ts'
 export {

--- a/packages/dsh-loopx-plugin/tests/goalbar-client.spec.tsx
+++ b/packages/dsh-loopx-plugin/tests/goalbar-client.spec.tsx
@@ -921,6 +921,37 @@ describe('GoalBar Connection and registration boundaries', () => {
     )
   })
 
+  it('selects the DSH 0.1.5 shared API endpoint without prose heuristics', async () => {
+    const call = vi.fn((_channel: string, _endpoint: string, payload: unknown) => Promise.resolve({
+      ok: true as const,
+      value: {
+        v: GOALBAR_RESPONSE_VERSION,
+        op: 'read',
+        sessionId: (payload as { sessionId: string }).sessionId,
+        result: {
+          kind: 'hidden',
+          reason: 'binding_missing',
+          baseSessionEventSeq: null,
+          sourceRevision: REVISION_ONE,
+        },
+      },
+    }))
+    const rpc = createGoalBarRpc({ call }, true)
+    const controller = new AbortController()
+    await rpc.read('session-one', controller.signal)
+
+    expect(call).toHaveBeenCalledWith(
+      '/api',
+      'loopx.goalbar',
+      {
+        v: 'loopx_goalbar_request_v2',
+        op: 'read',
+        sessionId: 'session-one',
+      },
+      controller.signal,
+    )
+  })
+
   it('sends the complete V2 watch anchor on the exact watch endpoint', async () => {
     const call = vi.fn((_channel: string, _endpoint: string, payload: unknown) => Promise.resolve({
       ok: true as const,

--- a/packages/dsh-loopx-plugin/tests/goalbar-connection.spec.ts
+++ b/packages/dsh-loopx-plugin/tests/goalbar-connection.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/index.ts'
 import {
   createGoalBarConnectionHandler,
+  registerGoalBarConnectionTransport,
   registerGoalBarConnectionRpc,
 } from '../src/goalbar/connection-rpc.ts'
 import type {
@@ -71,6 +72,38 @@ function connectionCapture(): {
   return { connection, calls, disposed: () => disposeCalls }
 }
 
+function sharedApiConnectionCapture(): {
+  readonly connection: HostConnectionHandle
+  readonly routes: Array<{
+    readonly path: string
+    readonly methods: readonly string[]
+    readonly requestBody: string
+    readonly fetch: (request: Request) => Promise<Response>
+  }>
+  readonly disposed: () => number
+} {
+  const routes: Array<{
+    readonly path: string
+    readonly methods: readonly string[]
+    readonly requestBody: string
+    readonly fetch: (request: Request) => Promise<Response>
+  }> = []
+  let disposeCalls = 0
+  const connection = {
+    rpc: {
+      handle() { throw new Error('DSH 0.1.5 must use shared API Fetch routes') },
+      intercept() { throw new Error('not used') },
+    },
+    fetch: {
+      register(route: typeof routes[number]) {
+        routes.push(route)
+        return async () => { disposeCalls += 1 }
+      },
+    },
+  } as unknown as HostConnectionHandle
+  return { connection, routes, disposed: () => disposeCalls }
+}
+
 describe('GoalBar Connection carrier', () => {
   it('registers the real handler at loopback-only /loopx and returns its disposer', async () => {
     const capture = connectionCapture()
@@ -91,6 +124,46 @@ describe('GoalBar Connection carrier', () => {
       new AbortController().signal,
     )
     expect(result).toEqual({ ok: true, value: readResponse() })
+
+    await dispose()
+    expect(capture.disposed()).toBe(1)
+  })
+
+  it('uses DSH 0.1.5 authenticated shared-API routes without caller WebServer access', async () => {
+    const capture = sharedApiConnectionCapture()
+    const service: GoalBarServiceHandle = {
+      handle: async () => readResponse(),
+      dispose: async () => {},
+    }
+    const dispose = registerGoalBarConnectionTransport(capture.connection, service)
+
+    expect(capture.routes.map(route => route.path)).toEqual([
+      '/api/loopx.goalbar',
+    ])
+    const readRoute = capture.routes[0]
+    expect(readRoute).toMatchObject({
+      methods: ['POST'],
+      requestBody: 'buffered',
+    })
+    const response = await readRoute?.fetch(new Request(
+      'http://dsh.internal/api/loopx.goalbar',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          type: 'client-request',
+          rpcId: 'rpc-shared-api',
+          method: 'loopx.goalbar',
+          payload: readRequest(),
+        }),
+      },
+    ))
+    expect(response?.status).toBe(200)
+    expect(await response?.json()).toEqual({
+      type: 'server-response',
+      rpcId: 'rpc-shared-api',
+      result: { ok: true, value: readResponse() },
+    })
 
     await dispose()
     expect(capture.disposed()).toBe(1)
@@ -210,6 +283,10 @@ describe('GoalBar Connection carrier', () => {
 })
 
 describe('package-root GoalBar Host', () => {
+  it('keeps the package-root dependency set stable across DSH carriers', () => {
+    expect(inject).toEqual(['agents', 'connection', 'loopxBootstrap'])
+  })
+
   it('constructs one real service, registers authority, cancels watch, and disposes', async () => {
     const capture = connectionCapture()
     const session = {
@@ -235,7 +312,6 @@ describe('package-root GoalBar Host', () => {
     } as unknown as Context
 
     expect(name).toBe('dsh-loopx-plugin')
-    expect(inject).toEqual(['agents', 'connection', 'loopxBootstrap'])
     apply(ctx)
     expect(capture.calls[0]).toMatchObject({
       channel: '/loopx', authority: 'loopback',


### PR DESCRIPTION
## Summary

- register GoalBar through DSH 0.1.5's authenticated shared API carrier instead of the generic route path that loses `WebServer` injection under Cordis 4
- select the carrier by typed runtime capabilities while retaining the legacy `/loopx` carrier for supported older DSH releases
- pin a clean-container DSH 0.1.5 regression covering bootstrap, launch-token authentication, and a real GoalBar read; publish the fix as plugin `0.1.1-beta.5`

## Issue Or Task

- Closes #4195
- Contributor task ID: N/A

## Validation

- Tested revision: `ccdd32c1d775b699336f2b6c1a2d2bc626b14552`
- Run state: finished
- Input classes: synthetic, public_fixture

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| `static` | `passed` | `pnpm typecheck`; host, client, and test TypeScript projects passed. |
| `unit` | `passed` | `pnpm test`; 10 files and 184 tests passed, including shared-carrier selection and response-envelope coverage. |
| `real_entrypoint` | `passed` | Packed plugin started under DSH `0.1.5-rc.1`; authenticated web startup, Client serving, shared-API GoalBar read, loopback rejection, teardown, and legacy packed-carrier behavior passed. |
| `regression_parity` | `passed` | The public issue's DSH 0.1.5 `webServer` injection failure reproduced before the fix; the fixed packed runtime passed on DSH 0.1.5, while the supported DSH 0.1.1 legacy profile/runtime path remained green. |
| `integration` | `passed` | `pnpm smoke:peer-range`, `smoke:artifact`, `smoke:profile`, and `smoke:runtime` passed sequentially. |
| `integration` | `passed` | `pnpm smoke:docker` passed in clean Debian with Node 22, DSH `0.1.5-rc.1`, PEP 668 private installation, launch-token authentication, and typed `session_unavailable` GoalBar readback. |
| `static` | `passed` | Public/private scan and `git diff --check` passed. |
| `integration` | `passed` | `loopx canary premerge --from-git-diff --goal-id loopx-meta` passed 16 selected checks with zero failures or manual holds under the supported Node 22/Python 3.11+ toolchain. |

- Coverage and gaps: The changed host/client carriers, old-version parity, package artifacts, real DSH 0.1.5 entrypoint, authentication boundary, and clean installation are covered. The existing owner-reviewed browser-mounted React interaction remains a manual release gate; this fix does not change React behavior or configure a model provider.

See [validation disclosure guidance](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md#validation-disclosure).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

## LoopX Area

- [ ] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [x] Capability or extension (providers, adapters, skills)
- [ ] Public docs or presentation surface (README, protocols, dashboard)
- [x] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [ ] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [x] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: #4195

## Shared-authority RFC fixture impact

N/A. This PR repairs the DSH extension transport and does not change TypeScript control-plane or shared Goal Authority semantics.

## Boundary Checklist

- [x] Neither the diff nor this PR body/comments/attachments disclose private state, credentials, raw traces or verifier output, internal links, or local machine paths (including `.loopx/`, `.codex/goals/`, and live `ACTIVE_GOAL_STATE.md`).
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).
