### PR TITLE
fix(lark): keep manager received ACK visible after its answer

### DIFF
--- a/loopx/extensions/lark/docs/lark-event-inbox.md
+++ b/loopx/extensions/lark/docs/lark-event-inbox.md
@@ -255,9 +255,10 @@ messages; use `configured_chat_all` for complete collaboration threads:
 For every reply-enabled Inbox, a missing `reply.received_reaction_emoji`
 defaults to `Get`. Set it explicitly to the empty string to disable this
 provider write. The reaction belongs to the same explicit sender boundary as
-source-thread replies, but only the Agent's turn-start hook may create it:
-realtime collection persists events without reacting, and the hook writes the
-reaction only after it has read and confirmed a still-pending human message.
+source-thread replies. The Agent's turn-start hook creates it after reading and
+confirming a still-pending human message; the synchronous manager route creates
+it immediately before invoking the manager. Realtime collection alone persists
+events without reacting.
 The receipt therefore means "read into the Agent processing chain"; it does not
 mean "collector stored the event", "the Bot was mentioned", "a reply is due",
 or "processing completed". Mention, reply, question, and material-review
@@ -284,9 +285,16 @@ received reaction. The default `Get` satisfies that requirement; when the read
 acknowledgement is explicitly disabled, processing reaction must also be
 disabled. When both are configured, the host should run
 `lark-inbox processing` immediately before interpreting an actionable item.
-LoopX first adds the processing reaction and then removes the received
-reaction. A verified source-thread reply removes any remaining lifecycle
-reaction. If the provider cannot delete a reaction, the operation fails with a
+`reply.received_reaction_policy` selects `transient` (the generic Inbox default)
+or `retain`. With `transient`, LoopX first adds the processing reaction and then
+removes the received reaction; a verified source-thread reply removes remaining
+lifecycle reactions. With `retain`, the received reaction remains visible during
+processing and after the answer; completion removes only processing reactions.
+Generated manager routes default to `retain`, so their `Get` receipt does not
+disappear when the answer arrives. Bound Goal routes keep `transient` behavior.
+Retention uses the existing private reaction ledger across restart and replay;
+it neither recreates reactions on historical messages nor means work completed.
+If the provider cannot delete a transient reaction, the operation fails with a
 retryable cleanup status instead of claiming completion.
 
 Reaction ids are stored only in an owner-private receipt ledger under the

--- a/loopx/extensions/lark/event_inbox.py
+++ b/loopx/extensions/lark/event_inbox.py
@@ -146,6 +146,9 @@ def load_lark_event_inbox_config(
         ).strip()
     else:
         received_reaction_emoji = "Get" if reply_enabled else ""
+    received_reaction_policy = reply_payload.get("received_reaction_policy", "transient")
+    if received_reaction_policy not in ("transient", "retain"):
+        raise ValueError("lark inbox received_reaction_policy must be transient or retain")
     processing_reaction_emoji = str(
         reply_payload.get("processing_reaction_emoji") or ""
     ).strip()
@@ -222,6 +225,7 @@ def load_lark_event_inbox_config(
             "placement_policy": placement_policy,
             "editorial_style": editorial_style,
             "received_reaction_emoji": received_reaction_emoji,
+            "received_reaction_policy": received_reaction_policy,
             "processing_reaction_emoji": processing_reaction_emoji,
         },
         "material_review": {

--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -938,6 +938,9 @@ def _inbox_config(
             "chat_id": chat_id,
             "placement_policy": "source_context",
             "editorial_style": "bullet_points_preferred",
+            "received_reaction_policy": (
+                "retain" if route.get("conversation_kind") == "manager" else "transient"
+            ),
         },
     }
     config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -1045,7 +1048,8 @@ def process_lark_goal_topic_event(
             "inbox_config_ref": config_ref,
         }
     # Receipt ACK is visible while the synchronous manager is reasoning. The
-    # private reaction ledger makes retries idempotent; final reply owns cleanup.
+    # private reaction ledger makes retries idempotent. Manager received ACKs
+    # remain visible; final reply only clears transient processing indicators.
     # A cosmetic reaction failure must not suppress the actual answer.
     received_reaction = None
     if route.get("conversation_kind") == "manager":

--- a/loopx/extensions/lark/inbox_reactions.py
+++ b/loopx/extensions/lark/inbox_reactions.py
@@ -892,7 +892,7 @@ def _mark_lark_event_inbox_processing_locked(
         created_count = 1
 
     deleted_count = 0
-    if received is not None:
+    if received is not None and config["reply"].get("received_reaction_policy") != "retain":
         if not _delete_reaction(
             runner=runner,
             profile=profile,
@@ -964,6 +964,10 @@ def _complete_lark_event_inbox_reactions_locked(
         inbox=inbox,
         message_id=normalized,
     )
+    # A received ACK records consumption, not unfinished processing. Retention
+    # keeps that provider receipt visible after the answer and across replay.
+    if config["reply"].get("received_reaction_policy") == "retain":
+        receipts = {phase: row for phase, row in receipts.items() if phase != "received"}
     configured = bool(
         config["reply"].get("received_reaction_emoji")
         or config["reply"].get("processing_reaction_emoji")

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -1416,7 +1416,15 @@ def test_manager_receives_reaction_before_answer_and_preserves_sender(tmp_path, 
     result = runtime.process_lark_goal_topic_event(**kwargs)
     assert result["ok"], result
     assert result["status"] == "replied_and_acknowledged"
-    assert ("cleanup" in stages) == bool(reaction_ok)
+    assert "cleanup" not in stages  # Manager receipt ACK survives its answer.
+    if reaction_ok:
+        from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
+        from loopx.extensions.lark.inbox_reactions import lark_inbox_reaction_receipts
+        config = load_lark_event_inbox_config(
+            project=kwargs["runtime_root"], config_path=result["inbox_config_ref"])
+        assert config["reply"]["received_reaction_policy"] == "retain"
+        assert lark_inbox_reaction_receipts(
+            inbox=config["inbox_path"], message_id="om_incoming")["received"]["emoji_type"] == "Get"
     before = list(stages)
     assert runtime.process_lark_goal_topic_event(**kwargs)["status"] == "already_acknowledged"
     assert stages == before

--- a/tests/extensions/test_lark_retained_ack.py
+++ b/tests/extensions/test_lark_retained_ack.py
@@ -1,0 +1,89 @@
+"""Received ACK retention is separate from transient processing and source ACK."""
+
+import json
+
+import pytest
+
+from loopx.extensions.lark.event_inbox import load_lark_event_inbox_config
+from loopx.extensions.lark.inbox_reactions import (
+    complete_lark_event_inbox_reactions,
+    lark_inbox_reaction_receipts,
+    mark_lark_event_inbox_processing,
+    record_lark_inbox_reaction,
+)
+from tests.extensions.test_lark_inbox_reactions import _fixture, ReactionRunner
+
+
+def test_retained_ack_survives_processing_completion_and_restart(tmp_path):
+    config, inbox, project = _fixture(tmp_path)
+    payload = json.loads(config.read_text())
+    payload["reply"]["received_reaction_policy"] = "retain"
+    config.write_text(json.dumps(payload))
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="received",
+        reaction_id="reaction_Get",
+        emoji_type="Get",
+    )
+    args = dict(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+    )
+    processing = ReactionRunner()
+    assert mark_lark_event_inbox_processing(**args, runner=processing)["ok"]
+    assert not any("delete" in c for c in processing.calls)
+    assert set(
+        lark_inbox_reaction_receipts(inbox=inbox, message_id=args["message_id"])
+    ) == {"received", "processing"}
+    # A newly constructed runner simulates service restart; only disk receipts survive.
+    completion = ReactionRunner()
+    result = complete_lark_event_inbox_reactions(**args, runner=completion)
+    assert result["ok"] and result["deleted_count"] == 1
+    assert all(
+        c[c.index("--reaction-id") + 1] == "reaction_OnIt" for c in completion.calls
+    )
+    assert set(
+        lark_inbox_reaction_receipts(inbox=inbox, message_id=args["message_id"])
+    ) == {"received"}
+    replay = ReactionRunner()
+    assert complete_lark_event_inbox_reactions(**args, runner=replay)["ok"]
+    assert replay.calls == []
+
+
+def test_generic_default_cleans_only_recorded_reaction(tmp_path):
+    config, inbox, project = _fixture(tmp_path)
+    record_lark_inbox_reaction(
+        inbox=inbox,
+        message_id="om_reaction_fixture",
+        phase="received",
+        reaction_id="reaction_Get",
+        emoji_type="Get",
+    )
+    parsed = load_lark_event_inbox_config(project=project, config_path=config)
+    assert parsed["reply"]["received_reaction_policy"] == "transient"
+    runner = ReactionRunner()
+    result = complete_lark_event_inbox_reactions(
+        project=project,
+        config_path=config,
+        message_id="om_reaction_fixture",
+        execute=True,
+        runner=runner,
+    )
+    assert result["deleted_count"] == 1
+    assert (
+        lark_inbox_reaction_receipts(inbox=inbox, message_id="om_reaction_fixture")
+        == {}
+    )
+
+
+@pytest.mark.parametrize("value", ["", None, True, [], "typo"])
+def test_invalid_retention_does_not_silently_change_behavior(tmp_path, value):
+    config, _, project = _fixture(tmp_path)
+    payload = json.loads(config.read_text())
+    payload["reply"]["received_reaction_policy"] = value
+    config.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="received_reaction_policy"):
+        load_lark_event_inbox_config(project=project, config_path=config)


### PR DESCRIPTION
Manager receipt reactions disappeared when the answer arrived because reply cleanup deleted both received and processing reactions. Manager routes now retain their received ACK, so users can still see that their message entered the processing chain after the answer.

The Lark extension owns an explicit `received_reaction_policy`: generated manager routes select `retain`, while ordinary Inboxes and bound Goal routes preserve the `transient` default. The existing private receipt ledger provides restart/replay idempotency. Completion still clears processing indicators; a retained ACK does not claim task completion or grant authority. Existing historical reactions are not recreated automatically.

Validation: 143 tests across manager routing, reaction lifecycle, turn-start sync and reply sizing passed; Lark event Inbox smoke and Ruff passed. Regression coverage checks retention through processing/completion/restart, replay without provider calls, generic-default cleanup and invalid policy rejection. Live provider create/readback also verified the received reaction using the configured bot identity. Installed completion/replay acceptance follows deployment.
