### PR TITLE
refactor(todos): type canonical projection delivery outcomes

### DIFF
--- a/loopx/control_plane/coordination/todo_compatibility_edit.ts
+++ b/loopx/control_plane/coordination/todo_compatibility_edit.ts
@@ -2,6 +2,7 @@ import type { JsonObject } from "../effect_program.ts";
 import type { AuthorityStore } from "./authority_store.ts";
 import { canonicalAuthorityBytes, canonicalAuthorityObject, canonicalAuthoritySha256, requireAuthorityStoreId } from "./authority_store_codec.ts";
 import { prepareCoordinationProjectionCommit, indexCoordinationProjection, validateCoordinationTodoReadModel } from "./coordination_projection.ts";
+import { projectionDelivery } from "../todos/projection_delivery.ts";
 
 export const TODO_COMPATIBILITY_EDIT_SCHEMA = "loopx_todo_compatibility_edit_request_v0";
 export const TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA = "loopx_todo_compatibility_edit_result_v0";
@@ -75,7 +76,7 @@ export async function editCoordinationTodo(
         status: status === "applied" && !original.changed ? "no_change" : status,
         changed: status !== "replayed" && original.changed,
         provider_revision: receipt.provider_revision, cursor: receipt.cursor,
-        projection_delivery: original.changed ? "pending" : "not_required",
+        projection_delivery: projectionDelivery(original.changed),
         projection_source: "committed_authority_journal",
       };
     };

--- a/loopx/control_plane/coordination/todo_update.ts
+++ b/loopx/control_plane/coordination/todo_update.ts
@@ -25,6 +25,7 @@ import { evaluateCoordinationTerminalFence, COORDINATION_TERMINAL_FENCE_REQUEST_
 import { leaseEpoch } from "../work_items/task_lease_acquire.ts";
 import { parseIsoTimestamp } from "../runtime_timestamp.ts";
 import { normalizeNativePlanningIntent, planNativeTodoUpdate } from "../todos/native_update_plan.ts";
+import { projectionDelivery } from "../todos/projection_delivery.ts";
 
 export const COORDINATION_TODO_UPDATE_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_update_request_v0";
@@ -137,7 +138,7 @@ function replayUpdate(
     changed: status !== "replayed" && original.changed,
     todo_id: input.todo_id, provider_revision: receipt.provider_revision,
     cursor: receipt.cursor, original_receipt: original,
-    projection_delivery: original.changed ? "pending" : "not_required",
+    projection_delivery: projectionDelivery(original.changed),
     projection_source: "committed_authority_journal"};
 }
 

--- a/loopx/control_plane/todos/projection_delivery.ts
+++ b/loopx/control_plane/todos/projection_delivery.ts
@@ -1,0 +1,7 @@
+/** Canonical projection-delivery state returned by Todo mutations. */
+export type TodoProjectionDelivery = "pending" | "not_required";
+
+/** Keep mutation results consistent and make the no-op meaning explicit. */
+export function projectionDelivery(changed: boolean): TodoProjectionDelivery {
+  return changed ? "pending" : "not_required";
+}

--- a/loopx/control_plane/todos/projection_delivery.ts
+++ b/loopx/control_plane/todos/projection_delivery.ts
@@ -1,7 +1,15 @@
 /** Canonical projection-delivery state returned by Todo mutations. */
-export type TodoProjectionDelivery = "pending" | "not_required";
+export type TodoProjectionDelivery = "pending" | "delivered" | "current" | "not_required";
 
 /** Keep mutation results consistent and make the no-op meaning explicit. */
 export function projectionDelivery(changed: boolean): TodoProjectionDelivery {
   return changed ? "pending" : "not_required";
+}
+
+/** Decode provider readback without letting ad-hoc strings cross the boundary. */
+export function parseProjectionDelivery(value: unknown): TodoProjectionDelivery {
+  if (value === "pending" || value === "delivered" || value === "current" || value === "not_required") {
+    return value;
+  }
+  throw new Error("projection_delivery is unsupported");
 }

--- a/tests/control_plane_ts/projection_delivery.test.ts
+++ b/tests/control_plane_ts/projection_delivery.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseProjectionDelivery, projectionDelivery } from "../../loopx/control_plane/todos/projection_delivery.ts";
+
+test("projection delivery maps mutation and no-op outcomes", () => {
+  assert.equal(projectionDelivery(true), "pending");
+  assert.equal(projectionDelivery(false), "not_required");
+});
+
+test("projection delivery parser accepts provider readback states", () => {
+  for (const value of ["pending", "delivered", "current", "not_required"]) {
+    assert.equal(parseProjectionDelivery(value), value);
+  }
+  assert.throws(() => parseProjectionDelivery("unknown"));
+});


### PR DESCRIPTION
## Summary
Continue the canonical Todo authority/projection migration with a typed projection-delivery contract.

### Scope
- Centralize mutation and no-op delivery states (`pending`, `not_required`).
- Type and validate provider readback states (`delivered`, `current`).
- Add durable TypeScript contract tests so update/terminal/projection callers cannot silently drift in string semantics.

This is a bounded stage of the two RFC migration: it narrows the shared protocol before the next terminal-lifecycle/outbox consolidation. Legacy Markdown remains a compatibility projection and is not made authoritative.

### Validation
- Focused projection-delivery TypeScript tests pass.
- Full provider and end-to-end validation remains required before merge.
