### PR TITLE
refactor(todos): unify cross-language projection delivery semantics

### DIFF
--- a/loopx/control_plane/todos/provider_projection.py
+++ b/loopx/control_plane/todos/provider_projection.py
@@ -14,6 +14,7 @@ import os
 import json
 import stat
 import tempfile
+from enum import StrEnum
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,28 @@ from .completion_validation_store import load_completion_validation_declarations
 
 
 TODO_PROJECTION_DELIVERY_SCHEMA = "loopx_todo_projection_delivery_v0"
+
+
+class ProjectionDeliveryStatus(StrEnum):
+    """Stable cross-language states for canonical Todo display delivery."""
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    CURRENT = "current"
+    NOT_REQUIRED = "not_required"
+
+
+def parse_projection_delivery(value: object) -> ProjectionDeliveryStatus:
+    try:
+        return ProjectionDeliveryStatus(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"unsupported projection_delivery: {value!r}") from error
+
+
+def projection_delivery_requires_ack(value: object) -> bool:
+    return parse_projection_delivery(value) in {
+        ProjectionDeliveryStatus.DELIVERED,
+        ProjectionDeliveryStatus.CURRENT,
+    }
 
 
 def _read_text_exact(path: Path) -> str:
@@ -202,10 +225,10 @@ def settle_canonical_todo_projection(
     """Drain the committed provider head, preserving a successful mutation."""
 
     if payload.get("dry_run") is True or payload.get("status") == "planned":
-        payload["projection_delivery"] = "not_required"
+        payload["projection_delivery"] = ProjectionDeliveryStatus.NOT_REQUIRED.value
         payload["projection_outbox"] = {
             "schema_version": TODO_PROJECTION_DELIVERY_SCHEMA,
-            "status": "not_required",
+            "status": ProjectionDeliveryStatus.NOT_REQUIRED.value,
             "source": "committed_authority_journal",
         }
         return payload
@@ -246,13 +269,16 @@ def settle_canonical_todo_projection(
         delivery["trigger_provider_revision"] = trigger_revision
     if isinstance(trigger_cursor, str) and trigger_cursor:
         delivery["trigger_cursor"] = trigger_cursor
-    payload["projection_delivery"] = delivery["status"]
+    payload["projection_delivery"] = parse_projection_delivery(delivery["status"]).value
     payload["projection_outbox"] = delivery
     return payload
 
 
 __all__ = [
     "TODO_PROJECTION_DELIVERY_SCHEMA",
+    "ProjectionDeliveryStatus",
+    "parse_projection_delivery",
+    "projection_delivery_requires_ack",
     "project_current_canonical_todos",
     "settle_canonical_todo_projection",
 ]

--- a/loopx/control_plane/todos/provider_terminal_lifecycle.py
+++ b/loopx/control_plane/todos/provider_terminal_lifecycle.py
@@ -36,7 +36,7 @@ from .completion_validation import (
 from .contract import resolve_next_user_task_class
 from .mutation_authority import normalize_todo_lifecycle_authority
 from .path_resolution import resolve_todo_state_path
-from .provider_projection import settle_canonical_todo_projection
+from .provider_projection import projection_delivery_requires_ack, settle_canonical_todo_projection
 from .successor_derivation import build_successor_intents
 
 _TERMINAL_REQUEST_SCHEMA = "loopx_local_coordination_todo_terminal_lifecycle_request_v0"
@@ -564,7 +564,7 @@ def archive_canonical_todos_if_promoted(
     if (
         not dry_run
         and response.get("moved_count", 0) > 0
-        and response.get("projection_delivery") in {"delivered", "current"}
+        and projection_delivery_requires_ack(response.get("projection_delivery"))
     ):
         # The native owner retains the attempt until its external projection
         # provider succeeds. An ACK failure must preserve the committed result

--- a/tests/control_plane/test_todo_provider_projection.py
+++ b/tests/control_plane/test_todo_provider_projection.py
@@ -181,3 +181,11 @@ def test_explicit_projection_fences_requested_revision(
         )
 
     assert state_file.read_text(encoding="utf-8") == SOURCE
+
+
+def test_projection_delivery_status_contract_is_strict():
+    assert provider_projection.parse_projection_delivery("delivered") is provider_projection.ProjectionDeliveryStatus.DELIVERED
+    assert provider_projection.projection_delivery_requires_ack("current") is True
+    assert provider_projection.projection_delivery_requires_ack("pending") is False
+    with pytest.raises(ValueError, match="unsupported projection_delivery"):
+        provider_projection.parse_projection_delivery("completed")


### PR DESCRIPTION
## Summary
Unify canonical Todo projection-delivery semantics across the Python provider boundary, extending the typed control-plane work tracked by #4274.

### Semantic changes
- Introduce one strict Python status contract for `pending`, `delivered`, `current`, and `not_required`.
- Validate provider readback before it is copied into mutation payloads.
- Gate archive acknowledgement through the shared delivered/current predicate instead of a duplicated string set.
- Preserve canonical authority and Markdown compatibility projection boundaries.

### Fixture and validation
- Extended `test_todo_provider_projection.py` with strict parser, acknowledgement, and invalid-state cases.
- `python -m pytest -q tests/control_plane/test_todo_provider_projection.py` (4 passed).
- Real local `loopx-meta` readback via `todo list --format json --thin` succeeded; counts were read from the live projection.

This is a focused follow-up refactor across the two RFC migration boundaries; it does not launch benchmark jobs or alter scoring.
