### PR TITLE
fix(lark): deliver full manager reports within provider byte limits

### DIFF
--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -33,6 +33,7 @@ from .goal_channel_contracts import LarkTopicEventDecisionReason, bindings_for_g
 from .goal_channel_targets import goal_channel_target_for_name
 from .goal_topic_connections import decide_lark_topic_event
 from .inbox_reply import CommandRunner, reply_lark_event_inbox
+from .outbound import LarkOutboundTextError
 from .inbox_reactions import (
     _create_reaction, _delete_reaction, ensure_lark_event_inbox_received_reaction,
 )
@@ -1075,13 +1076,13 @@ def process_lark_goal_topic_event(
     connector = connector if isinstance(connector, Mapping) else None
     effect_receipt: Mapping[str, Any] | None = None
     if isinstance(answer_result, Mapping):
-        reply_text = str(answer_result.get("response_text") or "").strip()[:6000]
+        reply_text = str(answer_result.get("response_text") or "").strip()
         candidate_receipt = answer_result.get("effect_receipt")
         effect_receipt = (
             candidate_receipt if isinstance(candidate_receipt, Mapping) else None
         )
     else:
-        reply_text = str(answer_result or "").strip()[:6000]
+        reply_text = str(answer_result or "").strip()
     if not reply_text:
         return {
             "ok": False,
@@ -1103,14 +1104,31 @@ def process_lark_goal_topic_event(
                 "inbox_config_ref": config_ref,
                 "ack_decision": effect_decision,
             }
-    reply = reply_lark_event_inbox(
-        project=root,
-        config_path=config_path,
-        message_id=message_id,
-        text=reply_text,
-        execute=True,
-        runner=reply_runner,
-    )
+    try:
+        reply = reply_lark_event_inbox(
+            project=root,
+            config_path=config_path,
+            message_id=message_id,
+            text=reply_text,
+            execute=True,
+            runner=reply_runner,
+        )
+    except LarkOutboundTextError:
+        if route.get("conversation_kind") != "manager":
+            raise
+        # The persisted answer remains intact. A format failure is not a model
+        # failure, and must not strand the source or silently truncate its reply.
+        failure_code = "reply_format_invalid"
+        reply = reply_lark_event_inbox(
+            project=root,
+            config_path=config_path,
+            message_id=message_id,
+            text=("回答已生成并保存，但长度或格式不符合飞书发送要求，正文尚未送达。"
+                  "请在 LoopX 前端同一管家会话查看完整回答。"
+                  "管家不会自动重新运行这条请求。"),
+            execute=True,
+            runner=reply_runner,
+        )
     if not reply.get("ok"):
         return {
             "ok": False,

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -19,6 +19,7 @@ from .outbound import (
     lark_provider_preview_matches_outbound,
     lark_readback_matches_outbound,
     normalize_lark_outbound_text,
+    validate_lark_text_request_size,
 )
 
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
@@ -176,7 +177,12 @@ def _deliver_lark_inbox_outbound(
         raise ValueError(
             "lark inbox reply source message is not captured by this inbox"
         )
-    reply_text = normalize_lark_outbound_text(text)
+    reply_text = normalize_lark_outbound_text(
+        text, limit=None if source_event is not None else 1200,
+    )
+    # Reject an oversized content lower bound before building a CLI argument.
+    # The full rendered request body is checked again after provider preview.
+    validate_lark_text_request_size({"content": json.dumps({"text": reply_text}, ensure_ascii=False, separators=(",", ":"))})
     if not reply_text:
         raise ValueError("lark inbox reply requires non-empty text")
 
@@ -393,6 +399,14 @@ def _deliver_lark_inbox_outbound(
             format_preflight_passed=True,
             provider_preview_performed=True,
         )
+    preview_payload = _json_object(preview.get("stdout"))
+    preview_data = preview_payload.get("data")
+    api_calls = preview_payload.get("api")
+    if not isinstance(api_calls, list) and isinstance(preview_data, Mapping):
+        api_calls = preview_data.get("api")
+    for call in api_calls if isinstance(api_calls, list) else []:
+        if isinstance(call, Mapping) and isinstance(call.get("body"), Mapping):
+            validate_lark_text_request_size(call["body"])
     guidance = None
     if before_send is not None:
         # Bind review to destination/profile as well as content and placement.

--- a/loopx/extensions/lark/outbound.py
+++ b/loopx/extensions/lark/outbound.py
@@ -146,11 +146,20 @@ def normalized_lark_lines(value: Any) -> str:
     return "\n".join(lines)
 
 
-def normalize_lark_outbound_text(value: Any, *, limit: int = 1200) -> str:
+# Text request bodies: https://open.feishu.cn/document/server-docs/im-v1/message/reply
+# Use decimal KB conservatively; count UTF-8 JSON bytes, not display characters.
+LARK_TEXT_REQUEST_MAX_BYTES = 150_000
+
+
+class LarkOutboundTextError(ValueError):
+    """A local text-format failure before any provider write."""
+
+
+def normalize_lark_outbound_text(value: Any, *, limit: int | None = 1200) -> str:
     text = str(value or "").replace("\r\n", "\n").replace("\r", "\n")
     outside_code = FENCED_CODE_PATTERN.sub("", text)
     if r"\n" in outside_code:
-        raise ValueError(
+        raise LarkOutboundTextError(
             "Lark outbound text contains a literal backslash-n outside fenced code; "
             "pass real newlines"
         )
@@ -158,20 +167,26 @@ def normalize_lark_outbound_text(value: Any, *, limit: int = 1200) -> str:
     if "<at" in without_structured_mentions.lower() or "</at>" in (
         without_structured_mentions.lower()
     ):
-        raise ValueError(
+        raise LarkOutboundTextError(
             "Lark outbound text contains a malformed or unsupported <at> node"
         )
     if LITERAL_MENTION_PATTERN.search(without_structured_mentions):
-        raise ValueError(
+        raise LarkOutboundTextError(
             "Lark outbound notification contains a literal @ mention; resolve the "
             "member identity and use a structured <at ...> node"
         )
     normalized = normalized_lark_lines(text)
-    if len(normalized) > limit:
-        raise ValueError(
+    if limit is not None and len(normalized) > limit:
+        raise LarkOutboundTextError(
             f"Lark outbound text exceeds the {limit}-character delivery limit"
         )
     return normalized
+
+
+def validate_lark_text_request_size(body: Mapping[str, Any]) -> None:
+    size = len(json.dumps(body, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+    if size > LARK_TEXT_REQUEST_MAX_BYTES:
+        raise LarkOutboundTextError("Lark text request exceeds the 150 KB provider limit")
 
 
 def lark_provider_preview_matches_outbound(

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -1482,3 +1482,75 @@ def test_manager_terminal_failure_replies_once_before_ack(
     else:
         assert any(x["message_id"] == "om_incoming" for x in pending["items"])
         assert not result.get("source_acknowledged")
+
+
+@pytest.mark.parametrize("body", ["完整报告" * 400, "x" * 6001, "测" * 40000, "测" * 50000, r"private\nformat"])
+@pytest.mark.parametrize("reply_ok", [True, False])
+def test_manager_report_delivery_preserves_body_and_reports_format_failure(
+    tmp_path, monkeypatch, body, reply_ok,
+):
+    from loopx.extensions.lark import goal_topic_runtime as runtime
+    from loopx.extensions.lark.inbox_reply import send_lark_inbox_message
+    from loopx.extensions.lark.outbound import LarkOutboundTextError
+
+    target_path, binding_path = tmp_path / "targets.json", tmp_path / "bindings.json"
+    _seed_legacy_topic(target_path, binding_path)
+    original_decide = runtime.decide_lark_topic_event
+
+    def manager_decision(**kw):
+        result = original_decide(**kw)
+        result["route"].update(
+            conversation_kind="manager", ingress_mode="session_queue",
+            event_id=kw["event"]["event_id"],
+            connector={"response_policy": "topic_reply"},
+        )
+        return result
+
+    monkeypatch.setattr(runtime, "decide_lark_topic_event", manager_decision)
+    monkeypatch.setattr(runtime, "ensure_lark_event_inbox_received_reaction",
+                        lambda **kw: {"ok": True, "status": "already_received"})
+    state, answered = {}, []
+    runner = _reply_runner(state)
+
+    def answer(route, text):
+        answered.append(text)
+        return {"response_text": body, "effect_receipt": runtime._session_turn_effect(route)}
+
+    def reply(args):
+        if not reply_ok and "+messages-reply" in args and "--dry-run" not in args:
+            return {"returncode": 1}
+        return runner(args)
+
+    kwargs = dict(
+        target_payload=read_goal_channel_targets(target_path),
+        binding_payloads={"goal-alpha": read_goal_channel_binding(binding_path)},
+        event={"event_id": "evt_incoming", "message_id": "om_incoming",
+               "chat_id": "oc_public_fixture", "root_id": "om_topic_alpha",
+               "create_time": "2026-08-14T21:00:00Z", "content": "@linkmacbot report",
+               "mentioned": True, "sender_type": "user"},
+        runtime_root=tmp_path / "runtime", answer=answer, reply_runner=reply,
+    )
+    result = runtime.process_lark_goal_topic_event(**kwargs)
+    valid = len(body.encode("utf-8")) < 150_000 and body != r"private\nformat"
+    if valid:
+        assert state["reply_text"] == body  # No truncation, including the last character.
+        assert result["ok"] is reply_ok
+    else:
+        assert body not in state["reply_text"]
+        assert "正文尚未送达" in state["reply_text"]
+        assert result["ok"] is False
+        if reply_ok:
+            assert result["reason"] == "reply_format_invalid"
+            assert result["failure_reply_verified"]
+    pending = inspect_lark_event_inbox(project=kwargs["runtime_root"],
+                                      config_path=Path(result["inbox_config_ref"]))
+    if reply_ok:
+        assert pending["items"] == []
+        assert runtime.process_lark_goal_topic_event(**kwargs)["status"] == "already_acknowledged"
+        assert len(answered) == 1
+    else:
+        assert any(x["message_id"] == "om_incoming" for x in pending["items"])
+    # Root notifications retain their existing compact limit.
+    with pytest.raises(LarkOutboundTextError):
+        send_lark_inbox_message(project=kwargs["runtime_root"],
+                               config_path=result["inbox_config_ref"], text="x" * 1201)

--- a/tests/extensions/test_lark_reply_size.py
+++ b/tests/extensions/test_lark_reply_size.py
@@ -1,0 +1,28 @@
+"""Text transport budgets count UTF-8 serialized request bytes, not characters."""
+
+import pytest
+
+from loopx.extensions.lark.outbound import (
+    LarkOutboundTextError,
+    validate_lark_text_request_size,
+)
+
+
+@pytest.mark.parametrize("value", ["x" * 149992, "测" * 49997, "😀" * 37498])
+def test_provider_byte_budget_accepts_large_text(value):
+    # {"x":""} costs eight bytes; UTF-8 code points have different costs.
+    validate_lark_text_request_size({"x": value})
+
+
+@pytest.mark.parametrize("value", ["x" * 149993, "测" * 49998, "😀" * 37499])
+def test_provider_byte_budget_rejects_oversize_utf8(value):
+    with pytest.raises(LarkOutboundTextError):
+        validate_lark_text_request_size({"x": value})
+
+
+def test_request_budget_counts_escaping_and_envelope():
+    validate_lark_text_request_size({"x": '"' * 74996})
+    with pytest.raises(LarkOutboundTextError):
+        validate_lark_text_request_size({"x": '"' * 74997})
+    with pytest.raises(LarkOutboundTextError):
+        validate_lark_text_request_size({"x": "x" * 149992, "uuid": "reply-identity"})


### PR DESCRIPTION
A manager can finish a report while its Lark source remains unanswered: the runtime accepted up to 6,000 characters, but the shared sender rejected replies above 1,200 characters and the exception escaped the terminal-notice path.

Source-bound replies now retain the complete answer and use the documented 150 KB text-request budget, measured as UTF-8 JSON bytes including the provider-preview envelope. Standalone notifications retain their existing compact default. Local format/size failures produce a verified diagnostic reply; source ACK still requires delivery readback, and no model request is replayed.

Validation: 192 focused Lark runtime, connection, reaction and byte-budget tests; inbox smoke; Ruff and diff checks. Provider dry-run preserved 6,001 and 40,000 CJK characters. An actual report above the former limit was sent and read back exactly; large dry-runs are not server acceptance tests. Standard premerge results will be recorded before merge.

The existing bundled Lark outbound adapter owns this change; no new capability, authorization grant or state store. Beyond the provider limit, the persisted full answer remains available in Chat and Lark receives a diagnostic instead of truncated text.
