### PR TITLE
test(dashboard): await persisted Goal order after reload

### DIFF
--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -1369,7 +1369,18 @@ async function main() {
     if (page.url() !== beforeDragUrl) throw new Error('Dragging accidentally selected a Goal');
     await checkpointCoverage();
     await page.reload({ waitUntil: 'networkidle' });
-    if (JSON.stringify(await readOrder()) !== JSON.stringify(expectedOrder)) throw new Error('Goal order did not survive reload');
+    // Network idleness does not establish React/status-projection readiness.
+    // Wait for the persisted order itself, retaining a bounded failure when it
+    // is lost or wrong rather than accepting whichever rows happen to render.
+    try {
+      await page.waitForFunction((expected) => {
+        const actual = [...document.querySelectorAll('.personal-goal-list:not(.is-stopped) .personal-goal-row')]
+          .map((row) => row.getAttribute('data-reorder-goal'));
+        return JSON.stringify(actual) === JSON.stringify(expected);
+      }, expectedOrder, { timeout: 6_000 });
+    } catch (error) {
+      throw new Error(`Goal order did not survive reload: expected=${JSON.stringify(expectedOrder)} actual=${JSON.stringify(await readOrder())}`, { cause: error });
+    }
     // Escape cancels rather than committing a partially completed gesture.
     const cancelStart = await activeRows.first().locator('.personal-goal-link').boundingBox();
     const cancelEnd = await activeRows.nth(2).boundingBox();


### PR DESCRIPTION
The dashboard coverage job introduced with #4239 reached the existing reload/reorder assertion before the status-driven sidebar was ready on the hosted runner. The smoke compared the current DOM immediately after network idleness, which does not establish React/projection readiness.

Wait up to six seconds for the exact persisted Goal order after reload. An absent or incorrect order still fails, now reporting both expected and actual IDs. This changes only the browser test synchronization; no production UI, storage rule, coverage threshold, or check is disabled.

Validation: the development Chromium smoke passed with coverage collection enabled, exercising both sub-agent configuration entry points as well as persisted Goal ordering. This follow-up is based on the merged #4239 commit and contains one test-file change. Hosted checks remain required; no self-merge.
