### PR TITLE
refactor(todo): unify decision dependency rules and repair gate scope contradictions

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2664,6 +2664,14 @@ The original direction remains; execution cards expand these stages rather than 
 
 #### Durability execution cards
 
+The T3 decision-dependency read policy now shares one TS owner for scope coverage,
+exact links and consistency diagnostics. Explicit gate recipients are independent
+of claim attribution; conflicting exact targets request repair rather than grant
+approval. This removes duplicate consumer knowledge, not provider transactions.
+It does not qualify D1/D2, alter the default provider, or relax D3 promotion holds.
+Markdown remains the permanent one-way display; the remaining execution cards
+below are unchanged.
+
 Use the [TS execution cards](typescript-control-plane-migration-v0.md#execution-cards-after-the-current-stack)
 for command inventory, update/monitor transactions and consumer deletion. Do not
 repeat that plan in a second implementation or treat a merged read-policy PR

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -2131,6 +2131,12 @@ summary，之前消费 legacy summary；真实 CLI 覆盖容量变化和 promote
 缺失且不写回的场景。这不代表所有 quota source 路径已闭合，不授予 monitor 写回
 权限，也不改变 provider 默认与 promotion hold。
 
+T3 decision-dependency 读取策略现由同一 TS owner 解释 scope coverage、精确链接和
+一致性诊断。显式 gate 接收者独立于 claim 归属，精确目标矛盾要求修复而非授予批准。
+这删除的是重复的 consumer 知识，不是 provider transaction；不代表 D1/D2 已资格化，
+不改变默认 provider 或放宽 D3 promotion hold。Markdown 继续作为永久单向展示，
+后续执行卡与退役条件保留。
+
 **D1 — 资格化永久投影交付，可与 T1/T2 重叠推进。**
 
 T2 的无 lease 原生 Monitor 观察与独立后继现由同一 canonical CAS／receipt 提交；

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -528,7 +528,21 @@ no active receipt. Explicit user-gate metadata replaces notification heuristics
 for this authority surface. These corrections are disclosed in the
 [decision-scope contract](../../reference/protocols/decision-scope-v0.md#decision-chronology-not-display-order).
 Legacy all-undated source-order compatibility remains; native display order is
-not authority. Scope coverage and open-gate routing are not migrated by this slice.
+not authority.
+
+Decision dependency consumer closure: `todos/decision_scope.ts` now owns scope
+coverage, exact-target relations, standing-receipt scoping and consistency
+diagnostics. Quota selection shares its explicit gate-recipient predicate:
+`global_gate` / `blocks_agent` take precedence over claim attribution. An exact
+link to a different Todo cannot silently satisfy a broad scope dependency; it
+produces a repair diagnostic, not approval or automatic retargeting. Python keeps
+legacy decoding and repair presentation, not a second rule implementation.
+Agent fallback, global Todo and summary consumers batch their candidate relations
+to avoid one RPC per pair. Legacy completion still uses the shared coverage rule.
+Validation covers the production-scale fixture, complete provider reads beyond
+display limits, stale/missing display, and isolated real-state snapshot parity.
+Remaining T3 work includes legacy action-token fallback routing and consumers
+that reconstruct diagnostics from compact summaries; do not call those migrated.
 This does not close T1/T2, all T3 consumers, or any durability/promotion hold.
 
 The list-filter consumer now uses `compact_evaluated_todo_group` instead of

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -407,7 +407,17 @@ Canonical 读取在生成展示 index 前使用完整 Todo 快照，包括保留
 通知文案启发式。上述有意语义修正见
 [decision-scope 协议](../../reference/protocols/decision-scope-v0.md#decision-chronology-not-display-order)。
 全部无时间的 legacy 决策保留源顺序兼容，native 展示顺序不充当授权证据；本批不迁移
-scope coverage 和 open-gate routing，不宣称 T1/T2、全部 T3 或持久化／promotion 完成。
+scope coverage 和 open-gate routing。
+
+后续 decision dependency consumer 闭合：`todos/decision_scope.ts` 统一作用域覆盖、
+精确目标关系、standing receipt 的 Agent 作用域与一致性诊断。Quota selection 共用
+显式 gate 接收者规则：`global_gate` / `blocks_agent` 优先于 claim 归属。精确链接指向
+别的 Todo 时，不能用宽 scope 静默满足当前依赖；输出修复诊断，不产生批准或自动改绑。
+Python 保留 legacy 解码和修复展示，删除第二套规则。Agent fallback、global Todo、
+summary 对候选关系批量调用，避免每对 Todo 一次 RPC；legacy completion 也复用覆盖规则。
+验证覆盖复杂容量 fixture、展示上限之外的完整 provider 来源、陈旧／缺失展示和隔离真实
+状态快照 parity。T3 仍需处理旧 action-token fallback 路由及从压缩 summary 重建诊断的
+消费者，不把它们列为已迁移；不宣称 T1/T2、全部 T3 或持久化／promotion 完成。
 
 列表过滤现改用 `compact_evaluated_todo_group`，不再用仅活动项重算 resume。
 初始解析／canonical 读取仍通过 TS owner 在完整来源上求值；过滤要求匹配的已求值

--- a/docs/reference/protocols/decision-scope-v0.md
+++ b/docs/reference/protocols/decision-scope-v0.md
@@ -221,6 +221,26 @@ unscoped multi-agent decisions never grant standing authority.
 
 ## Failure Semantics
 
+### Shared read-policy owner
+
+`control_plane/todos/decision_scope.ts` evaluates coverage, exact-target relations
+and consistency from decoded source facts. `global_gate=true` addresses all
+agents; otherwise an explicit `blocks_agent` determines the recipient even when
+`claimed_by` names another agent. Claim attribution is not a veto on that explicit
+recipient. With neither explicit field, the existing claim-scoped compatibility
+rule remains; multi-agent gates without explicit scope still require repair.
+
+A gate whose scope covers work A but whose `unblocks_todo_id` names work B produces
+`required_decision_scope_target_mismatch`. Another matching gate does not erase
+the contradictory record. Repair must reconcile owner intent; it cannot silently
+retarget the gate, remove the requirement or synthesize approval. This deliberately
+replaces a formerly false `consistent` diagnostic. A consistent open dependency
+still means waiting for a decision, not permission to execute.
+
+Legacy metadata codecs and operator repair copy remain in Python. Candidate-pair
+consumers use batched relations. No provider commit, lease, source promotion or
+Markdown writeback authority is added by this read-only contract.
+
 - Missing structured fields on legacy state: fall back to compatibility lint
   and emit a projection-gap repair hint.
 - Conflicting structured fields: fail closed with a concrete blocker.

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -11,7 +11,7 @@ from .agent_scope_frontier import (
     agent_scope_frontier_action as _agent_scope_frontier_action,
     build_agent_scope_frontier_payload,
 )
-from ..todos.decision_scope import todo_gate_relation, todo_gate_relation_blocks_agent
+from ..todos.decision_scope import todo_gate_relations, todo_gate_relation_blocks_agent
 from ..work_items.work_lane import (
     work_lane_contract_is_due_monitor_attempt,
     work_lane_contract_requires_current_agent_attempt,
@@ -225,14 +225,10 @@ def _todo_action_scope_tokens(item: dict[str, Any]) -> set[str]:
     return _action_scope_tokens_from_text(text)
 
 
-def _todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
-    return todo_gate_relation(gate, agent_item)
-
-
-def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any]) -> bool:
+def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any],
+                                 relation: dict[str, Any] | None) -> bool:
     if normalize_todo_global_gate(gate.get("global_gate")):
         return True
-    relation = _todo_gate_relation(gate, agent_item)
     if relation:
         return todo_gate_relation_blocks_agent(relation)
 
@@ -334,18 +330,20 @@ def _scoped_user_gate_fallback(
             if agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
         ]
     blocked_items: list[dict[str, Any]] = []
+    relations = todo_gate_relations(gates, executable_items)
     selected: dict[str, Any] | None = None
     blocking_gate: dict[str, Any] | None = None
-    for item in executable_items:
+    for item_index, item in enumerate(executable_items):
         matching_gate = next(
-            (gate for gate in gates if _user_gate_blocks_agent_item(gate, item)),
+            (gate for gate_index, gate in enumerate(gates)
+             if _user_gate_blocks_agent_item(gate, item, relations[gate_index][item_index])),
             None,
         )
         if matching_gate:
             blocking_gate = blocking_gate or matching_gate
             text = str(item.get("text") or "").strip()
             blocked_item = compact_todo_summary_item(item, text=text)
-            relation = _todo_gate_relation(matching_gate, item)
+            relation = relations[gates.index(matching_gate)][item_index]
             if relation:
                 blocked_item["todo_gate_relation"] = relation
             blocked_items.append(blocked_item)
@@ -366,7 +364,7 @@ def _scoped_user_gate_fallback(
     )
     if selected_is_deferred_replan:
         selected_item["fallback_kind"] = "deferred_successor_replan"
-    selected_relation = _todo_gate_relation(gate_to_surface, selected)
+    selected_relation = relations[gates.index(gate_to_surface)][executable_items.index(selected)]
     if selected_relation:
         selected_item["todo_gate_relation"] = selected_relation
     gate_text = str(gate_to_surface.get("text") or "").strip()

--- a/loopx/control_plane/effect_runtime_handlers.ts
+++ b/loopx/control_plane/effect_runtime_handlers.ts
@@ -144,6 +144,7 @@ import {
 } from "./coordination/todo_lifecycle_decision.ts";
 import { evaluateCoordinationTodoArchiveSelection } from "./coordination/todo_archive_selection.ts";
 import {evaluateStandingDecisionProjection} from "./todos/standing_decision.ts";
+import {evaluateDecisionScope} from "./todos/decision_scope.ts";
 import {captureArchivedTodoDependencies} from "./todos/archive_capture.ts";
 import { evaluateCoordinationTodoSuccessorDerivation } from "./coordination/todo_successor_derivation.ts";
 import {
@@ -378,6 +379,7 @@ export function createEffectRuntimeHandlers(
     ["todo.field_update.plan", planTodoFieldUpdate],
     ["todo.public_update.plan", planPublicTodoUpdate],
     ["todo.standing_decision.project", evaluateStandingDecisionProjection],
+    ["todo.decision_scope.evaluate", evaluateDecisionScope],
     ["todo.archive.capture_dependencies", captureArchivedTodoDependencies],
     ["todo.monitor_metadata.plan", planMonitorMetadata],
     ["todo.authoring_scope.plan", planTodoAuthoringScope],

--- a/loopx/control_plane/todos/decision_scope.py
+++ b/loopx/control_plane/todos/decision_scope.py
@@ -1,320 +1,114 @@
-"""Decision-scope relation helpers for LoopX user gates.
-
-This module keeps user-gate dependency semantics out of quota allocation so
-other control-plane surfaces can reason about the same exact-todo and
-decision-scope relations without importing the quota runtime.
-"""
-
+"""Legacy input codec for the single typed decision-dependency rule owner."""
 from __future__ import annotations
 
 from typing import Any
 
+from ..effect_runtime import effect_runtime_result
 from .contract import (
-    normalize_todo_blocks_agent,
-    normalize_todo_claimed_by,
-    normalize_todo_decision_scope,
-    normalize_todo_decision_scope_outcomes,
-    normalize_todo_global_gate,
-    normalize_todo_id,
-    normalize_todo_required_decision_scopes,
+    normalize_todo_blocks_agent, normalize_todo_claimed_by,
+    normalize_todo_decision_scope, normalize_todo_decision_scope_outcomes,
+    normalize_todo_global_gate, normalize_todo_id, normalize_todo_required_decision_scopes,
 )
 from .user_gate import is_user_gate_todo_item
-
-DECISION_SCOPE_GRANULARITY_RANK = {
-    "action": 0,
-    "lane": 1,
-    "goal": 2,
-    "project": 3,
-    "global": 4,
-}
 
 TODO_GATE_BLOCKING_STATES = frozenset(
     {"gate_targets_todo", "gate_covers_action", "projection_repair_required"}
 )
-
 DECISION_SCOPE_CONSISTENCY_SCHEMA_VERSION = "required_decision_scope_consistency_v0"
 STANDING_DECISION_AUTHORITY_SCHEMA_VERSION = "standing_decision_authority_v0"
 _AGENT_SUMMARY_ITEM_KEYS = (
-    "current_agent_claimed_open_items",
-    "current_agent_claimed_advancement_items",
-    "first_executable_items",
-    "executable_backlog_items",
-    "first_open_items",
-    "backlog_items",
-    "items",
+    "current_agent_claimed_open_items", "current_agent_claimed_advancement_items",
+    "first_executable_items", "executable_backlog_items", "first_open_items", "backlog_items", "items",
 )
 _USER_SUMMARY_ITEM_KEYS = (
-    "gate_open_items",
-    "user_action_open_items",
-    "first_open_items",
-    "backlog_items",
-    "items",
-    "other_agent_scoped_items",
+    "gate_open_items", "user_action_open_items", "first_open_items",
+    "backlog_items", "items", "other_agent_scoped_items",
 )
 
 
-def _summary_open_items(
-    summary: dict[str, Any] | None,
-    *,
-    keys: tuple[str, ...],
-) -> list[dict[str, Any]]:
-    if not isinstance(summary, dict):
-        return []
-    items: list[dict[str, Any]] = []
-    seen: set[tuple[Any, Any, Any]] = set()
-    for key in keys:
-        values = summary.get(key)
-        if not isinstance(values, list):
-            continue
-        for item in values:
-            if not isinstance(item, dict) or item.get("done") is True:
-                continue
-            if str(item.get("status") or "open") not in {"open", "blocked"}:
-                continue
-            identity = (item.get("todo_id"), item.get("index"), item.get("text"))
-            if identity in seen:
-                continue
-            seen.add(identity)
-            items.append(item)
-    return items
+def _evaluate(operation: str, **facts: Any) -> Any:
+    result = effect_runtime_result("todo.decision_scope.evaluate", {
+        "schema_version": "todo_decision_scope_request_v0", "operation": operation, **facts,
+    })
+    if not isinstance(result, dict) or result.get("schema_version") != "todo_decision_scope_result_v0":
+        raise TypeError("invalid typed decision scope projection")
+    return result["result"]
 
 
-def _source_open_items(items: list[dict[str, Any]] | None) -> list[dict[str, Any]]:
-    if items is None:
-        return []
-    return [
-        item
-        for item in items
-        if isinstance(item, dict)
-        and item.get("done") is not True
-        and str(item.get("status") or "open") in {"open", "blocked"}
-    ]
-
-
-def _gate_owner_compatible(gate: dict[str, Any], *, agent_id: str | None) -> bool:
-    if normalize_todo_global_gate(gate.get("global_gate")):
-        return True
-    normalized_agent_id = normalize_todo_claimed_by(agent_id)
-    blocks_agent = normalize_todo_blocks_agent(gate.get("blocks_agent"))
-    claimed_by = normalize_todo_claimed_by(gate.get("claimed_by"))
-    if not normalized_agent_id:
-        return not blocks_agent and not claimed_by
-    if blocks_agent and blocks_agent != normalized_agent_id:
-        return False
-    return not claimed_by or claimed_by == normalized_agent_id
-
-
-def _scope_identity(scope: dict[str, Any]) -> str:
-    return f"{scope['kind']}:{scope['granularity']}:{scope['scope_key']}"
-
-
-def standing_decision_authority_for_agent(
-    authority: dict[str, Any] | None,
-    *,
-    agent_id: str | None,
-) -> dict[str, Any] | None:
-    """Filter standing decision receipts to one agent lane."""
-
-    if not isinstance(authority, dict):
-        return None
-    entries = authority.get("entries")
-    if not isinstance(entries, list):
-        return None
-    compatible = [
-        dict(entry)
-        for entry in entries
-        if isinstance(entry, dict)
-        and _gate_owner_compatible(entry, agent_id=agent_id)
-    ]
-    raw_conflicts = authority.get("conflicts")
-    conflicts = [
-        dict(entry)
-        for entry in (raw_conflicts if isinstance(raw_conflicts, list) else [])
-        if isinstance(entry, dict) and _gate_owner_compatible(entry, agent_id=agent_id)
-    ]
-    if not compatible and not conflicts:
-        return None
+def _facts(item: dict[str, Any]) -> dict[str, Any]:
     return {
-        "schema_version": STANDING_DECISION_AUTHORITY_SCHEMA_VERSION,
-        "agent_id": normalize_todo_claimed_by(agent_id),
-        "active_count": sum(entry.get("active") is True for entry in compatible),
-        "inactive_count": sum(entry.get("active") is not True for entry in compatible),
-        "entries": compatible,
-        **({"conflicts": conflicts, "conflict_count": len(conflicts)} if conflicts else {}),
+        "todo_id": normalize_todo_id(item.get("todo_id")),
+        "status": str(item.get("status") or "open"), "done": item.get("done") is True,
+        "claimed_by": normalize_todo_claimed_by(item.get("claimed_by")),
+        "blocks_agent": normalize_todo_blocks_agent(item.get("blocks_agent")),
+        "global_gate": bool(normalize_todo_global_gate(item.get("global_gate"))),
+        "unblocks_todo_id": normalize_todo_id(item.get("unblocks_todo_id")),
+        "decision_scope": normalize_todo_decision_scope(item.get("decision_scope")),
+        "required_decision_scopes": normalize_todo_required_decision_scopes(item.get("required_decision_scopes")),
+        "decision_scope_outcomes": normalize_todo_decision_scope_outcomes(item.get("decision_scope_outcomes")),
+        # Preserve the existing legacy classification boundary, not new prose authority.
+        "is_gate": is_user_gate_todo_item(item),
     }
 
 
-def _standing_authority_receipts_covering(
-    authority: dict[str, Any] | None,
-    required_scope: dict[str, Any],
-    *,
-    agent_id: str | None,
-) -> list[dict[str, Any]]:
-    scoped = standing_decision_authority_for_agent(authority, agent_id=agent_id)
-    if not scoped:
+def _source(summary: dict[str, Any] | None, source: list[dict[str, Any]] | None,
+            keys: tuple[str, ...]) -> list[dict[str, Any]]:
+    if source is not None:
+        return [_facts(item) for item in source if isinstance(item, dict)]
+    if not isinstance(summary, dict):
         return []
-    return [
-        entry
-        for entry in scoped["entries"]
-        if entry.get("active") is True
-        and decision_scope_covers(entry.get("decision_scope"), required_scope)
-    ]
+    result = []
+    seen = set()
+    for key in keys:
+        values = (summary or {}).get(key)
+        for item in values if isinstance(values, list) else []:
+            if not isinstance(item, dict):
+                continue
+            if item.get("done") is True or str(item.get("status") or "open") not in {"open", "blocked"}:
+                continue
+            identity = (item.get("todo_id"), item.get("index"), item.get("text"))
+            if identity not in seen:
+                seen.add(identity)
+                result.append(_facts(item))
+    return result
+
+
+def _authority(authority: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(authority, dict) or not isinstance(authority.get("entries"), list):
+        return None
+    def decoded(entry: dict[str, Any]) -> dict[str, Any]:
+        codecs = {"global_gate": normalize_todo_global_gate, "blocks_agent": normalize_todo_blocks_agent,
+                  "claimed_by": normalize_todo_claimed_by, "decision_scope": normalize_todo_decision_scope}
+        return {**entry, **{key: codec(entry[key]) for key, codec in codecs.items() if key in entry}}
+
+    return {**authority, "entries": [decoded(entry) for entry in authority["entries"] if isinstance(entry, dict)],
+            "conflicts": [decoded(entry) for entry in authority.get("conflicts", []) if isinstance(entry, dict)]
+            if isinstance(authority.get("conflicts"), list) else []}
+
+
+def standing_decision_authority_for_agent(authority: dict[str, Any] | None, *,
+                                          agent_id: str | None) -> dict[str, Any] | None:
+    if _authority(authority) is None:
+        return None
+    return _evaluate("standing", authority=_authority(authority),
+                     agent_id=normalize_todo_claimed_by(agent_id))
 
 
 def build_required_decision_scope_consistency(
-    agent_todo_summary: dict[str, Any] | None,
-    user_todo_summary: dict[str, Any] | None,
-    *,
-    agent_id: str | None,
-    registered_agent_ids: list[str] | None = None,
+    agent_todo_summary: dict[str, Any] | None, user_todo_summary: dict[str, Any] | None, *,
+    agent_id: str | None, registered_agent_ids: list[str] | None = None,
     agent_source_items: list[dict[str, Any]] | None = None,
     user_source_items: list[dict[str, Any]] | None = None,
     standing_decision_authority: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Validate that blocking decision dependencies resolve to live user gates."""
-
-    agent_items = (
-        _source_open_items(agent_source_items)
-        if agent_source_items is not None
-        else _summary_open_items(agent_todo_summary, keys=_AGENT_SUMMARY_ITEM_KEYS)
+    return _evaluate("consistency",
+        agent_items=_source(agent_todo_summary, agent_source_items, _AGENT_SUMMARY_ITEM_KEYS),
+        user_items=_source(user_todo_summary, user_source_items, _USER_SUMMARY_ITEM_KEYS),
+        agent_id=normalize_todo_claimed_by(agent_id),
+        registered_agents=sorted({value for raw in registered_agent_ids or []
+                                  if (value := normalize_todo_claimed_by(raw))}),
+        standing_authority=_authority(standing_decision_authority),
     )
-    user_items = (
-        _source_open_items(user_source_items)
-        if user_source_items is not None
-        else _summary_open_items(user_todo_summary, keys=_USER_SUMMARY_ITEM_KEYS)
-    )
-    gates = [item for item in user_items if is_user_gate_todo_item(item)]
-    user_actions = [item for item in user_items if not is_user_gate_todo_item(item)]
-    errors: list[dict[str, Any]] = []
-    checked_scope_count = 0
-    terminal_outcome_count = 0
-    standing_authority_match_count = 0
-
-    registered_agents = sorted(
-        {
-            normalized
-            for value in registered_agent_ids or []
-            if (normalized := normalize_todo_claimed_by(value))
-        }
-    )
-    if len(registered_agents) > 1:
-        for gate in gates:
-            if normalize_todo_global_gate(gate.get("global_gate")):
-                continue
-            if normalize_todo_blocks_agent(gate.get("blocks_agent")):
-                continue
-            errors.append(
-                {
-                    "reason_code": "multi_agent_user_gate_missing_scope",
-                    "user_todo_id": normalize_todo_id(gate.get("todo_id")),
-                    "registered_agent_ids": registered_agents,
-                }
-            )
-
-    for agent_item in agent_items:
-        claimed_by = normalize_todo_claimed_by(agent_item.get("claimed_by"))
-        normalized_agent_id = normalize_todo_claimed_by(agent_id)
-        if claimed_by and normalized_agent_id and claimed_by != normalized_agent_id:
-            continue
-        effective_owner = normalized_agent_id or claimed_by
-        required_scopes = normalize_todo_required_decision_scopes(
-            agent_item.get("required_decision_scopes")
-        )
-        for required_scope in required_scopes:
-            checked_scope_count += 1
-            matching_gates = [
-                gate
-                for gate in gates
-                if decision_scope_covers(gate.get("decision_scope"), required_scope)
-            ]
-            compatible_gates = [
-                gate
-                for gate in matching_gates
-                if _gate_owner_compatible(gate, agent_id=effective_owner)
-            ]
-            if compatible_gates:
-                continue
-            standing_receipts = _standing_authority_receipts_covering(
-                standing_decision_authority,
-                required_scope,
-                agent_id=effective_owner,
-            )
-            if standing_receipts:
-                standing_authority_match_count += 1
-                continue
-            terminal_outcomes = [
-                item
-                for item in normalize_todo_decision_scope_outcomes(
-                    agent_item.get("decision_scope_outcomes")
-                )
-                if item.get("outcome") in {"reject", "cancel"}
-                and decision_scope_covers(
-                    item.get("decision_scope"),
-                    required_scope,
-                )
-            ]
-            if terminal_outcomes:
-                terminal_outcome_count += 1
-                if str(agent_item.get("status") or "open") != "blocked":
-                    errors.append(
-                        {
-                            "reason_code": "terminal_decision_outcome_target_not_blocked",
-                            "agent_todo_id": normalize_todo_id(
-                                agent_item.get("todo_id")
-                            ),
-                            "required_scope": _scope_identity(required_scope),
-                            "related_user_todo_ids": [
-                                item["source_todo_id"] for item in terminal_outcomes
-                            ],
-                        }
-                    )
-                continue
-            scoped_authority = standing_decision_authority_for_agent(
-                standing_decision_authority, agent_id=effective_owner,
-            ) or {}
-            conflicts = [item for item in scoped_authority.get("conflicts", [])
-                         if decision_scope_covers(item.get("decision_scope"), required_scope)]
-            matching_actions = [
-                item
-                for item in user_actions
-                if decision_scope_covers(item.get("decision_scope"), required_scope)
-            ]
-            if conflicts:
-                reason_code = "standing_decision_order_unresolved"
-                related_ids = sorted({todo_id for item in conflicts
-                                      if isinstance(item.get("source_todo_ids"), list)
-                                      for todo_id in item["source_todo_ids"] if isinstance(todo_id, str)})
-            elif matching_actions:
-                reason_code = "non_blocking_user_action_scope_collision"
-                related_ids = [todo_id for item in matching_actions
-                               if (todo_id := normalize_todo_id(item.get("todo_id"))) is not None]
-            elif matching_gates:
-                reason_code = "required_decision_scope_gate_owner_mismatch"
-                related_ids = [todo_id for item in matching_gates
-                               if (todo_id := normalize_todo_id(item.get("todo_id"))) is not None]
-            else:
-                reason_code = "dangling_required_decision_scope"
-                related_ids = []
-            errors.append(
-                {
-                    "reason_code": reason_code,
-                    "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-                    "required_scope": _scope_identity(required_scope),
-                    "related_user_todo_ids": [item for item in related_ids if item],
-                }
-            )
-
-    return {
-        "schema_version": DECISION_SCOPE_CONSISTENCY_SCHEMA_VERSION,
-        "ok": not errors,
-        "status": "consistent" if not errors else "projection_repair_required",
-        "agent_id": normalize_todo_claimed_by(agent_id),
-        "checked_agent_todo_count": len(agent_items),
-        "checked_required_scope_count": checked_scope_count,
-        "terminal_outcome_count": terminal_outcome_count,
-        "standing_authority_match_count": standing_authority_match_count,
-        "errors": errors,
-    }
 
 
 def build_required_decision_scope_repair_hint(
@@ -382,6 +176,15 @@ def build_required_decision_scope_repair_hint(
                 "required_decision_scopes or invent approval merely to clear this conflict"
             ),
         )
+    elif any(isinstance(error, dict) and error.get("reason_code") == "required_decision_scope_target_mismatch"
+             for error in errors):
+        result.update(
+            reason="a scope-covering user gate explicitly targets a different Todo",
+            repair_focus=(
+                "reconcile the exact target and required scope against owner intent; do not "
+                "remove the requirement, retarget the gate, or invent approval merely to clear the conflict"
+            ),
+        )
     return result
 
 
@@ -390,118 +193,27 @@ def decision_scope_covers(gate_scope: Any, required_scope: Any) -> bool:
     required = normalize_todo_decision_scope(required_scope)
     if not gate or not required:
         return False
-    if gate["kind"] != required["kind"]:
-        return False
-    if gate["scope_key"] not in {required["scope_key"], "*"}:
-        return False
-    return DECISION_SCOPE_GRANULARITY_RANK[gate["granularity"]] >= DECISION_SCOPE_GRANULARITY_RANK[
-        required["granularity"]
-    ]
+    return _evaluate("covers", gate_scope=gate, required_scope=required)
 
 
-def decision_scope_gate_relation(
-    gate: dict[str, Any],
-    agent_item: dict[str, Any],
-) -> dict[str, Any] | None:
-    gate_scope = normalize_todo_decision_scope(gate.get("decision_scope"))
-    required_scopes = normalize_todo_required_decision_scopes(
-        agent_item.get("required_decision_scopes")
-    )
-    if not gate_scope:
-        return None
-    if not required_scopes:
-        return {
-            "schema_version": "decision_scope_relation_v0",
-            "source": "decision_scope",
-            "state": "independent",
-            "reason": "agent_todo_has_no_required_decision_scopes",
-            "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-            "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-            "decision_scope": gate_scope,
-            "required_decision_scopes": [],
-        }
-    for required_scope in required_scopes:
-        if decision_scope_covers(gate_scope, required_scope):
-            return {
-                "schema_version": "decision_scope_relation_v0",
-                "source": "decision_scope",
-                "state": "gate_covers_action",
-                "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-                "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-                "decision_scope": gate_scope,
-                "matched_required_decision_scope": required_scope,
-                "required_decision_scopes": required_scopes,
-            }
-    return {
-        "schema_version": "decision_scope_relation_v0",
-        "source": "decision_scope",
-        "state": "independent",
-        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-        "agent_todo_id": normalize_todo_id(agent_item.get("todo_id")),
-        "decision_scope": gate_scope,
-        "required_decision_scopes": required_scopes,
-    }
+def decision_scope_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
+    return _evaluate("scope_relation", gate=_facts(gate), item=_facts(agent_item))
 
 
-def exact_todo_gate_relation(
-    gate: dict[str, Any],
-    agent_item: dict[str, Any],
-) -> dict[str, Any] | None:
-    target_todo_id = normalize_todo_id(gate.get("unblocks_todo_id"))
-    if not target_todo_id:
-        return None
-    agent_todo_id = normalize_todo_id(agent_item.get("todo_id"))
-    return {
-        "schema_version": "todo_gate_relation_v0",
-        "source": "unblocks_todo_id",
-        "state": "gate_targets_todo" if target_todo_id == agent_todo_id else "independent",
-        "gate_todo_id": normalize_todo_id(gate.get("todo_id")),
-        "target_todo_id": target_todo_id,
-        "agent_todo_id": agent_todo_id,
-    }
+def exact_todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
+    return _evaluate("exact_relation", gate=_facts(gate), item=_facts(agent_item))
 
 
 def todo_gate_relation(gate: dict[str, Any], agent_item: dict[str, Any]) -> dict[str, Any] | None:
-    exact_relation = exact_todo_gate_relation(gate, agent_item)
-    scope_relation = decision_scope_gate_relation(gate, agent_item)
+    return _evaluate("relation", gate=_facts(gate), item=_facts(agent_item))
 
-    if (
-        exact_relation
-        and scope_relation
-        and exact_relation.get("state") == "independent"
-        and scope_relation.get("state") == "gate_covers_action"
-    ):
-        return {
-            "schema_version": "todo_gate_relation_v0",
-            "source": "unblocks_todo_id+decision_scope",
-            "state": "projection_repair_required",
-            "reason": "decision_scope_covers_agent_todo_but_unblocks_todo_targets_different_todo",
-            "gate_todo_id": exact_relation.get("gate_todo_id"),
-            "target_todo_id": exact_relation.get("target_todo_id"),
-            "agent_todo_id": exact_relation.get("agent_todo_id"),
-            "exact_todo_relation": exact_relation,
-            "decision_scope_relation": scope_relation,
-        }
 
-    if exact_relation and exact_relation.get("state") == "gate_targets_todo":
-        if scope_relation:
-            exact_relation["decision_scope_relation"] = scope_relation
-        return exact_relation
-
-    if scope_relation and scope_relation.get("state") == "gate_covers_action":
-        if exact_relation:
-            scope_relation["exact_todo_relation"] = exact_relation
-        return scope_relation
-
-    if exact_relation:
-        if scope_relation:
-            exact_relation["decision_scope_relation"] = scope_relation
-        return exact_relation
-
-    return scope_relation
+def todo_gate_relations(gates: list[dict[str, Any]], items: list[dict[str, Any]]) -> list[list[dict[str, Any] | None]]:
+    """Evaluate a consumer's candidate set in one RPC, retaining positional identity."""
+    if not gates or not items:
+        return [[] for _ in gates]
+    return _evaluate("relations", gates=[_facts(gate) for gate in gates], items=[_facts(item) for item in items])
 
 
 def todo_gate_relation_blocks_agent(relation: dict[str, Any] | None) -> bool:
-    if not relation:
-        return False
-    return relation.get("state") in TODO_GATE_BLOCKING_STATES
+    return bool(relation and relation.get("state") in TODO_GATE_BLOCKING_STATES)

--- a/loopx/control_plane/todos/decision_scope.ts
+++ b/loopx/control_plane/todos/decision_scope.ts
@@ -1,0 +1,160 @@
+/** Read-only decision dependency rules over one complete source snapshot.
+ * A consistent dependency is not approval, a lease, or a mutation receipt. */
+import type {JsonObject} from "../effect_program.ts";
+import {requireJsonObject, optionalNonEmptyString} from "../runtime_decode.ts";
+import {gateAddressesAgent} from "./gate_scope.ts";
+
+export const DECISION_SCOPE_REQUEST_SCHEMA = "todo_decision_scope_request_v0";
+const RANK: Readonly<Record<string, number>> = {action: 0, lane: 1, goal: 2, project: 3, global: 4};
+const KINDS = new Set(["private_read", "write_scope", "resource", "production", "public_claim", "direction", "other"]);
+const object = (value: unknown): value is JsonObject => value !== null && typeof value === "object" && !Array.isArray(value);
+const rows = (value: unknown): JsonObject[] => {
+  if (!Array.isArray(value)) throw new TypeError("decision scope rows must be an array");
+  return value.map(item => requireJsonObject(item, "decision scope row"));
+};
+const text = (value: unknown): string | null => typeof value === "string" && value ? value : null;
+
+export function decisionScopeCovers(gate: unknown, required: unknown): boolean {
+  if (!object(gate) || !object(required)) return false;
+  const valid = (scope: JsonObject) => KINDS.has(String(scope.kind)) && Object.hasOwn(RANK, String(scope.granularity)) &&
+    typeof scope.scope_key === "string" && /^(?:\*|[a-z0-9][a-z0-9_.:@*/-]{0,95})$/u.test(scope.scope_key);
+  return valid(gate) && valid(required) && gate.kind === required.kind &&
+    (gate.scope_key === "*" || gate.scope_key === required.scope_key) && RANK[String(gate.granularity)] >= RANK[String(required.granularity)];
+}
+
+function addressed(gate: JsonObject, agent: string | null): boolean {
+  return gateAddressesAgent({global: gate.global_gate === true, blocks: text(gate.blocks_agent), claim: text(gate.claimed_by)}, agent);
+}
+
+export function scopeStandingAuthority(value: unknown, agent: string | null): JsonObject | null {
+  if (!object(value) || !Array.isArray(value.entries)) return null;
+  const entries = rows(value.entries).filter(item => addressed(item, agent));
+  const conflicts = rows(value.conflicts ?? []).filter(item => addressed(item, agent));
+  if (!entries.length && !conflicts.length) return null;
+  return {schema_version: "standing_decision_authority_v0", agent_id: agent,
+    active_count: entries.filter(e => e.active === true).length,
+    inactive_count: entries.filter(e => e.active !== true).length, entries,
+    ...(conflicts.length ? {conflicts, conflict_count: conflicts.length} : {})};
+}
+
+export function decisionScopeRelation(gate: JsonObject, item: JsonObject): JsonObject | null {
+  const scope = gate.decision_scope;
+  if (!object(scope)) return null;
+  const required = rows(item.required_decision_scopes ?? []);
+  const matched = required.find(value => decisionScopeCovers(scope, value));
+  return {schema_version: "decision_scope_relation_v0", source: "decision_scope",
+    state: matched ? "gate_covers_action" : "independent",
+    ...(!required.length ? {reason: "agent_todo_has_no_required_decision_scopes"} : {}),
+    gate_todo_id: gate.todo_id ?? null, agent_todo_id: item.todo_id ?? null,
+    decision_scope: scope, ...(matched ? {matched_required_decision_scope: matched} : {}), required_decision_scopes: required};
+}
+
+export function exactTodoGateRelation(gate: JsonObject, item: JsonObject): JsonObject | null {
+  const target = text(gate.unblocks_todo_id);
+  if (!target) return null;
+  return {schema_version: "todo_gate_relation_v0", source: "unblocks_todo_id",
+    state: target === item.todo_id ? "gate_targets_todo" : "independent",
+    gate_todo_id: gate.todo_id ?? null, target_todo_id: target, agent_todo_id: item.todo_id ?? null};
+}
+
+export function todoGateRelation(gate: JsonObject, item: JsonObject): JsonObject | null {
+  const exact = exactTodoGateRelation(gate, item), scope = decisionScopeRelation(gate, item);
+  if (exact?.state === "independent" && scope?.state === "gate_covers_action") {
+    return {schema_version: "todo_gate_relation_v0", source: "unblocks_todo_id+decision_scope",
+      state: "projection_repair_required", reason: "decision_scope_covers_agent_todo_but_unblocks_todo_targets_different_todo",
+      gate_todo_id: exact.gate_todo_id, target_todo_id: exact.target_todo_id,
+      agent_todo_id: exact.agent_todo_id, exact_todo_relation: exact, decision_scope_relation: scope};
+  }
+  if (exact?.state === "gate_targets_todo") return {...exact, ...(scope ? {decision_scope_relation: scope} : {})};
+  if (scope?.state === "gate_covers_action") return {...scope, ...(exact ? {exact_todo_relation: exact} : {})};
+  return exact ? {...exact, ...(scope ? {decision_scope_relation: scope} : {})} : scope;
+}
+
+function open(items: JsonObject[]): JsonObject[] {
+  return items.filter(item => item.done !== true && ["open", "blocked"].includes(String(item.status || "open")));
+}
+function scopeId(scope: JsonObject): string { return `${scope.kind}:${scope.granularity}:${scope.scope_key}`; }
+
+export function decisionScopeConsistency(request: JsonObject): JsonObject {
+  const agent = optionalNonEmptyString(request.agent_id, "agent_id");
+  const agents = rows(request.agent_items), users = open(rows(request.user_items));
+  const items = open(agents), gates = users.filter(item => item.is_gate === true), actions = users.filter(item => item.is_gate !== true);
+  if (!Array.isArray(request.registered_agents) || request.registered_agents.some(id => typeof id !== "string")) {
+    throw new TypeError("registered agents must be normalized strings");
+  }
+  const registered = [...new Set(request.registered_agents as string[])].sort();
+  const errors: JsonObject[] = [];
+  if (registered.length > 1) for (const gate of gates) {
+    if (gate.global_gate !== true && !gate.blocks_agent) errors.push({reason_code: "multi_agent_user_gate_missing_scope",
+      user_todo_id: gate.todo_id ?? null, registered_agent_ids: registered});
+  }
+  let checked = 0, terminals = 0, approvals = 0;
+  for (const item of items) {
+    const claim = text(item.claimed_by);
+    if (claim && agent && claim !== agent) continue;
+    const owner = agent || claim;
+    const authority = scopeStandingAuthority(request.standing_authority, owner);
+    for (const scope of rows(item.required_decision_scopes ?? [])) {
+      checked++;
+      const matching = gates.filter(gate => decisionScopeCovers(gate.decision_scope, scope));
+      const compatible = matching.filter(gate => addressed(gate, owner));
+      // Exact targeting is a restriction, not a hint that a broad scope can erase.
+      const conflicting = compatible.filter(gate => todoGateRelation(gate, item)?.state === "projection_repair_required");
+      if (conflicting.length) {
+        errors.push({reason_code: "required_decision_scope_target_mismatch", agent_todo_id: item.todo_id ?? null,
+          required_scope: scopeId(scope), related_user_todo_ids: conflicting.map(g => g.todo_id).filter(Boolean)});
+        continue;
+      }
+      if (compatible.length) continue;
+      if (rows(authority?.entries ?? []).some(entry => entry.active === true && decisionScopeCovers(entry.decision_scope, scope))) {
+        approvals++; continue;
+      }
+      const outcomes = rows(item.decision_scope_outcomes ?? []).filter(outcome => ["reject", "cancel"].includes(String(outcome.outcome)) &&
+        decisionScopeCovers(outcome.decision_scope, scope));
+      if (outcomes.length) {
+        terminals++;
+        if ((item.status || "open") !== "blocked") errors.push({reason_code: "terminal_decision_outcome_target_not_blocked",
+          agent_todo_id: item.todo_id ?? null, required_scope: scopeId(scope), related_user_todo_ids: outcomes.map(o => o.source_todo_id)});
+        continue;
+      }
+      const conflicts = rows(authority?.conflicts ?? []).filter(entry => decisionScopeCovers(entry.decision_scope, scope));
+      const matchingActions = actions.filter(action => decisionScopeCovers(action.decision_scope, scope));
+      let reason = "dangling_required_decision_scope", related: unknown[] = [];
+      if (conflicts.length) {
+        reason = "standing_decision_order_unresolved";
+        related = [...new Set(conflicts.flatMap(c => Array.isArray(c.source_todo_ids) ? c.source_todo_ids.filter(id => typeof id === "string") : []))].sort();
+      } else if (matchingActions.length) {
+        reason = "non_blocking_user_action_scope_collision"; related = matchingActions.map(a => a.todo_id).filter(Boolean);
+      } else if (matching.length) {
+        reason = "required_decision_scope_gate_owner_mismatch"; related = matching.map(g => g.todo_id).filter(Boolean);
+      }
+      errors.push({reason_code: reason, agent_todo_id: item.todo_id ?? null, required_scope: scopeId(scope),
+        related_user_todo_ids: related as string[]});
+    }
+  }
+  return {schema_version: "required_decision_scope_consistency_v0", ok: !errors.length,
+    status: errors.length ? "projection_repair_required" : "consistent", agent_id: agent,
+    checked_agent_todo_count: items.length, checked_required_scope_count: checked,
+    terminal_outcome_count: terminals, standing_authority_match_count: approvals, errors};
+}
+
+export function evaluateDecisionScope(value: unknown): JsonObject {
+  const request = requireJsonObject(value, "decision scope request");
+  if (request.schema_version !== DECISION_SCOPE_REQUEST_SCHEMA) throw new TypeError("decision scope request schema mismatch");
+  let result: JsonObject | boolean | null | (JsonObject | null)[][];
+  switch (request.operation) {
+    case "consistency": result = decisionScopeConsistency(request); break;
+    case "standing": result = scopeStandingAuthority(request.authority, optionalNonEmptyString(request.agent_id, "agent_id")); break;
+    case "covers": result = decisionScopeCovers(request.gate_scope, request.required_scope); break;
+    case "relations": {
+      const items = rows(request.items);
+      result = rows(request.gates).map(gate => items.map(item => todoGateRelation(gate, item)));
+      break;
+    }
+    case "relation": result = todoGateRelation(requireJsonObject(request.gate, "gate"), requireJsonObject(request.item, "item")); break;
+    case "scope_relation": result = decisionScopeRelation(requireJsonObject(request.gate, "gate"), requireJsonObject(request.item, "item")); break;
+    case "exact_relation": result = exactTodoGateRelation(requireJsonObject(request.gate, "gate"), requireJsonObject(request.item, "item")); break;
+    default: throw new TypeError("unsupported decision scope operation");
+  }
+  return {schema_version: "todo_decision_scope_result_v0", result};
+}

--- a/loopx/control_plane/todos/gate_scope.ts
+++ b/loopx/control_plane/todos/gate_scope.ts
@@ -1,0 +1,12 @@
+/** Addressed permission scope is independent of execution ownership. */
+export interface GateScope {
+  global: boolean;
+  blocks: string | null;
+  claim: string | null;
+}
+
+export function gateAddressesAgent(gate: GateScope, agent: string | null): boolean {
+  if (gate.global) return true;
+  if (gate.blocks) return gate.blocks === agent;
+  return !gate.claim || gate.claim === agent;
+}

--- a/loopx/control_plane/todos/quota_selection.ts
+++ b/loopx/control_plane/todos/quota_selection.ts
@@ -3,6 +3,7 @@ import { EffectRuntimeRequestError } from "../effect_runtime_errors.ts";
 import { requireJsonObject, requireBoolean, requireInteger, requireStringArray,
   optionalNonEmptyString } from "../runtime_decode.ts";
 import { projectTodoResumePlanning } from "./resume_planning.ts";
+import { gateAddressesAgent } from "./gate_scope.ts";
 
 interface Row {
   payload: JsonObject; display: JsonObject; claim: string | null;
@@ -37,7 +38,7 @@ const bucket = (row: Row, agent: string) => row.claim === agent ? 0 : row.claim 
 
 /** A gate addresses a lane; it is not a job whose claim grants execution. */
 function gateApplies(row: Row, agent: string | null): boolean {
-  return !agent || row.global || (row.blocks ? row.blocks === agent : !row.claim || row.claim === agent);
+  return !agent || gateAddressesAgent(row, agent);
 }
 function actionApplies(row: Row, agent: string | null): boolean {
   const bound = row.bound ?? row.claim;

--- a/loopx/global_todos.py
+++ b/loopx/global_todos.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .control_plane.runtime.time import now_utc_iso
-from .control_plane.todos.decision_scope import todo_gate_relation
+from .control_plane.todos.decision_scope import todo_gate_relations
 from .control_plane.todos.user_gate import open_user_gate_todo_items
 from .presentation.markdown import as_dict, as_list
 from .presentation.public_safety import public_safe_boundary, redact_public_text
@@ -200,12 +200,13 @@ def _verified_blocked_ids(
             blocked_ids.add(todo_id)
 
     user_summary = as_dict(payload.get("user_todo_summary"))
-    for gate in open_user_gate_todo_items(user_summary):
+    gates = open_user_gate_todo_items(user_summary)
+    relations = todo_gate_relations(gates, [as_dict(record.get("item")) for record in records.values()])
+    for gate, gate_relations in zip(gates, relations, strict=True):
         exact_todo_id = str(gate.get("unblocks_todo_id") or "").strip()
         if exact_todo_id in records:
             blocked_ids.add(exact_todo_id)
-        for todo_id, record in records.items():
-            relation = todo_gate_relation(gate, as_dict(record.get("item")))
+        for todo_id, relation in zip(records, gate_relations, strict=True):
             if relation and relation.get("state") in {
                 "gate_targets_todo",
                 "gate_covers_action",

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .control_plane.runtime.time import now_utc, now_utc_iso
-from .control_plane.todos.decision_scope import todo_gate_relation
+from .control_plane.todos.decision_scope import todo_gate_relations
 from .control_plane.todos.user_gate import open_user_gate_todo_items
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
@@ -245,8 +245,8 @@ def _blocked_refs_for_gate(
     exact_todo_id = str(gate_item.get("unblocks_todo_id") or "").strip()
     if exact_todo_id:
         return [exact_todo_id]
-    for agent_item in _agent_todo_candidates(quota_payload):
-        relation = todo_gate_relation(gate_item, agent_item)
+    candidates = _agent_todo_candidates(quota_payload)
+    for agent_item, relation in zip(candidates, todo_gate_relations([gate_item], candidates)[0], strict=True):
         if not relation or relation.get("state") not in {
             "gate_targets_todo",
             "gate_covers_action",

--- a/tests/control_plane/test_canonical_goal_governance.py
+++ b/tests/control_plane/test_canonical_goal_governance.py
@@ -45,6 +45,28 @@ def _alignment(paths):
     return project_shared_goal_alignment(goal_id=GOAL_ID, agent_id="agent-a", project=paths["project"])
 
 
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("display", ["stale", "missing"])
+def test_quota_diagnoses_exact_gate_conflict_from_complete_provider(tmp_path, native, display):
+    scope = {"schema_version": "decision_scope_v0", "kind": "write_scope", "granularity": "action", "scope_key": "release"}
+    records = [_record(f"todo_unrelated_{index}", claimed_by="agent-a") for index in range(40)]
+    records.extend([
+        _record("todo_required", claimed_by="agent-a", required_decision_scopes=[scope]),
+        _record("todo_gate", role="user", source_section="User Todo", task_class="user_gate",
+                blocks_agent="agent-a", decision_scope=scope, unblocks_todo_id="todo_unrelated_0"),
+    ])
+    paths = _canonical(tmp_path, records, native=native)
+    if display == "missing":
+        paths["state_file"].unlink()
+    before = paths["state_file"].read_bytes() if paths["state_file"].exists() else None
+    code, result = run_json_cli_result("quota", "should-run", "--goal-id", GOAL_ID,
+        "--agent-id", "agent-a", registry_path=paths["registry"])
+    assert code == 0, result
+    assert result["effective_action"] == "todo_decision_scope_projection_repair", result
+    assert "required_decision_scope_target_mismatch" in json.dumps(result)
+    assert (paths["state_file"].read_bytes() if paths["state_file"].exists() else None) == before
+
+
 def _mutate_provider(paths):
     root = Path(__file__).resolve().parents[2]
     store = (root / "loopx/control_plane/coordination/file_authority_store.ts").as_uri()

--- a/tests/control_plane/test_todo_decision_scope_consistency.py
+++ b/tests/control_plane/test_todo_decision_scope_consistency.py
@@ -24,6 +24,39 @@ SCOPE = {
 }
 
 
+def test_explicit_gate_scope_is_not_cancelled_by_another_claimant() -> None:
+    gate = {"todo_id": "todo_scoped_gate", "status": "open", "task_class": "user_gate",
+            "blocks_agent": AGENT_ID, "claimed_by": "agent-b", "decision_scope": SCOPE}
+    result = build_required_decision_scope_consistency(
+        _agent_summary(), _user_summary(gate), agent_id=AGENT_ID,
+        registered_agent_ids=[AGENT_ID, "agent-b"],
+    )
+    assert result["ok"] is True
+    assert result["errors"] == []
+
+
+def test_exact_link_to_other_work_cannot_satisfy_a_required_scope() -> None:
+    gate = {"todo_id": "todo_scoped_gate", "status": "open", "task_class": "user_gate",
+            "blocks_agent": AGENT_ID, "unblocks_todo_id": "todo_different_work", "decision_scope": SCOPE}
+    result = build_required_decision_scope_consistency(
+        _agent_summary(), _user_summary(gate), agent_id=AGENT_ID,
+    )
+    assert result["ok"] is False
+    assert result["errors"][0]["reason_code"] == "required_decision_scope_target_mismatch"
+    hint = build_required_decision_scope_repair_hint(result)
+    assert "owner intent" in hint["repair_focus"]
+    assert "invent approval" in hint["repair_focus"]
+
+
+def test_standing_scope_legacy_codec_is_retained() -> None:
+    authority = {"entries": [{"active": True, "global_gate": "yes", "decision_scope": "direction:action:publish_quality_contract"}]}
+    scoped = standing_decision_authority_for_agent(authority, agent_id=AGENT_ID)
+    assert scoped["active_count"] == 1
+    assert build_required_decision_scope_consistency(
+        _agent_summary(), {}, agent_id=AGENT_ID, standing_decision_authority=authority,
+    )["standing_authority_match_count"] == 1
+
+
 def _agent_summary() -> dict:
     return {
         "first_open_items": [

--- a/tests/control_plane_ts/decision_scope.test.ts
+++ b/tests/control_plane_ts/decision_scope.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {JsonObject} from "../../loopx/control_plane/effect_program.ts";
+import {decisionScopeConsistency, decisionScopeCovers, evaluateDecisionScope, todoGateRelation} from "../../loopx/control_plane/todos/decision_scope.ts";
+import {productionScaleCoordinationFixture} from "./production_scale_coordination_fixture.ts";
+
+const scope = {kind: "write_scope", granularity: "action", scope_key: "release"};
+const item: JsonObject = {todo_id: "todo_work", status: "open", claimed_by: "agent-a", required_decision_scopes: [scope]};
+const gate: JsonObject = {todo_id: "todo_gate", status: "open", is_gate: true, blocks_agent: "agent-a", decision_scope: scope};
+const request = (users: JsonObject[], extra: JsonObject = {}): JsonObject => ({
+  agent_id: "agent-a", registered_agents: ["agent-a", "agent-b"], agent_items: [item], user_items: users, ...extra,
+});
+
+test("scope is exact or an explicit wildcard, not a prefix or a prose match", () => {
+  for (const [patch, expected] of [
+    [{scope_key: "*", granularity: "goal"}, true], [{scope_key: "release/*"}, false],
+    [{kind: "private_read"}, false], [{granularity: "invalid"}, false],
+  ] as const) assert.equal(decisionScopeCovers({...scope, ...patch}, scope), expected);
+  assert.equal(decisionScopeCovers(scope, {...scope, granularity: "goal"}), false);
+});
+
+test("explicit recipient takes precedence over claim; another agent does not inherit it", () => {
+  const claimed = {...gate, claimed_by: "agent-b"};
+  assert.equal(decisionScopeConsistency(request([claimed])).ok, true);
+  const other = decisionScopeConsistency(request([claimed], {agent_id: "agent-b", agent_items: [{...item, claimed_by: "agent-b"}]}));
+  assert.equal((other.errors as JsonObject[])[0].reason_code, "required_decision_scope_gate_owner_mismatch");
+  assert.equal(decisionScopeConsistency(request([{...claimed, global_gate: true}])).ok, true);
+});
+
+test("exact target conflicts cannot become scope-wide approval or be masked by another gate", () => {
+  const conflicting = {...gate, unblocks_todo_id: "todo_other"};
+  for (const gates of [[conflicting], [conflicting, gate], [gate, conflicting]]) {
+    const result = decisionScopeConsistency(request(gates));
+    assert.equal(result.ok, false);
+    assert.equal(result.standing_authority_match_count, 0);
+    assert.equal((result.errors as JsonObject[])[0].reason_code, "required_decision_scope_target_mismatch");
+  }
+  assert.equal(todoGateRelation(conflicting, item)?.state, "projection_repair_required");
+  assert.equal(todoGateRelation({...gate, unblocks_todo_id: "todo_work"}, item)?.state, "gate_targets_todo");
+});
+
+test("nonblocking actions and closed gates do not satisfy a live requirement", () => {
+  for (const patch of [{is_gate: false}, {status: "done", done: true}, {status: "deferred"}]) {
+    assert.equal(decisionScopeConsistency(request([{...gate, ...patch}])).ok, false);
+  }
+  assert.equal(decisionScopeConsistency(request([gate])).standing_authority_match_count, 0);
+});
+
+test("terminal outcomes remain obligations: rejection requires a blocked target", () => {
+  const rejected = {...item, decision_scope_outcomes: [{outcome: "reject", decision_scope: scope, source_todo_id: "todo_gate"}]};
+  assert.equal(decisionScopeConsistency(request([], {agent_items: [rejected]})).ok, false);
+  const blocked = decisionScopeConsistency(request([], {agent_items: [{...rejected, status: "blocked"}]}));
+  assert.equal(blocked.ok, true);
+  assert.equal(blocked.terminal_outcome_count, 1);
+});
+
+test("complete production-scale history preserves the conflict beyond display limits without mutation", () => {
+  const fixture = productionScaleCoordinationFixture("goal-fixture");
+  const records = fixture.projection.todos as JsonObject[];
+  const input = request([...records.filter(row => row.role === "user").map(row => ({...row, is_gate: row.task_class === "user_gate"})),
+    {...gate, unblocks_todo_id: "todo_other"}], {agent_items: [...records.filter(row => row.role === "agent"), item]});
+  const before = JSON.stringify(input);
+  const result = decisionScopeConsistency(input);
+  assert.ok((result.errors as JsonObject[]).some(error => error.agent_todo_id === "todo_work" && error.reason_code === "required_decision_scope_target_mismatch"));
+  assert.equal(JSON.stringify(input), before);
+});
+
+test("batched relations preserve pair ordering and fail on unknown protocol operations", () => {
+  const result = evaluateDecisionScope({schema_version: "todo_decision_scope_request_v0", operation: "relations", gates: [gate], items: [item, {...item, required_decision_scopes: []}]});
+  assert.deepEqual(result.result, [[todoGateRelation(gate, item), todoGateRelation(gate, {...item, required_decision_scopes: []})]]);
+  assert.throws(() => evaluateDecisionScope({schema_version: "todo_decision_scope_request_v0", operation: "approve"}), /unsupported/);
+});


### PR DESCRIPTION
## Summary

- Consolidate decision-scope coverage, exact Todo links, standing-receipt lane scoping and consistency diagnostics in `todos/decision_scope.ts`. Share the explicit gate-recipient predicate with quota selection.
- Fix two contradictions: an explicit `blocks_agent` is not canceled by another claimant; a scope-covering gate targeting a different Todo cannot yield a false `consistent` dependency.
- Batch candidate relations for agent fallback, global Todo and summary consumers. Retire the Python rule implementation while retaining legacy metadata decoding and existing completion imports.
- Update both bilingual RFCs without removing the remaining T1–T4 / D1–D3 plan. Production code is net -114 lines; the overall diff additionally includes regression coverage and documentation.

## Semantics and boundaries

This is not an all-parity refactor. The two corrected cases had failing-before regression tests. Contradictory exact targeting now emits `required_decision_scope_target_mismatch`; another matching gate does not hide the contradictory record. The repair hint requires reconciliation with owner intent, not automatic retargeting, deleting requirements, or inventing approval.

An open dependency being consistent is not approval. User actions remain nonblocking; rejection/cancellation still requires the corresponding blocked target. Explicit global-gate authoring, claims, leases, provider commits, default provider selection and promotion holds are unchanged. Legacy codecs normalize standing-scope metadata before the typed read rule. Existing action-token fallback and compact-summary diagnostic consumers remain named T3 follow-ups, not claimed as migrated.

Nearest owner: existing Todo domain / quota read policy; no new capability or provider. The bounded future-facing pass removes duplicate recipient knowledge and batches relation calls rather than adding a new inventory or migration framework.

## Validation

- Tested revision: `378c1a351` (runtime/test commit `08ed25e59`; final commit is documentation only).
- Run state: `finished`
- Input classes: `synthetic`, `public_fixture`, `authorized_private_read_only`

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| static | passed | `npm run typecheck:control-plane`, Ruff on changed Python files, `git diff --check`, public/private diff scan |
| unit / integration | passed | 141 Python tests across decision scope, standing chronology, canonical status/planning/governance, user-gate progress, lifecycle/CLI validation, global Todos and summary |
| unit | passed | `npm run test:control-plane`: 1,109 passed, one PostgreSQL environment-dependent test skipped |
| real_backend / real_entrypoint | passed | Isolated real File authority store, legacy/native record modes; public `quota should-run` detects conflicts beyond 40 preceding candidates despite stale/missing Markdown, without rewriting display |
| regression_parity | passed | Both intended corrections failed before implementation. Existing production-scale fixture extended through decision dependency tests; isolated authorized snapshot with 4k+ archived rows across nine agent lanes has equal baseline/head diagnostics. Actual status entrypoint and CLI succeeded; copied state remained unchanged |
| real_entrypoint | passed | `quota-agent-scoped-user-gate-smoke.py`, `todo-standing-decision-authority-smoke.py`; status/quota performance smoke: ~1.3s/~2.6s under the existing 3.5s budgets, including malformed-state arm |

Coverage and gaps: Python is targeted, not a full-suite claim. Initial TS suite invocation picked an unsupported system Python in subprocess tests; rerunning with the supported repository environment passed. No model-token qualification was run: this changes deterministic read rules, not host prompts. No UI markup/layout change; the shipped global Todo/summary consumers are exercised through their regression suites. No Lark-specific surface is added. No live Goal was promoted or mutated, and no raw snapshot/log is attached.

PostgreSQL transaction conformance and three-arm promotion rehearsal are not claimed: no authority-store transaction, runtime routing, compatibility-projection writer or promotion behavior changes in this PR. This is T3 consumer-rule closure, not durability qualification.

## Type of Change

- [x] Bug fix with accompanying refactoring (semantic changes disclosed above)
- [x] Documentation update
- [x] Test update

## LoopX Area / Technical Direction

- [x] Control plane
- [x] Core control-plane hardening
- Target base branch: `main`
- Direction tracker: TypeScript migration T3; shared-authority consumer consistency only

## Shared-authority RFC fixture impact

- Production-scale fixture schema: `loopx_coordination_production_scale_fixture_v0`
- Semantic dimensions: explicit recipient vs claimant, exact-link/scope contradiction, terminal outcomes, large-history completeness and read-only evaluation.
- Provider arms: real File store, both legacy/native record formats. Other store implementations unchanged.
- Read-only legacy/file/PostgreSQL three-arm rehearsal: not applicable to this read-policy-only slice; required promotion qualification remains open.

## Boundary Checklist

- [x] No private state, credentials, raw traces, internal links, or local machine paths in the diff or public evidence.
- [x] Scoped to the Todo decision-dependency owner and its active consumers.
- [x] Every commit includes DCO sign-off.
- [x] T1/T2, remaining T3 consumers, durability and promotion requirements remain explicit.
