### PR TITLE
fix(lark): retry transient bot auth verification

### DIFF
--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -305,8 +305,13 @@ can read the configured chat. A profile/app mismatch fails with
 `lark_inbox_reply_sender_identity_mismatch`; a profile that cannot access the
 configured chat fails with
 `lark_inbox_reply_sender_not_in_configured_chat`. Neither failure falls back
-to another app. Public results contain only compact status/receipt fields, not
-the profile, chat id, message id, reply text, or provider payload.
+to another app. Inbox and Goal Channel replies retry only the provider's
+explicit transient `verify_failed` Bot identity state, up to three checks.
+Command failures, malformed identity responses, and configured Bot name
+mismatches fail immediately; membership, provider preview, idempotency, send,
+and readback gates remain unchanged. Public results contain only compact
+status/receipt fields, not the profile, chat id, message id, reply text, or
+provider payload.
 
 ## Host collector lifecycle
 

--- a/loopx/extensions/lark/inbox_reply.py
+++ b/loopx/extensions/lark/inbox_reply.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import subprocess
 from collections.abc import Callable, Mapping, Sequence
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,13 @@ from .outbound import (
 )
 
 CommandRunner = Callable[[Sequence[str]], Mapping[str, Any]]
+BOT_IDENTITY_VERIFY_ATTEMPTS = 3
+
+
+class BotIdentityVerification(str, Enum):
+    VERIFIED = "verified"
+    RETRYABLE_VERIFY_FAILED = "retryable_verify_failed"
+    REJECTED = "rejected"
 
 
 def _default_runner(args: Sequence[str]) -> Mapping[str, Any]:
@@ -90,6 +98,51 @@ def _message(value: Any, message_id: str) -> Mapping[str, Any] | None:
             None,
         )
     return None
+
+
+def _bot_identity_verification(
+    *,
+    runner: CommandRunner,
+    base: Sequence[str],
+    expected_name: str,
+) -> BotIdentityVerification:
+    auth = _call(runner, [*base, "auth", "status", "--verify", "--json"])
+    if auth.get("returncode") != 0:
+        return BotIdentityVerification.REJECTED
+    identities = _json_object(auth.get("stdout")).get("identities")
+    identity = identities.get("bot") if isinstance(identities, Mapping) else None
+    if not isinstance(identity, Mapping):
+        return BotIdentityVerification.REJECTED
+    if identity.get("available") is True and identity.get("verified") is True:
+        return (
+            BotIdentityVerification.VERIFIED
+            if str(identity.get("appName") or "") == expected_name
+            else BotIdentityVerification.REJECTED
+        )
+    if str(identity.get("status") or "") == "verify_failed":
+        return BotIdentityVerification.RETRYABLE_VERIFY_FAILED
+    return BotIdentityVerification.REJECTED
+
+
+def _bot_identity_verified(
+    *,
+    runner: CommandRunner,
+    base: Sequence[str],
+    expected_name: str,
+) -> bool:
+    """Retry only the provider's explicit transient verification state."""
+
+    for _attempt in range(BOT_IDENTITY_VERIFY_ATTEMPTS):
+        result = _bot_identity_verification(
+            runner=runner,
+            base=base,
+            expected_name=expected_name,
+        )
+        if result is BotIdentityVerification.VERIFIED:
+            return True
+        if result is BotIdentityVerification.REJECTED:
+            return False
+    return False
 
 
 def _result(
@@ -234,15 +287,10 @@ def _deliver_lark_inbox_outbound(
         )
 
     base = ["lark-cli", "--profile", profile]
-    auth = _call(runner, base + ["auth", "status", "--verify", "--json"])
-    identities = _json_object(auth.get("stdout")).get("identities")
-    identity = identities.get("bot", {}) if isinstance(identities, Mapping) else {}
-    identity_verified = bool(
-        auth.get("returncode") == 0
-        and isinstance(identity, Mapping)
-        and identity.get("available") is True
-        and identity.get("verified") is True
-        and str(identity.get("appName") or "") == reply_config["bot_display_name"]
+    identity_verified = _bot_identity_verified(
+        runner=runner,
+        base=base,
+        expected_name=str(reply_config["bot_display_name"]),
     )
     if not identity_verified:
         return _result(

--- a/tests/extensions/test_lark_inbox_reactions.py
+++ b/tests/extensions/test_lark_inbox_reactions.py
@@ -327,6 +327,7 @@ class ReplyRunner:
         include_mentioned_member: bool = True,
         member_bucket: str = "users",
         member_read_denied: bool = False,
+        auth_failures: int = 0,
     ) -> None:
         self.calls: list[list[str]] = []
         self.matching_readback = matching_readback
@@ -336,11 +337,29 @@ class ReplyRunner:
         self.include_mentioned_member = include_mentioned_member
         self.member_bucket = member_bucket
         self.member_read_denied = member_read_denied
+        self.auth_failures = auth_failures
 
     def __call__(self, args: Sequence[str]) -> dict[str, Any]:
         call = list(args)
         self.calls.append(call)
         if call[3:6] == ["auth", "status", "--verify"]:
+            if self.auth_failures:
+                self.auth_failures -= 1
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "identities": {
+                                "bot": {
+                                    "available": False,
+                                    "verified": False,
+                                    "status": "verify_failed",
+                                }
+                            }
+                        }
+                    ),
+                    "stderr": "",
+                }
             return {
                 "returncode": 0,
                 "stdout": json.dumps(
@@ -764,6 +783,85 @@ def test_reply_preview_verifies_provider_without_writing(tmp_path: Path) -> None
     ]
     assert len(provider_calls) == 1
     assert "--dry-run" in provider_calls[0]
+
+
+def test_reply_retries_transient_bot_identity_verification(tmp_path: Path) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(auth_failures=1)
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="处理完成",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "sent_verified"
+    auth_calls = [
+        call for call in runner.calls if call[3:6] == ["auth", "status", "--verify"]
+    ]
+    assert len(auth_calls) == 2
+
+
+def test_reply_fails_closed_after_bounded_bot_identity_retries(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner(auth_failures=3)
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="处理完成",
+        execute=True,
+        runner=runner,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "gate_required"
+    assert result["blocker"] == "lark_inbox_reply_sender_identity_mismatch"
+    auth_calls = [
+        call for call in runner.calls if call[3:6] == ["auth", "status", "--verify"]
+    ]
+    assert len(auth_calls) == 3
+    assert not any(
+        "+messages-send" in call or "+messages-reply" in call for call in runner.calls
+    )
+
+
+def test_reply_does_not_retry_permanent_bot_identity_mismatch(
+    tmp_path: Path,
+) -> None:
+    config, _, project = _fixture(tmp_path, lifecycle=False)
+    runner = ReplyRunner()
+
+    def mismatched_name(args: Sequence[str]) -> dict[str, Any]:
+        result = runner(args)
+        if list(args)[3:6] == ["auth", "status", "--verify"]:
+            payload = json.loads(result["stdout"])
+            payload["identities"]["bot"]["appName"] = "Another Bot"
+            result["stdout"] = json.dumps(payload)
+        return result
+
+    result = reply_lark_event_inbox(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        text="处理完成",
+        execute=True,
+        runner=mismatched_name,
+    )
+
+    assert result["ok"] is False
+    assert result["blocker"] == "lark_inbox_reply_sender_identity_mismatch"
+    auth_calls = [
+        call for call in runner.calls if call[3:6] == ["auth", "status", "--verify"]
+    ]
+    assert len(auth_calls) == 1
 
 
 def test_reply_rejects_literal_backslash_n_before_provider(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- retry the read-only Bot identity verification probe up to three times before failing closed
- keep sender name matching and all downstream membership, preview, idempotency, and readback gates unchanged
- cover transient recovery and bounded permanent failure

## Validation

- `uv run --with pytest pytest -q tests/extensions/test_lark_inbox_reactions.py tests/extensions/test_lark_goal_topic_runtime.py tests/extensions/test_lark_reply_size.py` (112 passed)
- `uv run --with ruff ruff check loopx/extensions/lark/inbox_reply.py tests/extensions/test_lark_inbox_reactions.py`
- `loopx canary premerge --from-git-diff` (9 selected checks passed, 0 failures, 0 manual holds)

## Boundary

No message body, credential, local profile, destination, or private runtime state is committed. This change adds no new send authority and still rejects delivery after three failed identity checks.

## Future-facing pass

Applied at the existing Lark inbox provider boundary; no broader retry framework was introduced because the observed issue is specific to the read-only Bot identity preflight.