### PR TITLE
Read remote manager progress from scoped SSH Core evidence

### DIFF
--- a/loopx/capabilities/manager_context/README.md
+++ b/loopx/capabilities/manager_context/README.md
@@ -91,12 +91,41 @@ recent delivery window is still yesterday through now; arbitrary artifact paths
 and external links are not fetched. Existing non-Codex adapters retain their
 context projection until they implement an equivalent tool contract.
 
-Manager context version 8 starts a fresh upstream session for older manager
+Manager context version 9 starts a fresh upstream session for older manager
 contexts. The logical Chat session and its receipts remain intact. Runtime support
 uses the Codex app-server dynamic tool protocol; explicit upstream terminal
 errors remain errors and are not retried as part of inspection. The version
 change refreshes the operating contract on existing installations;
 resuming an old upstream thread would retain its previous instructions.
+
+### Remote evidence sources
+
+The manager discovers SSH aliases through the same host catalog as the frontend
+source switcher. `loopx_manager_read view=sources` lists eligible sources; select
+`source_id=ssh:<alias>` for portfolio, Todo or delivery reads. Reads execute a
+fixed, bounded CLI projection on the selected host, using its global registry,
+not local tasks whose titles mention SSH. Source host and Goal ID jointly identify
+the evidence; a missing declared execution `host_id` does not erase source provenance.
+
+Owner-local conversations may inspect configured hosts on demand. External
+conversations require a persistent, exact host/Goal read grant from the local
+operator, in addition to their live connection authorization:
+
+```sh
+loopx manager-inbox configure-ssh-read-scope --channel-id manager.external.0123456789abcdef01234567 --ssh-host research-host --read-goal-id project-a --execute
+```
+
+Omit `--execute` for a preview; pass no Goals to revoke that host. This grants
+summary reads only, not delegation, shell commands or remote writes. Changed
+grants invalidate upstream manager context; revocation during a read discards
+the result. No remote connections occur merely to list sources. Offline hosts,
+older unsupported remote runtimes and missing Goals remain explicit unknowns.
+
+The remote CLI uses `goal-portfolio --manager-view portfolio|todos|deliveries`
+and the same Core readers as the local manager. Pagination remains explicit.
+Delivery reads support `days=1..90` so latest known historical outcomes can be
+explained alongside fresh current Todos without pretending stale execution is
+current. Both hosts need the updated LoopX runtime.
 
 
 ## A delegation returns automatically

--- a/loopx/capabilities/manager_context/evidence_export.py
+++ b/loopx/capabilities/manager_context/evidence_export.py
@@ -1,0 +1,48 @@
+"""CLI wire projection reusing the manager's existing Core providers."""
+
+import json
+from pathlib import Path
+
+
+def export_page(registry_path, runtime_root_arg, args):
+    from ...paths import resolve_runtime_root
+    from ...chat_manager_context import manager_turn_context
+    from .inspection import ManagerInspection, TOOL_NAME
+
+    registry = json.loads(Path(registry_path).read_text())
+    root = resolve_runtime_root(registry, runtime_root_arg, registry_path=registry_path)
+    ids = args.portfolio_goal_ids
+    if not 1 <= args.limit <= 12 or not 1 <= args.days <= 90 or args.offset < 0:
+        raise ValueError("invalid evidence bounds")
+    if args.manager_view != "portfolio" and (not ids or len(ids) != 1):
+        raise ValueError("one exact Goal required for details")
+    if args.manager_view == "portfolio":
+        # Local CLI authority chooses the scope before collection; all exported
+        # fields use the same audience-safe projection as the manager.
+        session = {"channel_id": "manager" if ids is None else "manager.export"}
+        context = manager_turn_context(
+            registry_path, session, root, authorized_goal_ids=ids, include_details=False
+        )
+    else:
+        available = {g.get("id") for g in registry.get("goals", [])}
+        context = {"goals": [{"goal_id": g} for g in ids if g in available]}
+    inspector = ManagerInspection(
+        context=context,
+        registry_path=registry_path,
+        runtime_root=root,
+        owner_scope=False,
+        scope_valid=lambda: True,
+        record=lambda _: None,
+    )
+    query = {"view": args.manager_view, "offset": args.offset, "limit": args.limit}
+    if args.manager_view == "portfolio":
+        query["include_stopped"] = args.include_stopped
+    else:
+        query["goal_id"] = ids[0]
+    if args.manager_view == "deliveries":
+        query["days"] = args.days
+    result = inspector.read(TOOL_NAME, query)
+    for row in result.get("rows", []):
+        row.setdefault("goal_id", query.get("goal_id"))
+    result["schema_version"] = "manager_evidence_page_v1"
+    return result

--- a/loopx/capabilities/manager_context/inspection.py
+++ b/loopx/capabilities/manager_context/inspection.py
@@ -27,8 +27,10 @@ READ_TOOL = {
         "properties": {
             "view": {
                 "type": "string",
-                "enum": ["portfolio", "todos", "deliveries", "handoffs"],
+                "enum": ["sources", "portfolio", "todos", "deliveries", "handoffs"],
             },
+            "source_id": {"type": "string", "description": "Default local. For SSH use an exact source_id from view=sources; local Goal IDs do not discover remote Goals."},
+            "days": {"type": "integer", "minimum": 1, "maximum": 90, "description": "Deliveries lookback; expand for latest known progress older than yesterday."},
             "goal_id": {"type": "string"},
             "request_id": {
                 "type": "string",
@@ -72,6 +74,8 @@ def manager_index(context: dict[str, Any]) -> dict[str, Any]:
             if row.get("activation_state") != "stopped"
         ],
         "context_delegation": context.get("context_delegation"),
+        "evidence_sources": context.get("evidence_sources", [])[:12],
+        "evidence_source_count": len(context.get("evidence_sources", [])),
         "read_tool": TOOL_NAME,
     }
 
@@ -87,6 +91,8 @@ class ManagerInspection:
         scope_valid: Callable[[], bool],
         record: Callable[[dict[str, Any]], None],
         channel_id: str | None = None,
+        remote_runner=None,
+        ssh_config_path=None,
     ) -> None:
         self.context = context
         self.registry_path = registry_path
@@ -95,6 +101,12 @@ class ManagerInspection:
         self.scope_valid = scope_valid
         self.record = record
         self.channel_id = channel_id
+        self.remote_runner = remote_runner
+        self.ssh_config_path = ssh_config_path
+
+    def sources(self):
+        from .ssh_evidence import sources
+        return sources(self.runtime_root, self.channel_id, self.owner_scope, self.ssh_config_path)
 
     def read(self, tool: str, arguments: Any) -> dict[str, Any]:
         if tool != TOOL_NAME or not isinstance(arguments, dict):
@@ -106,13 +118,15 @@ class ManagerInspection:
             "limit",
             "include_stopped",
             "request_id",
+            "source_id",
+            "days",
         }:
             return {"ok": False, "error": "invalid_arguments"}
         view, goal_id = arguments.get("view"), arguments.get("goal_id")
         offset, limit = arguments.get("offset", 0), arguments.get("limit", 8)
         include_stopped = arguments.get("include_stopped", False)
         if (
-            view not in {"portfolio", "todos", "deliveries", "handoffs"}
+            view not in {"sources", "portfolio", "todos", "deliveries", "handoffs"}
             or ("request_id" in arguments and view != "handoffs")
             or type(include_stopped) is not bool
             or ("include_stopped" in arguments and view != "portfolio")
@@ -121,8 +135,31 @@ class ManagerInspection:
             or type(limit) is not int
             or not 1 <= limit <= 12
             or (goal_id is not None and not isinstance(goal_id, str))
+            or ("days" in arguments and (view != "deliveries" or type(arguments["days"]) is not int or not 1 <= arguments["days"] <= 90))
+            or not isinstance(arguments.get("source_id", "local"), str)
         ):
             return {"ok": False, "error": "invalid_arguments"}
+        if not self.scope_valid():
+            return {"ok": False, "error": "authorization_changed"}
+        source_id = arguments.get("source_id", "local")
+        if view == "sources":
+            rows = self.sources()
+            if not self.scope_valid():
+                return {"ok": False, "error": "authorization_changed"}
+            result = {"ok": True, "view": view, "rows": rows[offset:offset + limit],
+                      "matched": len(rows), "next_offset": offset + limit if offset + limit < len(rows) else None,
+                      "note": "Configured sources are not yet read. Select source_id for remote evidence; an empty local host_id does not imply missing remote Goals."}
+            self.record(result)
+            return result
+        if source_id != "local":
+            if not source_id.startswith("ssh:") or view == "handoffs" or (view != "portfolio" and not goal_id):
+                return {"ok": False, "error": "invalid_remote_read"}
+            from .ssh_evidence import read_remote
+            result = read_remote(self.runtime_root, self.channel_id, self.owner_scope, arguments,
+                                 self.scope_valid, config_path=self.ssh_config_path,
+                                 **({"runner": self.remote_runner} if self.remote_runner else {}))
+            self.record(result)
+            return result
         goals = {r["goal_id"]: r for r in self.context.get("goals", [])}
         if (goal_id is not None and goal_id not in goals) or (
             view not in {"portfolio", "handoffs"} and not goal_id
@@ -174,7 +211,7 @@ class ManagerInspection:
             matched = source.get("coverage", {}).get("active")
         else:
             source = read_manager_delivery_history(
-                self.runtime_root, goal_id, limit=limit, offset=offset
+                self.runtime_root, goal_id, limit=limit, offset=offset, lookback_days=arguments.get("days", 1)
             )
             page = source.pop("deliveries", [])
             matched = source.get("coverage", {}).get("matched")
@@ -230,6 +267,8 @@ class ManagerInspection:
             ),
             "oversized_rows": oversized,
             "initial_snapshot_id": self.context.get("snapshot_id"),
+            "source_id": "local",
+            "source_host": "local",
         }
         self.record(result)
         return result

--- a/loopx/capabilities/manager_context/skills/loopx-manager/SKILL.md
+++ b/loopx/capabilities/manager_context/skills/loopx-manager/SKILL.md
@@ -10,6 +10,16 @@ description: Inspect authorized LoopX Goals, Todos and deliveries to explain pro
 Choose reads according to the user's question. The initial Goal directory is
 an index, not a completed investigation. In Chat, use `loopx_manager_read`:
 
+- `sources`: discover configured and audience-authorized evidence sources.
+  For a remote/SSH question, select the matching `source_id` (for example
+  `ssh:research-host`) for portfolio, Todo and delivery reads. Never substitute
+  local tasks mentioning SSH for a report from the remote registry. An empty
+  declared `host_id` is not a reason to skip an available SSH source: the read
+  supplies `source_host` and source-qualified Goal identity. Report each source's
+  actual coverage and failures. Configuration/discovery alone is not a read.
+  For an all-host report, inspect authorized sources and disclose any not reached;
+  do not present a local-only read as coverage of all machines.
+
 - `portfolio`: discover authorized Goals, source quality and coverage. Stopped
   Goals are excluded by default. Use `include_stopped: true` only for an
   explicit historical/stopped-Goal question; a specific Goal ID can then be read.
@@ -18,6 +28,10 @@ an index, not a completed investigation. In Chat, use `loopx_manager_read`:
 - `deliveries` with a Goal ID: inspect recorded findings, evidence references
   and validation for the recent reporting window. Join the supplied titles;
   distinguish recorded claims from independently verified artifacts.
+  When asked for latest known progress rather than only yesterday, use `days`
+  (1..90) to inspect older recorded deliveries and state their actual dates.
+  Current Todo reads and historical outcomes remain useful even when live
+  execution status is stale; do not present old records as newly executed work.
 
 - `handoffs`: inspect this audience's delegated requests, optionally with an exact
   `request_id` or Goal ID. Distinguish delivery, receiver CLI read, decision,

--- a/loopx/capabilities/manager_context/ssh_evidence.py
+++ b/loopx/capabilities/manager_context/ssh_evidence.py
@@ -1,0 +1,172 @@
+"""Read scoped Core evidence from an operator-configured SSH source."""
+
+import json
+import re
+import shlex
+import subprocess
+
+from . import POLICY_SCHEMA, _root, _read, _write
+from ...file_lock import exclusive_file_lock
+from ...control_plane.status.ssh_host_catalog import configured_ssh_host_aliases
+
+
+def grants(root, channel):
+    try:
+        policy = _read(_root(root) / "policy.json")
+        if policy.get("schema_version") != POLICY_SCHEMA:
+            return {}
+        raw = policy.get("sources", {}).get(channel, {}).get("evidence_ssh_hosts", {})
+        return {
+            h: sorted(set(ids))
+            for h, ids in raw.items()
+            if isinstance(h, str)
+            and isinstance(ids, list)
+            and ids
+            and len(ids) <= 128
+            and all(
+                isinstance(g, str)
+                and re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,159}", g)
+                for g in ids
+            )
+        }
+    except (OSError, ValueError, TypeError, AttributeError):
+        return {}
+
+
+def configure(root, *, channel, host, goal_ids, execute=False, config_path=None):
+    if not re.fullmatch(r"manager\.external\.[a-f0-9]{24}", channel):
+        raise ValueError("exact external manager channel required")
+    if host not in configured_ssh_host_aliases(config_path):
+        raise ValueError("host must be an existing SSH alias")
+    if len(goal_ids) > 128 or any(
+        not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,159}", g) for g in goal_ids
+    ):
+        raise ValueError("bounded exact remote Goal IDs required")
+    ids = sorted(set(goal_ids))
+    if execute:
+        path = _root(root) / "policy.json"
+        with exclusive_file_lock(path.with_suffix(".lock")):
+            policy = (
+                _read(path)
+                if path.exists()
+                else {"schema_version": POLICY_SCHEMA, "sources": {}}
+            )
+            if policy.get("schema_version") != POLICY_SCHEMA:
+                raise ValueError("invalid manager policy")
+            sources = (
+                policy.setdefault("sources", {})
+                .setdefault(channel, {})
+                .setdefault("evidence_ssh_hosts", {})
+            )
+            if ids:
+                sources[host] = ids
+            else:
+                sources.pop(host, None)
+            _write(path, policy)
+    return {
+        "ok": True,
+        "executed": execute,
+        "source_id": "ssh:" + host,
+        "goal_ids": ids,
+        "scope": "audience_remote_goal_summaries",
+    }
+
+
+def sources(root, channel, owner, config_path=None):
+    allowed = grants(root, channel)
+    return [{"source_id": "local", "source_host": "local", "status": "available"}] + [
+        {
+            "source_id": "ssh:" + h,
+            "source_host": h,
+            "status": "not_read",
+            "scope": "remote_registry" if owner else "explicit_goal_grant",
+        }
+        for h in configured_ssh_host_aliases(config_path)
+        if owner or h in allowed
+    ]
+
+
+def read_remote(
+    root, channel, owner, args, scope_valid, *, runner=subprocess.run, config_path=None
+):
+    host = args["source_id"].removeprefix("ssh:")
+    before = grants(root, channel)
+    if (
+        not scope_valid()
+        or host not in configured_ssh_host_aliases(config_path)
+        or (not owner and host not in before)
+    ):
+        return {"ok": False, "error": "source_outside_available_scope"}
+    goal = args.get("goal_id")
+    if goal and not owner and goal not in before[host]:
+        return {"ok": False, "error": "goal_outside_available_scope"}
+    # Values are validated/quoted; the model cannot choose a binary, path or command.
+    argv = [
+        "goal-portfolio",
+        "--manager-view",
+        args["view"],
+        "--offset",
+        str(args.get("offset", 0)),
+        "--limit",
+        str(args.get("limit", 8)),
+        "--days",
+        str(args.get("days", 1)),
+    ]
+    for gid in ([goal] if goal else (None if owner else before[host])) or []:
+        argv += ["--goal-id", gid]
+    if args.get("include_stopped"):
+        argv += ["--include-stopped"]
+    command = (
+        'exec "$HOME/.local/bin/loopx" --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" --format json '
+        + shlex.join(argv)
+    )
+    ssh = [
+        "ssh",
+        "-T",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "ForwardX11=no",
+    ]
+    if config_path:
+        ssh += ["-F", str(config_path)]
+    try:
+        result = runner(
+            [*ssh, host, command], capture_output=True, text=True, timeout=45
+        )
+        if result.returncode or len(result.stdout) > 100000:
+            raise ValueError("remote read unavailable")
+        packet = json.loads(result.stdout)
+        if (
+            not isinstance(packet, dict)
+            or packet.get("schema_version") != "manager_evidence_page_v1"
+            or not isinstance(packet.get("rows"), list)
+            or any(not isinstance(r, dict) for r in packet["rows"])
+        ):
+            raise ValueError("remote protocol unavailable")
+        if (
+            not scope_valid()
+            or (not owner and before != grants(root, channel))
+            or host not in configured_ssh_host_aliases(config_path)
+        ):
+            return {"ok": False, "error": "authorization_changed"}
+        if not owner and any(
+            r.get("goal_id") not in before[host] for r in packet["rows"]
+        ):
+            return {"ok": False, "error": "remote_scope_mismatch"}
+        packet.update(source_id=args["source_id"], source_host=host)
+        packet["rows"] = [
+            {**r, "source_id": args["source_id"], "source_host": host}
+            for r in packet["rows"]
+        ]
+        return packet
+    except (OSError, ValueError, TypeError, subprocess.SubprocessError):
+        return {
+            "ok": False,
+            "source_id": args["source_id"],
+            "error": "remote_evidence_unavailable_or_upgrade_required",
+            "coverage": {"discovered": None, "complete": False},
+            "rows": [],
+        }

--- a/loopx/chat_manager.py
+++ b/loopx/chat_manager.py
@@ -38,6 +38,7 @@ MANAGER_AGENT_OBJECTIVE = (
     "If the target is missing or ambiguous, explain the exact gap instead of guessing. "
     "Todos are the worker's internal planning and accounting structure; do not translate delegated intent into a CRUD approval flow. "
     "Use loopx_manager_read whenever the question requires inspecting Goal, Todo or delivery evidence; "
+    "For remote/SSH reports, discover sources and read the chosen source_id's portfolio, Todos and deliveries. Local tasks mentioning SSH are not remote evidence. "
     "the initial directory is not a completed investigation. Choose and paginate reads autonomously. "
     "Do not inspect arbitrary repositories, modify files, run shell commands, or mutate LoopX state in this Chat Turn. "
     "Delegate ordinary requested work to the responsible worker with the original intent and constraints; "
@@ -85,7 +86,7 @@ def open_manager_session(
     )
 
 
-MANAGER_CONTEXT_VERSION = 8
+MANAGER_CONTEXT_VERSION = 9
 
 
 def manager_skill_text() -> str:

--- a/loopx/chat_manager_context.py
+++ b/loopx/chat_manager_context.py
@@ -16,9 +16,14 @@ from .goal_portfolio import build_goal_portfolio
 from .chat import redact_local_paths
 
 
-def manager_authorization_scope_id(goal_ids: list[str]) -> str:
+def manager_authorization_scope_id(goal_ids: list[str], *, runtime_root=None, channel_id=None) -> str:
     """Opaque identity for the exact external Goal evidence scope."""
     normalized = sorted(set(goal_ids))
+    if runtime_root is not None and channel_id:
+        from .capabilities.manager_context.ssh_evidence import grants
+        remote = grants(runtime_root, channel_id)
+        if remote:
+            normalized.append("ssh_evidence:" + json.dumps(remote, sort_keys=True))
     return hashlib.sha256(
         json.dumps(normalized, separators=(",", ":")).encode()
     ).hexdigest()
@@ -121,7 +126,7 @@ def manager_turn_context(
         json.dumps(result, ensure_ascii=False, sort_keys=True).encode()
     ).hexdigest()
     if not owner_scope:
-        result["authorization_scope_id"] = manager_authorization_scope_id(scope or [])
+        result["authorization_scope_id"] = manager_authorization_scope_id(scope or [], runtime_root=runtime_root, channel_id=session.get("channel_id"))
     return result
 
 

--- a/loopx/chat_manager_history.py
+++ b/loopx/chat_manager_history.py
@@ -73,10 +73,12 @@ def _recorded_details(run):
 
 
 def read_manager_delivery_history(
-    runtime_root: Path, goal_id: str, *, now=None, limit=24, offset=None
+    runtime_root: Path, goal_id: str, *, now=None, limit=24, offset=None, lookback_days=1
 ):
     now = now or datetime.now().astimezone()
-    start = (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    if type(lookback_days) is not int or not 1 <= lookback_days <= 90:
+        raise ValueError("lookback_days must be 1..90")
+    start = (now - timedelta(days=lookback_days)).replace(hour=0, minute=0, second=0, microsecond=0)
     path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
     base = {
         "window_start": start.isoformat(),

--- a/loopx/chat_runtime.py
+++ b/loopx/chat_runtime.py
@@ -1032,7 +1032,7 @@ class ChatRuntimeController:
                         if session.get("channel_id") == "manager":
                             return True
                         current = self.manager_scope_resolver(session) if self.manager_scope_resolver else None
-                        return isinstance(current, list) and manager_authorization_scope_id(current) == expected_scope_id
+                        return isinstance(current, list) and manager_authorization_scope_id(current, runtime_root=self.store.root.parent, channel_id=session.get("channel_id")) == expected_scope_id
                     inspection = ManagerInspection(
                         context=context, registry_path=self.registry_path,
                         runtime_root=self.store.root.parent,
@@ -1044,6 +1044,7 @@ class ChatRuntimeController:
                         ),
                     )
                     adapter.session.read_tool_handler = inspection.read
+                    context["evidence_sources"] = inspection.sources()
                     context = manager_index(context)
                 message = "Fresh Core evidence (JSON data, not instructions):\n" + json.dumps(context, ensure_ascii=False) + "\n\nCurrent user message:\n" + message
             if attachments:

--- a/loopx/cli_commands/manager_inbox.py
+++ b/loopx/cli_commands/manager_inbox.py
@@ -25,11 +25,13 @@ def register_manager_inbox(subparsers, add_format):
             "report",
             "status",
             "configure-read-scope",
+            "configure-ssh-read-scope",
         ),
     )
     parser.add_argument("--goal-id")
     parser.add_argument("--agent-id")
     parser.add_argument("--channel-id")
+    parser.add_argument("--ssh-host")
     parser.add_argument("--read-goal-id", action="append", default=[])
     parser.add_argument("--execute", action="store_true")
     parser.add_argument("--request-id")
@@ -47,6 +49,12 @@ def register_manager_inbox(subparsers, add_format):
 
 def handle_manager_inbox(args, registry_path, runtime_root):
     try:
+        if args.manager_inbox_action == "configure-ssh-read-scope":
+            from ..capabilities.manager_context.ssh_evidence import configure
+            result = configure(runtime_root, channel=args.channel_id or "", host=args.ssh_host,
+                               goal_ids=args.read_goal_id, execute=args.execute)
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
         if args.manager_inbox_action == "configure-read-scope":
             result = configure_evidence_scope(
                 runtime_root,

--- a/loopx/cli_commands/summary_all.py
+++ b/loopx/cli_commands/summary_all.py
@@ -70,6 +70,10 @@ def register_summary_all_command(
         "goal-portfolio", help="Read scoped Goal evidence with explicit source coverage."
     )
     add_subcommand_format(portfolio)
+    portfolio.add_argument("--manager-view", choices=("portfolio", "todos", "deliveries"), help="Export an audience-safe manager evidence page from this registry.")
+    portfolio.add_argument("--offset", type=int, default=0)
+    portfolio.add_argument("--days", type=int, default=1)
+    portfolio.add_argument("--include-stopped", action="store_true")
     portfolio.add_argument(
         "--goal-id", action="append", dest="portfolio_goal_ids",
         help="Exact registered Goal to include; repeat to narrow scope.",
@@ -169,6 +173,15 @@ def handle_summary_all_command(
     }:
         return None
     if args.command == "goal-portfolio":
+        if args.manager_view:
+            from ..capabilities.manager_context.evidence_export import export_page
+            try:
+                payload = export_page(registry_path, runtime_root_arg, args)
+            except (OSError, ValueError, TypeError):
+                payload = {"ok": False, "error": "manager_evidence_unavailable_or_invalid", "rows": []}
+            import json
+            print_payload(payload, output_format(args), lambda p: json.dumps(p, ensure_ascii=False, indent=2))
+            return 0 if payload.get("ok") else 1
         try:
             payload = build_goal_portfolio(
                 registry_path=registry_path,

--- a/tests/test_manager_ssh_evidence.py
+++ b/tests/test_manager_ssh_evidence.py
@@ -1,0 +1,280 @@
+"""Remote reports select real sources and preserve scoped Core evidence."""
+
+import json
+import subprocess
+import shlex
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from loopx.capabilities.manager_context.ssh_evidence import configure, grants
+from loopx.capabilities.manager_context.inspection import ManagerInspection, TOOL_NAME
+from loopx.capabilities.manager_context.evidence_export import export_page
+from loopx.chat_manager_context import manager_authorization_scope_id
+from loopx.chat_manager_history import read_manager_delivery_history
+
+
+@pytest.fixture
+def remote(tmp_path):
+    config = tmp_path / "ssh_config"
+    config.write_text(
+        "Host research-host\n  HostName example.invalid\nHost unrelated\n  HostName other.invalid\n"
+    )
+    channel = "manager.external." + "a" * 24
+    configure(
+        tmp_path,
+        channel=channel,
+        host="research-host",
+        goal_ids=["remote-goal"],
+        execute=True,
+        config_path=config,
+    )
+    calls, records = [], []
+
+    def run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "schema_version": "manager_evidence_page_v1",
+                    "ok": True,
+                    "rows": [{"goal_id": "remote-goal", "title": "Actual remote task"}],
+                    "source": {"coverage": {"discovered": 1}},
+                    "next_offset": None,
+                }
+            ),
+        )
+
+    inspection = ManagerInspection(
+        context={"goals": [{"goal_id": "local-goal", "host_id": None}]},
+        registry_path=tmp_path / "registry.json",
+        runtime_root=tmp_path,
+        owner_scope=False,
+        channel_id=channel,
+        scope_valid=lambda: True,
+        record=records.append,
+        remote_runner=run,
+        ssh_config_path=config,
+    )
+    return inspection, calls, records, channel, config
+
+
+def test_remote_source_is_discovered_and_read_without_local_host_metadata(remote):
+    tool, calls, records, _, _ = remote
+    sources = tool.read(TOOL_NAME, {"view": "sources"})
+    assert [r["source_id"] for r in sources["rows"]] == ["local", "ssh:research-host"]
+    assert not calls
+    result = tool.read(
+        TOOL_NAME,
+        {"view": "todos", "source_id": "ssh:research-host", "goal_id": "remote-goal"},
+    )
+    assert result["ok"] and result["rows"][0]["title"] == "Actual remote task"
+    assert result["source_host"] == result["rows"][0]["source_host"] == "research-host"
+    argv, opts = calls[0]
+    assert (
+        argv[-2] == "research-host"
+        and '"$HOME/.codex/loopx/registry.global.json"' in argv[-1]
+    )
+    assert "--manager-view todos" in argv[-1] and "--goal-id remote-goal" in argv[-1]
+    assert "BatchMode=yes" in argv and opts["timeout"] == 45
+    assert records[-1] == result
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        {"view": "todos", "source_id": "ssh:research-host", "goal_id": "local-goal"},
+        {"view": "portfolio", "source_id": "ssh:unrelated"},
+        {"view": "portfolio", "source_id": "ssh:unconfigured"},
+        {"view": "handoffs", "source_id": "ssh:research-host"},
+        {
+            "view": "deliveries",
+            "source_id": "ssh:research-host",
+            "goal_id": "remote-goal",
+            "days": 999,
+        },
+    ],
+)
+def test_invalid_or_unauthorized_queries_never_connect(remote, query):
+    tool, calls, *_ = remote
+    assert not tool.read(TOOL_NAME, query)["ok"]
+    assert not calls
+
+
+def test_remote_grant_revocation_discards_inflight_result_and_changes_context_identity(
+    remote,
+):
+    tool, calls, _, channel, config = remote
+    old = manager_authorization_scope_id(
+        ["local-goal"], runtime_root=tool.runtime_root, channel_id=channel
+    )
+    original = tool.remote_runner
+
+    def revoke(*args, **kwargs):
+        result = original(*args, **kwargs)
+        configure(
+            tool.runtime_root,
+            channel=channel,
+            host="research-host",
+            goal_ids=[],
+            execute=True,
+            config_path=config,
+        )
+        return result
+
+    tool.remote_runner = revoke
+    result = tool.read(
+        TOOL_NAME, {"view": "portfolio", "source_id": "ssh:research-host"}
+    )
+    assert result == {"ok": False, "error": "authorization_changed"}
+    assert not grants(tool.runtime_root, channel)
+    assert old != manager_authorization_scope_id(
+        ["local-goal"], runtime_root=tool.runtime_root, channel_id=channel
+    )
+
+
+def test_old_or_offline_remote_is_unknown_not_empty_healthy(remote):
+    tool, *_ = remote
+
+    def unavailable(*_, **__):
+        raise subprocess.TimeoutExpired("ssh", 45)
+
+    tool.remote_runner = unavailable
+    result = tool.read(
+        TOOL_NAME, {"view": "portfolio", "source_id": "ssh:research-host"}
+    )
+    assert not result["ok"] and result["coverage"] == {
+        "discovered": None,
+        "complete": False,
+    }
+
+
+def test_export_uses_canonical_todos_and_never_returns_owner_private_continuation(
+    tmp_path, monkeypatch
+):
+    import loopx.chat_manager_details as details
+
+    registry = tmp_path / "registry.json"
+    registry.write_text(
+        json.dumps({"goals": [{"id": "remote-goal", "repo": str(tmp_path)}]})
+    )
+    monkeypatch.setattr(
+        details,
+        "list_goal_todos",
+        lambda **_: {
+            "ok": True,
+            "source": "canonical",
+            "todos": [
+                {
+                    "todo_id": "t1",
+                    "text": "Validate delivery",
+                    "status": "open",
+                    "note": "Private deliberation",
+                }
+            ],
+        },
+    )
+    args = SimpleNamespace(
+        portfolio_goal_ids=["remote-goal"],
+        manager_view="todos",
+        limit=8,
+        offset=0,
+        days=1,
+    )
+    packet = export_page(registry, str(tmp_path), args)
+    assert packet["schema_version"] == "manager_evidence_page_v1"
+    assert packet["rows"][0]["goal_id"] == "remote-goal"
+    assert packet["rows"][0]["title"] == "Validate delivery"
+    assert "Private deliberation" not in json.dumps(packet)
+
+
+def test_delivery_lookback_can_explain_stale_goals_without_redating_outcomes(tmp_path):
+    now = datetime.now(timezone.utc)
+    old = (now - timedelta(days=4)).isoformat()
+    index = tmp_path / "goals" / "remote-goal" / "runs" / "index.jsonl"
+    index.parent.mkdir(parents=True)
+    index.write_text(
+        json.dumps(
+            {
+                "generated_at": old,
+                "goal_id": "remote-goal",
+                "agent_id": "worker",
+                "todo_id": "t1",
+                "delivery_outcome": "outcome_progress",
+                "classification": "validated_result",
+            }
+        )
+        + "\n"
+    )
+    assert not read_manager_delivery_history(tmp_path, "remote-goal", now=now)[
+        "deliveries"
+    ]
+    history = read_manager_delivery_history(
+        tmp_path, "remote-goal", now=now, lookback_days=7
+    )
+    assert len(history["deliveries"]) == 1
+    assert old in json.dumps(history["deliveries"])
+
+
+def test_ssh_wire_arguments_execute_real_remote_cli_projection(remote, tmp_path):
+    tool, _, _, _, _ = remote
+    registry = tmp_path / "remote-registry.json"
+    registry.write_text(
+        json.dumps({"goals": [{"id": "remote-goal", "repo": str(tmp_path)}]})
+    )
+
+    def execute_cli(argv, **kwargs):
+        arguments = shlex.split(argv[-1].split("--format json ", 1)[1])
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(tmp_path / "remote-runtime"),
+                "--format",
+                "json",
+                *arguments,
+            ],
+            **kwargs,
+        )
+
+    tool.remote_runner = execute_cli
+    result = tool.read(
+        TOOL_NAME, {"view": "portfolio", "source_id": "ssh:research-host", "limit": 3}
+    )
+    assert result["ok"]
+    assert result["rows"][0]["goal_id"] == "remote-goal"
+    assert result["rows"][0]["source_host"] == "research-host"
+    assert result["rows"][0]["quality"] != "verified"
+
+
+def test_sources_paginate_and_malformed_remote_output_is_unknown(remote):
+    tool, _, _, _, _ = remote
+    tool.context["goals"].append({"goal_id": "remote-goal", "title": "Local namesake"})
+    first = tool.read(TOOL_NAME, {"view": "sources", "limit": 1})
+    assert first["next_offset"] == 1 and first["matched"] == 2
+    assert (
+        tool.read(TOOL_NAME, {"view": "sources", "offset": 1})["rows"][0]["source_id"]
+        == "ssh:research-host"
+    )
+    assert (
+        tool.read(
+            TOOL_NAME,
+            {
+                "view": "todos",
+                "source_id": "ssh:research-host",
+                "goal_id": "remote-goal",
+            },
+        )["rows"][0]["title"]
+        == "Actual remote task"
+    )
+    tool.remote_runner = lambda *_, **__: SimpleNamespace(returncode=0, stdout="[]")
+    assert not tool.read(
+        TOOL_NAME, {"view": "portfolio", "source_id": "ssh:research-host"}
+    )["ok"]


### PR DESCRIPTION
Remote progress questions previously inspected only the local registry, then substituted local tasks mentioning SSH when Goal host metadata was empty. The manager can now select a real SSH evidence source and read its Goal portfolio, current Todos and recorded outcomes through the same Core providers used locally.

Configured SSH aliases reuse the frontend host catalog. Owner-local reads are available on demand; group reads require persistent exact host/Goal summary grants and the existing live connection authorization. Grants are checked around reads and included in upstream context identity. SSH executes only a fixed bounded CLI projection against the remote global registry; the model cannot choose commands or paths. Failures and older unsupported runtimes remain explicit unknowns. Source host qualifies Goal identity independently of optional declared execution-host metadata.

Delivery reads support an explicit 1–90 day lookback so a progress report can explain older recorded outcomes alongside freshly read Todos. Dates and artifact-verification limits remain visible. The built-in manager skill and context version are updated; no new automation or parallel progress store is introduced.

Validation: 102 focused tests including real CLI export, unauthorized-source rejection, revocation during reads, source provenance, old/outage behavior and historical dates; actual Chat server smoke. Premerge results and live remote acceptance will be recorded separately. Public diff contains only runtime, CLI, built-in instructions and durable tests; host identities, audience grants and live reports remain private.
