### PR TITLE
fix(update): harden pinned installs and separate prompt readiness

### DIFF
--- a/docs/reference/automation-prompt-upgrades.md
+++ b/docs/reference/automation-prompt-upgrades.md
@@ -35,14 +35,32 @@ not Todo, quota or scheduler authority.
 
 ## Automatic upgrade and manual adoption
 
-`loopx update --apply` now captures an owner-only snapshot **before** replacing
+`loopx update apply` now captures an owner-only snapshot **before** replacing
 the runtime and invokes `automation-prompts sync-installed` in the **new**
 runtime afterward. Exact recognized managed bootstraps and byte-identical
 prompts reproduced by the old installed generator may migrate automatically.
 An automation name, matching prose or Goal id alone never authorizes adoption.
 Custom instructions remain `review_required`; a canary executable, different
 registry/home or changed preview is not silently retargeted. Binary-install
-success and prompt-migration success are reported separately.
+success and prompt-migration success are reported separately. `upgrade_complete`
+is true only when runtime qualification and prompt reconciliation both succeed;
+the existing `ok` field retains its runtime-result meaning. A successful install
+and core doctor still run prompt reconciliation when an optional extension
+fails its doctor, without clearing that extension failure or its repair action.
+Failed installation or core doctor never starts prompt writes.
+
+Upgrading from a CLI that predates this hook cannot retroactively capture its
+old template evidence. After installation, run the new `automation-prompts plan`
+and review/adopt the selected tasks through the App. Never interpret absence of
+a migration report as proof of migration, or loosen exact-template ownership
+to make a historical custom prompt appear automatically eligible.
+
+Archive updates pinned with `--ref <full-commit-SHA>` download that exact archive
+without a GitHub commit-API lookup. Symbolic refs still require resolution to a
+full hexadecimal SHA. If the public API fails, the installer can reuse existing
+`gh` authentication for the same GitHub repository/ref under a bounded timeout;
+it neither logs in nor selects another ref. If both routes fail, retry with an
+independently verified full SHA. Downloads have bounded timeouts and retries.
 
 **Exact managed v1 wrappers upgrade to v2 automatically through this path;
 they do not require per-task approval.** `automation-prompts plan` is only a
@@ -173,6 +191,11 @@ thin 指令；之后升级 LoopX 即可让下一轮采用新版规则，无需�
 仅完整匹配的托管指令可自动更新；自定义内容不猜测合并、不自动删除。macOS
 已匹配的 heartbeat 存储支持 App 运行中直接写入，仅改 prompt，持有数据库写锁
 直到 TOML 交付和读回完成。两种存储并非一个原子事务；冲突或异常保留私有日志，
-不伪报成功。日程、暂停状态、模型、线程、通知偏好和历史均不迁移。
+不伪报成功。`upgrade_complete` 同时覆盖 runtime 与 prompt；可选扩展检查失败
+不阻止已经通过安装和核心 doctor 的 runtime 继续迁移 prompt，扩展故障仍保留。
+首次从不含迁移钩子的旧 CLI 升级，应再用新版 plan 审阅并采用旧任务，不能把
+缺少迁移报告当作已迁移。完整 SHA 下载不依赖提交查询；分支查询失败可复用已有
+gh 登录，仍失败则明确要求已核验 SHA，不切换分支或静默覆盖自定义指令。
+日程、暂停状态、模型、线程、通知偏好和历史均不迁移。
 不支持的存储仍需原生 API；运行中的本轮不热切换。普通测试不消耗模型 token，
 真实模型发布资格仍需独立评测，不能由迁移成功推断。

--- a/loopx/control_plane/heartbeat/installed_prompt_update.py
+++ b/loopx/control_plane/heartbeat/installed_prompt_update.py
@@ -87,6 +87,8 @@ def reconcile(*, before: dict, registry: Path, home: Path,
             result["status"] = "missing"
         elif now["status"] in {"current", "unmanaged", "blocked"}:
             result["status"] = now["status"]
+            if now.get("reason"):
+                result["reason"] = now["reason"]
         elif any(old.get(key) != now.get(key) for key in
                  ("source_sha256", "prompt_sha256", "target_thread_id", "goal_id", "agent_id")):
             result["status"] = "changed_since_snapshot"
@@ -143,12 +145,24 @@ def update_with_prompts(payload: dict, *, registry: Path, runtime_root: str | No
     except (ValueError, OSError, sqlite3.Error) as error:
         before = {"ok": False, "status": "discovery_failed", "reason": str(error)}
     updated = runtime_update(payload, timeout_seconds=timeout_seconds)
-    if not updated.get("ok"):
+    # Optional extension qualification is not binary installation readiness.
+    # Do not strand managed prompts after a successful install + core doctor,
+    # but preserve the failed aggregate result and its original repair action.
+    runtime_ready = bool(updated.get("ok"))
+    execution = updated.get("execution", {})
+    installed = runtime_ready or (updated.get("changes_applied") is True
+        and execution.get("install_returncode") == 0
+        and execution.get("doctor_returncode") == 0)
+    updated["upgrade_complete"] = False
+    if not installed:
         updated["automation_prompt_upgrade"] = {"status": "skipped_runtime_update_failed"}
         return updated
     if not before.get("ok") or not before.get("entries"):
         updated["automation_prompt_upgrade"] = {
             key: value for key, value in before.items() if key in {"ok", "status", "reason"}}
+        updated["upgrade_complete"] = runtime_ready and before.get("ok") is True
+        if not before.get("ok") and runtime_ready:
+            updated["recommended_action"] = "Runtime updated; automation discovery failed. Review automation-prompts plan through the App before adopting prompts."
         return updated
     directory = Path(tempfile.mkdtemp(prefix="loopx-prompt-update-"))
     plan_file = directory / "before.json"
@@ -176,13 +190,16 @@ def update_with_prompts(payload: dict, *, registry: Path, runtime_root: str | No
         report = {"ok": False, "status": "reconciliation_failed"}
     if not report.get("ok"):
         report["snapshot_file"] = str(plan_file)
-        updated["recommended_action"] = "Runtime updated; review pending automation prompts using the App API, or retry the saved snapshot with the App closed."
-        updated["next_action"] = {"kind": "apply_host_prompt_updates", "mutating": True,
-            "requires_explicit_approval": False,
-            "reason": "Only byte-exact managed prompts have automatic adoption authority; custom entries require separate review.",
-            "api_updates": report.get("api_updates", [])}
+        if runtime_ready:
+            updated["recommended_action"] = "Runtime updated; review pending automation prompts using the App API, or retry sync-installed with the saved snapshot. Custom prompts and alternate loader bindings require explicit review."
+            updated["next_action"] = {"kind": "apply_host_prompt_updates", "mutating": True,
+                "requires_explicit_approval": any(row.get("status") == "review_required"
+                    for row in report.get("results", [])),
+                "reason": "Only byte-exact managed prompts have automatic adoption authority; custom entries require separate review.",
+                "api_updates": report.get("api_updates", [])}
     else:
         plan_file.unlink()
         directory.rmdir()
     updated["automation_prompt_upgrade"] = report
+    updated["upgrade_complete"] = runtime_ready and report.get("ok") is True
     return updated

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -1386,8 +1386,12 @@ def render_update_plan_markdown(payload: dict[str, Any]) -> str:
     if isinstance(prompt_upgrade, dict):
         lines.extend(["", "## Automation Prompts", "",
                       f"- Status: `{prompt_upgrade.get('status')}`"])
+        if "upgrade_complete" in payload:
+            lines.append(f"- Upgrade complete (runtime + prompts): `{payload['upgrade_complete']}`")
         for item in prompt_upgrade.get("results", []):
             lines.append(f"- `{item['automation_id']}`: `{item['status']}`")
+            if item.get("reason"):
+                lines.append(f"  - {item['reason']}")
         if prompt_upgrade.get("snapshot_file"):
             lines.append(f"- Private recovery snapshot: `{prompt_upgrade['snapshot_file']}`")
         if prompt_upgrade.get("next_action"):

--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -37,7 +37,16 @@ if [[ -z "$archive_url" ]]; then
     echo "loopx installer error: LOOPX_REPO must use GitHub owner/name syntax" >&2
     exit 2
   fi
-  commit_api_url="$("$python_bin" - "$repo" "$ref" <<'PY'
+  if [[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+    # Immutable inputs need no branch-resolution service (or GitHub API quota).
+    resolved_commit="$(printf '%s' "$ref" | tr '[:upper:]' '[:lower:]')"
+    if [[ -n "${LOOPX_RESOLVED_SOURCE_GIT_COMMIT:-}" \
+      && "$(printf '%s' "$LOOPX_RESOLVED_SOURCE_GIT_COMMIT" | tr '[:upper:]' '[:lower:]')" != "$resolved_commit" ]]; then
+      echo "loopx installer error: resolved commit disagrees with the requested full SHA" >&2
+      exit 2
+    fi
+  else
+    commit_api_url="$("$python_bin" - "$repo" "$ref" <<'PY'
 from urllib.parse import quote
 import sys
 
@@ -49,22 +58,50 @@ print(
 )
 PY
 )"
-  curl -fsSL \
+    if ! curl -fsSL --connect-timeout 10 --max-time 30 --retry 2 --retry-max-time 45 \
     -H 'Accept: application/vnd.github+json' \
     -H 'User-Agent: LoopX-installer' \
-    "$commit_api_url" -o "$tmp_dir/commit.json"
-  resolved_commit="$("$python_bin" - "$tmp_dir/commit.json" <<'PY'
+      "$commit_api_url" -o "$tmp_dir/commit.json"; then
+      # Reuse an existing login when available; never request credentials or
+      # fall back to a different branch. Keep both transport and capture bounded.
+      echo "loopx installer: public commit lookup failed; trying existing GitHub CLI authentication" >&2
+      "$python_bin" - "$commit_api_url" "$tmp_dir/commit.json" <<'PY'
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from urllib.parse import urlsplit
+
+gh = shutil.which("gh")
+if gh:
+    try:
+        with Path(sys.argv[2]).open("wb") as output:
+            result = subprocess.run(
+                [gh, "api", "--hostname", "github.com", urlsplit(sys.argv[1]).path],
+                stdout=output, stderr=subprocess.DEVNULL, timeout=30, check=False,
+            )
+        if result.returncode == 0:
+            raise SystemExit(0)
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+raise SystemExit("Commit lookup failed. Retry with LOOPX_REF=<verified full commit SHA>; "
+                 "no runtime was installed and no alternate ref was selected.")
+PY
+    fi
+    resolved_commit="$("$python_bin" - "$tmp_dir/commit.json" <<'PY'
 import json
+import re
 import sys
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     payload = json.load(handle)
 sha = payload.get("sha")
-if not isinstance(sha, str) or len(sha) != 40:
+if not isinstance(sha, str) or re.fullmatch(r"[0-9a-fA-F]{40}", sha) is None:
     raise SystemExit("GitHub commit response did not include a full SHA")
-print(sha)
+print(sha.lower())
 PY
 )"
+  fi
   export LOOPX_RESOLVED_SOURCE_GIT_COMMIT="$resolved_commit"
   archive_url="https://codeload.github.com/$repo/tar.gz/$resolved_commit"
 fi
@@ -75,7 +112,8 @@ extract_dir="$tmp_dir/extract"
 mkdir -p "$extract_dir"
 
 echo "loopx installer: downloading $archive_url" >&2
-curl -fsSL "$archive_url" -o "$archive_path"
+curl -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-max-time 150 \
+  "$archive_url" -o "$archive_path"
 archive_sha256="$("$python_bin" - "$archive_path" <<'PY'
 from pathlib import Path
 import hashlib

--- a/tests/control_plane/test_automation_prompt_upgrade.py
+++ b/tests/control_plane/test_automation_prompt_upgrade.py
@@ -189,12 +189,14 @@ def test_runtime_update_invokes_new_cli_and_migrates_only_managed_prompts(tmp_pa
         runtime_update=lambda payload, **_: {**payload, "ok": True, "changes_applied": True})
     assert len(invoked) == 1 and result["ok"]
     report = result["automation_prompt_upgrade"]
+    assert result["upgrade_complete"] is managed_v1
     assert report["status"] == ("current" if managed_v1 else "attention_required")
     assert report["results"] == [{"automation_id": "watch", "status": "updated" if managed_v1 else "review_required"}]
     if managed_v1:
         assert "snapshot_file" not in report
     else:
         assert Path(report["snapshot_file"]).exists()
+        assert result["next_action"]["requires_explicit_approval"] is True
     after_manifest = tomllib.loads(path.read_text())
     assert after_manifest == {**manifest, "prompt": desired if managed_v1 else manifest["prompt"]}
     with sqlite3.connect(database) as connection:
@@ -217,6 +219,40 @@ def test_failed_install_never_attempts_prompt_writes(tmp_path, monkeypatch):
         timeout_seconds=1, runtime_update=lambda payload, **_: {"ok": False})
     assert result["automation_prompt_upgrade"]["status"] == "skipped_runtime_update_failed"
     assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("install_code,doctor_code,changes_applied,expected_status", [
+    (0, 0, True, "attention_required"),
+    (1, 0, True, "skipped_runtime_update_failed"),
+    (0, 1, True, "skipped_runtime_update_failed"),
+    (0, 0, False, "skipped_runtime_update_failed"),
+])
+def test_prompt_reconciliation_is_independent_of_optional_extension_health(
+    tmp_path, monkeypatch, install_code, doctor_code, changes_applied, expected_status,
+):
+    from loopx.control_plane.heartbeat import installed_prompt_update as lifecycle
+    home, path, _, registry, _ = fixture(tmp_path)
+    monkeypatch.setattr("loopx.upgrade.codex_home", lambda: home)
+    real_run = subprocess.run
+    calls = []
+    def run(command, **kwargs):
+        calls.append(command)
+        # Exercise real new-runtime CLI and SQLite/TOML readback.
+        return real_run(command, capture_output=True, text=True, timeout=60)
+    monkeypatch.setattr(lifecycle.subprocess, "run", run)
+    runtime_result = {"ok": False, "changes_applied": changes_applied,
+        "execution": {"install_returncode": install_code, "doctor_returncode": doctor_code,
+                      "extension_doctor_returncode": 1},
+        "next_action": {"kind": "review_or_rollback"}, "recommended_action": "Inspect optional extensions"}
+    result = lifecycle.update_with_prompts(
+        {"install_lifecycle": {"execution_driver": "python_pip"}}, registry=registry,
+        runtime_root=None, timeout_seconds=60, runtime_update=lambda *_, **__: runtime_result)
+    assert result["automation_prompt_upgrade"]["status"] == expected_status
+    assert len(calls) == (1 if expected_status == "attention_required" else 0)
+    assert not result["ok"] and not result["upgrade_complete"]
+    assert result["next_action"] == {"kind": "review_or_rollback"}
+    assert result["recommended_action"] == "Inspect optional extensions"
+    assert "bootstrap" not in tomllib.loads(path.read_text())["prompt"]
 
 
 def test_update_identifies_owned_legacy_body_and_migrates_without_changing_schedule(tmp_path, monkeypatch):

--- a/tests/test_archive_installer_commit_response.py
+++ b/tests/test_archive_installer_commit_response.py
@@ -38,13 +38,16 @@ def test_invalid_commit_override_precedes_temp_directory_failure(tmp_path):
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX archive installer")
-@pytest.mark.parametrize("valid", [True, False])
-def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
+@pytest.mark.parametrize("valid", [True, False, "nonhex"])
+@pytest.mark.parametrize("ref_kind", ["branch", "sha"])
+@pytest.mark.parametrize("api_mode", ["public", "authenticated", "unavailable"])
+def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid, ref_kind, api_mode):
     source = Path(__file__).resolve().parents[1]
     sha = "a" * 40
     fixture = tmp_path / "response.json"
     fixture.write_text(
-        json.dumps({"sha": sha if valid else None, "patch": "x" * 524288})
+        json.dumps({"sha": "z" * 40 if valid == "nonhex" else sha if valid else None,
+                    "patch": "x" * 524288})
     )
     package = tmp_path / "package" / "scripts"
     package.mkdir(parents=True)
@@ -66,6 +69,9 @@ def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
         + shlex.quote(
             "import os,sys,shutil; "
             "args=sys.argv[1:]; "
+            "is_api=any('api.github.com' in a for a in args); "
+            "open(os.environ['TEST_CALLS'],'a').write('api\\n' if is_api else 'archive\\n'); "
+            "sys.exit(22) if is_api and (os.environ['TEST_REF_KIND']=='sha' or os.environ['TEST_API_MODE']!='public') else None; "
             "source=os.environ['TEST_RESPONSE'] if any('api.github.com' in a for a in args) "
             "else os.environ['TEST_ARCHIVE']; "
             "target=args[args.index('-o')+1] if '-o' in args else None; "
@@ -74,6 +80,15 @@ def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
         + ' "$@"\n'
     )
     curl.chmod(0o755)
+    gh = binary / "gh"
+    gh.write_text("#!/bin/sh\nexec " + shlex.quote(sys.executable) + " -c " + shlex.quote(
+        "import os,sys; "
+        "assert sys.argv[1:]==['api','--hostname','github.com','/repos/huangruiteng/loopx/commits/stable']; "
+        "open(os.environ['TEST_CALLS'],'a').write('authenticated\\n'); "
+        "sys.exit(1) if os.environ['TEST_API_MODE']=='unavailable' else None; "
+        "sys.stdout.write(open(os.environ['TEST_RESPONSE']).read())"
+    ) + ' "$@"\n')
+    gh.chmod(0o755)
     scratch = tmp_path / "scratch"
     scratch.mkdir()
     receipt = tmp_path / "receipt"
@@ -82,7 +97,10 @@ def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
         PATH=f"{binary}{os.pathsep}{env['PATH']}",
         TMPDIR=str(scratch),
         LOOPX_PYTHON=sys.executable,
-        LOOPX_REF=sha,
+        LOOPX_REF=sha if ref_kind == "sha" else "stable",
+        TEST_REF_KIND=ref_kind,
+        TEST_API_MODE=api_mode,
+        TEST_CALLS=str(tmp_path / "calls"),
         TEST_RESPONSE=str(fixture),
         TEST_ARCHIVE=str(archive),
         TEST_RECEIPT=str(receipt),
@@ -94,7 +112,11 @@ def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
         text=True,
         timeout=30,
     )
-    if valid:
+    if ref_kind == "branch" and api_mode == "unavailable":
+        assert result.returncode != 0
+        assert "verified full commit SHA" in result.stderr
+        assert not receipt.exists()
+    elif valid is True or ref_kind == "sha":
         assert result.returncode == 0, result.stderr
         assert receipt.read_text().strip() == sha
     else:
@@ -102,3 +124,9 @@ def test_commit_response_uses_file_transport_and_cleans_up(tmp_path, valid):
         assert "did not include a full SHA" in result.stderr
         assert not receipt.exists()
     assert list(scratch.iterdir()) == []
+    calls = (tmp_path / "calls").read_text().splitlines()
+    if ref_kind == "sha":
+        assert calls == ["archive"]
+    else:
+        assert calls[0] == "api"
+        assert ("authenticated" in calls) == (api_mode != "public")


### PR DESCRIPTION
## Summary

- Pinned full-SHA archive installs bypass unnecessary GitHub commit resolution. Symbolic refs retain exact resolution, with bounded authenticated `gh` fallback and no alternate-ref fallback.
- After successful binary installation and core doctor, reconcile managed prompts even if an optional extension doctor fails. Preserve the extension failure and original repair action.
- Report `upgrade_complete` separately from the existing runtime `ok` result; retain blocked-entry reasons and require review for custom prompts or alternate loader bindings.
- Document first-upgrade limitations for older CLIs without the migration hook. No fuzzy prompt adoption, scheduler mutation, session migration, or new capability/provider.

## Validation

- Tested revision: 934b2db44
- Run state: finished
- Input classes: synthetic

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| `unit` / `integration` | `passed` | 85 passed: `tests/test_self_update_runtime_activation.py`, `tests/test_self_update_download.py`, `tests/test_archive_installer_commit_response.py`, `tests/control_plane/test_automation_prompt_upgrade.py`. One native-Windows-only test skipped on macOS. |
| `real_entrypoint` | `passed` | Shipped shell installer executed with real archive extraction and synthetic transport/installation target; new-runtime Python CLI exercised against isolated real SQLite/TOML stores. |
| `regression_parity` | `passed` | Before the fix, full-SHA installs still queried the failing API, and non-hex 40-character responses were accepted (4 new regression cases failed). After the fix, pinned installs make only the archive request; symbolic auth fallback and failure cases are covered. |
| `static` | `passed` | Ruff on changed Python files, `bash -n scripts/install-from-github.sh`, diff whitespace and public/private scans. |

Coverage: exact SHA, public/authenticated/unavailable lookup, malformed SHA, temporary-file cleanup, core-install/doctor failures, optional-extension failure, custom/canary prompt non-adoption, replay, and SQLite/TOML preservation. No live model calls: this change does not alter inner prompt or Todo/quota semantics. Full hosted CI and post-merge installation are reported separately; tests do not simulate the whole GitHub service or prove long-horizon model uplift.

## Design / risk

The existing installer owns transport; the existing heartbeat upgrade boundary owns prompt readiness. No new abstraction or second migration engine. The default change is deliberate: optional extension failure no longer suppresses otherwise safe prompt reconciliation, but still prevents a fully healthy upgrade result. Exact-template ownership, same-home checks, compare-and-swap, and schedule/thread boundaries remain unchanged.

## Boundary checklist

- [x] No private prompts, session data, local paths, credentials or raw logs in this diff/body.
- [x] Dedicated branch based on current main; one cohesive fix with focused regressions.
- [x] DCO sign-off.
- [x] Owner authorized self-merge and a task-scoped local Git-window bypass after validation.

Shared-authority RFC fixture impact: N/A; no authority-store, Todo, projection-routing or promotion change.
