### PR TITLE
docs(dsh): require marketplace release handoff

### DIFF
--- a/packages/dsh-loopx-plugin/README.md
+++ b/packages/dsh-loopx-plugin/README.md
@@ -130,6 +130,35 @@ token authentication, and an authenticated GoalBar read through DSH's shared
 API carrier. It requires Docker, `uv`, and network access for base images and
 never opens a browser or configures a model provider.
 
+## Maintainer release and marketplace handoff
+
+A DSH plugin release is complete only after its immutable GitHub asset exists
+and an update pull request has been opened against the upstream
+[`awesome-dsh-plugin`](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
+marketplace. Marketplace maintainers retain merge authority; publishing a
+LoopX release does not grant authority over that catalog.
+
+For every DSH plugin release:
+
+1. Update the package version and this README's pinned install URL. Run the
+   typecheck, tests, and the built, packed, runtime, profile, and Docker smokes
+   listed above.
+2. Prepare complete bilingual GitHub release notes. Run
+   `examples/release/release-readiness-doc-smoke.py` with one `--surface` for
+   every optional capability changed by the release.
+3. Merge the exact reviewed commit, pack from that immutable tag target, and
+   publish both the version tag and `dsh-loopx-plugin-<version>.tgz` asset.
+4. Read the remote release body back and rerun the release-readiness smoke.
+   Download the remote asset and verify that its SHA-256 matches the local
+   package before advertising it.
+5. In a clean fork branch of `awesome-dsh-plugin`, update only
+   `data/plugins/huangruiteng__loopx--packages-dsh-loopx-plugin.yml` to the new
+   immutable asset URL. Confirm the URL resolves, then run
+   `node scripts/generate-readme.mjs --check` and `git diff --check`.
+6. Open an upstream marketplace pull request and link it from the release
+   closeout. Do not describe the release as marketplace-published until that
+   pull request is merged by the upstream maintainers.
+
 ## Shadow observer (default off)
 
 `src/observer.ts`, exported as `dsh-loopx-plugin/observer`, is the


### PR DESCRIPTION
## Summary

- define the DSH plugin release-to-marketplace handoff as a maintainer requirement
- require remote release-body and asset readback before advertising a release
- name the canonical upstream marketplace row and its validation commands
- preserve upstream marketplace maintainers as the merge authority

## Why

The DSH plugin had an established marketplace submission history, but the handoff was not part of the durable package release flow. This made a successful GitHub release easy to mistake for completed marketplace publication.

## Validation

- DSH quality phase: typecheck, 184 tests, peer-range smoke
- DSH package phase: build, artifact smoke, profile smoke
- DSH runtime phase: packed GoalBar runtime and lifecycle smoke
- public/private boundary scan
- `git diff --check`
- `loopx canary premerge --from-git-diff --goal-id loopx-meta`: 16 selected, 0 failures, 0 holds (supported Node 24 / Python 3.12 toolchain)
- change-quality receipt: `cqr_33fa4d7b99977a20592b`

Future-facing refactor pass: no code abstraction was needed. The package README is the narrow existing owner for the release instructions, so this change adds one checklist without a new workflow or schema.
