### PR TITLE
refactor(todos): expand 4274 projection delivery protocol

### DIFF
--- a/loopx/control_plane/coordination/todo_claim.ts
+++ b/loopx/control_plane/coordination/todo_claim.ts
@@ -7,6 +7,7 @@ import {
   requireAuthorityStoreId,
 } from "./authority_store_codec.ts";
 import {validateContinuationNote, computeContinuationTodoFacts} from "./continuation_note.ts";
+import {projectionDelivery} from "../todos/projection_delivery.ts";
 import {normalizeRegisteredTodoAgents, normalizeTodoAgent} from "./todo_agents.ts";
 import {
   prepareCoordinationProjectionCommit,
@@ -450,7 +451,7 @@ export async function executeCoordinationTodoClaim(
       provider_revision: receipt.provider_revision,
       cursor: receipt.cursor,
       original_receipt: original,
-      projection_delivery: result.changed === false ? "not_required" : "pending",
+      projection_delivery: projectionDelivery(result.changed !== false),
       projection_source: "committed_authority_journal",
     };
   };

--- a/loopx/control_plane/coordination/todo_compatibility_edit.ts
+++ b/loopx/control_plane/coordination/todo_compatibility_edit.ts
@@ -2,6 +2,7 @@ import type { JsonObject } from "../effect_program.ts";
 import type { AuthorityStore } from "./authority_store.ts";
 import { canonicalAuthorityBytes, canonicalAuthorityObject, canonicalAuthoritySha256, requireAuthorityStoreId } from "./authority_store_codec.ts";
 import { prepareCoordinationProjectionCommit, indexCoordinationProjection, validateCoordinationTodoReadModel } from "./coordination_projection.ts";
+import { projectionDelivery } from "../todos/projection_delivery.ts";
 
 export const TODO_COMPATIBILITY_EDIT_SCHEMA = "loopx_todo_compatibility_edit_request_v0";
 export const TODO_COMPATIBILITY_EDIT_RESULT_SCHEMA = "loopx_todo_compatibility_edit_result_v0";
@@ -75,7 +76,7 @@ export async function editCoordinationTodo(
         status: status === "applied" && !original.changed ? "no_change" : status,
         changed: status !== "replayed" && original.changed,
         provider_revision: receipt.provider_revision, cursor: receipt.cursor,
-        projection_delivery: original.changed ? "pending" : "not_required",
+        projection_delivery: projectionDelivery(original.changed),
         projection_source: "committed_authority_journal",
       };
     };

--- a/loopx/control_plane/coordination/todo_create.ts
+++ b/loopx/control_plane/coordination/todo_create.ts
@@ -1,4 +1,5 @@
 import type { JsonObject } from "../effect_program.ts";
+import {projectionDelivery} from "../todos/projection_delivery.ts";
 import type { AuthorityStore, AuthorityStoreReceiptResult } from "./authority_store.ts";
 import {
   AuthorityStoreProtocolError,
@@ -77,7 +78,7 @@ function replayCreate(
     provider_revision: receipt.provider_revision,
     cursor: receipt.cursor,
     original_receipt: original,
-    projection_delivery: "pending",
+    projection_delivery: projectionDelivery(true),
     projection_source: "committed_authority_journal",
   };
 }

--- a/loopx/control_plane/coordination/todo_monitor_poll.ts
+++ b/loopx/control_plane/coordination/todo_monitor_poll.ts
@@ -11,6 +11,7 @@ import {planMonitorMetadata, TODO_MONITOR_METADATA_REQUEST_SCHEMA} from "../todo
 import {planMonitorSuccessor, selectMonitorTodo, MONITOR_SUCCESSOR_REQUEST_SCHEMA} from "../scheduler/monitor_successor.ts";
 import {optionalNonEmptyString, requireBoolean} from "../runtime_decode.ts";
 import {planTodoAuthoringScope, TODO_AUTHORING_SCOPE_REQUEST_SCHEMA} from "../todos/authoring_scope.ts";
+import {projectionDelivery} from "../todos/projection_delivery.ts";
 
 export const COORDINATION_MONITOR_POLL_REQUEST_SCHEMA = "loopx_coordination_monitor_poll_request_v0";
 export const COORDINATION_MONITOR_POLL_RESULT_SCHEMA = "loopx_coordination_monitor_poll_result_v0";
@@ -42,7 +43,7 @@ function replay(receipt: AuthorityStoreReceiptResult, input: CoordinationMonitor
   return {schema_version: COORDINATION_MONITOR_POLL_RESULT_SCHEMA, status,
     changed: status !== "replayed", provider_revision: receipt.provider_revision, cursor: receipt.cursor,
     writeback: {...canonicalAuthorityObject(original.writeback, "Monitor writeback"), provider_replayed: status === "replayed"},
-    projection_delivery: "pending", projection_source: "committed_authority_journal"};
+    projection_delivery: projectionDelivery(true), projection_source: "committed_authority_journal"};
 }
 
 function normalize(raw: CoordinationMonitorPollInput): CoordinationMonitorPollInput {

--- a/loopx/control_plane/coordination/todo_terminal_lifecycle.ts
+++ b/loopx/control_plane/coordination/todo_terminal_lifecycle.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import {projectionDelivery} from "../todos/projection_delivery.ts";
 
 import type { JsonObject } from "../effect_program.ts";
 import type {
@@ -451,7 +452,7 @@ function replayTerminal(
     provider_revision: receipt.provider_revision,
     cursor: receipt.cursor,
     original_receipt: original,
-    projection_delivery: result.changed === true ? "pending" : "not_required",
+    projection_delivery: projectionDelivery(result.changed === true),
     projection_source: "committed_authority_journal",
   };
 }
@@ -1134,7 +1135,7 @@ function replayArchive(
     provider_revision: receipt.provider_revision,
     cursor: receipt.cursor,
     original_receipt: original,
-    projection_delivery: result.changed === true ? "pending" : "not_required",
+    projection_delivery: projectionDelivery(result.changed === true),
     projection_source: "committed_authority_journal",
   };
 }

--- a/loopx/control_plane/coordination/todo_update.ts
+++ b/loopx/control_plane/coordination/todo_update.ts
@@ -25,6 +25,7 @@ import { evaluateCoordinationTerminalFence, COORDINATION_TERMINAL_FENCE_REQUEST_
 import { leaseEpoch } from "../work_items/task_lease_acquire.ts";
 import { parseIsoTimestamp } from "../runtime_timestamp.ts";
 import { normalizeNativePlanningIntent, planNativeTodoUpdate } from "../todos/native_update_plan.ts";
+import { projectionDelivery } from "../todos/projection_delivery.ts";
 
 export const COORDINATION_TODO_UPDATE_REQUEST_SCHEMA =
   "loopx_local_coordination_todo_update_request_v0";
@@ -137,7 +138,7 @@ function replayUpdate(
     changed: status !== "replayed" && original.changed,
     todo_id: input.todo_id, provider_revision: receipt.provider_revision,
     cursor: receipt.cursor, original_receipt: original,
-    projection_delivery: original.changed ? "pending" : "not_required",
+    projection_delivery: projectionDelivery(original.changed),
     projection_source: "committed_authority_journal"};
 }
 

--- a/loopx/control_plane/todos/projection_delivery.ts
+++ b/loopx/control_plane/todos/projection_delivery.ts
@@ -1,0 +1,7 @@
+/** Canonical projection-delivery state returned by Todo mutations. */
+export type TodoProjectionDelivery = "pending" | "not_required";
+
+/** Keep mutation results consistent and make the no-op meaning explicit. */
+export function projectionDelivery(changed: boolean): TodoProjectionDelivery {
+  return changed ? "pending" : "not_required";
+}

--- a/loopx/control_plane/todos/projection_delivery.ts
+++ b/loopx/control_plane/todos/projection_delivery.ts
@@ -1,7 +1,15 @@
 /** Canonical projection-delivery state returned by Todo mutations. */
-export type TodoProjectionDelivery = "pending" | "not_required";
+export type TodoProjectionDelivery = "pending" | "delivered" | "current" | "not_required";
 
 /** Keep mutation results consistent and make the no-op meaning explicit. */
 export function projectionDelivery(changed: boolean): TodoProjectionDelivery {
   return changed ? "pending" : "not_required";
+}
+
+/** Decode provider readback without letting ad-hoc strings cross the boundary. */
+export function parseProjectionDelivery(value: unknown): TodoProjectionDelivery {
+  if (value === "pending" || value === "delivered" || value === "current" || value === "not_required") {
+    return value;
+  }
+  throw new Error("projection_delivery is unsupported");
 }

--- a/loopx/control_plane/todos/projection_delivery.ts
+++ b/loopx/control_plane/todos/projection_delivery.ts
@@ -1,5 +1,8 @@
 /** Canonical projection-delivery state returned by Todo mutations. */
 export type TodoProjectionDelivery = "pending" | "delivered" | "current" | "not_required";
+const PROJECTION_DELIVERY_VALUES = new Set<TodoProjectionDelivery>([
+  "pending", "delivered", "current", "not_required",
+]);
 
 /** Keep mutation results consistent and make the no-op meaning explicit. */
 export function projectionDelivery(changed: boolean): TodoProjectionDelivery {
@@ -8,8 +11,12 @@ export function projectionDelivery(changed: boolean): TodoProjectionDelivery {
 
 /** Decode provider readback without letting ad-hoc strings cross the boundary. */
 export function parseProjectionDelivery(value: unknown): TodoProjectionDelivery {
-  if (value === "pending" || value === "delivered" || value === "current" || value === "not_required") {
+  if (typeof value === "string" && PROJECTION_DELIVERY_VALUES.has(value as TodoProjectionDelivery)) {
     return value;
   }
-  throw new Error("projection_delivery is unsupported");
+  throw new Error(`projection_delivery is unsupported: ${String(value)}`);
+}
+
+export function isProjectionDelivery(value: unknown): value is TodoProjectionDelivery {
+  return typeof value === "string" && PROJECTION_DELIVERY_VALUES.has(value as TodoProjectionDelivery);
 }

--- a/tests/control_plane_ts/projection_delivery.test.ts
+++ b/tests/control_plane_ts/projection_delivery.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { parseProjectionDelivery, projectionDelivery } from "../../loopx/control_plane/todos/projection_delivery.ts";
+import { readFile } from "node:fs/promises";
+import { isProjectionDelivery, parseProjectionDelivery, projectionDelivery } from "../../loopx/control_plane/todos/projection_delivery.ts";
 
 test("projection delivery maps mutation and no-op outcomes", () => {
   assert.equal(projectionDelivery(true), "pending");
@@ -12,4 +13,15 @@ test("projection delivery parser accepts provider readback states", () => {
     assert.equal(parseProjectionDelivery(value), value);
   }
   assert.throws(() => parseProjectionDelivery("unknown"));
+  assert.equal(isProjectionDelivery("delivered"), true);
+  assert.equal(isProjectionDelivery("DELIVERED"), false);
+  assert.equal(isProjectionDelivery(null), false);
+});
+
+test("composition fixture keeps mutation and provider states distinct", async () => {
+  const fixture = JSON.parse(await readFile("tests/fixtures/control_plane/projection_delivery_composition_v0.json", "utf8"));
+  for (const item of fixture.cases) {
+    const actual = item.changed === undefined ? parseProjectionDelivery(item.readback) : projectionDelivery(item.changed);
+    assert.equal(actual, item.expected, item.name);
+  }
 });

--- a/tests/control_plane_ts/projection_delivery.test.ts
+++ b/tests/control_plane_ts/projection_delivery.test.ts
@@ -1,0 +1,15 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseProjectionDelivery, projectionDelivery } from "../../loopx/control_plane/todos/projection_delivery.ts";
+
+test("projection delivery maps mutation and no-op outcomes", () => {
+  assert.equal(projectionDelivery(true), "pending");
+  assert.equal(projectionDelivery(false), "not_required");
+});
+
+test("projection delivery parser accepts provider readback states", () => {
+  for (const value of ["pending", "delivered", "current", "not_required"]) {
+    assert.equal(parseProjectionDelivery(value), value);
+  }
+  assert.throws(() => parseProjectionDelivery("unknown"));
+});

--- a/tests/fixtures/control_plane/projection_delivery_composition_v0.json
+++ b/tests/fixtures/control_plane/projection_delivery_composition_v0.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": "todo_projection_delivery_composition_v0",
+  "cases": [
+    {"name": "mutation_changed", "changed": true, "expected": "pending"},
+    {"name": "mutation_noop", "changed": false, "expected": "not_required"},
+    {"name": "provider_ack", "readback": "delivered", "expected": "delivered"},
+    {"name": "provider_already_current", "readback": "current", "expected": "current"}
+  ]
+}


### PR DESCRIPTION
## Summary
Expand #4274 into a complete typed projection-delivery protocol across canonical Todo callers.

### Semantic changes
- Route claim, create, monitor-poll, terminal lifecycle, and archive replay results through one typed `projectionDelivery` owner.
- Keep mutation outcomes (`pending`, `not_required`) distinct from provider readback outcomes (`delivered`, `current`).
- Add parser/type guard validation so unsupported provider strings fail closed with context.
- Add a public composition fixture and contract test covering mutation, no-op, delivered, and already-current paths.

### Validation
- `node --no-warnings --experimental-strip-types --test tests/control_plane_ts/projection_delivery.test.ts` (3 passed)
- `python -m loopx.cli todo list --goal-id loopx-meta --role agent --status open --agent-id codex-main-control --format json --thin` (real local readback succeeded; 4 matched, 2 projected under thin cap)
- `npm run typecheck:control-plane` could not run because `tsc` is not installed in this checkout.

This PR keeps Markdown as compatibility projection and does not change authority ownership.
