### PR TITLE
fix(extensions): preserve selected launcher path

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -904,15 +904,17 @@ declarative and does not import the module.
 
 ### Local executable locations
 
-Successful executable install/upgrade and doctor operations save the resolved
-absolute entrypoint in the host-local revision state, separately from the
-portable manifest. Enable, rollback, update-time revalidation and invocation use
-that revision's saved location instead of rediscovering a same-named executable
-on the current shell PATH. File-identity checks remain mandatory; a missing
-saved executable does not fall back to another PATH entry. Package upgrades
-resolve and verify the new revision's executable through the explicit upgrade
-workflow. Bundled `python_module` providers continue using the current LoopX
-interpreter and retain their existing identity checks.
+Successful executable install/upgrade and doctor operations save the selected
+absolute launcher path in the host-local revision state, separately from the
+portable manifest. When that launcher is a symlink, identity checks still hash
+the final executable artifact while the launcher directory remains the child
+process PATH prefix. Enable, rollback, update-time revalidation and invocation
+use that revision's saved location instead of rediscovering a same-named
+executable on the current shell PATH. File-identity checks remain mandatory; a
+missing saved executable does not fall back to another PATH entry. Package
+upgrades resolve and verify the new revision's executable through the explicit
+upgrade workflow. Bundled `python_module` providers continue using the current
+LoopX interpreter and retain their existing identity checks.
 
 For executable providers, only the child process prepends the executable's
 directory to PATH, so tools installed in the same environment remain available.

--- a/loopx/extensions/readiness.py
+++ b/loopx/extensions/readiness.py
@@ -24,7 +24,8 @@ class ResolvedRuntimeEntrypoint:
 
 
 def runtime_process_environment(
-    path_prefix: str | None, base: Mapping[str, str] | None = None,
+    path_prefix: str | None,
+    base: Mapping[str, str] | None = None,
 ) -> Mapping[str, str] | None:
     if path_prefix is None:
         return base
@@ -66,12 +67,22 @@ def _file_identity(path: Path, *, executable: bool) -> tuple[Path, str] | None:
 def resolved_entrypoint_identity(command: str) -> tuple[Path, str] | None:
     if "/" in command or "\\" in command:
         path = Path(command).expanduser()
+        if not path.is_absolute():
+            path = Path(os.path.abspath(path))
     else:
         resolved = shutil.which(command)
         if resolved is None:
             return None
         path = Path(resolved)
-    return _file_identity(path, executable=True)
+    identified = _file_identity(path, executable=True)
+    if identified is None:
+        return None
+    # Hash the final executable artifact, but retain the launcher path selected
+    # by the operator. Package managers commonly expose console scripts through
+    # a shared symlink directory; sibling tools in that directory must remain
+    # available to the provider subprocess even when the link target lives in
+    # an isolated package environment.
+    return path, identified[1]
 
 
 def resolve_runtime_entrypoint(
@@ -135,6 +146,7 @@ def extension_doctor(
     elif available and not execute:
         status = "probe_required"
     elif available:
+        assert identity_before is not None
         argv = [
             *identity_before.argv_prefix,
             *[str(value) for value in runtime.get("args") or []],
@@ -177,7 +189,11 @@ def extension_doctor(
         "status": status,
         "available": available,
         "verified": verified,
-        "entrypoint_identity": identity_before.identity if verified else None,
+        "entrypoint_identity": (
+            identity_before.identity
+            if verified and identity_before is not None
+            else None
+        ),
         "failure_kind": failure_kind,
         "external_writes_performed": False,
     }

--- a/tests/extensions/test_extension_runtime.py
+++ b/tests/extensions/test_extension_runtime.py
@@ -1944,6 +1944,44 @@ def test_executable_location_survives_path_changes_upgrade_and_rollback(tmp_path
     assert missing["status"] == "entrypoint_missing"  # Never switch to the unrelated PATH copy.
 
 
+def test_executable_location_preserves_launcher_directory_for_sibling_tools(
+    tmp_path, monkeypatch,
+):
+    launcher_bin = tmp_path / "launcher-bin"
+    package_bin = tmp_path / "package-bin"
+    unrelated = tmp_path / "unrelated"
+    for directory in (launcher_bin, package_bin, unrelated):
+        directory.mkdir()
+    package_provider = _provider(package_bin / "provider")
+    launcher_provider = launcher_bin / "provider"
+    launcher_provider.symlink_to(package_provider)
+    companion = _provider(launcher_bin / "companion")
+    package_provider.write_text(package_provider.read_text().replace(
+        "import json",
+        f"import shutil\nassert shutil.which('companion') == {str(companion)!r}\nimport json",
+    ))
+    manifest = _standalone_manifest(
+        tmp_path / "manifest.toml", entrypoint=Path("provider"),
+    )
+    state_file = tmp_path / "state.json"
+
+    monkeypatch.setenv("PATH", str(launcher_bin))
+    install_extension(manifest, state_file=state_file, execute=True)
+    state = json.loads(state_file.read_text())
+    revision = state["extensions"]["test-standalone-extension"]["revisions"][0]
+    assert revision["entrypoint_path"] == str(launcher_provider)
+
+    monkeypatch.setenv("PATH", str(unrelated))
+    assert doctor_installed_extension(
+        "test-standalone-extension", state_file=state_file, execute=True,
+    )["verified"]
+    result = run_standalone_extension(
+        "test-standalone-extension", state_file=state_file,
+        request={"schema_version": "test_extension_request_v0"}, execute=True,
+    )
+    assert result["status"] == "succeeded"
+
+
 def test_legacy_doctor_captures_location_only_after_success(tmp_path, monkeypatch):
     provider = _provider(tmp_path / "provider")
     manifest = _standalone_manifest(tmp_path / "manifest.toml", entrypoint=Path("provider"))


### PR DESCRIPTION
## Summary

- retain the operator-selected executable launcher path while hashing the final artifact
- keep sibling CLIs in the launcher directory available to external provider subprocesses
- document symlinked launcher behavior and add a real-path regression covering non-interactive PATH changes

The branch is rebased on current `main` at `091379eb3`; exact head is `32463e2d8`.

## Validation

- 63 extension runtime tests passed
- Ruff and Python compile checks passed on changed Python files
- scoped mypy passed
- public/private scan passed for all three changed files
- packaged Dashboard `build:chat` passed and produced no tracked asset delta, resolving the prior Frontstage integration hold
- LoopX premerge gate passed: 10 selected checks, 0 failures, 0 manual holds
- exact-scope change-quality receipt: `cqr_254367eb0a7d03601aa7`, valid for fingerprint `254367eb0a7d03601aa7ee52473ea6e6d7cc7bb271655a1312adb0bb47e76339`

## Scope

This is provider-neutral extension lifecycle behavior. It does not add provider-specific configuration, credentials, permission changes or another location authority. Identity remains bound to the final executable artifact; only the saved launch location and child-only PATH prefix retain the operator-selected symlink directory.
