### PR TITLE
fix(test): disambiguate pending reply from live announcements

### DIFF
--- a/docs/development/testing-and-quality.md
+++ b/docs/development/testing-and-quality.md
@@ -123,6 +123,12 @@ coverage. 新的前端豁免由目标分支已审阅的策略控制；CI 自身�
 PRs opened before activation may need a branch update to produce the new
 required check; an old green suite alone does not supply a missing aggregate.
 
+Browser waits must target the intended surface: a visible pending-message label
+and an accessibility live region may contain the same words. Use a scoped or
+exact locator and retain the bounded completion assertion; do not suppress a
+strict-mode ambiguity with a retry or a longer timeout. 浏览器等待应区分消息提示与
+无障碍播报，不能把定位歧义误报成恢复超时，也不能通过删掉播报来让测试通过。
+
 ### Refactor Real-Path Gate / 重构真实路径门
 
 The PR review capability's `observable_semantics` evidence gate applies to

--- a/examples/personal-workspace-browser-smoke.mjs
+++ b/examples/personal-workspace-browser-smoke.mjs
@@ -2918,7 +2918,9 @@ async function main() {
       await page.locator(".personal-goal-link").first().click();
       await goalNavigation.getByRole("button", { name: "Chat" }).click();
       await page.getByText("保持运行，用于验证刷新恢复。").waitFor({ state: "visible", timeout: 10_000 });
-      await page.getByText("正在整理…").waitFor({ state: "hidden", timeout: 10_000 });
+      // The live region also contains "<Agent>: 正在整理…" while a reply is
+      // pending. Target the visible message placeholder, not both surfaces.
+      await page.getByText("正在整理…", { exact: true }).waitFor({ state: "hidden", timeout: 10_000 });
       const recovered = page.__loopxRuntime.sessions.get(recoveryTurn.sessionId);
       if (recovered?.active_turn_id !== null && recovered?.active_turn_id !== recoveryTurn.turnId) {
         throw new Error("Recovered Session points at a different active Turn");


### PR DESCRIPTION
## Summary

Fix the remaining Dashboard CI recovery failure after #4241 and #4250. The detailed log from [main qualification](https://github.com/huangruiteng/loopx/actions/runs/34614728080) shows a **Playwright strict-mode violation**, not an elapsed recovery timeout: the substring locator matches both the accessibility live announcement and the pending message.

Use exact pending-message text matching. Keep the live region, the ten-second completion bound, and the session/completion-replay assertions introduced by #4250. Record the locator lesson in the existing testing guide.

## Scope and product judgment

Only the existing browser acceptance fixture and developer testing guidance change. No product frontend/backend, packaged assets, settings, runtime state, coverage threshold or CI exemption changes. No UI preview or companion configuration work is needed because the product surface is unchanged. The owning boundary is browser qualification, not a new capability or abstraction.

The timing dependence explains why local/packaged runs passed: if completion removes the message first, the broad locator no longer matches two elements. Increasing the timeout cannot fix a strict-mode error.

## Validation

- Run state: running
- Input classes: synthetic, public_fixture
- Real browser: Node 22 development smoke with CI coverage enabled passed **all 24 criteria** on latest main plus this fix.
- Negative controls: reproduced the old strict-mode error with both real DOM elements; the actual changed wait still times out while the pending message exists, with or without a live region; after the message clears, the wait succeeds while the live region remains. Four controls passed; the temporary probe is not shipped.
- JavaScript syntax and diff whitespace passed. Public/private scan is clean; only two explicit public paths staged.
- Packaged browser: **all 24 criteria passed** using the shipped Dashboard assets.
- CI policy/workflow regressions: **37 passed** (7 policy/gate tests and 30 workflow/Sonar tests). Hosted Linux qualification will be reported before claiming the CI failure closed.
- No paid-model tests, live Goal writes, provider transactions or installation changes. No merge authorization assumed.
