### PR TITLE
fix(manager): retain concrete Core findings in progress reports

### DIFF
--- a/docs/reference/protocols/manager-evidence-and-continuity-v0.md
+++ b/docs/reference/protocols/manager-evidence-and-continuity-v0.md
@@ -92,6 +92,18 @@ unknown. Collection is capped at 128 Goals and eight agents per Goal, with
 explicit omissions. Recorded evidence references identify Core receipts, not
 independent artifact verification.
 
+Each dated delivery now includes bounded `recorded_details` from the same Core
+run index: the Agent's checkpoint explanation, observed reality, path outcome,
+result class, probe kind and surface identity. Missing, malformed and truncated
+fields are explicit. Evidence identifiers are hashed into stable lineage refs,
+with included/omitted counts; they are not artifact access capabilities.
+The manager should explain these concrete recorded findings and counterevidence,
+joined to the task title, rather than return only receipt IDs and future plans.
+These facts retain `recorded_claim_not_independent_verification` and
+`artifact_read_status=not_read`. No repository, arbitrary path, URL or transcript
+reader is added. Existing owner/external scope checks and snapshot identity
+cover this hydration; there is no second progress store or extra history scan.
+
 ## A bounded portfolio with explicit coverage
 
 Discover Goals from the authorized registry inventory, including unavailable

--- a/loopx/chat_manager.py
+++ b/loopx/chat_manager.py
@@ -23,6 +23,10 @@ MANAGER_AGENT_OBJECTIVE = (
     "For dated progress reports, inspect recent_delivery_history for every authorized Goal and join todo_id to current_todos.todos and completed_todos for concrete titles. "
     "Filter by the requested calendar date in the user timezone; distinguish recorded delivery time, actual completion, and independently verified artifacts. "
     "Do not let a newer delivery hide yesterday's receipts. Report useful recorded outcomes with their verification level, then name exact remaining gaps. "
+    "Read each delivery's recorded_details: checkpoint_reason and observed_reality describe recorded findings, while result_class and probe_kind describe the reported validation. "
+    "Synthesize concrete results and counterevidence across receipts; do not replace them with counts, IDs, follow-up plans, or generic missing-evidence disclaimers. "
+    "A checkpoint reason is an Agent's explanation, not independent proof. Respect field_coverage and evidence_coverage; hashed evidence refs are lineage, not fetchable artifacts. "
+    "When artifact_read_status is not_read, distinguish the useful recorded finding from verification still missing instead of discarding the finding. "
     "Prefer short paragraphs or bullets to large tables. For Lark use plain text paragraphs and bullets without Markdown bold, code fences or tables. "
     "Default to intent delegation: for an explicit request to pass context, objectives or constraints to another Agent, use context_handoff "
     "with the exact goal_id and agent_id from the supplied context_delegation catalog. This is already authorized "
@@ -77,7 +81,7 @@ def open_manager_session(
     )
 
 
-MANAGER_CONTEXT_VERSION = 4
+MANAGER_CONTEXT_VERSION = 5
 
 
 def manager_model_config() -> dict[str, str]:

--- a/loopx/chat_manager_history.py
+++ b/loopx/chat_manager_history.py
@@ -13,6 +13,65 @@ from .control_plane.work_items.delivery_outcome import PROGRESS_DELIVERY_OUTCOME
 from .history import STATUS_NEUTRAL_CLASSIFICATIONS, load_index
 
 
+def _recorded_details(run):
+    """Hydrate existing Core fields; never dereference artifact paths or URLs."""
+    observation = run.get("progress_observation")
+    checkpoint = run.get("vision_checkpoint")
+    vision = run.get("agent_vision")
+    observation = observation if isinstance(observation, dict) else {}
+    checkpoint = checkpoint if isinstance(checkpoint, dict) else {}
+    vision = vision if isinstance(vision, dict) else {}
+    delta = vision.get("path_delta")
+    delta = delta if isinstance(delta, dict) else {}
+    fields = {
+        "checkpoint_reason": (checkpoint.get("unchanged_reason"), 600),
+        "observed_reality": (delta.get("observed_reality"), 420),
+        "path_outcome": (delta.get("outcome"), 40),
+        "result_class": (observation.get("result_class"), 80),
+        "probe_kind": (observation.get("probe_kind"), 160),
+        "surface_id": (observation.get("surface_id"), 160),
+    }
+    values = {
+        key: _text(value, limit)
+        for key, (value, limit) in fields.items()
+        if isinstance(value, str) and value.strip()
+    }
+    evidence = observation.get("evidence_ids")
+    valid_evidence = isinstance(evidence, list) and all(
+        isinstance(item, str) and item.strip() for item in evidence
+    )
+    # Stable references preserve lineage without exposing file locations or
+    # treating arbitrary evidence identifiers as fetch instructions.
+    refs = [
+        "sha256:" + hashlib.sha256(item.encode()).hexdigest()
+        for item in evidence[:8]
+    ] if valid_evidence else []
+    return {
+        "source": "core_run_index",
+        "verification": "recorded_claim_not_independent_verification",
+        "artifact_read_status": "not_read",
+        **values,
+        "field_coverage": {
+            "missing": [key for key in fields if key not in values],
+            "truncated": [
+                key for key, (value, limit) in fields.items()
+                if isinstance(value, str) and len(value.strip()) > limit
+            ],
+            "invalid": [
+                key for key, (value, _) in fields.items()
+                if value is not None and not isinstance(value, str)
+            ],
+        },
+        "evidence_refs": refs,
+        "evidence_coverage": {
+            "status": "read" if valid_evidence else "missing_or_invalid",
+            "known": len(evidence) if valid_evidence else None,
+            "included": len(refs),
+            "omitted": max(0, len(evidence) - len(refs)) if valid_evidence else None,
+        },
+    }
+
+
 def read_manager_delivery_history(
     runtime_root: Path, goal_id: str, *, now=None, limit=24
 ):
@@ -67,7 +126,7 @@ def read_manager_delivery_history(
             evidence = any(
                 a.get("latest_evidence_delivery_run") for a in semantic["agents"]
             )
-            observation = run.get("progress_observation") or {}
+            details = _recorded_details(run)
             rows.append(
                 {
                     "recorded_at": at.isoformat(),
@@ -80,7 +139,8 @@ def read_manager_delivery_history(
                     "verification": "core_recorded_evidence_refs"
                     if evidence
                     else "agent_reported_outcome",
-                    "evidence_count": len(observation.get("evidence_ids") or []),
+                    "recorded_details": details,
+                    "evidence_count": details["evidence_coverage"]["known"],
                     "source_ref": "sha256:"
                     + hashlib.sha256(
                         json.dumps(run, sort_keys=True).encode()

--- a/tests/test_chat_manager_report.py
+++ b/tests/test_chat_manager_report.py
@@ -105,6 +105,59 @@ def test_new_day_does_not_evict_previous_day(tmp_path):
     assert any(r["recorded_at"].startswith("2026-01-01") for r in x["deliveries"])
 
 
+def test_report_retains_concrete_findings_without_fetching_artifacts(tmp_path):
+    p = tmp_path / "goals" / "alpha" / "runs" / "index.jsonl"
+    p.parent.mkdir(parents=True)
+    row = {
+        "generated_at": "2026-01-01T12:00:00+00:00",
+        "goal_id": "alpha", "agent_id": "worker", "todo_id": "todo_check",
+        "classification": "comparison_validated",
+        "delivery_outcome": "outcome_progress",
+        "json_path": str(tmp_path / "must-not-read.json"),
+        "vision_checkpoint": {"unchanged_reason": "The new result disproves the initial assumption."},
+        "agent_vision": {"path_delta": {
+            "outcome": "replan", "observed_reality": "Two controls passed; the third remained inconclusive."
+        }},
+        "progress_observation": {
+            "result_class": "advanced", "probe_kind": "paired-control",
+            "surface_id": "comparison",
+            "evidence_ids": [str(tmp_path / "private-artifact")] * 10,
+        },
+    }
+    p.write_text(json.dumps(row))
+    result = read_manager_delivery_history(
+        tmp_path, "alpha", now=datetime(2026, 1, 2, 3, tzinfo=timezone.utc)
+    )
+    detail = result["deliveries"][0]["recorded_details"]
+    assert detail["checkpoint_reason"] == row["vision_checkpoint"]["unchanged_reason"]
+    assert detail["observed_reality"].startswith("Two controls passed")
+    assert detail["probe_kind"] == "paired-control"
+    assert detail["verification"] == "recorded_claim_not_independent_verification"
+    assert detail["artifact_read_status"] == "not_read"
+    assert detail["evidence_coverage"] == {"status": "read", "known": 10, "included": 8, "omitted": 2}
+    assert all(ref.startswith("sha256:") for ref in detail["evidence_refs"])
+    assert "private-artifact" not in json.dumps(result)
+    assert "must-not-read" not in json.dumps(result)
+
+
+def test_detail_missing_invalid_truncated_and_redacted_are_explicit():
+    from loopx.chat_manager_history import _recorded_details
+
+    detail = _recorded_details({
+        "vision_checkpoint": {"unchanged_reason": "x" * 1000},
+        "agent_vision": {"path_delta": {"observed_reality": {"unexpected": "payload"}}},
+        "progress_observation": {"evidence_ids": "not-a-list", "probe_kind": "api_key=private-value"},
+    })
+    assert detail["field_coverage"]["truncated"] == ["checkpoint_reason"]
+    assert detail["field_coverage"]["invalid"] == ["observed_reality"]
+    assert "result_class" in detail["field_coverage"]["missing"]
+    assert "private-value" not in json.dumps(detail)
+    assert "unexpected" not in json.dumps(detail)
+    assert detail["evidence_coverage"]["known"] is None
+    assert detail["evidence_refs"] == []
+    assert _recorded_details({})["field_coverage"]["missing"]
+
+
 def test_local_scope_configuration_validates_goals_and_preserves_targets(tmp_path):
     import pytest
     from loopx.capabilities.manager_context import configure_evidence_scope


### PR DESCRIPTION
Manager reports could list delivery identities and follow-up plans while omitting concrete findings already stored in Core. Supply bounded checkpoint explanations, observed reality, result/probe fields and opaque evidence lineage from the existing authorized run-index read; update the default manager instructions to explain those findings with their verification limits.

The change stays in the built-in manager projection. It adds no artifact reader, filesystem access, new capability, or authority store. Existing scope/revocation and snapshot boundaries remain in place. Missing, invalid and truncated fields remain explicit; recorded claims never imply independent artifact verification. Existing managed sessions migrate to the updated instructions.

Validation: 64 focused tests covering manager context/history, Todo details, portfolio, delegation, Lark API and Codex-home isolation; Chat HTTP and runtime/restart smokes; Ruff and diff checks; four-path public-boundary scan. Read-only integration against three registered Goals confirmed concrete findings are present while artifacts remain marked unread. The contract check passed with three pre-existing registry/history warnings outside this diff.

This is a risk-based premerge set for the changed presentation, session migration and scope surfaces. No trading or state-transition semantics change. Live installed-model and fresh external-entry qualification remain rollout checks. The adjacent refactor is intentionally small: one private projection helper reuses the existing scan rather than adding a parallel receipt store or reader.
