### PR TITLE
fix(manager): report authorized cross-goal deliveries in Lark

### DIFF
--- a/loopx/capabilities/manager_context/README.md
+++ b/loopx/capabilities/manager_context/README.md
@@ -35,3 +35,35 @@ completion. Later new evidence can generate a new decision through the ordinary
 worker planning workflow; do not overwrite the original receipt. This feature
 adds no periodic automation, forced wakeup, Todo priority or protected-operation
 permission. Existing private inbox records are retained when delivery is revoked.
+
+## Audience-authorized Goal summaries
+
+An external manager's connection anchor is not its entire portfolio. The local
+operator may grant a particular manager audience an explicit list of registered
+Goals, independently of the sender-bound context-delegation targets:
+
+```sh
+loopx manager-inbox configure-read-scope --channel-id manager.external.0123456789abcdef01234567 --read-goal-id project-a --read-goal-id project-b
+loopx manager-inbox configure-read-scope --channel-id manager.external.0123456789abcdef01234567 --read-goal-id project-a --read-goal-id project-b --execute
+```
+
+Use the exact channel identity from the existing manager session. The first
+command is a read-only configuration preview; `--execute` is a trusted local
+operator action, never a manager-generated proposal. Grant only Goal summaries
+that may be visible to everyone in that audience. This does not authorize raw
+private files, trading, mutation, or context delegation. New registered Goals
+are not automatically added. Configure with no `--read-goal-id` to revoke the
+read scope. Existing installations without a grant retain their connection
+scope; removing the field restores that default. Private policy is stored under
+`<runtime>/.local/manager-context/policy.json`, in `sources[channel].evidence_goal_ids`.
+The live connection must still match; disabled, ambiguous or replaced sessions
+cannot use an old grant. Every turn rechecks scope and discards upstream context
+when it changes.
+
+The manager now receives recent Core delivery receipts from the previous local
+calendar day through collection time, separate from current Todo freshness.
+Accounting rows are excluded before the presentation cap. Completed Todo titles
+help explain recorded deliveries; archive coverage and omitted rows are explicit.
+Reported outcomes and evidence-bearing receipts remain distinct, and neither
+means the referenced artifact was inspected. Lark text replies preserve paragraphs
+and use plain-text report formatting.

--- a/loopx/capabilities/manager_context/__init__.py
+++ b/loopx/capabilities/manager_context/__init__.py
@@ -327,3 +327,56 @@ def turn_start_hook(
             "ordering": "before_work",
         },
     )
+
+
+def evidence_goal_scope(runtime_root: Path, channel: str) -> list[str] | None:
+    """Audience-wide read grant; absent preserves the existing connection scope.
+
+    Separate from sender-bound context delivery targets. An explicit empty grant
+    revokes access. Malformed policy fails closed, never widens to the registry.
+    """
+    path = _root(runtime_root) / "policy.json"
+    if not path.exists():
+        return None
+    try:
+        policy = _read(path)
+        if policy.get("schema_version") != POLICY_SCHEMA:
+            return []
+        source = policy.get("sources", {}).get(channel, {})
+        if "evidence_goal_ids" not in source:
+            return None
+        ids = source["evidence_goal_ids"]
+        if not isinstance(ids, list) or any(
+            not isinstance(v, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,159}", v)
+            for v in ids
+        ):
+            return []
+        return sorted(set(ids))
+    except (OSError, ValueError, TypeError, AttributeError):
+        return []
+
+
+def configure_evidence_scope(runtime_root: Path, registry_path: Path, *, channel: str,
+                             goal_ids: list[str], execute: bool = False) -> dict:
+    """Local operator grants only selected Goal summaries to an exact audience."""
+    if not re.fullmatch(r"manager\.external\.[a-f0-9]{24}", channel):
+        raise ValueError("an exact external manager channel is required")
+    registry = load_registry(registry_path)
+    available = {g.get("id") for g in registry.get("goals", []) if isinstance(g, dict)}
+    if any(g not in available for g in goal_ids):
+        raise ValueError("every read Goal must be registered")
+    ids = sorted(set(goal_ids))
+    path = _root(runtime_root) / "policy.json"
+    if execute:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with exclusive_file_lock(path.with_suffix(".lock")):
+            policy = _read(path) if path.exists() else {"schema_version": POLICY_SCHEMA, "sources": {}}
+            if policy.get("schema_version") != POLICY_SCHEMA:
+                raise ValueError("invalid manager policy")
+            policy.setdefault("sources", {}).setdefault(channel, {})["evidence_goal_ids"] = ids
+            _write(path, policy)
+        if evidence_goal_scope(runtime_root, channel) != ids:
+            raise ValueError("read scope verification failed")
+    return {"ok": True, "executed": execute, "channel_id": channel,
+            "evidence_goal_ids": ids, "scope": "audience_goal_summaries",
+            "delegation_authority_changed": False}

--- a/loopx/chat_manager.py
+++ b/loopx/chat_manager.py
@@ -20,7 +20,10 @@ MANAGER_AGENT_OBJECTIVE = (
     "Use concrete task titles and short evidence references, not an ID-only inventory. Do not ask the user to perform reads already supplied here. "
     "If a current Todo read is unavailable or truncated, name that exact gap. Historical gate IDs alone are not proof of a current gate. "
     "Do not mistake old plans, quota events or an open record for newly completed work. "
-    "Prefer short paragraphs or bullets to large tables. "
+    "For dated progress reports, inspect recent_delivery_history for every authorized Goal and join todo_id to current_todos.todos and completed_todos for concrete titles. "
+    "Filter by the requested calendar date in the user timezone; distinguish recorded delivery time, actual completion, and independently verified artifacts. "
+    "Do not let a newer delivery hide yesterday's receipts. Report useful recorded outcomes with their verification level, then name exact remaining gaps. "
+    "Prefer short paragraphs or bullets to large tables. For Lark use plain text paragraphs and bullets without Markdown bold, code fences or tables. "
     "Default to intent delegation: for an explicit request to pass context, objectives or constraints to another Agent, use context_handoff "
     "with the exact goal_id and agent_id from the supplied context_delegation catalog. This is already authorized "
     "context delivery, not a Todo proposal: do not ask for another confirmation, set priority, change a plan, "
@@ -74,7 +77,7 @@ def open_manager_session(
     )
 
 
-MANAGER_CONTEXT_VERSION = 3
+MANAGER_CONTEXT_VERSION = 4
 
 
 def manager_model_config() -> dict[str, str]:

--- a/loopx/chat_manager_context.py
+++ b/loopx/chat_manager_context.py
@@ -6,10 +6,12 @@ import hashlib
 import json
 from collections.abc import Callable
 from pathlib import Path
+from datetime import datetime, timezone
 from typing import Any
 
 from .chat_manager import manager_model_config
 from .chat_manager_details import read_manager_goal_details
+from .chat_manager_history import read_manager_delivery_history
 from .goal_portfolio import build_goal_portfolio
 from .chat import redact_local_paths
 
@@ -65,6 +67,7 @@ def manager_turn_context(
         pass
     rows = []
     for row in portfolio.get("goals", []):
+        history = read_manager_delivery_history(runtime_root, row["goal_id"])
         rows.append(
             {
                 "goal_id": row["goal_id"],
@@ -87,8 +90,10 @@ def manager_turn_context(
                     for a in row.get("agents", [])
                 ],
                 "deliveries": row.get("deliveries", []),
+                "recent_delivery_history": history,
                 "current_todos": read_manager_goal_details(
                     registry_path, runtime_root, row["goal_id"], owner_scope=owner_scope,
+                    completed_todo_ids={r["todo_id"] for r in history["deliveries"]},
                 ),
             }
         )
@@ -104,6 +109,11 @@ def manager_turn_context(
         "warnings": portfolio.get("warnings", []),
         "limitations": portfolio.get("limitations", []),
     }
+    result["portfolio_snapshot_id"] = result["snapshot_id"]
+    result["collection_completed_at"] = datetime.now(timezone.utc).isoformat()
+    result["snapshot_id"] = "sha256:" + hashlib.sha256(
+        json.dumps(result, ensure_ascii=False, sort_keys=True).encode()
+    ).hexdigest()
     if not owner_scope:
         result["authorization_scope_id"] = manager_authorization_scope_id(scope or [])
     return result

--- a/loopx/chat_manager_details.py
+++ b/loopx/chat_manager_details.py
@@ -19,7 +19,7 @@ def _text(value: object, limit: int = 420) -> str:
 
 def read_manager_goal_details(
     registry_path: Path, runtime_root: Path, goal_id: str, *, owner_scope: bool,
-    limit: int = 48,
+    limit: int = 48, completed_todo_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     """Use Core's canonical-first read; never parse a private project document."""
     observed_at = datetime.now(timezone.utc).isoformat()
@@ -47,6 +47,8 @@ def read_manager_goal_details(
             if owner_scope:
                 row["continuation"] = _text(record.get("note") or record.get("continuation_hint"), 280)
             rows.append(row)
+        completed = [r for r in records if r.get("status") == "done"
+                     and (completed_todo_ids is None or r.get("todo_id") in completed_todo_ids)]
         revision = "sha256:" + hashlib.sha256(
             json.dumps(records, sort_keys=True, ensure_ascii=False).encode()
         ).hexdigest()
@@ -59,6 +61,19 @@ def read_manager_goal_details(
             "coverage": {"active": len(active), "included": len(rows),
                          "omitted": max(0, len(active) - len(rows))},
             "todos": rows,
+            "completed_todos": [
+                {"todo_id": _text(r.get("todo_id"), 160),
+                 "title": _text(r.get("title") or r.get("text")),
+                 "status": "done"}
+                for r in completed
+            ][-48:],
+            "completed_coverage": {
+                "known": sum(r.get("status") == "done" for r in records),
+                "matched": len(completed),
+                "included": min(48, len(completed)),
+                "omitted": max(0, len(completed) - 48),
+                "archive_read": False,
+            },
             "limitations": [
                 "These are currently declared Todo records, not proof of recent execution or renewed owner intent.",
                 "Run-history age does not invalidate this independent Todo read. Do not infer deadlines from priority or list order.",

--- a/loopx/chat_manager_history.py
+++ b/loopx/chat_manager_history.py
@@ -1,0 +1,128 @@
+"""Recent Core delivery receipts, filtered before presentation limits."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import hashlib
+import json
+from pathlib import Path
+
+from .chat_manager_details import _text
+from .control_plane.runtime.run_context_retention import goal_semantic_history_from_runs
+from .control_plane.work_items.delivery_outcome import PROGRESS_DELIVERY_OUTCOMES
+from .history import STATUS_NEUTRAL_CLASSIFICATIONS, load_index
+
+
+def read_manager_delivery_history(
+    runtime_root: Path, goal_id: str, *, now=None, limit=24
+):
+    now = now or datetime.now().astimezone()
+    start = (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
+    base = {
+        "window_start": start.isoformat(),
+        "window_end": now.isoformat(),
+        "observed_at": datetime.now(timezone.utc).isoformat(),
+        "deliveries": [],
+    }
+    try:
+        if not path.is_file():
+            raise OSError("missing Core run index")
+        before = path.stat()
+        runs, raw_count = load_index(path)
+        after = path.stat()
+
+        def signature(st):
+            return (st.st_dev, st.st_ino, st.st_size, st.st_mtime_ns)
+
+        if signature(before) != signature(after):
+            return {
+                **base,
+                "status": "conflicting",
+                "coverage": {"matched": None, "included": 0, "omitted": None},
+            }
+
+        rows = []
+        invalid = 0
+        for run in runs:
+            if run.get("classification") in STATUS_NEUTRAL_CLASSIFICATIONS:
+                continue
+            if run.get("delivery_outcome") not in PROGRESS_DELIVERY_OUTCOMES:
+                continue
+            try:
+                at = datetime.fromisoformat(
+                    str(run.get("generated_at")).replace("Z", "+00:00")
+                )
+                if at.tzinfo is None:
+                    raise ValueError("timestamp has no offset")
+            except ValueError:
+                invalid += 1
+                continue
+            if not start <= at <= now:
+                continue
+            if run.get("goal_id") not in (None, goal_id):
+                invalid += 1
+                continue
+            semantic = goal_semantic_history_from_runs([run])
+            evidence = any(
+                a.get("latest_evidence_delivery_run") for a in semantic["agents"]
+            )
+            observation = run.get("progress_observation") or {}
+            rows.append(
+                {
+                    "recorded_at": at.isoformat(),
+                    "goal_id": goal_id,
+                    "agent_id": _text(run.get("agent_id"), 160),
+                    "todo_id": _text(run.get("todo_id"), 160),
+                    "classification": _text(run.get("classification"), 200),
+                    "reported_follow_up": _text(run.get("recommended_action"), 360),
+                    "outcome": run["delivery_outcome"],
+                    "verification": "core_recorded_evidence_refs"
+                    if evidence
+                    else "agent_reported_outcome",
+                    "evidence_count": len(observation.get("evidence_ids") or []),
+                    "source_ref": "sha256:"
+                    + hashlib.sha256(
+                        json.dumps(run, sort_keys=True).encode()
+                    ).hexdigest(),
+                }
+            )
+        rows.sort(key=lambda r: datetime.fromisoformat(r["recorded_at"]), reverse=True)
+        included = []
+        day_counts = {}
+        for row in rows:
+            day = (
+                datetime.fromisoformat(row["recorded_at"])
+                .astimezone(now.tzinfo)
+                .date()
+                .isoformat()
+            )
+            day_counts[day] = day_counts.get(day, 0) + 1
+            if day_counts[day] <= limit:
+                included.append(row)
+        return {
+            **base,
+            "status": "read",
+            "source_revision": "sha256:"
+            + hashlib.sha256(str(signature(after)).encode()).hexdigest(),
+            "deliveries": included,
+            "coverage": {
+                "index_records": raw_count,
+                "matched": len(rows),
+                "included": len(included),
+                "omitted": len(rows) - len(included),
+                "matched_by_day": day_counts,
+                "limit_per_day": limit,
+                "invalid_delivery_records": invalid,
+            },
+            "limitations": [
+                "Recorded time is not necessarily work time. Agent-reported outcomes are not independent verification.",
+                "Evidence references identify receipts; referenced artifacts have not been read.",
+            ],
+        }
+    except (OSError, ValueError, TypeError, KeyError):
+        return {
+            **base,
+            "status": "unavailable",
+            "coverage": {"matched": None, "included": 0, "omitted": None},
+        }

--- a/loopx/chat_server.py
+++ b/loopx/chat_server.py
@@ -1465,7 +1465,7 @@ def serve_chat(
         manager_scope_resolver=lambda session: authorized_manager_goal_ids(
             build_lark_goal_topic_runtime_snapshot(
                 registry_path=server.registry_path, runtime_root_override=server.runtime_root_override,
-            ), session,
+            ), session, runtime_root=runtime_root,
         ),
         codex_bin=codex_bin,
         claude_bin=claude_bin,

--- a/loopx/cli_commands/manager_inbox.py
+++ b/loopx/cli_commands/manager_inbox.py
@@ -3,7 +3,11 @@
 import json
 from ..agent_registry import registered_agent_ids_for_goal
 from ..history import load_registry
-from ..capabilities.manager_context import acknowledge, pending
+from ..capabilities.manager_context import (
+    acknowledge,
+    pending,
+    configure_evidence_scope,
+)
 
 
 def register_manager_inbox(subparsers, add_format):
@@ -12,9 +16,14 @@ def register_manager_inbox(subparsers, add_format):
         help="Read context handed to an Agent and record its replan decision.",
     )
     add_format(parser)
-    parser.add_argument("manager_inbox_action", choices=("read", "acknowledge"))
-    parser.add_argument("--goal-id", required=True)
-    parser.add_argument("--agent-id", required=True)
+    parser.add_argument(
+        "manager_inbox_action", choices=("read", "acknowledge", "configure-read-scope")
+    )
+    parser.add_argument("--goal-id")
+    parser.add_argument("--agent-id")
+    parser.add_argument("--channel-id")
+    parser.add_argument("--read-goal-id", action="append", default=[])
+    parser.add_argument("--execute", action="store_true")
     parser.add_argument("--request-id")
     parser.add_argument("--decision", choices=("adopt", "defer", "reject", "no_change"))
     parser.add_argument("--reason")
@@ -22,6 +31,16 @@ def register_manager_inbox(subparsers, add_format):
 
 def handle_manager_inbox(args, registry_path, runtime_root):
     try:
+        if args.manager_inbox_action == "configure-read-scope":
+            result = configure_evidence_scope(
+                runtime_root,
+                registry_path,
+                channel=args.channel_id or "",
+                goal_ids=args.read_goal_id,
+                execute=args.execute,
+            )
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
         registry = load_registry(registry_path)
         goal = next(
             (g for g in registry.get("goals", []) if g.get("id") == args.goal_id), None

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -1034,15 +1034,13 @@ def process_lark_goal_topic_event(
     connector = connector if isinstance(connector, Mapping) else None
     effect_receipt: Mapping[str, Any] | None = None
     if isinstance(answer_result, Mapping):
-        reply_text = " ".join(str(answer_result.get("response_text") or "").split())[
-            :1200
-        ]
+        reply_text = str(answer_result.get("response_text") or "").strip()[:6000]
         candidate_receipt = answer_result.get("effect_receipt")
         effect_receipt = (
             candidate_receipt if isinstance(candidate_receipt, Mapping) else None
         )
     else:
-        reply_text = " ".join(str(answer_result or "").split())[:1200]
+        reply_text = str(answer_result or "").strip()[:6000]
     if not reply_text:
         return {
             "ok": False,

--- a/loopx/extensions/lark/manager_routing.py
+++ b/loopx/extensions/lark/manager_routing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import Any
+from pathlib import Path
 
 from ...chat_manager import manager_channel
 from ..external_connector_runtime import project_external_connector_status
@@ -128,7 +129,7 @@ def _valid_manager_binding(goal_id, binding, routing) -> bool:
 
 
 def authorized_manager_goal_ids(
-    snapshot: Mapping[str, Any], session: Mapping[str, Any]
+    snapshot: Mapping[str, Any], session: Mapping[str, Any], *, runtime_root: Path | None = None
 ) -> list[str]:
     """Resolve current external read authority; a session's old Goal is not a grant."""
     candidates = []
@@ -168,4 +169,9 @@ def authorized_manager_goal_ids(
         or not _valid_manager_binding(goal_id, binding, routing)
     ):
         return []
+    if runtime_root is not None:
+        from ...capabilities.manager_context import evidence_goal_scope
+        grant = evidence_goal_scope(runtime_root, str(session.get("channel_id") or ""))
+        if grant is not None:
+            return grant
     return [goal_id]

--- a/tests/extensions/test_lark_goal_topic_connections.py
+++ b/tests/extensions/test_lark_goal_topic_connections.py
@@ -2861,3 +2861,23 @@ def test_manager_read_scope_follows_live_authorized_connection(tmp_path, mutatio
     assert authorized_manager_goal_ids(snapshot, session) == (
         ["goal-alpha"] if mutation == "none" else []
     )
+
+
+def test_manager_explicit_audience_scope_still_requires_live_binding(tmp_path):
+    import json
+    from loopx.extensions.lark.manager_routing import authorized_manager_goal_ids
+    from loopx.capabilities.manager_context import POLICY_SCHEMA
+    kwargs, _state, bindings = _manager_fixture(tmp_path)
+    targets = read_goal_channel_targets(kwargs["target_path"])
+    route = decide_lark_topic_event(target_payload=targets,
+        binding_payloads={"goal-alpha": bindings},
+        event={"chat_id":CHAT_ID,"message_id":"om_scope_multi","mentions":[{"id":APP_ID}]})["route"]
+    session = {"session_id":"manager-session","agent_id":"codex","channel_id":route["manager_channel_id"]}
+    snapshot = {"target_payload":targets,"binding_payloads":{"goal-alpha":bindings}}
+    path=tmp_path/'.local'/'manager-context'/'policy.json'
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"schema_version":POLICY_SCHEMA,"sources":{
+        session['channel_id']:{'evidence_goal_ids':['goal-alpha','goal-beta']}}}))
+    assert authorized_manager_goal_ids(snapshot,session,runtime_root=tmp_path)==['goal-alpha','goal-beta']
+    session['session_id']='different-session'
+    assert authorized_manager_goal_ids(snapshot,session,runtime_root=tmp_path)==[]

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -298,7 +298,7 @@ def test_agent_session_topic_acks_after_effect_and_verified_reply(
     def answer(route: dict[str, Any], _text: str) -> dict[str, Any]:
         assert route["event_id"] == "evt_effect_committed"
         return {
-            "response_text": "work completed",
+            "response_text": "work completed\n\n• Evidence verified\n• Next step recorded",
             "effect_receipt": {
                 "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
                 "event_id": route["event_id"],
@@ -325,7 +325,7 @@ def test_agent_session_topic_acks_after_effect_and_verified_reply(
 
     assert result["ok"] is True
     assert result["status"] == "replied_and_acknowledged", result
-    assert state["reply_text"] == "work completed"
+    assert state["reply_text"] == "work completed\n\n• Evidence verified\n• Next step recorded"
     projection = inspect_lark_event_inbox(
         project=tmp_path / "runtime",
         config_path=Path(result["inbox_config_ref"]),

--- a/tests/test_chat_manager_details.py
+++ b/tests/test_chat_manager_details.py
@@ -21,7 +21,8 @@ def test_current_owner_decision_keeps_task_meaning_and_relation(monkeypatch, tmp
     assert result['todos'][0]['title'] == 'Approve the launch copy'
     assert result['todos'][0]['unblocks_todo_id'] == 'todo_work'
     assert result['todos'][1]['title'] == 'Publish the reviewed launch packet'
-    assert 'todo_closed' not in str(result)
+    assert result['completed_todos'][0]['todo_id'] == 'todo_closed'
+    assert all(r['todo_id'] != 'todo_closed' for r in result['todos'])
     external = details.read_manager_goal_details(tmp_path/'r', tmp_path, 'alpha', owner_scope=False, limit=1)
     assert external['coverage']['omitted'] == 1
     assert 'continuation' not in external['todos'][0]

--- a/tests/test_chat_manager_report.py
+++ b/tests/test_chat_manager_report.py
@@ -1,0 +1,138 @@
+import json
+from datetime import datetime, timezone
+
+from loopx.chat_manager_history import read_manager_delivery_history
+from loopx.capabilities.manager_context import evidence_goal_scope, POLICY_SCHEMA
+
+
+def test_filter_delivery_window_before_cap_and_exclude_accounting(tmp_path):
+    p = tmp_path / "goals" / "alpha" / "runs" / "index.jsonl"
+    p.parent.mkdir(parents=True)
+    rows = [
+        {
+            "generated_at": "2026-01-01T12:00:00+00:00",
+            "goal_id": "alpha",
+            "agent_id": "worker",
+            "todo_id": "todo_ship",
+            "classification": "released",
+            "delivery_outcome": "outcome_progress",
+        }
+    ]
+    rows += [
+        {
+            "generated_at": f"2026-01-02T01:{i:02}:00+00:00",
+            "classification": "quota_slot_spent",
+            "delivery_outcome": "surface_only",
+        }
+        for i in range(50)
+    ]
+    p.write_text("\n".join(json.dumps(r) for r in rows))
+    x = read_manager_delivery_history(
+        tmp_path, "alpha", now=datetime(2026, 1, 2, 2, tzinfo=timezone.utc), limit=1
+    )
+    assert x["coverage"]["matched"] == 1
+    assert x["deliveries"][0]["todo_id"] == "todo_ship"
+    assert x["deliveries"][0]["verification"] == "agent_reported_outcome"
+
+
+def test_missing_history_and_invalid_time_are_not_zero_progress(tmp_path):
+    assert read_manager_delivery_history(tmp_path, "alpha")["status"] == "unavailable"
+    p = tmp_path / "goals" / "alpha" / "runs" / "index.jsonl"
+    p.parent.mkdir(parents=True)
+    p.write_text(
+        json.dumps(
+            {"generated_at": "yesterday", "delivery_outcome": "outcome_progress"}
+        )
+    )
+    x = read_manager_delivery_history(tmp_path, "alpha")
+    assert x["coverage"]["invalid_delivery_records"] == 1
+
+
+def test_audience_read_grant_is_distinct_from_delegation_and_revocable(tmp_path):
+    assert evidence_goal_scope(tmp_path, "manager.external.test") is None
+    p = tmp_path / ".local" / "manager-context" / "policy.json"
+    p.parent.mkdir(parents=True)
+    source = {
+        "sender_ids": ["owner"],
+        "targets": [{"goal_id": "private", "agent_id": "worker"}],
+    }
+
+    def write():
+        p.write_text(
+            json.dumps(
+                {
+                    "schema_version": POLICY_SCHEMA,
+                    "sources": {"manager.external.test": source},
+                }
+            )
+        )
+
+    write()
+    assert evidence_goal_scope(tmp_path, "manager.external.test") is None
+    source["evidence_goal_ids"] = ["beta", "alpha"]
+    write()
+    assert evidence_goal_scope(tmp_path, "manager.external.test") == ["alpha", "beta"]
+    source["evidence_goal_ids"] = []
+    write()
+    assert evidence_goal_scope(tmp_path, "manager.external.test") == []
+    source["evidence_goal_ids"] = ["*"]
+    write()
+    assert evidence_goal_scope(tmp_path, "manager.external.test") == []
+    assert evidence_goal_scope(tmp_path, "manager.external.other") is None
+
+
+def test_new_day_does_not_evict_previous_day(tmp_path):
+    p = tmp_path / "goals" / "alpha" / "runs" / "index.jsonl"
+    p.parent.mkdir(parents=True)
+    rows = [
+        {
+            "generated_at": at,
+            "delivery_outcome": "outcome_progress",
+            "agent_id": "worker",
+        }
+        for at in [
+            "2026-01-01T12:00:00+00:00",
+            "2026-01-02T01:00:00+00:00",
+            "2026-01-02T02:00:00+00:00",
+        ]
+    ]
+    p.write_text("\n".join(json.dumps(r) for r in rows))
+    x = read_manager_delivery_history(
+        tmp_path, "alpha", now=datetime(2026, 1, 2, 3, tzinfo=timezone.utc), limit=1
+    )
+    assert x["coverage"]["included"] == 2
+    assert x["coverage"]["omitted"] == 1
+    assert any(r["recorded_at"].startswith("2026-01-01") for r in x["deliveries"])
+
+
+def test_local_scope_configuration_validates_goals_and_preserves_targets(tmp_path):
+    import pytest
+    from loopx.capabilities.manager_context import configure_evidence_scope
+
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps({"goals": [{"id": "alpha"}]}))
+    channel = "manager.external." + "a" * 24
+    path = tmp_path / ".local" / "manager-context" / "policy.json"
+    preview = configure_evidence_scope(
+        tmp_path, registry, channel=channel, goal_ids=["alpha"]
+    )
+    assert preview["executed"] is False and not path.exists()
+    with pytest.raises(ValueError):
+        configure_evidence_scope(
+            tmp_path, registry, channel=channel, goal_ids=["unknown"], execute=True
+        )
+    configure_evidence_scope(
+        tmp_path, registry, channel=channel, goal_ids=["alpha"], execute=True
+    )
+    assert evidence_goal_scope(tmp_path, channel) == ["alpha"]
+    config = json.loads(path.read_text())
+    config["sources"][channel]["targets"] = [{"goal_id": "alpha", "agent_id": "worker"}]
+    path.write_text(json.dumps(config))
+    configure_evidence_scope(
+        tmp_path, registry, channel=channel, goal_ids=[], execute=True
+    )
+    assert evidence_goal_scope(tmp_path, channel) == []
+    assert (
+        json.loads(path.read_text())["sources"][channel]["targets"]
+        == config["sources"][channel]["targets"]
+    )


### PR DESCRIPTION
An external manager answering a cross-Goal daily report could see only its connection anchor, active Todos and the latest delivery. Yesterday's work therefore disappeared, while the Lark adapter flattened the remaining answer into one truncated paragraph.

This change adds an explicit, revocable audience read scope through the existing manager-context policy and local CLI. Live connection identity and per-turn authorization checks remain required; existing installations retain their anchor scope. Read grants do not grant delegation, mutation or access to private source files.

Manager evidence now includes recent Core delivery receipts, filtered before a per-calendar-day cap, plus completed Todo titles referenced by those receipts. Missing history, omitted rows, reported outcomes and uninspected artifact references remain explicit. Default manager instructions explain dated reporting, and Lark text replies preserve paragraphs.

Validation: 132 focused manager-context, authorization, Todo and Lark runtime tests passed; Chat runtime HTTP/restart smoke, Ruff and diff/public-boundary checks passed. A read-only local qualification exercised the real registered Core sources and live audience binding. No private qualification data is included.

Design/risk: reuse canonical Core reads and the existing capability policy rather than introduce a second progress store. The new grant is opt-in and exact-audience; malformed/revoked grants fail closed, another session cannot reuse a grant, and write-only delegation targets do not imply read authority. The report window is the previous host-local calendar day through collection time. Receipt time is not proof of completion time, archived Todo bodies and referenced artifacts are not read, and this does not claim independent artifact verification.
