### PR TITLE
refactor: trim thin heartbeat agent input

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -356,12 +356,15 @@ project-agnostic; if a behavior needs to be remembered across workers, write it
 to active state, run history, the registry, or a generated prompt contract
 rather than hand-editing the automation body.
 
-`loopx heartbeat-prompt --format json` emits an `interface_budget`
-object for the selected mode. It reports the rendered prompt's `char_count`,
-`line_count`, normalized `budget_char_count`, `max_chars`, and
-`within_budget`. `upgrade-plan --format json` carries the same budget summary
-inside each generated prompt, so local default-promotion checks can flag prompt
-bloat without parsing prose or relying on a chat thread.
+`loopx heartbeat-prompt --thin --format json` emits the versioned
+`heartbeat_agent_input_v1` Agent-input envelope. Its compact
+`interface_budget` reports `mode`, normalized `budget_char_count`, `max_chars`,
+and `within_budget`; generator diagnostics and duplicate commands stay out of
+the recurring Agent hot path. Human-readable Markdown and non-thin JSON modes
+retain the richer generator packet, including `char_count` and `line_count`.
+`upgrade-plan --format json` also carries that richer budget summary inside
+each generated prompt, so local default-promotion checks can flag prompt bloat
+without parsing prose or relying on a chat thread.
 
 `upgrade-plan --format json` also carries a compact `prompt_policy_audit` for
 installed prompts when their body is available through the local Codex App

--- a/docs/reference/contracts/interface-budget-contract.md
+++ b/docs/reference/contracts/interface-budget-contract.md
@@ -13,11 +13,25 @@ and size/count budgets.
 | `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 13000` | `nested_keys <= 330` | `top_level_keys <= 52` |
 | `dashboard_status_json` | operator dashboard | render first-screen operator state | `history`, run artifacts, or project-local adapter output | `json_chars <= 18500` | `nested_keys <= 260` | `top_level_keys <= 25` |
 
-These four budgets measure compact in-memory machine payloads. They do not
-measure the exact text written to stdout: JSON indentation, compatibility
-projections, repeated commands, and Markdown wrappers can make emitted output
-materially larger. The emitted-output qualification matrix below measures that
-separate boundary through the real CLI entry point.
+These four budgets measure compact machine payloads. For
+`heartbeat_prompt_json`, the measured payload is the actual
+`heartbeat_agent_input_v1` projection emitted by the recurring-host
+`heartbeat-prompt --thin --format json` path, not the richer internal
+generator payload. Visible one-shot Goal hosts retain their host-specific
+activation packet. The other payloads are measured before stdout formatting. JSON
+indentation and Markdown wrappers can make emitted output materially larger;
+the emitted-output qualification matrix below measures that separate boundary
+through the real CLI entry point.
+
+The successful thin heartbeat projection contains only `schema_version`,
+`ok`, `goal_id`, optional `agent_id`, `task_body`, and the compact
+`interface_budget`; exact Turn identity and `bootstrap=true` are included only
+when requested. Generator provenance, resolved paths, mode booleans, policy
+source strings, runtime diagnostics, and command copies already embedded in
+`task_body` stay out of the Agent input. A failed projection contains the
+schema, `ok=false`, Goal/optional Agent identity, and the actionable `error`.
+Use Markdown output for human generator diagnostics or a non-thin JSON mode
+for the richer generator packet; neither is the recurring Agent hot path.
 
 The heartbeat envelope ceiling covers the unbound and representative agent/scope-bound
 Codex App thin fixtures. It includes generator metadata and repeated bound commands,
@@ -46,7 +60,7 @@ details and command prefixes still belong in compact references or cold paths.
 | `status --goal-id` | absolute hot path | todo-count growth; task graph excluded by default | `--include-task-graph`, `history`, run artifacts |
 | `diagnose --goal-id` | explicit-limit cold path | `--limit 5` fixture matrix | status plus goal-specific quota/todo reads |
 | `review-packet --handoff-only` | absolute hot path | todo-count growth plus handoff semantic anchors | full `review-packet`, run artifacts |
-| `heartbeat-prompt --thin` | absolute hot path | agent scope and multi-agent fixture matrix | `--compact`, `--full` |
+| `heartbeat-prompt --thin` | absolute hot path | agent scope, multi-agent fixture matrix, and exact Agent-input field allowlist | Markdown diagnostics, `--compact`, `--full` |
 | `todo list` | baseline and growth | todo-count growth and agent filtering semantics | `--thin`, `--limit N`, role/status filters, direct todo-id lifecycle commands |
 | `history --limit 5` | explicit-limit cold path | returned-run bound | individual run JSON/Markdown artifacts |
 | `evidence-log --thin --limit 5` | explicit-limit cold path | returned-evidence bound | referenced run-history and rollout-event artifacts |

--- a/docs/reference/protocols/host-integration-plugin-plan-v0.md
+++ b/docs/reference/protocols/host-integration-plugin-plan-v0.md
@@ -87,6 +87,12 @@ The plugin should not hand-copy project-specific policy into the automation.
 It should store only host-owned scheduling metadata, such as the current
 `reset_token`, last applied RRULE, and unchanged-poll state.
 
+With JSON output, this command returns the versioned
+`heartbeat_agent_input_v1` projection. Host adapters consume `goal_id`, the
+optional `agent_id`, and `task_body`; they must not depend on generator paths,
+duplicate lifecycle commands, or diagnostic metadata. Those details remain
+available through human-readable Markdown output and non-thin generator modes.
+
 Exit criteria:
 
 - Missing agent identity fails closed when the goal has registered agents.

--- a/examples/control_plane/cli-output-probe-runner.py
+++ b/examples/control_plane/cli-output-probe-runner.py
@@ -54,6 +54,7 @@ def _receipt_row(
     measurement: dict,
     text: str,
     variant_id: str | None = None,
+    output_contract_version: str | None = None,
 ) -> dict:
     payload = measurement.get("payload")
     return {
@@ -63,6 +64,7 @@ def _receipt_row(
         "scenario": scenario,
         "format": output_format,
         "qualification_policy": qualification_policy,
+        "output_contract_version": output_contract_version,
         "chars": measurement["chars"],
         "utf8_bytes": measurement["utf8_bytes"],
         "lines": measurement["lines"],
@@ -157,6 +159,11 @@ def _default_rows(
                         markdown_anchor=surface.markdown_anchor,
                         measurement=measurement,
                         text=text,
+                        output_contract_version=(
+                            getattr(surface, "output_contract_version", None)
+                            if output_format == "json"
+                            else None
+                        ),
                     )
                 )
     return rows

--- a/examples/control_plane/heartbeat-prompt-error-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-error-smoke.py
@@ -29,21 +29,11 @@ def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def assert_failure_payload(payload: dict) -> None:
+    assert set(payload) == {"schema_version", "ok", "goal_id", "error"}, payload
+    assert payload["schema_version"] == "heartbeat_agent_input_v1", payload
     assert payload["ok"] is False, payload
     assert payload["goal_id"] == GOAL_ID, payload
     assert "--agent-scope requires --agent-id" in payload["error"], payload
-    assert payload["active_state"] == str(ACTIVE_STATE), payload
-    assert payload["active_state_source"] == "explicit", payload
-    assert payload["resolved_active_state"] == str(ACTIVE_STATE), payload
-    assert payload["compact"] is False, payload
-    assert payload["brief"] is False, payload
-    assert payload["thin"] is True, payload
-    assert "full" not in payload, payload
-    assert payload["cli_bin"] == "loopx", payload
-    assert payload["agent_id"] is None, payload
-    assert payload["agent_scopes"] == [SCOPE], payload
-    assert payload["expanded_prompt_command"].endswith(f"--agent-scope '{SCOPE}'"), payload
-    assert payload["task_body"] is None, payload
 
 
 def main() -> int:
@@ -125,7 +115,7 @@ def main() -> int:
         invalid_scope_payload
     )
     assert invalid_scope_payload["agent_id"] == AGENT_ID, invalid_scope_payload
-    assert invalid_scope_payload["agent_scopes"] == [INVALID_SCOPE], invalid_scope_payload
+    assert "agent_scopes" not in invalid_scope_payload, invalid_scope_payload
 
     print("heartbeat-prompt-error-smoke ok")
     return 0

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -26,7 +26,10 @@ from heartbeat_prompt_fixtures import (  # noqa: E402
     assert_prompt_budget,
     normalized,
 )
-from loopx.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402
+from loopx.heartbeat_prompt import (  # noqa: E402
+    HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
+    build_heartbeat_prompt,
+)
 
 
 def user_output_policy(task_body: str, *, mode: str) -> dict[str, str]:
@@ -1119,13 +1122,15 @@ def main() -> int:
     )
     cli_payload = json.loads(cli_json.stdout)
     assert cli_payload["task_body"] == default_payload["task_body"], cli_payload
-    assert cli_payload["compact"] is False, cli_payload
-    assert cli_payload["brief"] is False, cli_payload
-    assert cli_payload["thin"] is True, cli_payload
+    assert set(cli_payload) == {
+        "schema_version",
+        "ok",
+        "goal_id",
+        "task_body",
+        "interface_budget",
+    }, cli_payload
+    assert cli_payload["schema_version"] == HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
     assert cli_payload["interface_budget"]["mode"] == "thin", cli_payload
-    assert "full" not in cli_payload, cli_payload
-    assert cli_payload["cli_bin"] == "loopx", cli_payload
-    assert cli_payload["active_state_source"] == "explicit", cli_payload
 
     cli_full_json = subprocess.run(
         [
@@ -1220,8 +1225,8 @@ def main() -> int:
     )
     cli_thin_payload = json.loads(cli_thin_json.stdout)
     assert cli_thin_payload["task_body"] == thin_payload["task_body"], cli_thin_payload
-    assert cli_thin_payload["thin"] is True, cli_thin_payload
-    assert cli_thin_payload["cli_bin"] == "loopx", cli_thin_payload
+    assert cli_thin_payload["schema_version"] == HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
+    assert "thin_prompt_command" not in cli_thin_payload, cli_thin_payload
 
     cli_canary_json = subprocess.run(
         [
@@ -1410,12 +1415,10 @@ def main() -> int:
             text=True,
         )
         cli_registry_thin_payload = json.loads(cli_registry_thin_json.stdout)
-        assert cli_registry_thin_payload["thin"] is True, cli_registry_thin_payload
+        assert cli_registry_thin_payload["schema_version"] == HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
         assert cli_registry_thin_payload["agent_id"] == "codex-main-control", cli_registry_thin_payload
-        assert cli_registry_thin_payload["active_state"] == "the registry-declared active state", (
-            cli_registry_thin_payload
-        )
-        assert cli_registry_thin_payload["resolved_active_state"] == str(state_file), cli_registry_thin_payload
+        assert "active_state" not in cli_registry_thin_payload, cli_registry_thin_payload
+        assert "resolved_active_state" not in cli_registry_thin_payload, cli_registry_thin_payload
         assert "Advance `public-heartbeat-goal` from the registry-declared active state." in (
             cli_registry_thin_payload["task_body"]
         ), cli_registry_thin_payload
@@ -1480,16 +1483,9 @@ def main() -> int:
         ).stdout
         cli_profile_scoped_payload = json.loads(cli_profile_scoped_json)
         assert cli_profile_scoped_payload["agent_id"] == "codex-side-bypass", cli_profile_scoped_payload
-        assert cli_profile_scoped_payload["agent_scopes"] == ["productization showcase docs lane"], (
-            cli_profile_scoped_payload
-        )
-        assert cli_profile_scoped_payload["agent_scope_source"] == "agent_profile_v1", cli_profile_scoped_payload
-        assert cli_profile_scoped_payload["thin_prompt_command"] == (
-            "loopx heartbeat-prompt --thin --goal-id public-heartbeat-goal --agent-id codex-side-bypass"
-        ), cli_profile_scoped_payload
-        assert "--agent-scope" not in cli_profile_scoped_payload["thin_prompt_command"], (
-            cli_profile_scoped_payload
-        )
+        assert "agent_scopes" not in cli_profile_scoped_payload, cli_profile_scoped_payload
+        assert "agent_scope_source" not in cli_profile_scoped_payload, cli_profile_scoped_payload
+        assert "thin_prompt_command" not in cli_profile_scoped_payload, cli_profile_scoped_payload
         assert "productization showcase docs lane" in normalized(cli_profile_scoped_payload["task_body"]), (
             cli_profile_scoped_payload
         )
@@ -1664,14 +1660,10 @@ def main() -> int:
             text=True,
         )
         cli_global_fallback_payload = json.loads(cli_global_fallback_json.stdout)
-        assert cli_global_fallback_payload["thin"] is True, cli_global_fallback_payload
+        assert cli_global_fallback_payload["schema_version"] == HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
         assert cli_global_fallback_payload["agent_id"] == "codex-side-bypass", cli_global_fallback_payload
-        assert cli_global_fallback_payload["active_state_source"] == f"registry:{global_registry_path}", (
-            cli_global_fallback_payload
-        )
-        assert cli_global_fallback_payload["resolved_active_state"] == str(state_file), (
-            cli_global_fallback_payload
-        )
+        assert "active_state_source" not in cli_global_fallback_payload, cli_global_fallback_payload
+        assert "resolved_active_state" not in cli_global_fallback_payload, cli_global_fallback_payload
         cli_global_agent_json = subprocess.run(
             [
                 sys.executable,

--- a/examples/control_plane/hot-path-interface-budget-smoke.py
+++ b/examples/control_plane/hot-path-interface-budget-smoke.py
@@ -25,7 +25,10 @@ from loopx.extensions.presentation import (  # noqa: E402
     publish_extension_projection,
 )
 from loopx.extensions.runtime import install_extension  # noqa: E402
-from loopx.heartbeat_prompt import build_heartbeat_prompt  # noqa: E402
+from loopx.heartbeat_prompt import (  # noqa: E402
+    build_heartbeat_prompt,
+    project_heartbeat_agent_input,
+)
 from loopx.interface_budget import build_interface_budget_cadence  # noqa: E402
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
@@ -390,10 +393,12 @@ def main() -> int:
         )
         review_packet = build_review_packet(status_payload, goal_id=GOAL_ID, action_kind="codex")
         handoff_payload = review_packet_handoff_only_payload(review_packet)
-        heartbeat_payload = build_heartbeat_prompt(
-            goal_id=GOAL_ID,
-            thin=True,
-            runtime_profile="codex_app_heartbeat",
+        heartbeat_payload = project_heartbeat_agent_input(
+            build_heartbeat_prompt(
+                goal_id=GOAL_ID,
+                thin=True,
+                runtime_profile="codex_app_heartbeat",
+            )
         )
         # Real automations normally bind an agent; the unbound fixture alone
         # misses repeated identity/scope arguments in the generator envelope.

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -766,23 +766,22 @@ def main() -> int:
         )
         payload = json.loads(cli.stdout)
         assert payload["ok"] is True, payload
-        assert payload["quota_guard_command"] == (
+        assert payload["schema_version"] == "heartbeat_agent_input_v1", payload
+        expected_quota_guard = (
             'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
             'quota should-run --goal-id installer-smoke-goal '
             '--turn-instance-id "${LOOPX_TURN:?}"'
-        ), payload
-        assert payload["quota_spend_command"] == (
-            'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
-            "quota spend-slot --goal-id installer-smoke-goal --slots 1 --source heartbeat --execute"
-        ), payload
-        assert payload["thin"] is True, payload
+        )
+        assert expected_quota_guard in payload["task_body"], payload
         assert payload["interface_budget"]["mode"] == "thin", payload
         assert payload["interface_budget"]["within_budget"] is True, payload
-        assert "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>" in payload["progress_refresh_state_command"], payload
-        assert "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>" in payload["progress_refresh_state_command"], payload
-        assert "--delivery-batch-scale multi_surface" not in payload["progress_refresh_state_command"], payload
-        assert "--delivery-outcome outcome_progress" not in payload["progress_refresh_state_command"], payload
-        assert "<PUBLIC_SAFE_PROGRESS_CLASSIFICATION>" in payload["progress_refresh_state_command"], payload
+        for generator_only_field in (
+            "quota_guard_command",
+            "quota_spend_command",
+            "progress_refresh_state_command",
+            "cli_bin",
+        ):
+            assert generator_only_field not in payload, payload
         assert normal_turns_use_cli_interaction_contract(payload["task_body"]), payload
         assert not normal_turns_use_cli_interaction_contract(
             "Normal turns use the runtime skill; recovery may inspect CLI `interaction_contract`."
@@ -794,7 +793,6 @@ def main() -> int:
         assert "not a command-prefix assignment" in payload["task_body"], payload
         assert "guard receipt; 2 stalls->replan" in payload["task_body"], payload
         assert "no-change=`surface_only`/no spend" in payload["task_body"], payload
-        assert payload["cli_bin"] == "loopx", payload
 
         canary_cli = subprocess.run(
             [

--- a/examples/subcommand-format-smoke.py
+++ b/examples/subcommand-format-smoke.py
@@ -136,7 +136,7 @@ def main() -> int:
             "json",
         )
         assert heartbeat["ok"] is True, heartbeat
-        assert heartbeat["thin"] is True, heartbeat
+        assert heartbeat["schema_version"] == "heartbeat_agent_input_v1", heartbeat
         assert heartbeat["interface_budget"]["mode"] == "thin", heartbeat
 
         upgrade = cli_json(registry_path, "upgrade-plan", "--format", "json")

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -26,6 +26,7 @@ from ..heartbeat_prequota import (
 from ..heartbeat_prompt import (
     build_heartbeat_prompt,
     build_heartbeat_prompt_error_payload,
+    project_heartbeat_agent_input,
     render_heartbeat_prompt_markdown,
 )
 from ..kiro_cli_goal_mode import KIRO_CLI_BIN
@@ -507,6 +508,11 @@ def handle_support_control_command(
         active_state_source = None
         registered_agents = None
         effective_agent_id = args.agent_id
+        requested_runtime_profile = (
+            SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT.value
+            if args.codex_app
+            else args.runtime_profile
+        )
         try:
             active_state, resolved_active_state, active_state_source = (
                 resolve_heartbeat_active_state(
@@ -562,11 +568,7 @@ def handle_support_control_command(
                     "--runtime-profile cannot be combined with --host-surface, "
                     "--scheduler-owner, or --execution-mode"
                 )
-            runtime_profile = (
-                SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT.value
-                if args.codex_app
-                else args.runtime_profile
-            )
+            runtime_profile = requested_runtime_profile
             payload = build_heartbeat_prompt(
                 goal_id=args.goal_id,
                 active_state=active_state,
@@ -644,7 +646,27 @@ def handle_support_control_command(
                 registered_agents=registered_agents,
                 available_capabilities=args.available_capabilities,
             )
-        print_payload(payload, output_format(args), render_heartbeat_prompt_markdown)
+        selected_output_format = output_format(args)
+        recurring_runtime_profile = requested_runtime_profile in {
+            None,
+            SchedulerRuntimeProfile.CODEX_APP_HEARTBEAT.value,
+            SchedulerRuntimeProfile.GENERIC_CLI_AGENT_LOOP.value,
+        }
+        recurring_thin_surface = bool(
+            recurring_runtime_profile and args.visible_goal_host is None
+        )
+        output_payload = (
+            project_heartbeat_agent_input(payload)
+            if selected_output_format == "json"
+            and payload.get("thin") is True
+            and recurring_thin_surface
+            else payload
+        )
+        print_payload(
+            output_payload,
+            selected_output_format,
+            render_heartbeat_prompt_markdown,
+        )
         return 0 if payload.get("ok") else 1
 
     supervisor_result = handle_supervisor_control_command(

--- a/loopx/control_plane/heartbeat/agent_input.py
+++ b/loopx/control_plane/heartbeat/agent_input.py
@@ -1,0 +1,82 @@
+"""Agent-facing projection for a generated thin heartbeat prompt."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION = "heartbeat_agent_input_v1"
+_AGENT_BUDGET_FIELDS = (
+    "mode",
+    "budget_char_count",
+    "max_chars",
+    "within_budget",
+)
+
+
+def _require_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"heartbeat agent input requires non-empty {field}")
+    return value
+
+
+def _project_interface_budget(payload: dict[str, Any]) -> dict[str, Any]:
+    source = payload.get("interface_budget")
+    if not isinstance(source, dict):
+        raise ValueError("heartbeat agent input requires interface_budget")
+    projected = {field: source.get(field) for field in _AGENT_BUDGET_FIELDS}
+    if not isinstance(projected["mode"], str):
+        raise ValueError("heartbeat agent input requires interface_budget.mode")
+    for field in ("budget_char_count", "max_chars"):
+        if not isinstance(projected[field], int):
+            raise ValueError(f"heartbeat agent input requires interface_budget.{field}")
+    if not isinstance(projected["within_budget"], bool):
+        raise ValueError(
+            "heartbeat agent input requires interface_budget.within_budget"
+        )
+    return projected
+
+
+def project_heartbeat_agent_input(payload: dict[str, Any]) -> dict[str, Any]:
+    """Keep only fields needed to install or execute one thin heartbeat.
+
+    The builder payload is intentionally richer because upgrade, diagnostics,
+    and Markdown rendering consume its generator metadata.  The thin JSON CLI
+    surface is an Agent input, so commands and policy already embedded in the
+    task body must not be duplicated beside it.
+    """
+
+    if payload.get("thin") is not True:
+        raise ValueError("heartbeat agent input projection requires thin mode")
+    ok = payload.get("ok")
+    if not isinstance(ok, bool):
+        raise ValueError("heartbeat agent input requires boolean ok")
+
+    projected: dict[str, Any] = {
+        "schema_version": HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
+        "ok": ok,
+        "goal_id": _require_string(payload, "goal_id"),
+    }
+    agent_id = payload.get("agent_id")
+    if agent_id is not None and not isinstance(agent_id, str):
+        raise ValueError("heartbeat agent input requires string or null agent_id")
+    if agent_id:
+        projected["agent_id"] = agent_id
+
+    if ok:
+        projected["task_body"] = _require_string(payload, "task_body")
+        projected["interface_budget"] = _project_interface_budget(payload)
+        turn_instance_id = payload.get("turn_instance_id")
+        if turn_instance_id is not None:
+            if not isinstance(turn_instance_id, str) or not turn_instance_id:
+                raise ValueError(
+                    "heartbeat agent input requires non-empty turn_instance_id"
+                )
+            projected["turn_instance_id"] = turn_instance_id
+        if payload.get("bootstrap") is True:
+            projected["bootstrap"] = True
+        return projected
+
+    projected["error"] = _require_string(payload, "error")
+    return projected

--- a/loopx/control_plane/testing/cli_output_budget.py
+++ b/loopx/control_plane/testing/cli_output_budget.py
@@ -4,6 +4,9 @@ import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from loopx.control_plane.heartbeat.agent_input import (
+    HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
+)
 from loopx.control_plane.testing.cli_output_semantics import (
     action_signature_semantic_sha256,
     json_shape_paths as collect_json_shape_paths,
@@ -40,6 +43,7 @@ class CliOutputBudgetSpec:
     max_lines: dict[str, dict[OutputFormat, int]]
     scale_axis: str | None = None
     max_json_growth_chars_per_unit: int | None = None
+    output_contract_version: str | None = None
 
 
 @dataclass(frozen=True)
@@ -250,21 +254,28 @@ CLI_OUTPUT_BUDGET_SPECS: tuple[CliOutputBudgetSpec, ...] = (
         owner="heartbeat automation",
         consumer_action="wake and route one bounded turn",
         qualification_policy="absolute_hot_path",
-        cold_path="heartbeat-prompt --compact or --full",
-        semantic_json_keys=("task_body", "quota_guard_command", "interface_budget"),
+        cold_path=(
+            "heartbeat-prompt Markdown diagnostics, --compact, or --full"
+        ),
+        semantic_json_keys=(
+            "schema_version",
+            "task_body",
+            "interface_budget",
+        ),
         markdown_anchor="# Heartbeat Automation Prompt",
         max_chars={
-            "small": {"json": 6_000, "markdown": 5_100},
-            "crowded": {"json": 6_000, "markdown": 5_100},
-            "multi_agent": {"json": 6_000, "markdown": 5_100},
+            "small": {"json": 3_400, "markdown": 5_100},
+            "crowded": {"json": 3_400, "markdown": 5_100},
+            "multi_agent": {"json": 3_400, "markdown": 5_100},
         },
         max_lines={
-            "small": {"json": 58, "markdown": 72},
-            "crowded": {"json": 58, "markdown": 72},
-            "multi_agent": {"json": 58, "markdown": 72},
+            "small": {"json": 18, "markdown": 72},
+            "crowded": {"json": 18, "markdown": 72},
+            "multi_agent": {"json": 18, "markdown": 72},
         },
         scale_axis="todo_count",
         max_json_growth_chars_per_unit=4,
+        output_contract_version=HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
     ),
     CliOutputBudgetSpec(
         surface_id="todo_list",

--- a/loopx/control_plane/testing/cli_output_differential.py
+++ b/loopx/control_plane/testing/cli_output_differential.py
@@ -4,6 +4,7 @@ import math
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
+from ..heartbeat.agent_input import HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
 from ..quota.turn_envelope import (
     ACTION_SIGNATURE_COVERAGE_V0,
     ACTION_SIGNATURE_COVERAGE_V1,
@@ -461,6 +462,20 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
     if candidate.get("format") != output_format:
         failures.append("format changed")
 
+    base_output_contract = base.get("output_contract_version")
+    candidate_output_contract = candidate.get("output_contract_version")
+    heartbeat_agent_input_migration = bool(
+        row_id.startswith("surface/heartbeat_prompt_thin/")
+        and output_format == "json"
+        and base_output_contract is None
+        and candidate_output_contract == HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
+    )
+    if (
+        candidate_output_contract != base_output_contract
+        and not heartbeat_agent_input_migration
+    ):
+        failures.append("output_contract_version changed")
+
     migration = _schema_migration_state(
         base,
         candidate,
@@ -538,12 +553,21 @@ def _compare_row(base: dict[str, Any], candidate: dict[str, Any]) -> dict[str, A
         if delta > allowance:
             failures.append(f"{metric} grew by {delta}; allowance is {allowance}")
 
-    for field in ("semantic_json_keys",):
-        missing = _removed(base, candidate, field)
+    if output_format == "json":
+        missing = _removed(base, candidate, "semantic_json_keys")
         if missing:
             preview = ", ".join(missing[:5])
             suffix = f" (+{len(missing) - 5} more)" if len(missing) > 5 else ""
-            failures.append(f"{field} removed: {preview}{suffix}")
+            message = f"semantic_json_keys removed: {preview}{suffix}"
+            if heartbeat_agent_input_migration:
+                review_signals.append(message)
+            else:
+                failures.append(message)
+
+    if heartbeat_agent_input_migration:
+        review_signals.append(
+            "output contract migrated: generator payload -> heartbeat_agent_input_v1"
+        )
 
     for field in ("json_shape_paths", "markdown_headings"):
         missing = _removed(base, candidate, field)

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -13,6 +13,10 @@ from .control_plane.heartbeat.agent import (
     normalize_agent_scopes,
     render_peer_agent_scope_instruction,
 )
+from .control_plane.heartbeat.agent_input import (
+    HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
+    project_heartbeat_agent_input,
+)
 from .control_plane.heartbeat.budget import (
     INTERFACE_BUDGET_CHARS,
     NATIVE_GOAL_HOST_MAX_CHARS,
@@ -51,6 +55,7 @@ __all__ = [
     "DEFAULT_MATERIAL_QUEUE_RULE",
     "DEFAULT_PERMISSION_RULE",
     "HEARTBEAT_NOTIFICATION_RULE_SHORT",
+    "HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION",
     "HEARTBEAT_VISION_WRITEBACK_RULE_SHORT",
     "INTERFACE_BUDGET_CHARS",
     "NATIVE_GOAL_HOST_MAX_CHARS",
@@ -77,6 +82,7 @@ __all__ = [
     "normalize_agent_scope",
     "normalize_agent_scopes",
     "prompt_budget_text",
+    "project_heartbeat_agent_input",
     "render_ark_managed_agent_goal_task_body",
     "render_brief_heartbeat_task_body",
     "render_compact_heartbeat_task_body",

--- a/tests/control_plane/test_cli_output_differential.py
+++ b/tests/control_plane/test_cli_output_differential.py
@@ -236,6 +236,78 @@ def test_shrink_with_semantic_shape_retained_passes() -> None:
     assert compare_cli_output_receipts(base, candidate)["ok"] is True
 
 
+def test_heartbeat_agent_input_contract_migration_is_explicit_and_reviewable() -> None:
+    base = _row(
+        row_id="surface/heartbeat_prompt_thin/small/json",
+        surface_id="heartbeat_prompt_thin",
+        semantic_json_keys=["task_body", "quota_guard_command"],
+    )
+    candidate = _row(
+        row_id="surface/heartbeat_prompt_thin/small/json",
+        surface_id="heartbeat_prompt_thin",
+        chars=20_000,
+        utf8_bytes=20_000,
+        lines=500,
+        compact_payload_chars=10_000,
+        semantic_json_keys=["schema_version", "task_body", "interface_budget"],
+        output_contract_version="heartbeat_agent_input_v1",
+    )
+
+    result = compare_cli_output_receipts(_receipt(base), _receipt(candidate))
+
+    assert result["ok"] is True
+    assert result["review_required"] is True
+    assert result["rows"][0]["review_signals"] == [
+        "semantic_json_keys removed: quota_guard_command",
+        "output contract migrated: generator payload -> heartbeat_agent_input_v1",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("row_id", "base_contract", "candidate_contract"),
+    [
+        ("surface/status/small/json", None, "heartbeat_agent_input_v1"),
+        (
+            "surface/heartbeat_prompt_thin/small/json",
+            "heartbeat_agent_input_v0",
+            "heartbeat_agent_input_v1",
+        ),
+        (
+            "surface/heartbeat_prompt_thin/small/json",
+            None,
+            "heartbeat_agent_input_v2",
+        ),
+    ],
+)
+def test_output_contract_change_outside_declared_migration_fails_closed(
+    row_id: str,
+    base_contract: str | None,
+    candidate_contract: str,
+) -> None:
+    base = _row(
+        row_id=row_id,
+        output_contract_version=base_contract,
+    )
+    candidate = _row(
+        row_id=row_id,
+        chars=20_000,
+        utf8_bytes=20_000,
+        lines=500,
+        compact_payload_chars=10_000,
+        semantic_json_keys=["status_contract"],
+        output_contract_version=candidate_contract,
+    )
+
+    result = compare_cli_output_receipts(_receipt(base), _receipt(candidate))
+
+    assert result["ok"] is False
+    assert "output_contract_version changed" in result["rows"][0]["failures"]
+    assert any(
+        failure.startswith("semantic_json_keys removed")
+        for failure in result["rows"][0]["failures"]
+    )
+
+
 @pytest.mark.parametrize(
     ("candidate", "failure_fragment"),
     [
@@ -698,6 +770,21 @@ def test_markdown_heading_removal_requires_review() -> None:
     assert result["ok"] is True
     assert result["review_required"] is True
     assert "markdown_headings removed" in result["rows"][0]["review_signals"][0]
+
+
+def test_markdown_rows_ignore_json_only_semantic_metadata() -> None:
+    base = _row(
+        row_id="surface/status/small/markdown",
+        format="markdown",
+        semantic_json_keys=["legacy_json_key"],
+    )
+    candidate = copy.deepcopy(base)
+    candidate["semantic_json_keys"] = []
+
+    result = compare_cli_output_receipts(_receipt(base), _receipt(candidate))
+
+    assert result["ok"] is True
+    assert result["review_required"] is False
 
 
 def test_candidate_only_row_is_allowed_but_base_row_removal_fails() -> None:

--- a/tests/control_plane/test_fine_grained_turn_mode.py
+++ b/tests/control_plane/test_fine_grained_turn_mode.py
@@ -325,7 +325,9 @@ def test_heartbeat_cli_reads_sticky_fine_mode_from_registry(tmp_path: Path) -> N
     )
     payload = json.loads(completed.stdout)
 
-    assert payload["turn_mode"] == "fine_grained"
+    assert payload["schema_version"] == "heartbeat_agent_input_v1"
+    assert "turn_mode" not in payload
+    assert "turn_granularity" not in payload
     assert FINE_GRAINED_TURN_RULE in payload["task_body"]
 
 

--- a/tests/control_plane/test_heartbeat_agent_input.py
+++ b/tests/control_plane/test_heartbeat_agent_input.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from loopx.heartbeat_prompt import (
+    HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
+    build_heartbeat_prompt,
+    build_heartbeat_prompt_error_payload,
+    project_heartbeat_agent_input,
+)
+
+
+def test_thin_agent_input_excludes_generator_and_embedded_command_duplicates() -> None:
+    generated = build_heartbeat_prompt(
+        goal_id="heartbeat-agent-input",
+        thin=True,
+        agent_id="agent-a",
+        registered_agents=["agent-a", "agent-b"],
+        runtime_profile="codex_app_heartbeat",
+    )
+
+    projected = project_heartbeat_agent_input(generated)
+
+    assert set(projected) == {
+        "schema_version",
+        "ok",
+        "goal_id",
+        "agent_id",
+        "task_body",
+        "interface_budget",
+    }
+    assert projected["schema_version"] == HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION
+    assert projected["task_body"] == generated["task_body"]
+    assert projected["interface_budget"] == {
+        "mode": "thin",
+        "budget_char_count": generated["interface_budget"]["budget_char_count"],
+        "max_chars": generated["interface_budget"]["max_chars"],
+        "within_budget": generated["interface_budget"]["within_budget"],
+    }
+    for duplicate in (
+        "active_state",
+        "active_state_source",
+        "resolved_active_state",
+        "cli_bin",
+        "agent_model",
+        "agent_role",
+        "registered_agents",
+        "runtime_profile",
+        "scheduler_execution_context",
+        "expanded_prompt_command",
+        "thin_prompt_command",
+        "quota_guard_command",
+        "quota_spend_command",
+        "refresh_state_command",
+        "progress_refresh_state_command",
+        "cli_preflight",
+        "material_queue_rule",
+        "permission_rule",
+    ):
+        assert duplicate not in projected
+
+
+def test_thin_agent_input_keeps_exact_turn_and_bootstrap_identity_when_present() -> None:
+    generated = build_heartbeat_prompt(
+        goal_id="heartbeat-agent-input",
+        thin=True,
+        agent_id="agent-a",
+        registered_agents=["agent-a"],
+        runtime_profile="codex_app_heartbeat",
+        turn_instance_id="turn-2026-09-12",
+    )
+    generated["bootstrap"] = True
+
+    projected = project_heartbeat_agent_input(generated)
+
+    assert projected["turn_instance_id"] == "turn-2026-09-12"
+    assert projected["bootstrap"] is True
+
+
+def test_thin_agent_input_error_is_actionable_without_generator_diagnostics() -> None:
+    generated = build_heartbeat_prompt_error_payload(
+        goal_id="heartbeat-agent-input",
+        error="registered agent identity is required",
+        thin=True,
+    )
+
+    projected = project_heartbeat_agent_input(generated)
+
+    assert projected == {
+        "schema_version": HEARTBEAT_AGENT_INPUT_SCHEMA_VERSION,
+        "ok": False,
+        "goal_id": "heartbeat-agent-input",
+        "error": "registered agent identity is required",
+    }
+
+
+def test_agent_input_projection_rejects_non_thin_generator_payload() -> None:
+    generated = build_heartbeat_prompt(
+        goal_id="heartbeat-agent-input",
+        full=True,
+    )
+
+    with pytest.raises(ValueError, match="requires thin mode"):
+        project_heartbeat_agent_input(generated)

--- a/tests/control_plane/test_host_bootstrap_lifecycle.py
+++ b/tests/control_plane/test_host_bootstrap_lifecycle.py
@@ -41,7 +41,11 @@ def test_bootstrap_real_cli_load_is_one_level_and_retains_host(registry, flags):
     body = json.loads(loaded.stdout)
     direct = cli(registry, *flags)
     assert body["task_body"] == direct["task_body"]
-    assert body["runtime_profile"] == direct["runtime_profile"]
+    if flags == ["--codex-app"]:
+        assert body["schema_version"] == direct["schema_version"] == "heartbeat_agent_input_v1"
+        assert "runtime_profile" not in body
+    else:
+        assert body["runtime_profile"] == direct["runtime_profile"]
     assert body.get("bootstrap") is not True
     assert "interaction_contract" in body["task_body"]
 

--- a/tests/test_loopx_turn_driver.py
+++ b/tests/test_loopx_turn_driver.py
@@ -1436,8 +1436,9 @@ def test_heartbeat_cli_codex_app_alias_reaches_generated_quota_guard(
 
     payload = json.loads(output.getvalue())
     assert exit_code == 0, payload
-    assert payload["runtime_profile"] == "codex_app_heartbeat"
-    assert "--codex-app" in payload["quota_guard_command"]
+    assert payload["schema_version"] == "heartbeat_agent_input_v1"
+    assert "runtime_profile" not in payload
+    assert "quota_guard_command" not in payload
     assert "--codex-app" in payload["task_body"]
 
 


### PR DESCRIPTION
## Summary

- split recurring thin JSON output from the richer heartbeat generator packet with a versioned `heartbeat_agent_input_v1` allowlist
- retain only execution identity, task body, and compact budget proof on the Agent hot path while preserving rich Markdown, non-thin JSON, and visible Goal-host packets
- qualify the intentional schema migration in the base/head output ledger and keep unrelated output-contract changes fail closed

## Issue Or Task

- Closes #
- Contributor task ID: maintainer-requested heartbeat prompt output reduction

## Validation

- Tested revision: `66cf7b190df638cabc2a9193a0eedfd8366f5da1`
- Run state: finished
- Input classes: synthetic, authorized_private_read_only

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| `unit` | `passed` | 94 final-revision tests cover the projection allowlist, fine-grained task-body semantics, compact failures, exact-turn conditionals, and fail-closed migration rules; a broader 258-test focused set passed before the final constant-only simplification. |
| `real_entrypoint` | `passed` | Heartbeat success/error, hot-path budget, subcommand-format, packaged install, update, and peer-runtime paths passed through public CLI smokes. |
| `regression_parity` | `passed` | The full `origin/main`-to-candidate CLI output matrix passed; the intended thin-JSON field removal is recorded as the one-time `heartbeat_agent_input_v1` migration while unrelated removals remain blocking. |
| `real_entrypoint` | `passed` | The requested command was exercised read-only against an authorized real Goal; only field names and bounded sizes were inspected, and no private values were retained or published. |
| `static` | `passed` | Ruff, repository-configured mypy, Python compile checks, diff checks, and the candidate public-boundary scan passed. |
| `integration` | `passed` | Risk-based premerge ran 18 selected checks with zero failures, warnings, or manual holds. |

- Coverage and gaps: the changed behavior is a CLI projection boundary, not a provider or authority-store mutation, so PostgreSQL and model-provider qualification are not applicable. CI remains the independent exact-commit confirmation.

See [validation disclosure guidance](https://github.com/huangruiteng/loopx/blob/main/CONTRIBUTING.md#validation-disclosure).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [x] Test update

The breaking surface is intentionally narrow: recurring `heartbeat-prompt --thin --format json` consumers must read the new versioned envelope rather than generator-only fields. The executable `task_body` contract remains present.

## LoopX Area

- [x] Control plane (goals, todos, quota, scheduler, registry, runtime)
- [ ] Benchmark boundary (adapters, runners, verifiers, scoring, evidence)
- [ ] Capability or extension (providers, adapters, skills)
- [x] Public docs or presentation surface (README, protocols, dashboard)
- [ ] Build, packaging, installer, or CI
- [x] Host or runtime integration

## Technical Direction

- [x] Core control-plane hardening
- [ ] Long-horizon benchmark evidence
- [ ] Operator surface and IM integration
- [ ] Shared Goal Authority and cross-host coordination
- [ ] Architecture and research incubator

- Target base branch: `main`
- Direction tracker or promotion unit: default Agent-facing output budget and semantic ledger

## Shared-authority RFC fixture impact

N/A. This PR changes only heartbeat Agent-input projection and its output-budget qualification; it does not change authority providers, runtime routing, or compatibility projection.

## Boundary Checklist

- [x] Neither the diff nor this PR body/comments/attachments disclose private state, credentials, raw traces or verifier output, internal links, or local machine paths (including `.loopx/`, `.codex/goals/`, and live `ACTIVE_GOAL_STATE.md`).
- [x] I did not duplicate maintainer-owned benchmark work unless a maintainer split out a public issue for it.
- [x] I kept the change scoped to the linked issue/task.
- [x] Every commit includes a DCO `Signed-off-by` trailer (`git commit -s`).

Change-quality receipt: `cqr_78a731e8d143e33f9bb9` (valid for the exact rebased commit and diff; 19 files, no blockers).
