### PR TITLE
fix(periodic-report): accept UTC without tzdata

### DIFF
--- a/loopx/capabilities/periodic_report/goal_configuration.py
+++ b/loopx/capabilities/periodic_report/goal_configuration.py
@@ -30,10 +30,11 @@ def normalize_configuration(value: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(enabled, bool):
         raise TypeError("periodic_report.enabled must be a boolean")
     timezone = str(value.get("timezone") or "UTC").strip()
-    try:
-        ZoneInfo(timezone)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError("periodic_report.timezone is unknown") from exc
+    if timezone != "UTC":
+        try:
+            ZoneInfo(timezone)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError("periodic_report.timezone is unknown") from exc
     profile_preset = str(value.get("profile_preset") or "").strip()
     route_ref = str(value.get("route_ref") or "").strip()
     if enabled and (not profile_preset or not route_ref):

--- a/loopx/capabilities/periodic_report/machine_defaults.py
+++ b/loopx/capabilities/periodic_report/machine_defaults.py
@@ -128,10 +128,11 @@ def normalize_periodic_report_machine_defaults(
         periodic.get("timezone", "UTC"),
         "periodic_report.timezone",
     )
-    try:
-        ZoneInfo(timezone)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError("periodic_report.timezone is unknown") from exc
+    if timezone != "UTC":
+        try:
+            ZoneInfo(timezone)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError("periodic_report.timezone is unknown") from exc
     normalized_periodic: dict[str, Any] = {
         "schema_version": PERIODIC_REPORT_MACHINE_DEFAULTS_SCHEMA,
         "enabled": enabled,
@@ -258,10 +259,11 @@ def _normalized_goal_subscription(
     timezone_name = _text(
         config.get("timezone", "UTC"), "goal periodic_report.timezone"
     )
-    try:
-        ZoneInfo(timezone_name)
-    except ZoneInfoNotFoundError as exc:
-        raise ValueError("goal periodic_report.timezone is unknown") from exc
+    if timezone_name != "UTC":
+        try:
+            ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError("goal periodic_report.timezone is unknown") from exc
     profile_preset = str(config.get("profile_preset") or "").strip() or None
     route_ref = str(config.get("route_ref") or "").strip() or None
     if enabled:
@@ -292,7 +294,8 @@ def _invalid_goal_subscription_fields(config: Mapping[str, Any]) -> tuple[str, .
         timezone_name = _text(
             config.get("timezone", "UTC"), "goal periodic_report.timezone"
         )
-        ZoneInfo(timezone_name)
+        if timezone_name != "UTC":
+            ZoneInfo(timezone_name)
     except (TypeError, ValueError, ZoneInfoNotFoundError):
         invalid.append("timezone")
     if enabled is True:

--- a/tests/capabilities/test_periodic_report_machine_defaults.py
+++ b/tests/capabilities/test_periodic_report_machine_defaults.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from zoneinfo import ZoneInfoNotFoundError
 
 import pytest
 
+from loopx.capabilities.periodic_report import machine_defaults as periodic_defaults
 from loopx.capabilities.machine_configuration.builtins import (
     build_builtin_machine_configuration_registry,
 )
@@ -86,6 +88,20 @@ def _remove_defaults(runtime_root: Path) -> None:
         execute=True,
         expected_plan_revision=preview["plan_revision"],
     )
+
+
+def test_utc_defaults_do_not_require_an_external_timezone_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def missing_timezone(_name: str) -> None:
+        raise ZoneInfoNotFoundError
+
+    monkeypatch.setattr(periodic_defaults, "ZoneInfo", missing_timezone)
+
+    build_builtin_machine_configuration_registry()
+    subscription = resolve_goal_periodic_report_subscription(_goal("research"), None)
+
+    assert subscription["timezone"] == "UTC"
 
 
 def test_machine_defaults_require_a_route_when_weekly_reports_are_enabled() -> None:


### PR DESCRIPTION
## Summary

- treat canonical UTC as valid without requiring an external IANA timezone database
- preserve strict ZoneInfo validation for every other timezone
- cover Windows-style missing-tzdata behavior with a regression test

## Root cause

The Windows packaged install has no external tzdata package. Validating the built-in UTC periodic-report default through ZoneInfo raised ZoneInfoNotFoundError, so quota should-run failed closed. This is the shared baseline failure currently visible on #4204 and #4133.

## Validation

- 45 focused periodic-report/configuration tests passed
- scoped Ruff passed
- full mypy passed
- git diff --check passed
- the same fix previously passed the Windows PowerShell job on #4233 exact head 06699be30b8f7718789d458678942a38ede52bb8