### PR TITLE
fix(lark): deliver manager terminal failure receipts

### DIFF
--- a/loopx/extensions/lark/README.md
+++ b/loopx/extensions/lark/README.md
@@ -351,7 +351,13 @@ recorded separately from its logical identity.
 A manager connection uses `conversation_kind=manager`. Preview has no session
 creation side effect. On apply, the Chat service opens or resumes the manager's
 exact audience session and binds `session_queue`; delivery waits for that turn
-and its verified reply, without waiting for a scheduled Agent wakeup. Group-root
+and its verified reply, without waiting for a scheduled Agent wakeup. When a
+manager Turn ends in a persisted failure, the same verified-reply path sends a
+bounded failure notice before acknowledging the source. Unknown upstream
+details are not copied into the group. The connection keeps its processing
+failure state; delivery of that notice is not a successful model answer.
+An unverified outbound notice leaves the source pending, and a verified notice
+prevents duplicate source events from replaying the failed request. Group-root
 mentions and addressed replies can reach the manager without an invented Topic
 root. Exact worker Topics retain their own routing, and ambiguous manager
 bindings fail closed.

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -45,6 +45,34 @@ ProcessFactory = Callable[[list[str]], Any]
 HealthSink = Callable[[Mapping[str, Any]], None]
 
 
+class LarkGoalTopicTurnFailed(RuntimeError):
+    """A terminal runtime receipt, without copying arbitrary upstream details."""
+
+    def __init__(self, error_code: str, effect_receipt: Mapping[str, Any]) -> None:
+        super().__init__("Lark Goal Topic turn did not complete")
+        self.error_code = error_code
+        self.effect_receipt = effect_receipt
+
+
+def _manager_failure_reply(error: Exception) -> tuple[str, str]:
+    labels = {
+        "cyber_policy": "上游安全策略拦截",
+        "misalignment_policy_violation": "上游策略拦截",
+        "usage_limit_exceeded": "上游用量限制",
+        "rate_limit_exceeded": "上游请求频率限制",
+        "context_window_exceeded": "上下文超限",
+        "unauthorized": "上游身份验证失败",
+        "idle_timeout": "等待上游响应超时",
+        "hard_timeout": "处理超过时间限制",
+        "interrupted": "处理已中断",
+        "manager_authorization_unavailable": "当前连接的授权范围不可用",
+    }
+    raw_code = error.error_code if isinstance(error, LarkGoalTopicTurnFailed) else ""
+    code = raw_code if raw_code in labels else "processing_failed"
+    label = labels.get(code, "管家处理失败")
+    return code, f"已收到你的消息，但本次未能完成：{label}。没有生成完整答复，本次请求不会自动重放。"
+
+
 _EVENT_PROJECTION = (
     '{schema_version:"lark_event_inbox_event_v0",'
     "event_id:(.event_id // .message_id // .id),"
@@ -67,6 +95,21 @@ _EVENT_EXIT_REASON = re.compile(r"\(reason: (limit|timeout|signal)\)$")
 def _opaque_digest(*values: Any) -> str:
     joined = "\0".join(str(value or "") for value in values)
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:32]
+
+
+def _session_turn_effect(route: Mapping[str, Any]) -> dict[str, Any]:
+    # Committed means the runtime has persisted a terminal receipt, not that
+    # the model succeeded. Response verification remains a separate ACK gate.
+    return {
+        "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
+        "event_id": str(route.get("event_id") or route.get("message_id") or ""),
+        "effect_id": "session-turn-" + _opaque_digest(
+            route.get("session_id"), route.get("message_id"),
+            route.get("topic_root_message_id"),
+        ),
+        "effect_kind": ExternalEffectKind.WORKING_SESSION_TURN.value,
+        "status": "committed",
+    }
 
 
 def _active_profile_configs(snapshot: Mapping[str, Any]) -> dict[str, dict[str, str]]:
@@ -610,20 +653,7 @@ class LarkGoalTopicRuntimeService:
                     )
                     return {
                         "response_text": response_text,
-                        "effect_receipt": {
-                            "schema_version": EFFECT_RECEIPT_SCHEMA_VERSION,
-                            "event_id": str(
-                                route.get("event_id") or route.get("message_id") or ""
-                            ),
-                            "effect_id": "session-turn-"
-                            + _opaque_digest(
-                                route.get("session_id"),
-                                route.get("message_id"),
-                                route.get("topic_root_message_id"),
-                            ),
-                            "effect_kind": ExternalEffectKind.WORKING_SESSION_TURN.value,
-                            "status": "committed",
-                        },
+                        "effect_receipt": _session_turn_effect(route),
                     }
 
                 result = stream_lark_goal_topic_profile(
@@ -854,7 +884,11 @@ def answer_lark_goal_topic(
         turn_id=str(turn["turn_id"]),
     )
     if completed.get("status") != "completed":
-        raise RuntimeError(str(completed.get("error") or "Lark Goal Topic turn failed"))
+        if completed.get("status") not in {"failed", "timed_out", "interrupted"}:
+            raise RuntimeError("Lark Goal Topic turn has no terminal receipt")
+        raise LarkGoalTopicTurnFailed(
+            str(completed.get("error_code") or ""), _session_turn_effect(route),
+        )
     response = completed.get("response")
     reply_text = (
         str(response.get("message") or "") if isinstance(response, Mapping) else ""
@@ -1029,7 +1063,14 @@ def process_lark_goal_topic_event(
             logging.getLogger(__name__).warning("Lark manager received reaction was not verified")
     # Sender provenance comes from the provider event, never the model response.
     route = {**route, "source_sender_id": str(canonical.get("sender_id") or "")}
-    answer_result = answer(route, canonical["content"])
+    failure_code = None
+    try:
+        answer_result = answer(route, canonical["content"])
+    except LarkGoalTopicTurnFailed as exc:
+        if route.get("conversation_kind") != "manager":
+            raise
+        failure_code, failure_text = _manager_failure_reply(exc)
+        answer_result = {"response_text": failure_text, "effect_receipt": exc.effect_receipt}
     connector = route.get("connector")
     connector = connector if isinstance(connector, Mapping) else None
     effect_receipt: Mapping[str, Any] | None = None
@@ -1108,8 +1149,10 @@ def process_lark_goal_topic_event(
     )
 
     return {
-        "ok": True,
-        "status": "replied_and_acknowledged",
+        "ok": failure_code is None,
+        "status": "processing_failed" if failure_code else "replied_and_acknowledged",
+        **({"reason": failure_code, "failure_reply_verified": True,
+            "source_acknowledged": True} if failure_code else {}),
         "received_reaction_status": (received_reaction or {}).get("status"),
         "goal_id": route["goal_id"],
         "inbox_config_ref": config_ref,

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -1420,3 +1420,65 @@ def test_manager_receives_reaction_before_answer_and_preserves_sender(tmp_path, 
     before = list(stages)
     assert runtime.process_lark_goal_topic_event(**kwargs)["status"] == "already_acknowledged"
     assert stages == before
+
+
+@pytest.mark.parametrize("error_code,label", [
+    ("cyber_policy", "安全策略拦截"),
+    ("rate_limit_exceeded", "请求频率限制"),
+    ("private-upstream-detail", "管家处理失败"),
+])
+@pytest.mark.parametrize("reply_ok", [True, False])
+def test_manager_terminal_failure_replies_once_before_ack(
+    tmp_path, monkeypatch, error_code, label, reply_ok,
+):
+    from loopx.extensions.lark import goal_topic_runtime as runtime
+
+    target_path, binding_path = tmp_path / "targets.json", tmp_path / "bindings.json"
+    _seed_legacy_topic(target_path, binding_path)
+    original_decide = runtime.decide_lark_topic_event
+    def manager_decision(**kw):
+        result = original_decide(**kw)
+        result["route"].update(
+            conversation_kind="manager", ingress_mode="session_queue",
+            event_id=kw["event"]["event_id"],
+            connector={"response_policy": "topic_reply"},
+        )
+        return result
+    monkeypatch.setattr(runtime, "decide_lark_topic_event", manager_decision)
+    monkeypatch.setattr(runtime, "ensure_lark_event_inbox_received_reaction",
+                        lambda **kw: {"ok": True, "status": "already_received"})
+    state = {}
+    runner = _reply_runner(state)
+    calls = []
+    def answer(route, text):
+        calls.append(text)
+        raise runtime.LarkGoalTopicTurnFailed(error_code, runtime._session_turn_effect(route))
+    def reply(args):
+        if not reply_ok and "+messages-reply" in args and "--dry-run" not in args:
+            return {"returncode": 1, "stdout": "", "stderr": "private-transport-detail"}
+        return runner(args)
+    kwargs = dict(
+        target_payload=read_goal_channel_targets(target_path),
+        binding_payloads={"goal-alpha": read_goal_channel_binding(binding_path)},
+        event={"event_id": "evt_incoming", "message_id": "om_incoming",
+               "chat_id": "oc_public_fixture", "root_id": "om_topic_alpha",
+               "create_time": "2026-08-14T21:00:00Z", "content": "@linkmacbot report",
+               "mentioned": True, "sender_type": "user"},
+        runtime_root=tmp_path / "runtime", answer=answer, reply_runner=reply,
+    )
+    result = runtime.process_lark_goal_topic_event(**kwargs)
+    assert result["ok"] is False
+    assert label in state["reply_text"]
+    assert "private-" not in state["reply_text"] + str(result)
+    assert "不会自动重放" in state["reply_text"]
+    pending = inspect_lark_event_inbox(project=kwargs["runtime_root"],
+                                      config_path=Path(result["inbox_config_ref"]))
+    if reply_ok:
+        assert result["status"] == "processing_failed"
+        assert result["failure_reply_verified"] and result["source_acknowledged"]
+        assert pending["items"] == []
+        assert runtime.process_lark_goal_topic_event(**kwargs)["status"] == "already_acknowledged"
+        assert len(calls) == 1
+    else:
+        assert any(x["message_id"] == "om_incoming" for x in pending["items"])
+        assert not result.get("source_acknowledged")


### PR DESCRIPTION
A Lark manager message could be received and acknowledged with a reaction, then disappear from the user's perspective when the model Turn failed. The runtime raised an exception before the existing reply path, and the listener only recorded `processing_failed`.

Carry the persisted terminal failure as a typed receipt and send a bounded failure notice through the same verified Lark reply path. A failed model answer remains a processing failure, even after the notice is delivered. Acknowledge the source only after verified delivery, so duplicate source events do not rerun the model; an unverified reply remains pending. Unknown upstream details are never copied into the group. Ordinary worker connector effect requirements stay unchanged.

Validation: 115 Lark runtime/connection tests passed, including typed and unknown failures, reply failure, source-ACK ordering and duplicate delivery. Ruff and standard premerge passed: five catalog canaries, eight risk-profile smokes, public-boundary and direct compile/diff checks. Provider I/O in regression tests is synthetic; live delivery is a separate post-install acceptance.

Review: no actionable findings. The existing inbox reply/receipt mechanism remains the owner; a shared session-turn receipt builder removes duplication. `committed` describes a persisted terminal runtime result, not model success. No new model retries, authority, connector protocol or background scheduler is introduced. Eligible for the owner's authorized self-merge after hosted validation.
