### PR TITLE
docs(chat): explain event sequence ordering invariant

### DIFF
--- a/loopx/chat_store.py
+++ b/loopx/chat_store.py
@@ -1320,6 +1320,9 @@ class ChatSessionStore:
                 try:
                     with exclusive_file_lock(path, agent_id="loopx-chat", operation="append_chat_events"):
                         rows = self._event_rows_locked(session_id, turn_id)
+                        # Allocate after the last persisted sequence and append under the
+                        # same file lock: row order stays strictly increasing by sequence.
+                        # Compaction preserves this order but may leave sequence gaps.
                         sequence = int(rows[-1].get("sequence") or 0) if rows else 0
                         for event in pending:
                             sequence += 1
@@ -1355,6 +1358,8 @@ class ChatSessionStore:
         if rows is None:
             with exclusive_file_lock(path, agent_id="loopx-chat", operation="read_chat_events"):
                 rows = self._event_rows_locked(session_id, turn_id)
+        # Relies on the sequence ordering maintained by flush_events and compaction;
+        # gaps are valid, but inserting or rewriting rows must preserve that order.
         start = bisect_right(
             rows,
             after,


### PR DESCRIPTION
## Summary

Document the strictly increasing sequence order that `events_after` relies on for binary search. The writer comment explains locked sequence allocation and ordered append; the reader comment records that compaction may leave gaps while preserving order. Executable behavior is unchanged.

Closes #4192.

## Validation

- Tested revision: `1cc2218cf04833476481c9fcdb38d026d5319b5f`
- Run state: finished
- Input classes: synthetic

| Check kind | Result | Public-safe evidence / limitation |
| --- | --- | --- |
| unit / integration | passed | `python3 -m pytest -q tests/test_chat_event_cursor.py tests/test_attached_session_broker.py`: 17 passed, including cursor seeking and cross-instance event reconciliation. |
| static | passed | Python AST comparison against the parent is identical; `git diff --check` and `loopx check --scan-path loopx/chat_store.py` passed with no warnings. |
| manual | passed | Verified sequence allocation and append share the file lock, and compaction filters rows without reordering them. |

Coverage and gaps: this is a five-line code-comment change. No CLI, Dashboard, Lark, provider, or runtime behavior changes; existing tests and AST parity are sufficient for this scope. Full canary and live-service tests were not run. Hosted CI remains separate validation.

Future-facing pass: the invariant is documented at its existing writer and reader owners; no helper, runtime assertion, or additional abstraction is needed.

## Scope

- Type: documentation update; chat event storage.
- Technical direction: operator surface and IM integration.
- Target base branch: `main`.
- Shared-authority RFC fixture impact: N/A.

## Boundary Checklist

- [x] Diff and PR contain no private state, credentials, raw traces, internal links, or local machine paths.
- [x] No duplicated benchmark work or unrelated changes.
- [x] Every commit includes a DCO sign-off.
