### PR TITLE
feat(manager): track handoff receipts and linked Core work across Chat and Lark

### DIFF
--- a/loopx/capabilities/manager_context/README.md
+++ b/loopx/capabilities/manager_context/README.md
@@ -91,7 +91,42 @@ recent delivery window is still yesterday through now; arbitrary artifact paths
 and external links are not fetched. Existing non-Codex adapters retain their
 context projection until they implement an equivalent tool contract.
 
-Manager context version 6 starts a fresh upstream session for older manager
+Manager context version 7 starts a fresh upstream session for older manager
 contexts. The logical Chat session and its receipts remain intact. Runtime support
 uses the Codex app-server dynamic tool protocol; explicit upstream terminal
-errors remain errors and are not retried as part of inspection.
+errors remain errors and are not retried as part of inspection. The version
+change registers the expanded handoff tool schema on existing installations;
+resuming an old upstream thread would retain its previous dynamic tools.
+
+
+## Track a delegated request
+
+The default receiver hook checks for pending context. `manager-inbox read`
+records that its output supplied the original message to the receiver; a quota
+peek does not record a read. New delivery and decision records carry event
+timestamps. Historical records retain unknown times rather than using file
+modification time as a fabricated event.
+
+The receiver associates canonical work after deciding:
+
+```sh
+loopx manager-inbox link --goal-id research --agent-id worker \
+  --request-id <request-id> --related-todo-id <core-todo-id> \
+  --evidence-id sha256:<evidence-digest>
+loopx manager-inbox status --goal-id research --agent-id worker \
+  --request-id <request-id>
+```
+
+Links are bounded, additive and idempotent. Todo links must belong to the
+receiving Agent, and their current titles/statuses come from Core, not a copy in
+the inbox. Evidence links are receiver assertions, not independently verified
+artifacts. The inbox does not assign priority or declare overall completion.
+
+In frontend or Lark Chat, ask the manager whether a request was delivered/read,
+what decision was recorded, and which work it links to. Both entrances use
+`loopx_manager_read` with `view=handoffs`. External reads require the current
+Goal evidence grant and exact originating audience; they omit original message
+bodies and private decision reasons. Legacy audience recovery uses only the
+provider-recorded ingress, and ambiguous/missing provenance stays hidden.
+Revocation is checked before and after query. This does not append a message to
+an unrelated host session or create another scheduler.

--- a/loopx/capabilities/manager_context/__init__.py
+++ b/loopx/capabilities/manager_context/__init__.py
@@ -192,11 +192,12 @@ def deliver(
     path = _root(runtime_root) / "entries" / _hash(request) / (request_id + ".json")
     with exclusive_file_lock(path.with_suffix(".lock")):
         exists = path.exists()
-        if exists and _read(path) != value:
+        if exists and {k: v for k, v in _read(path).items() if k not in {"delivered_at", "source_channel"}} != value:
             raise ValueError("context request identity conflict")
         if not exists:
-            _write(path, value)
-        if _read(path) != value:
+            from .tracking import _now
+            _write(path, value | {"delivered_at": _now(), "source_channel": session.get("channel_id")})
+        if {k: v for k, v in _read(path).items() if k not in {"delivered_at", "source_channel"}} != value:
             raise ValueError("context delivery readback failed")
     return {
         "request_id": request_id,
@@ -263,9 +264,12 @@ def acknowledge(
     value = {"request_id": request_id, **target, "decision": decision, "reason": reason}
     path = _root(runtime_root) / "decisions" / (request_id + ".json")
     with exclusive_file_lock(path.with_suffix(".lock")):
-        if path.exists() and _read(path) != value:
-            raise ValueError("context decision already recorded")
-        _write(path, value)
+        if path.exists():
+            if {k: v for k, v in _read(path).items() if k != "decided_at"} != value:
+                raise ValueError("context decision already recorded")
+        else:
+            from .tracking import _now
+            _write(path, value | {"decided_at": _now()})
     return {"ok": True, **value}
 
 

--- a/loopx/capabilities/manager_context/inspection.py
+++ b/loopx/capabilities/manager_context/inspection.py
@@ -17,7 +17,7 @@ READ_TOOL = {
     "name": TOOL_NAME,
     "description": (
         "Read authorized LoopX Core evidence on demand: the global Goal portfolio, "
-        "one Goal's current Todos, or recorded deliveries. Use concrete evidence "
+        "one Goal's current Todos, recorded deliveries, or handoff receipt status. Use concrete evidence "
         "to answer progress and priority questions. Paginate with next_offset. "
         "No shell, writes, raw files, or additional Goal authorization."
     ),
@@ -25,8 +25,16 @@ READ_TOOL = {
         "type": "object",
         "additionalProperties": False,
         "properties": {
-            "view": {"type": "string", "enum": ["portfolio", "todos", "deliveries"]},
+            "view": {
+                "type": "string",
+                "enum": ["portfolio", "todos", "deliveries", "handoffs"],
+            },
             "goal_id": {"type": "string"},
+            "request_id": {
+                "type": "string",
+                "pattern": "^[a-f0-9]{64}$",
+                "description": "Handoffs only: exact request receipt ID.",
+            },
             "include_stopped": {
                 "type": "boolean",
                 "description": "Portfolio only: include stopped Goals for an explicit historical question.",
@@ -78,6 +86,7 @@ class ManagerInspection:
         owner_scope: bool,
         scope_valid: Callable[[], bool],
         record: Callable[[dict[str, Any]], None],
+        channel_id: str | None = None,
     ) -> None:
         self.context = context
         self.registry_path = registry_path
@@ -85,17 +94,26 @@ class ManagerInspection:
         self.owner_scope = owner_scope
         self.scope_valid = scope_valid
         self.record = record
+        self.channel_id = channel_id
 
     def read(self, tool: str, arguments: Any) -> dict[str, Any]:
         if tool != TOOL_NAME or not isinstance(arguments, dict):
             return {"ok": False, "error": "unsupported_read_tool"}
-        if set(arguments) - {"view", "goal_id", "offset", "limit", "include_stopped"}:
+        if set(arguments) - {
+            "view",
+            "goal_id",
+            "offset",
+            "limit",
+            "include_stopped",
+            "request_id",
+        }:
             return {"ok": False, "error": "invalid_arguments"}
         view, goal_id = arguments.get("view"), arguments.get("goal_id")
         offset, limit = arguments.get("offset", 0), arguments.get("limit", 8)
         include_stopped = arguments.get("include_stopped", False)
         if (
-            view not in {"portfolio", "todos", "deliveries"}
+            view not in {"portfolio", "todos", "deliveries", "handoffs"}
+            or ("request_id" in arguments and view != "handoffs")
             or type(include_stopped) is not bool
             or ("include_stopped" in arguments and view != "portfolio")
             or type(offset) is not int
@@ -107,7 +125,7 @@ class ManagerInspection:
             return {"ok": False, "error": "invalid_arguments"}
         goals = {r["goal_id"]: r for r in self.context.get("goals", [])}
         if (goal_id is not None and goal_id not in goals) or (
-            view != "portfolio" and not goal_id
+            view not in {"portfolio", "handoffs"} and not goal_id
         ):
             return {"ok": False, "error": "goal_outside_available_scope"}
         if not self.scope_valid():
@@ -123,6 +141,24 @@ class ManagerInspection:
             }
             page = rows[offset : offset + limit]
             matched = len(rows)
+        elif view == "handoffs":
+            from .tracking import query
+
+            try:
+                source = query(
+                    self.runtime_root,
+                    self.registry_path,
+                    goal_ids=[goal_id] if goal_id else list(goals),
+                    owner_scope=self.owner_scope,
+                    channel_id=self.channel_id,
+                    request_id=arguments.get("request_id"),
+                    offset=offset,
+                    limit=limit,
+                )
+            except (OSError, ValueError, TypeError):
+                return {"ok": False, "error": "handoff_query_unavailable_or_invalid"}
+            page = source.pop("rows")
+            matched = source.pop("matched")
         elif view == "todos":
             source = read_manager_goal_details(
                 self.registry_path,
@@ -183,7 +219,15 @@ class ManagerInspection:
             "next_offset": end
             if isinstance(matched, int) and page and end < matched
             else None,
-            "unknown": matched is None,
+            "unknown": matched is None
+            or (
+                view == "handoffs"
+                and (
+                    not source["coverage"]["scan_complete"]
+                    or not source["coverage"]["legacy_audience_scan_complete"]
+                    or bool(source["coverage"]["unreadable"])
+                )
+            ),
             "oversized_rows": oversized,
             "initial_snapshot_id": self.context.get("snapshot_id"),
         }

--- a/loopx/capabilities/manager_context/skills/loopx-manager/SKILL.md
+++ b/loopx/capabilities/manager_context/skills/loopx-manager/SKILL.md
@@ -19,6 +19,17 @@ an index, not a completed investigation. In Chat, use `loopx_manager_read`:
   and validation for the recent reporting window. Join the supplied titles;
   distinguish recorded claims from independently verified artifacts.
 
+- `handoffs`: inspect this audience's delegated requests, optionally with an exact
+  `request_id` or Goal ID. Distinguish delivery, receiver CLI read, decision,
+  linked current Core Todos, and evidence references. Paginate before concluding
+  a request is missing. Legacy read/timestamp gaps are unknown, not failed
+  delivery. A read receipt is not proof of understanding; adoption is not task
+  completion. Use the linked Goal/Todo identities to read `todos` and
+  `deliveries` when asked what changed or what was produced; a bare digest is
+  not a substantive result. Match the receiving Agent and Todo, and disclose
+  the delivery window and any missing evidence. Group queries omit private
+  receiver reasons and other audiences.
+
 These views reuse Goal Portfolio, Core Todo authority and Core run history,
 the same source boundaries behind LoopX's global-summary/global-todos/global-gates
 workflows. This Chat tool is a scoped read interface, not shell access to those
@@ -48,6 +59,8 @@ Use existing `context_handoff` for an explicit authorized delegation. Preserve
 the user's original objective and constraints; the receiving Agent decides
 how to replan. Do not convert ordinary delegation into a preview/confirmation
 flow or silently overwrite priorities. Report delivery only from its receipt.
+For follow-up questions about a handoff, query `handoffs` before asking the
+owner or claiming no receipt exists.
 
 Core owns truth and permissions. This skill supplies reasoning guidance, not
 new authority. Keep front-end and group answers within their respective scopes;

--- a/loopx/capabilities/manager_context/tracking.py
+++ b/loopx/capabilities/manager_context/tracking.py
@@ -1,0 +1,276 @@
+"""Receipt projection and explicit Core links for manager context handoffs.
+
+Receipts describe transport/consumption, never a second mutable work status.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+
+from . import _hash, _read, _root, _write
+from ...file_lock import exclusive_file_lock
+from ...todos import list_goal_todos
+from ...chat_manager_details import _text
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _entry(root, goal_id, agent_id, request_id):
+    if not isinstance(request_id, str) or not re.fullmatch(r"[a-f0-9]{64}", request_id):
+        raise ValueError("invalid context request id")
+    target = dict(goal_id=goal_id, agent_id=agent_id)
+    row = _read(_root(root) / "entries" / _hash(target) / (request_id + ".json"))
+    if any(row.get(k) != v for k, v in {**target, "request_id": request_id}.items()):
+        raise ValueError("context receipt scope mismatch")
+    return row
+
+
+def record_read(root: Path, items: list[dict]) -> None:
+    """CLI supplied these messages to the receiver; not proof of comprehension."""
+    for row in items:
+        _entry(root, row["goal_id"], row["agent_id"], row["request_id"])
+        path = _root(root) / "reads" / (row["request_id"] + ".json")
+        with exclusive_file_lock(path.with_suffix(".lock")):
+            if not path.exists():
+                _write(
+                    path,
+                    {k: row[k] for k in ("request_id", "goal_id", "agent_id")}
+                    | {
+                        "read_at": _now(),
+                        "kind": "receiver_cli_read",
+                    },
+                )
+
+
+def _core_todos(registry_path, root, goal_id):
+    result = list_goal_todos(
+        registry_path=registry_path, runtime_root_arg=str(root), goal_id=goal_id
+    )
+    if result.get("ok") is not True or result.get("state_event_projection_warning"):
+        raise ValueError("Core Todo authority unavailable")
+    return {r["todo_id"]: r for r in result.get("todos", []) if r.get("todo_id")}
+
+
+def link(root, registry_path, goal_id, agent_id, request_id, todo_ids, evidence_ids):
+    _entry(root, goal_id, agent_id, request_id)
+    if not todo_ids and not evidence_ids:
+        raise ValueError("at least one Core Todo or evidence reference required")
+    if len(todo_ids) > 16 or len(evidence_ids) > 16:
+        raise ValueError("too many context links")
+    if any(not re.fullmatch(r"todo_[a-f0-9]{12}", x) for x in todo_ids):
+        raise ValueError("invalid Core Todo id")
+    if any(not re.fullmatch(r"sha256:[a-f0-9]{64}", x) for x in evidence_ids):
+        raise ValueError("evidence references must be opaque SHA256 identifiers")
+    if todo_ids:
+        rows = _core_todos(registry_path, root, goal_id)
+        for tid in todo_ids:
+            row = rows.get(tid, {})
+            if row.get("claimed_by") != agent_id and row.get("bound_agent") != agent_id:
+                raise ValueError("linked Todo must belong to the receiving Agent")
+    path = _root(root) / "links" / (request_id + ".json")
+    with exclusive_file_lock(path.with_suffix(".lock")):
+        old, error = _receipt(
+            root,
+            "links",
+            {"request_id": request_id, "goal_id": goal_id, "agent_id": agent_id},
+        )
+        if error:
+            raise ValueError(error)
+        tids = sorted(set(old.get("todo_ids", [])) | set(todo_ids))
+        refs = sorted(set(old.get("evidence_ids", [])) | set(evidence_ids))
+        if len(tids) > 16 or len(refs) > 16:
+            raise ValueError("too many context links")
+        value = dict(
+            request_id=request_id,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            todo_ids=tids,
+            evidence_ids=refs,
+        )
+        if any(old.get(k) != v for k, v in value.items()):
+            _write(path, value | {"updated_at": _now()})
+    return {"ok": True, **value}
+
+
+def _receipt(root, lane, row):
+    path = _root(root) / lane / (row["request_id"] + ".json")
+    if not path.exists():
+        return {}, None
+    try:
+        value = _read(path)
+        if any(
+            value.get(k) != row.get(k) for k in ("goal_id", "agent_id", "request_id")
+        ):
+            raise ValueError("receipt identity conflict")
+        if lane == "decisions" and value.get("decision") not in {
+            "adopt",
+            "defer",
+            "reject",
+            "no_change",
+        }:
+            raise ValueError("invalid decision receipt")
+        if lane == "reads" and (
+            value.get("kind") != "receiver_cli_read"
+            or not isinstance(value.get("read_at"), str)
+        ):
+            raise ValueError("invalid read receipt")
+        if lane == "links":
+            for key, pattern in [
+                ("todo_ids", r"todo_[a-f0-9]{12}"),
+                ("evidence_ids", r"sha256:[a-f0-9]{64}"),
+            ]:
+                refs = value.get(key)
+                if (
+                    not isinstance(refs, list)
+                    or len(refs) > 16
+                    or any(
+                        not isinstance(ref, str) or not re.fullmatch(pattern, ref)
+                        for ref in refs
+                    )
+                ):
+                    raise ValueError("invalid linked reference")
+        return value, None
+    except (OSError, ValueError, TypeError):
+        return {}, lane + "_unreadable_or_conflicting"
+
+
+def query(
+    root,
+    registry_path,
+    *,
+    goal_ids,
+    owner_scope,
+    channel_id=None,
+    request_id=None,
+    agent_id=None,
+    offset=0,
+    limit=8,
+):
+    """External callers see only requests from their exact audience, never raw text."""
+    if request_id is not None and not re.fullmatch(r"[a-f0-9]{64}", request_id):
+        raise ValueError("invalid context request id")
+    if not owner_scope and not channel_id:
+        raise ValueError("handoff audience required")
+    if (
+        type(offset) is not int
+        or offset < 0
+        or type(limit) is not int
+        or not 1 <= limit <= 12
+    ):
+        raise ValueError("invalid context page")
+    # Legacy entries have no channel. Recover only provider-owned provenance,
+    # never infer audience from Goal identity or a model-authored field.
+    legacy_channels = {}
+    ingress_paths = sorted((_root(root) / "ingress").glob("*.json"))
+    for path in ingress_paths[:2000] if not owner_scope else []:
+        try:
+            item = _read(path)
+            legacy_channels.setdefault(item.get("source_id"), set()).add(
+                item.get("channel")
+            )
+        except (OSError, ValueError, TypeError):
+            continue
+    rows, unreadable = [], 0
+    paths = sorted(
+        (_root(root) / "entries").glob(
+            "*/" + (request_id + ".json" if request_id else "*.json")
+        )
+    )
+    for path in paths[:2000]:
+        try:
+            row = _read(path)
+            if row.get("goal_id") not in goal_ids:
+                continue
+            if agent_id is not None and row.get("agent_id") != agent_id:
+                continue
+            if request_id and row.get("request_id") != request_id:
+                continue
+            if not owner_scope:
+                audience = row.get("source_channel")
+                if audience != channel_id and not (
+                    audience is None
+                    and len(ingress_paths) <= 2000
+                    and legacy_channels.get(row.get("source_id")) == {channel_id}
+                ):
+                    continue
+            _entry(root, row["goal_id"], row["agent_id"], row["request_id"])
+            rows.append(row)
+        except (OSError, ValueError, KeyError, TypeError):
+            unreadable += 1
+    rows.sort(
+        key=lambda row: (row.get("delivered_at") or "", row["request_id"]), reverse=True
+    )
+    projected, todos_cache = [], {}
+    for row in rows[offset : offset + limit]:
+        read, read_error = _receipt(root, "reads", row)
+        decision, decision_error = _receipt(root, "decisions", row)
+        links, link_error = _receipt(root, "links", row)
+        warnings = [x for x in (read_error, decision_error, link_error) if x]
+        tids = links.get("todo_ids", [])
+        linked = []
+        if tids:
+            gid = row["goal_id"]
+            if gid not in todos_cache:
+                try:
+                    todos_cache[gid] = _core_todos(registry_path, root, gid)
+                except (OSError, ValueError, RuntimeError):
+                    todos_cache[gid] = {}
+            for tid in tids:
+                todo = todos_cache[gid].get(tid)
+                linked.append(
+                    {
+                        "todo_id": tid,
+                        "status": todo.get("status") if todo else "unknown",
+                        "title": _text(todo.get("text") or todo.get("title"))
+                        if todo
+                        else None,
+                        "source": "core_todo_current_read"
+                        if todo
+                        else "core_todo_unavailable_or_not_found",
+                    }
+                )
+        item = {k: row[k] for k in ("request_id", "goal_id", "agent_id", "source_id")}
+        item.update(
+            delivery={"status": "delivered", "at": row.get("delivered_at")},
+            read={
+                "status": "supplied_to_receiver"
+                if read
+                else "decision_exists_read_receipt_missing"
+                if decision
+                else "not_recorded",
+                "at": read.get("read_at"),
+            },
+            decision={
+                "status": decision.get("decision", "not_recorded"),
+                "at": decision.get("decided_at"),
+            },
+            linked_todos=linked,
+            evidence_refs=links.get("evidence_ids", []),
+            evidence_verification="receiver_linked_reference_not_independent_verification",
+            warnings=warnings,
+        )
+        if owner_scope:
+            item["decision"]["reason"] = decision.get("reason")
+        else:
+            item["decision"]["reason_visibility"] = "owner_only"
+        projected.append(item)
+    return {
+        "source": "manager_context_receipts_and_core_todos",
+        "observed_at": _now(),
+        "rows": projected,
+        "matched": len(rows),
+        "coverage": {
+            "scan_complete": len(paths) <= 2000,
+            "legacy_audience_scan_complete": owner_scope or len(ingress_paths) <= 2000,
+            "unreadable": unreadable,
+        },
+        "limitations": [
+            "Missing historical timestamps remain unknown; file mtime is not an event time.",
+            "Read receipt proves CLI provision, not model comprehension.",
+            "Adoption and linked Todo completion do not establish the overall request outcome.",
+        ],
+    }

--- a/loopx/chat_manager.py
+++ b/loopx/chat_manager.py
@@ -83,7 +83,7 @@ def open_manager_session(
     )
 
 
-MANAGER_CONTEXT_VERSION = 6
+MANAGER_CONTEXT_VERSION = 7
 
 
 def manager_skill_text() -> str:

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -1037,6 +1037,7 @@ class ChatRuntimeController:
                         context=context, registry_path=self.registry_path,
                         runtime_root=self.store.root.parent,
                         owner_scope=session.get("channel_id") == "manager",
+                        channel_id=session.get("channel_id"),
                         scope_valid=scope_valid,
                         record=lambda result: self.store.append_event(
                             session_id, turn_id, kind="manager.evidence_read", payload=result,

--- a/loopx/cli_commands/manager_inbox.py
+++ b/loopx/cli_commands/manager_inbox.py
@@ -17,7 +17,8 @@ def register_manager_inbox(subparsers, add_format):
     )
     add_format(parser)
     parser.add_argument(
-        "manager_inbox_action", choices=("read", "acknowledge", "configure-read-scope")
+        "manager_inbox_action",
+        choices=("read", "acknowledge", "link", "status", "configure-read-scope"),
     )
     parser.add_argument("--goal-id")
     parser.add_argument("--agent-id")
@@ -25,6 +26,10 @@ def register_manager_inbox(subparsers, add_format):
     parser.add_argument("--read-goal-id", action="append", default=[])
     parser.add_argument("--execute", action="store_true")
     parser.add_argument("--request-id")
+    parser.add_argument("--related-todo-id", action="append", default=[])
+    parser.add_argument("--evidence-id", action="append", default=[])
+    parser.add_argument("--offset", type=int, default=0)
+    parser.add_argument("--limit", type=int, default=8)
     parser.add_argument("--decision", choices=("adopt", "defer", "reject", "no_change"))
     parser.add_argument("--reason")
 
@@ -49,6 +54,40 @@ def handle_manager_inbox(args, registry_path, runtime_root):
             raise ValueError("recipient is not registered")
         if args.manager_inbox_action == "read":
             result = pending(runtime_root, args.goal_id, args.agent_id)
+            from ..capabilities.manager_context.tracking import record_read
+
+            record_read(runtime_root, result["items"])
+            result["followthrough"] = (
+                "After deciding, use manager-inbox link with --related-todo-id and/or --evidence-id (sha256) to associate Core work; do not copy progress into the inbox."
+            )
+        elif args.manager_inbox_action == "link":
+            from ..capabilities.manager_context.tracking import link
+
+            result = link(
+                runtime_root,
+                registry_path,
+                args.goal_id,
+                args.agent_id,
+                args.request_id or "",
+                args.related_todo_id,
+                args.evidence_id,
+            )
+        elif args.manager_inbox_action == "status":
+            from ..capabilities.manager_context.tracking import query
+
+            result = {
+                "ok": True,
+                **query(
+                    runtime_root,
+                    registry_path,
+                    goal_ids=[args.goal_id],
+                    owner_scope=True,
+                    request_id=args.request_id,
+                    agent_id=args.agent_id,
+                    offset=args.offset,
+                    limit=args.limit,
+                ),
+            }
         else:
             result = acknowledge(
                 runtime_root,

--- a/tests/test_manager_context_tracking.py
+++ b/tests/test_manager_context_tracking.py
@@ -1,0 +1,232 @@
+"""Handoff states, durable receipts and audience separation through real stores."""
+
+import json
+from argparse import Namespace
+
+import pytest
+
+import test_manager_context_handoff as handoff_tests
+from loopx.capabilities.manager_context import (
+    _hash,
+    _root,
+    _read,
+    _write,
+    deliver,
+    acknowledge,
+    pending,
+    turn_start_hook,
+    register_ingress,
+    POLICY_SCHEMA,
+)
+from loopx.capabilities.manager_context.tracking import query, record_read, link
+from loopx.capabilities.manager_context.inspection import ManagerInspection, TOOL_NAME
+from loopx.cli_commands.manager_inbox import handle_manager_inbox
+
+
+@pytest.fixture
+def fixture(tmp_path):
+    return handoff_tests.fixture.__wrapped__(tmp_path)
+
+
+def test_delivery_read_decision_are_separate_and_restart_safe(fixture, capsys):
+    root, registry, session, turn, target = fixture
+    rid = deliver(root, registry, session=session, turn=turn, request=target)[
+        "request_id"
+    ]
+
+    def status():
+        return query(root, registry, goal_ids=["research"], owner_scope=True)["rows"][0]
+
+    first = status()
+    assert first["delivery"]["at"] and first["read"]["status"] == "not_recorded"
+    turn_start_hook(root, registry, "research", "worker").producer()
+    assert status()["read"]["status"] == "not_recorded"
+    args = Namespace(manager_inbox_action="read", goal_id="research", agent_id="worker")
+    assert handle_manager_inbox(args, registry, root) == 0
+    assert json.loads(capsys.readouterr().out)["items"][0]["message"] == turn["message"]
+    read_at = status()["read"]["at"]
+    record_read(root, pending(root, "research", "worker")["items"])
+    assert status()["read"]["at"] == read_at
+    acknowledge(root, "research", "worker", rid, "adopt", "Investigate independently")
+    at = status()["decision"]["at"]
+    acknowledge(root, "research", "worker", rid, "adopt", "Investigate independently")
+    assert status()["decision"]["at"] == at
+    assert status()["decision"]["status"] == "adopt"
+    assert status()["linked_todos"] == []
+    assert deliver(root, registry, session=session, turn=turn, request=target)[
+        "replayed"
+    ]
+    assert status()["delivery"]["at"] == first["delivery"]["at"]
+
+
+def test_legacy_decision_is_not_a_fabricated_read(fixture):
+    root, registry, session, turn, target = fixture
+    rid = deliver(root, registry, session=session, turn=turn, request=target)[
+        "request_id"
+    ]
+    path = _root(root) / "entries" / _hash(target) / (rid + ".json")
+    old = _read(path)
+    old.pop("delivered_at")
+    old.pop("source_channel")
+    _write(path, old)
+    _write(
+        _root(root) / "decisions" / (rid + ".json"),
+        dict(request_id=rid, **target, decision="adopt", reason="Legacy"),
+    )
+    assert deliver(root, registry, session=session, turn=turn, request=target)[
+        "replayed"
+    ]
+    row = query(root, registry, goal_ids=["research"], owner_scope=True)["rows"][0]
+    assert row["delivery"]["at"] is None and row["decision"]["at"] is None
+    assert row["read"]["status"] == "decision_exists_read_receipt_missing"
+    assert row["read"]["at"] is None
+
+
+def test_external_query_is_exact_audience_not_just_goal(fixture):
+    root, registry, session, turn, target = fixture
+    web = deliver(root, registry, session=session, turn=turn, request=target)[
+        "request_id"
+    ]
+    ids = {}
+    for channel in ["manager.external.one", "manager.external.two"]:
+        external = dict(session, channel_id=channel)
+        incoming = dict(turn, origin="lark", client_turn_id=channel)
+        _write(
+            _root(root) / "policy.json",
+            {
+                "schema_version": POLICY_SCHEMA,
+                "sources": {channel: {"sender_ids": ["owner"], "targets": [target]}},
+            },
+        )
+        register_ingress(
+            root,
+            session_id=external["session_id"],
+            client_turn_id=channel,
+            channel=channel,
+            sender_id="owner",
+            message=turn["message"],
+            source_id="lark:" + channel,
+        )
+        rid = deliver(root, registry, session=external, turn=incoming, request=target)[
+            "request_id"
+        ]
+        acknowledge(
+            root, "research", "worker", rid, "adopt", "Private receiver rationale"
+        )
+        ids[channel] = rid
+
+    def tool(scope=lambda: True):
+        return ManagerInspection(
+            context={"goals": [{"goal_id": "research"}]},
+            registry_path=registry,
+            runtime_root=root,
+            owner_scope=False,
+            scope_valid=scope,
+            record=lambda _: None,
+            channel_id="manager.external.one",
+        )
+
+    rows = tool().read(TOOL_NAME, {"view": "handoffs"})["rows"]
+    assert [r["request_id"] for r in rows] == [ids["manager.external.one"]]
+    assert "Private receiver rationale" not in json.dumps(rows)
+    assert turn["message"] not in json.dumps(rows)
+    assert tool().read(TOOL_NAME, {"view": "handoffs", "request_id": web})["rows"] == []
+    revoked = iter([True, False])
+    assert (
+        tool(lambda: next(revoked)).read(TOOL_NAME, {"view": "handoffs"})["error"]
+        == "authorization_changed"
+    )
+    # Legacy same-source provenance still resolves; changing audience is not inferred.
+    path = (
+        _root(root)
+        / "entries"
+        / _hash(target)
+        / (ids["manager.external.one"] + ".json")
+    )
+    old = _read(path)
+    old.pop("source_channel")
+    _write(path, old)
+    assert tool().read(TOOL_NAME, {"view": "handoffs"})["included"] == 1
+
+
+def test_links_use_core_state_and_do_not_copy_progress(fixture, monkeypatch):
+    import loopx.capabilities.manager_context.tracking as tracking
+
+    root, registry, session, turn, target = fixture
+    rid = deliver(root, registry, session=session, turn=turn, request=target)[
+        "request_id"
+    ]
+    tid = "todo_123456789abc"
+    core = {
+        "ok": True,
+        "todos": [
+            {
+                "todo_id": tid,
+                "claimed_by": "worker",
+                "text": "Evaluate hypothesis",
+                "status": "open",
+            }
+        ],
+    }
+    monkeypatch.setattr(tracking, "list_goal_todos", lambda **_: core)
+    ref = "sha256:" + "a" * 64
+    link(root, registry, "research", "worker", rid, [tid], [ref])
+    path = _root(root) / "links" / (rid + ".json")
+    original = path.read_bytes()
+    link(root, registry, "research", "worker", rid, [tid], [ref])
+    assert path.read_bytes() == original
+    core["todos"][0]["status"] = "done"
+    row = query(root, registry, goal_ids=["research"], owner_scope=True)["rows"][0]
+    assert row["linked_todos"][0]["status"] == "done"
+    assert row["decision"]["status"] == "not_recorded"
+    assert row["evidence_refs"] == [ref]
+    with pytest.raises(ValueError):
+        link(root, registry, "research", "worker", rid, ["todo_ffffffffffff"], [])
+    with pytest.raises(ValueError):
+        link(root, registry, "research", "worker", rid, [], ["/private/raw.txt"])
+    assert "Evaluate hypothesis" not in path.read_text()
+
+
+def test_pagination_and_conflicts_do_not_erase_gaps(fixture):
+    root, registry, session, turn, target = fixture
+    for i in range(14):
+        deliver(
+            root,
+            registry,
+            session=session,
+            turn=dict(turn, client_turn_id=str(i)),
+            request=target,
+        )
+    first = query(root, registry, goal_ids=["research"], owner_scope=True, limit=12)
+    second = query(
+        root, registry, goal_ids=["research"], owner_scope=True, offset=12, limit=12
+    )
+    assert first["matched"] == 14 and len(second["rows"]) == 2
+    rid = first["rows"][0]["request_id"]
+    _write(
+        _root(root) / "decisions" / (rid + ".json"),
+        dict(request_id=rid, goal_id="other", agent_id="peer", decision="adopt"),
+    )
+    row = query(
+        root, registry, goal_ids=["research"], owner_scope=True, request_id=rid
+    )["rows"][0]
+    assert row["decision"]["status"] == "not_recorded"
+    assert row["warnings"] == ["decisions_unreadable_or_conflicting"]
+    links_path = _root(root) / "links" / (rid + ".json")
+    _write(
+        links_path,
+        dict(request_id=rid, **target, todo_ids=[], evidence_ids=["/private/secret"]),
+    )
+    row = query(
+        root, registry, goal_ids=["research"], owner_scope=True, request_id=rid
+    )["rows"][0]
+    assert row["evidence_refs"] == []
+    assert "links_unreadable_or_conflicting" in row["warnings"]
+    with pytest.raises(ValueError, match="links_unreadable_or_conflicting"):
+        link(root, registry, "research", "worker", rid, [], ["sha256:" + "b" * 64])
+    assert (
+        query(root, registry, goal_ids=["research"], owner_scope=True, agent_id="peer")[
+            "rows"
+        ]
+        == []
+    )


### PR DESCRIPTION
A manager could persist a context handoff but could not inspect its delivery or receiver decision, leaving follow-up questions with no evidence-backed answer. The shared manager read tool now exposes `handoffs`, used by frontend and Lark, with separate delivery/read/decision receipts and explicit links to current Core Todos and opaque evidence references.

Receiver CLI reads record an idempotent first-read receipt; quota peeks remain read-only. `manager-inbox link/status` reuse the builtin manager-context capability. Existing entries and decisions remain replay-compatible and missing historical timestamps stay unknown. Manager context version 7 refreshes old upstream tool schemas while preserving logical Chat history.

External queries require the current Goal scope and exact originating audience, redact original messages and private receiver reasons, and recheck authorization after reading. Links do not change priorities or create a second progress store. Evidence references are receiver assertions; they do not prove overall completion.

Validation: 38 focused tests passed, Chat runtime and agent integration smokes passed, Ruff and diff/privacy checks passed. Full risk-based premerge validation passed on the frozen commit. Real receipt queries were also checked locally under both audience projections without sending synthetic group messages.
