### PR TITLE
fix(skills): mark packaged workflows project-scoped

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -536,7 +536,9 @@ checkout to the default local release.
 
 - the CLI wrappers under `~/.local/bin`;
 - the local manual page under `~/.local/share/man`;
-- the LoopX Codex skills under `~/.codex/skills`.
+- the generated core LoopX Codex skill under `~/.codex/skills/loopx`; rich
+  project workflows remain release-owned sources until explicitly installed
+  into a connected project.
 
 Use the named update actions so read-only inspection and mutation are visible:
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -516,12 +516,14 @@ The checkout installer creates:
 - `~/.local/bin/loopx-canary`, pointing at the live checkout;
 - `~/.local/share/man/man1/loopx.1.gz`, so `man loopx` opens the short
   operator manual after the shell profile reloads;
-- reusable global LoopX Codex skills under `~/.codex/skills`;
+- the generated core LoopX Codex skill under `~/.codex/skills/loopx`;
 - canonical sources for project-scoped skills, which are not installed globally.
 
-Those global skills are the intended product surface for reusable LoopX
+The generated global entry is the intended product surface for reusable LoopX
 connection and control-plane behavior. Capability workflows that should only
-exist in selected repositories use managed project skills instead.
+exist in selected repositories stay in the release as canonical sources and
+use managed project skills instead; their source copies do not enter the
+global skill root.
 Project-specific state and private decisions stay in the local registry and
 active goal files.
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -19,20 +19,21 @@ links that snapshot into `~/.local/bin/loopx`. It also installs a
 gray-rollout goal controllers. This keeps default automations stable while
 allowing one canary goal to validate prompt/runtime changes before promotion.
 The installer adds the bin directory to the current shell profile when it is
-missing from `PATH`, and installs a snapshot of the `loopx-project` Codex
-skill into `~/.codex/skills` so future project agents use the same connection
-workflow. Use `loopx doctor` from any project folder to inspect the
+missing from `PATH`, and installs the generated core LoopX command skill into
+`~/.codex/skills/loopx`. Rich project workflows remain release-owned sources
+and are installed explicitly into a connected project. Use `loopx doctor` from
+any project folder to inspect the
 resolved command path, symlink target, release snapshot, canary wrapper,
 installed skill delivery-hint state, wrapper script, and Python import health.
 
 ## Global Skill Policy
 
-LoopX product behavior belongs in installed global Codex skills, not in
-one repository's `AGENTS.md`. Keep the global skills narrow and versioned:
-they should teach LoopX connection, quota/state/todo writeback,
-self-repair, and generic product contracts such as todo succession. Project
-state, benchmark-specific choices, private material, and one-off operator
-decisions stay in the registry, active state, run history, or project docs.
+Core LoopX product behavior belongs in the generated global Codex skill, not in
+one repository's `AGENTS.md`. Keep that global entry narrow and versioned: it
+teaches LoopX connection, quota/state/todo writeback, and generic contracts
+such as todo succession. Rich project workflows, benchmark-specific choices,
+private material, and one-off operator decisions stay in the release's
+project-skill sources, registry, active state, run history, or project docs.
 When a recurring behavior should improve every future worker, update the repo
 skill source and run `scripts/install-local.sh`; when it applies only to this
 repo's contribution hygiene, keep it in `AGENTS.md`.

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -116,6 +116,7 @@ def main() -> None:
         assert manifest["source"]["archive_sha256"], manifest
         assert manifest["skills"]["digest"], manifest
 
+        assert (home / ".codex" / "skills" / "loopx" / "SKILL.md").exists()
         for skill in (
             "loopx-project",
             "loopx-pr-program",
@@ -124,7 +125,10 @@ def main() -> None:
             "loopx-benchmark",
             "loopx-self-repair",
         ):
-            assert (home / ".codex" / "skills" / skill / "SKILL.md").exists(), skill
+            assert (release_root / "skills" / skill / "SKILL.md").exists(), skill
+            assert not (
+                home / ".codex" / "skills" / skill / ".loopx-skill-scope"
+            ).exists(), skill
         assert not (
             home / ".codex" / "skills" / "loopx-change-quality"
         ).exists()

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -80,9 +80,7 @@ def main() -> int:
         assert f"- executable: {bin_dir / 'loopx'}" in install.stdout, install.stdout
         assert f"- manpage: {man_root / 'man1' / 'loopx.1.gz'}" in install.stdout, install.stdout
         assert f"- canary executable: {bin_dir / 'loopx-canary'}" in install.stdout, install.stdout
-        assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
-        assert f"- skill: {codex_home / 'skills' / 'loopx-pr-program'}" in install.stdout, install.stdout
-        assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
+        assert f"- generated skill: {codex_home / 'skills' / 'loopx'}" in install.stdout, install.stdout
         assert "promotion-readiness evidence is missing" in install.stderr, install.stderr
         assert "non-blocking" in install.stderr, install.stderr
 
@@ -100,10 +98,17 @@ def main() -> int:
         assert 'export MANPATH="$HOME/.local/share/man:${MANPATH:-}"' in profile.read_text(
             encoding="utf-8"
         )
-        assert (codex_home / "skills" / "loopx-project" / "SKILL.md").is_file()
-        assert (codex_home / "skills" / "loopx-pr-program" / "SKILL.md").is_file()
-        assert (codex_home / "skills" / "loopx-pr-review" / "SKILL.md").is_file()
-        assert (codex_home / "skills" / "loopx-self-repair" / "SKILL.md").is_file()
+        assert (codex_home / "skills" / "loopx" / "SKILL.md").is_file()
+        for skill_id in (
+            "loopx-project",
+            "loopx-pr-program",
+            "loopx-pr-review",
+            "loopx-self-repair",
+        ):
+            assert (release_root / "skills" / skill_id / "SKILL.md").is_file()
+            assert not (
+                codex_home / "skills" / skill_id / ".loopx-skill-scope"
+            ).exists()
 
         cli_env = {**env, "PATH": f"{bin_dir}:{env['PATH']}"}
         doctor = run_loopx("doctor", cwd=root, env=cli_env)
@@ -114,10 +119,14 @@ def main() -> int:
         assert doctor["install_freshness"]["schema_version"] == "loopx_install_freshness_v0", doctor
         assert doctor["install_freshness"]["status"] == "unknown", doctor
         assert "huangruiteng.github.io/loopx/install.sh" in doctor["install_freshness"]["upgrade_command"], doctor
-        assert doctor["skills"]["loopx-project"]["exists"] is True, doctor
-        assert doctor["skills"]["loopx-pr-program"]["exists"] is True, doctor
-        assert doctor["skills"]["loopx-pr-review"]["exists"] is True, doctor
-        assert doctor["skills"]["loopx-self-repair"]["exists"] is True, doctor
+        assert doctor["skills"]["loopx"]["exists"] is True, doctor
+        for skill_id in (
+            "loopx-project",
+            "loopx-pr-program",
+            "loopx-pr-review",
+            "loopx-self-repair",
+        ):
+            assert doctor["skills"][skill_id]["required"] is False, doctor
 
         project = root / "sample-project"
         project.mkdir()

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -190,8 +190,8 @@ def main() -> int:
             env=cli_env,
         )
         assert heartbeat["ok"] is True, heartbeat
-        assert "quota should-run" in heartbeat["quota_guard_command"], heartbeat
-        assert "--source heartbeat --execute" in heartbeat["quota_spend_command"], heartbeat
+        assert "quota should-run" in heartbeat["task_body"], heartbeat
+        assert "must_attempt_work" in heartbeat["task_body"], heartbeat
 
     print("fresh-clone-quickstart-smoke ok")
     return 0

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -245,10 +245,9 @@ def main() -> int:
             f"- legacy command disabled: {bin_dir / 'goal-harness-canary.legacy-disabled'}"
             in install.stdout
         ), install.stdout
-        for skill_id in PACKAGED_HOST_SKILL_IDS:
-            assert (
-                f"- skill: {codex_home / 'skills' / skill_id}" in install.stdout
-            ), install.stdout
+        assert (
+            f"- generated skill: {codex_home / 'skills' / 'loopx'}" in install.stdout
+        ), install.stdout
         assert "project skill source:" in install.stdout, install.stdout
         assert "install explicitly per project" in install.stdout, install.stdout
         assert f"codex skills: {codex_home / 'skills'}" in install.stdout, install.stdout
@@ -348,8 +347,9 @@ def main() -> int:
             text=True,
         )
 
-        skill = codex_home / "skills" / "loopx-project" / "SKILL.md"
-        assert not skill.parent.is_symlink(), skill.parent
+        entry_skill = codex_home / "skills" / "loopx" / "SKILL.md"
+        assert entry_skill.is_file(), entry_skill
+        assert not entry_skill.parent.is_symlink(), entry_skill.parent
         skill_readback = json.loads(
             (codex_home / "skills" / ".loopx-skill-install.json").read_text(
                 encoding="utf-8"
@@ -357,44 +357,21 @@ def main() -> int:
         )
         assert skill_readback["integration_mode"] == "fixed_install_script"
         assert skill_readback["source"]["revision"] == source_commit
-        assert set(skill_readback["materialized_skill_ids"]) == {
-            "loopx",
-            *PACKAGED_HOST_SKILL_IDS,
-        }
-        skill_text = skill.read_text(encoding="utf-8")
+        assert set(skill_readback["materialized_skill_ids"]) == {"loopx"}
+        skill_text = entry_skill.read_text(encoding="utf-8")
         compact_skill_text = " ".join(skill_text.split())
         for phrase in (
-            "Set Up Recurring Heartbeats",
-            "loopx heartbeat-prompt",
-            "run a short steering audit before choosing work",
-            "at least three plausible next-action candidates",
-            "continuation check",
-            "compute quota separate from focus quota",
-            "Register Project Authority And Material Sources",
-            "doc-registry skill trigger",
-            "Diagnose For The User",
-            "loopx diagnose",
-            "Use those signals as evidence",
-            "Identify the target project and goal first",
-            "loopx register-authority-source",
-            "loopx import-doc-registry-authority",
-            "--source heartbeat --execute",
-            "Generate A Review Packet",
-            "loopx review-packet --goal-id",
-            "loopx review-packet --goal-id <STABLE_GOAL_ID> --handoff-only",
-            "loopx --format json review-packet --goal-id",
-            "target project agent must not run this draft",
-            "This command is read-only",
-            "JSON output returns a minimized handoff payload with `handoff_text` instead of the full operator packet",
-            "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
-            "--delivery-batch-scale <ACTUAL_DELIVERY_BATCH_SCALE>",
-            "--delivery-outcome <ACTUAL_DELIVERY_OUTCOME>",
-            "Never default or upgrade a smaller/preparatory turn",
-            "do not infer scale/outcome from the classification name",
+            "Treat this as the LoopX `/loopx` explicit LoopX command skill.",
+            "Identify the exact current host surface",
+            "`goal_start_contract` as authoritative",
+            "complete visible command arguments unchanged as one value",
+            "Consume the turn-start quota JSON packet exactly once",
+            "Keep public/private boundaries intact",
         ):
             assert phrase in compact_skill_text, phrase
         assert "JSON output still keeps the full payload" not in compact_skill_text, compact_skill_text
-        pr_review_skill = codex_home / "skills" / "loopx-pr-review" / "SKILL.md"
+        packaged_skills = release_root / "skills"
+        pr_review_skill = packaged_skills / "loopx-pr-review" / "SKILL.md"
         pr_review_text = " ".join(pr_review_skill.read_text(encoding="utf-8").split())
         for phrase in (
             "loopx --format json pr-review --state all",
@@ -413,7 +390,7 @@ def main() -> int:
         ):
             assert phrase in pr_review_text, phrase
         assert "Do not use this skill to approve" not in pr_review_text, pr_review_text
-        pr_program_skill = codex_home / "skills" / "loopx-pr-program" / "SKILL.md"
+        pr_program_skill = packaged_skills / "loopx-pr-program" / "SKILL.md"
         pr_program_text = " ".join(pr_program_skill.read_text(encoding="utf-8").split())
         for phrase in (
             "one `continuous_monitor` todo",
@@ -433,7 +410,7 @@ def main() -> int:
             in pr_review_metadata_text
         ), pr_review_metadata_text
         assert "Guide agentloop" not in pr_review_metadata_text, pr_review_metadata_text
-        auto_research_skill = codex_home / "skills" / "loopx-auto-research" / "SKILL.md"
+        auto_research_skill = packaged_skills / "loopx-auto-research" / "SKILL.md"
         assert not auto_research_skill.exists(), auto_research_skill
         material_skill = codex_home / "skills" / "loopx-material" / "SKILL.md"
         assert not material_skill.exists(), material_skill
@@ -451,7 +428,7 @@ def main() -> int:
         assert 'display_name: "LoopX"' in loopx_openai_metadata_text, loopx_openai_metadata_text
         assert 'display_name: "LoopX /loopx"' not in loopx_openai_metadata_text, loopx_openai_metadata_text
         assert "allow_implicit_invocation: false" in loopx_openai_metadata_text, loopx_openai_metadata_text
-        loopx_project_metadata = codex_home / "skills" / "loopx-project" / "agents" / "openai.yaml"
+        loopx_project_metadata = packaged_skills / "loopx-project" / "agents" / "openai.yaml"
         loopx_project_metadata_text = loopx_project_metadata.read_text(encoding="utf-8")
         assert 'display_name: "LoopX Project"' in loopx_project_metadata_text, loopx_project_metadata_text
         assert 'display_name: "LoopX"' not in loopx_project_metadata_text, loopx_project_metadata_text
@@ -464,7 +441,7 @@ def main() -> int:
         assert not (home / ".claude" / "settings.json").exists(), (
             "default installer must not install Claude adapter hooks/settings"
         )
-        doc_registry_skill = codex_home / "skills" / "loopx-doc-registry" / "SKILL.md"
+        doc_registry_skill = packaged_skills / "loopx-doc-registry" / "SKILL.md"
         doc_registry_text = " ".join(doc_registry_skill.read_text(encoding="utf-8").split())
         doc_registry_metadata = doc_registry_skill.parent / "agents" / "openai.yaml"
         doc_registry_metadata_text = doc_registry_metadata.read_text(encoding="utf-8")
@@ -477,7 +454,7 @@ def main() -> int:
             "loopx --registry .loopx/registry.json register-authority-source",
         ):
             assert phrase in doc_registry_text, phrase
-        benchmark_skill = codex_home / "skills" / "loopx-benchmark" / "SKILL.md"
+        benchmark_skill = packaged_skills / "loopx-benchmark" / "SKILL.md"
         benchmark_text = " ".join(
             benchmark_skill.read_text(encoding="utf-8").split()
         )
@@ -487,7 +464,7 @@ def main() -> int:
         assert 'display_name: "LoopX Benchmark"' in benchmark_metadata.read_text(
             encoding="utf-8"
         )
-        self_repair_skill = codex_home / "skills" / "loopx-self-repair" / "SKILL.md"
+        self_repair_skill = packaged_skills / "loopx-self-repair" / "SKILL.md"
         self_repair_text = " ".join(self_repair_skill.read_text(encoding="utf-8").split())
         for phrase in (
             "Build a compact evidence packet",
@@ -501,8 +478,7 @@ def main() -> int:
         ):
             assert phrase in self_repair_text, phrase
         self_repair_patterns = (
-            codex_home
-            / "skills"
+            packaged_skills
             / "loopx-self-repair"
             / "references"
             / "repair-patterns.md"
@@ -512,8 +488,7 @@ def main() -> int:
         assert "`skill_cli_contract_drift`" in self_repair_patterns_text, self_repair_patterns_text
         assert "`tiny_turn_under_delivery`" in self_repair_patterns_text, self_repair_patterns_text
         self_repair_issue_escalation = (
-            codex_home
-            / "skills"
+            packaged_skills
             / "loopx-self-repair"
             / "references"
             / "upstream-issue-escalation.md"
@@ -525,16 +500,12 @@ def main() -> int:
         assert "gh issue list" in self_repair_issue_escalation_text
         assert "gh issue create" in self_repair_issue_escalation_text
         assert (
-            codex_home / "skills" / "loopx-self-repair" / "agents" / "openai.yaml"
+            packaged_skills / "loopx-self-repair" / "agents" / "openai.yaml"
         ).is_file()
-        for implicit_skill_name in PACKAGED_HOST_SKILL_IDS:
-            implicit_metadata = codex_home / "skills" / implicit_skill_name / "agents" / "openai.yaml"
-            if implicit_metadata.exists():
-                implicit_metadata_text = implicit_metadata.read_text(encoding="utf-8")
-                assert "allow_implicit_invocation: false" not in implicit_metadata_text, (
-                    implicit_skill_name,
-                    implicit_metadata_text,
-                )
+        for project_skill_id in PACKAGED_HOST_SKILL_IDS:
+            assert not (
+                codex_home / "skills" / project_skill_id / ".loopx-skill-scope"
+            ).exists()
 
         cli_env = {**env, "PATH": f"{bin_dir}:{env['PATH']}"}
         runtime_run_dir = home / ".codex" / "loopx" / "goals" / "loopx-meta" / "runs"
@@ -583,7 +554,7 @@ def main() -> int:
             doctor_payload["release_manifest"]["manifest"]["source"]["git_commit"] == source_commit
         ), doctor_payload
         assert doctor_payload["release_manifest"]["manifest"]["skills"]["digest"] == release_manifest["skills"]["digest"], doctor_payload
-        assert doctor_payload["skill"]["path"] == str(skill), doctor_payload
+        assert doctor_payload["skill"]["path"] == str(entry_skill), doctor_payload
         assert doctor_payload["skill"]["exists"] is True, doctor_payload
         assert doctor_payload["skill"]["delivery_hints"] is True, doctor_payload
         assert "loopx-auto-research" not in doctor_payload["skills"], doctor_payload
@@ -595,10 +566,7 @@ def main() -> int:
         }.issubset(set(doctor_payload["project_scoped_skill_ids"])), doctor_payload
         assert doctor_payload["globally_visible_project_skills"] == [], doctor_payload
         for skill_id in PACKAGED_HOST_SKILL_IDS:
-            assert doctor_payload["skills"][skill_id]["exists"] is True, doctor_payload
-            assert (
-                doctor_payload["skills"][skill_id]["required_phrases"] is True
-            ), doctor_payload
+            assert doctor_payload["skills"][skill_id]["required"] is False, doctor_payload
         provenance = doctor_payload["release_provenance"]
         assert provenance["default_release"]["root"] == str(release_root), provenance
         assert provenance["default_release"]["release_id"] == release_root.name, provenance
@@ -643,7 +611,7 @@ def main() -> int:
         assert "installed_skill_delivery_hints: `True`" in doctor_markdown, doctor_markdown
         assert (
             "installed_required_skills: "
-            f"`{','.join(sorted(PACKAGED_HOST_SKILL_IDS))}`"
+            f"`{','.join(sorted(['loopx', *PACKAGED_HOST_SKILL_IDS]))}`"
             in doctor_markdown
         ), doctor_markdown
         assert "loopx_canary_realpath:" in doctor_markdown, doctor_markdown

--- a/loopx/capabilities/benchmark_toolkit/native_codex_profile.py
+++ b/loopx/capabilities/benchmark_toolkit/native_codex_profile.py
@@ -219,6 +219,10 @@ def _formal_install_environment(
             # non-interactive Goal worker and would mutate that tree after its
             # installer readback was written.
             "LOOPX_INSTALL_SLASH_COMMANDS": "0",
+            # Native profiles are isolated project roots, so they explicitly
+            # opt into the packaged skills marked project-scoped.  The normal
+            # contributor installer keeps those sources out of global roots.
+            "LOOPX_INSTALL_PROJECT_SKILLS": "1",
             "LOOPX_INSTALL_OPENCODE": "0",
             "LOOPX_INSTALL_CLAUDE": "0",
             "LOOPX_SKILL_DEDUPE_OTHER_ROOT": "0",

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -27,6 +27,7 @@ from .release_manifest import load_release_manifest, release_version_tag
 from .skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
     configured_host_skills_dir,
+    external_skill_set_ready,
     inspect_skill_install_readback,
     skill_has_required_phrases,
     skill_install_doctor_checks,
@@ -468,19 +469,21 @@ def build_install_freshness(
     required_skills = [
         skill for skill in skills.values() if skill.get("required", True)
     ]
-    skills_ready = bool(required_skills) and all(
+    readiness_skills = required_skills or list(skills.values())
+    skills_ready = bool(readiness_skills) and all(
         skill.get("exists")
         and skill.get("required_phrases")
         and not skill.get("route_conflict")
-        for skill in required_skills
+        for skill in readiness_skills
     )
     distribution_install = (
         python_distribution
         if isinstance(python_distribution, dict) and python_distribution.get("available")
         else None
     )
+    managed_skill_values = required_skills or list(skills.values())
     externally_managed_skills = skills_ready and any(
-        skill.get("managed_externally") for skill in required_skills
+        skill.get("managed_externally") for skill in managed_skill_values
     )
     skill_problem = require_installed_skills and not skills_ready
     if command_path is None:
@@ -935,6 +938,8 @@ def collect_doctor(
         if skill_name in skills:
             skills[skill_name]["required"] = False
     core_skill = skills["loopx"]
+    if not core_skill.get("exists") and external_skill_set_ready(skills, project_scoped_skill_ids):
+        core_skill["required"] = False
     skill_path = Path(str(core_skill["path"]))
     globally_visible_project_skills = [
         skill_name

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -27,9 +27,9 @@ from .release_manifest import load_release_manifest, release_version_tag
 from .skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
     configured_host_skills_dir,
+    external_skill_fallback_path,
     external_skill_set_ready,
     inspect_skill_install_readback,
-    skill_has_required_phrases,
     skill_install_doctor_checks,
     summarize_skill_routes,
 )
@@ -938,8 +938,8 @@ def collect_doctor(
         if skill_name in skills:
             skills[skill_name]["required"] = False
     core_skill = skills["loopx"]
-    if not core_skill.get("exists") and external_skill_set_ready(skills, project_scoped_skill_ids):
-        core_skill["required"] = False
+    if not core_skill.get("exists") and external_skill_set_ready(skills, project_scoped_skill_ids) and (fallback_path := external_skill_fallback_path(skills)):
+        core_skill.update(required=False, path=fallback_path)
     skill_path = Path(str(core_skill["path"]))
     globally_visible_project_skills = [
         skill_name

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -28,7 +28,9 @@ from .skill_install_readback import (
     ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS,
     configured_host_skills_dir,
     inspect_skill_install_readback,
+    skill_has_required_phrases,
     skill_install_doctor_checks,
+    summarize_skill_routes,
 )
 
 
@@ -743,70 +745,16 @@ def add_promotion_readiness_freshness(
     return result
 
 
-def skill_has_required_phrases(skill_path: Path, phrases: tuple[str, ...]) -> bool:
-    if not skill_path.exists():
-        return False
-    text = " ".join(skill_path.read_text(encoding="utf-8").split())
-    return all(phrase in text for phrase in phrases)
-
-
 def installed_skill_summary(skills_roots: tuple[Path, ...]) -> dict[str, dict[str, Any]]:
-    if not skills_roots:
-        raise ValueError("at least one Codex skill root is required")
-    primary_root = skills_roots[0]
-    summaries: dict[str, dict[str, Any]] = {}
-    for skill_name, phrases in REQUIRED_INSTALLED_SKILL_PHRASES.items():
-        candidates = [
-            (root, root / skill_name / "SKILL.md")
-            for root in skills_roots
-            if (root / skill_name / "SKILL.md").exists()
-        ]
-        selected = candidates[0] if len(candidates) == 1 else None
-        selected_root = selected[0] if selected else None
-        skill_path = selected[1] if selected else primary_root / skill_name / "SKILL.md"
-        route_conflict = len(candidates) > 1
-        summaries[skill_name] = {
-            "path": str(skill_path),
-            "candidate_paths": [str(path) for _, path in candidates],
-            "route_count": len(candidates),
-            "route_conflict": route_conflict,
-            "source_root": str(selected_root) if selected_root else None,
-            "managed_externally": bool(selected_root and selected_root != primary_root),
-            "exists": bool(candidates),
-            "required_phrases": bool(
-                selected and skill_has_required_phrases(skill_path, phrases)
-            ),
-        }
-    return summaries
+    return {
+        name: summarize_skill_routes(skills_roots, name, phrases, required=True)
+        for name, phrases in REQUIRED_INSTALLED_SKILL_PHRASES.items()
+    }
 
 
 def core_skill_summary(skills_roots: tuple[Path, ...]) -> dict[str, Any]:
     """Summarize the generated core ``loopx`` entry independently of rich workflows."""
-
-    if not skills_roots:
-        raise ValueError("at least one Codex skill root is required")
-    primary_root = skills_roots[0]
-    candidates = [
-        (root, root / "loopx" / "SKILL.md")
-        for root in skills_roots
-        if (root / "loopx" / "SKILL.md").exists()
-    ]
-    selected = candidates[0] if len(candidates) == 1 else None
-    selected_root = selected[0] if selected else None
-    skill_path = selected[1] if selected else primary_root / "loopx" / "SKILL.md"
-    return {
-        "path": str(skill_path),
-        "candidate_paths": [str(path) for _, path in candidates],
-        "route_count": len(candidates),
-        "route_conflict": len(candidates) > 1,
-        "source_root": str(selected_root) if selected_root else None,
-        "managed_externally": bool(selected_root and selected_root != primary_root),
-        "exists": bool(candidates),
-        "required_phrases": bool(
-            selected and skill_has_required_phrases(skill_path, CORE_LOOPX_SKILL_PHRASES)
-        ),
-        "required": True,
-    }
+    return summarize_skill_routes(skills_roots, "loopx", CORE_LOOPX_SKILL_PHRASES, required=True)
 
 
 def installed_skill_check(

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -938,7 +938,7 @@ def collect_doctor(
         if skill_name in skills:
             skills[skill_name]["required"] = False
     core_skill = skills["loopx"]
-    if not core_skill.get("exists") and external_skill_set_ready(skills, project_scoped_skill_ids) and (fallback_path := external_skill_fallback_path(skills)):
+    if not core_skill.get("exists") and external_skill_set_ready(skills, tuple(skill_id for skill_id in project_scoped_skill_ids if skill_id in skills)) and (fallback_path := external_skill_fallback_path(skills)):
         core_skill.update(required=False, path=fallback_path)
     skill_path = Path(str(core_skill["path"]))
     globally_visible_project_skills = [

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -469,7 +469,7 @@ def build_install_freshness(
     required_skills = [
         skill for skill in skills.values() if skill.get("required", True)
     ]
-    readiness_skills = required_skills or list(skills.values())
+    readiness_skills = required_skills or [skill for skill in skills.values() if skill.get("exists")]
     skills_ready = bool(readiness_skills) and all(
         skill.get("exists")
         and skill.get("required_phrases")

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -79,6 +79,11 @@ REQUIRED_INSTALLED_SKILL_PHRASES = {
         "Repair at the lowest durable layer",
     ),
 }
+CORE_LOOPX_SKILL_PHRASES = (
+    "Treat this as the LoopX `/loopx` explicit LoopX command skill.",
+    "Identify the exact current host surface",
+    "`goal_start_contract` as authoritative",
+)
 
 
 class GitRevisionRelation(str, Enum):
@@ -458,11 +463,14 @@ def build_install_freshness(
     if release_time:
         age_hours = round(max(0, (reference - release_time.astimezone(timezone.utc)).total_seconds()) / 3600, 2)
 
-    skills_ready = bool(skills) and all(
+    required_skills = [
+        skill for skill in skills.values() if skill.get("required", True)
+    ]
+    skills_ready = bool(required_skills) and all(
         skill.get("exists")
         and skill.get("required_phrases")
         and not skill.get("route_conflict")
-        for skill in skills.values()
+        for skill in required_skills
     )
     distribution_install = (
         python_distribution
@@ -470,7 +478,7 @@ def build_install_freshness(
         else None
     )
     externally_managed_skills = skills_ready and any(
-        skill.get("managed_externally") for skill in skills.values()
+        skill.get("managed_externally") for skill in required_skills
     )
     skill_problem = require_installed_skills and not skills_ready
     if command_path is None:
@@ -772,6 +780,35 @@ def installed_skill_summary(skills_roots: tuple[Path, ...]) -> dict[str, dict[st
     return summaries
 
 
+def core_skill_summary(skills_roots: tuple[Path, ...]) -> dict[str, Any]:
+    """Summarize the generated core ``loopx`` entry independently of rich workflows."""
+
+    if not skills_roots:
+        raise ValueError("at least one Codex skill root is required")
+    primary_root = skills_roots[0]
+    candidates = [
+        (root, root / "loopx" / "SKILL.md")
+        for root in skills_roots
+        if (root / "loopx" / "SKILL.md").exists()
+    ]
+    selected = candidates[0] if len(candidates) == 1 else None
+    selected_root = selected[0] if selected else None
+    skill_path = selected[1] if selected else primary_root / "loopx" / "SKILL.md"
+    return {
+        "path": str(skill_path),
+        "candidate_paths": [str(path) for _, path in candidates],
+        "route_count": len(candidates),
+        "route_conflict": len(candidates) > 1,
+        "source_root": str(selected_root) if selected_root else None,
+        "managed_externally": bool(selected_root and selected_root != primary_root),
+        "exists": bool(candidates),
+        "required_phrases": bool(
+            selected and skill_has_required_phrases(skill_path, CORE_LOOPX_SKILL_PHRASES)
+        ),
+        "required": True,
+    }
+
+
 def installed_skill_check(
     check_id: str,
     *,
@@ -942,15 +979,22 @@ def collect_doctor(
     local_bin = user_local_bin()
     skill_roots = codex_skill_roots()
     skills = installed_skill_summary(skill_roots)
-    project_skill = skills["loopx-project"]
-    skill_path = Path(str(project_skill["path"]))
+    skills["loopx"] = core_skill_summary(skill_roots)
     project_scoped_skill_ids = discover_project_scoped_skill_ids(
         repo_root / "skills"
     )
+    for skill_name in project_scoped_skill_ids:
+        if skill_name in skills:
+            skills[skill_name]["required"] = False
+    core_skill = skills["loopx"]
+    skill_path = Path(str(core_skill["path"]))
     globally_visible_project_skills = [
         skill_name
         for skill_name in project_scoped_skill_ids
-        if any((root / skill_name).exists() for root in skill_roots)
+        if any(
+            (root / skill_name / ".loopx-skill-scope").is_file()
+            for root in skill_roots
+        )
     ]
     default_release = command_root_summary(
         command_path,
@@ -1027,15 +1071,18 @@ def collect_doctor(
     externally_managed_skills = bool(
         install_freshness.get("externally_managed_skills")
     )
+    required_skill_values = [
+        skill for skill in skills.values() if skill.get("required", True)
+    ]
     external_skill_delivery = externally_managed_skills and all(
-        skill.get("managed_externally") for skill in skills.values()
+        skill.get("managed_externally") for skill in required_skill_values
     )
     if installed_skills_required:
         skill_delivery_status = (
             "ready"
             if all(
                 skill.get("exists") and skill.get("required_phrases")
-                for skill in skills.values()
+                for skill in required_skill_values
             )
             else "repair_recommended"
         )
@@ -1175,19 +1222,19 @@ def collect_doctor(
         },
         installed_skill_check(
             "installed_skill_exists",
-            actual_ok=bool(project_skill.get("exists")),
+            actual_ok=bool(core_skill.get("exists")),
             detail=str(skill_path),
             applicable=installed_skills_required,
         ),
         installed_skill_check(
             "installed_skill_delivery_hints",
-            actual_ok=bool(project_skill.get("required_phrases")),
+            actual_ok=bool(core_skill.get("required_phrases")),
             detail=str(skill_path),
             applicable=installed_skills_required,
         ),
         installed_skill_check(
             "installed_required_skills",
-            actual_ok=all(skill.get("exists") for skill in skills.values()),
+            actual_ok=all(skill.get("exists") for skill in required_skill_values),
             detail=",".join(sorted(skills)),
             applicable=installed_skills_required,
         ),
@@ -1195,7 +1242,7 @@ def collect_doctor(
             "installed_required_skill_routes",
             actual_ok=all(
                 skill.get("required_phrases") and not skill.get("route_conflict")
-                for skill in skills.values()
+                for skill in required_skill_values
             ),
             detail=",".join(
                 f"{name}=valid:{skill.get('required_phrases')};"
@@ -1297,10 +1344,10 @@ def collect_doctor(
         "upgrade_hint": install_freshness,
         "skill": {
             "path": str(skill_path),
-            "exists": bool(project_skill.get("exists")),
-            "delivery_hints": bool(project_skill.get("required_phrases")),
-            "route_conflict": bool(project_skill.get("route_conflict")),
-            "candidate_paths": list(project_skill.get("candidate_paths") or []),
+            "exists": bool(core_skill.get("exists")),
+            "delivery_hints": bool(core_skill.get("required_phrases")),
+            "route_conflict": bool(core_skill.get("route_conflict")),
+            "candidate_paths": list(core_skill.get("candidate_paths") or []),
         },
         "skill_delivery": skill_delivery,
         "skills": skills,

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -96,13 +96,14 @@ def external_skill_set_ready(
 ) -> bool:
     """Recognize a complete externally managed project-skill set."""
 
-    return bool(required_ids) and all(
+    known_ids = [skill_id for skill_id in required_ids if skill_id in skills]
+    return bool(known_ids) and all(
         isinstance(skill := skills.get(skill_id), Mapping)
         and bool(skill.get("exists"))
         and bool(skill.get("required_phrases"))
         and bool(skill.get("managed_externally"))
         and not bool(skill.get("route_conflict"))
-        for skill_id in required_ids
+        for skill_id in known_ids
     )
 
 

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -107,6 +107,16 @@ def external_skill_set_ready(
     )
 
 
+def external_skill_fallback_path(skills: Mapping[str, Mapping[str, Any]]) -> str | None:
+    """Return the external root's canonical core path for compatibility readback."""
+
+    for skill in skills.values():
+        source_root = skill.get("source_root")
+        if skill.get("managed_externally") and isinstance(source_root, str) and source_root:
+            return str(Path(source_root) / "loopx" / "SKILL.md")
+    return None
+
+
 def _user_home() -> Path:
     return Path.home().expanduser()
 

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -94,7 +94,10 @@ def summarize_skill_routes(
 def external_skill_set_ready(
     skills: Mapping[str, Mapping[str, Any]], required_ids: Sequence[str]
 ) -> bool:
-    """Recognize a complete externally managed project-skill set."""
+    """Recognize a complete externally managed project-skill set.
+
+    Callers pass the fixed-install summary IDs, not every source marker.
+    """
 
     return bool(required_ids) and all(
         isinstance(skill := skills.get(skill_id), Mapping)

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -51,6 +51,46 @@ ARK_MANAGED_AGENT_REQUIRED_SKILL_IDS = [
 ]
 
 
+def skill_has_required_phrases(skill_path: Path, phrases: tuple[str, ...]) -> bool:
+    if not skill_path.exists():
+        return False
+    text = " ".join(skill_path.read_text(encoding="utf-8").split())
+    return all(phrase in text for phrase in phrases)
+
+
+def summarize_skill_routes(
+    skills_roots: tuple[Path, ...],
+    skill_name: str,
+    phrases: tuple[str, ...],
+    *,
+    required: bool,
+) -> dict[str, Any]:
+    """Return one host-neutral read model for a skill across discovery roots."""
+
+    if not skills_roots:
+        raise ValueError("at least one Codex skill root is required")
+    primary_root = skills_roots[0]
+    candidates = [
+        (root, root / skill_name / "SKILL.md")
+        for root in skills_roots
+        if (root / skill_name / "SKILL.md").exists()
+    ]
+    selected = candidates[0] if len(candidates) == 1 else None
+    selected_root = selected[0] if selected else None
+    skill_path = selected[1] if selected else primary_root / skill_name / "SKILL.md"
+    return {
+        "path": str(skill_path),
+        "candidate_paths": [str(path) for _, path in candidates],
+        "route_count": len(candidates),
+        "route_conflict": len(candidates) > 1,
+        "source_root": str(selected_root) if selected_root else None,
+        "managed_externally": bool(selected_root and selected_root != primary_root),
+        "exists": bool(candidates),
+        "required_phrases": bool(selected and skill_has_required_phrases(skill_path, phrases)),
+        "required": required,
+    }
+
+
 def _user_home() -> Path:
     return Path.home().expanduser()
 

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -91,6 +91,21 @@ def summarize_skill_routes(
     }
 
 
+def external_skill_set_ready(
+    skills: Mapping[str, Mapping[str, Any]], required_ids: Sequence[str]
+) -> bool:
+    """Recognize a complete externally managed project-skill set."""
+
+    return bool(required_ids) and all(
+        isinstance(skill := skills.get(skill_id), Mapping)
+        and bool(skill.get("exists"))
+        and bool(skill.get("required_phrases"))
+        and bool(skill.get("managed_externally"))
+        and not bool(skill.get("route_conflict"))
+        for skill_id in required_ids
+    )
+
+
 def _user_home() -> Path:
     return Path.home().expanduser()
 

--- a/loopx/skill_install_readback.py
+++ b/loopx/skill_install_readback.py
@@ -96,14 +96,13 @@ def external_skill_set_ready(
 ) -> bool:
     """Recognize a complete externally managed project-skill set."""
 
-    known_ids = [skill_id for skill_id in required_ids if skill_id in skills]
-    return bool(known_ids) and all(
+    return bool(required_ids) and all(
         isinstance(skill := skills.get(skill_id), Mapping)
         and bool(skill.get("exists"))
         and bool(skill.get("required_phrases"))
         and bool(skill.get("managed_externally"))
         and not bool(skill.get("route_conflict"))
-        for skill_id in known_ids
+        for skill_id in required_ids
     )
 
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -316,6 +316,7 @@ install_workflow_skills() {
   local source_root="$2"
   local entry_cli_bin="$3"
   local skill_source skill_name skill_scope_file skill_target skill_tmp entry_status
+  local installed_skill_ids_text=""
   local -a installed_skill_ids=()
   skill_line="- skill: skipped"
   if [[ "$install_skill" == "0" || ! -d "$skills_source" ]]; then
@@ -367,11 +368,17 @@ install_workflow_skills() {
     skill_line="${skill_line}- skill: $skill_target"$'\n'
   done < <(find "$skills_source" -mindepth 1 -maxdepth 1 -type d -print | sort)
 
+  # The generated `$loopx` entry is the core LoopX route and must be
+  # materialized even when every rich workflow source is project-scoped.
+  # Keep its installation/readback independent from the optional global
+  # workflow copies so project-scope filtering cannot hide the main entry.
   if [[ "${#installed_skill_ids[@]}" -gt 0 ]]; then
-    if ! entry_status="$(
+    installed_skill_ids_text="$(printf '%s\n' "${installed_skill_ids[@]}")"
+  fi
+  if ! entry_status="$(
       LOOPX_SKILL_INSTALL_DIR="$skills_dir" \
         LOOPX_SKILL_INSTALL_SOURCE_ROOT="$source_root" \
-        LOOPX_SKILL_INSTALL_IDS="$(printf '%s\n' "${installed_skill_ids[@]}")" \
+        LOOPX_SKILL_INSTALL_IDS="$installed_skill_ids_text" \
         LOOPX_SKILL_INSTALLED_AT="$installed_at" \
         LOOPX_SKILL_ENTRY_CLI_BIN="$entry_cli_bin" \
         LOOPX_SKILL_ENTRY_HOST_SURFACE="$entry_host_surface" \
@@ -422,7 +429,7 @@ if os.environ.get("LOOPX_SKILL_DEDUPE_OTHER_ROOT") != "0":
         skills_dir=Path(os.environ["LOOPX_SKILL_INSTALL_DIR"]),
         execute=True,
     )
-    print(f"skill dedupe: {dedupe['reason']}")
+    print(f"skill dedupe: {dedupe['reason']}", file=sys.stderr)
 print(status)
 PY
     )"; then
@@ -435,7 +442,6 @@ PY
       skill_line="${skill_line}- generated skill: not materialized ($entry_status)"$'\n'
     fi
     skill_line="${skill_line}- skill readback: $skills_dir/.loopx-skill-install.json"$'\n'
-  fi
   skill_line="${skill_line%$'\n'}"
   rm -rf "$skill_install_lock"
   skill_install_lock_owned=0

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -16,6 +16,7 @@ Common environment variables:
   LOOPX_PROMOTE_DEFAULT=1          Promote this checkout as the default loopx.
   LOOPX_INSTALL_CANARY=0           Skip the loopx-canary executable.
   LOOPX_INSTALL_SKILL=0            Skip packaged workflow skills.
+  LOOPX_INSTALL_PROJECT_SKILLS=1   Include project-scoped skills in an isolated project profile.
   LOOPX_SKILLS_DIR=/path           Install workflow skills into this host-native root.
   LOOPX_SKILL_DEDUPE_OTHER_ROOT=1  Retire managed LoopX skill copies from the alternate well-known root.
   LOOPX_ENTRY_HOST_SURFACE=...     Bind generated $loopx to an exact host (ark-managed-agent).
@@ -67,6 +68,7 @@ fi
 man_root="${LOOPX_MAN_ROOT:-$HOME/.local/share/man}"
 man_dir="${LOOPX_MAN_DIR:-$man_root/man1}"
 install_skill="${LOOPX_INSTALL_SKILL:-1}"
+install_project_skills="${LOOPX_INSTALL_PROJECT_SKILLS:-0}"
 install_canary="${LOOPX_INSTALL_CANARY:-1}"
 promote_default_request="${LOOPX_PROMOTE_DEFAULT:-auto}"
 releases_dir="${LOOPX_RELEASES_DIR:-$HOME/.local/share/loopx/releases}"
@@ -352,7 +354,7 @@ install_workflow_skills() {
   while IFS= read -r skill_source; do
     skill_name="$(basename "$skill_source")"
     skill_scope_file="$skill_source/.loopx-skill-scope"
-    if [[ -f "$skill_scope_file" ]] && [[ "$(tr -d '[:space:]' <"$skill_scope_file")" == "project" ]]; then
+    if [[ "$install_project_skills" != "1" ]] && [[ -f "$skill_scope_file" ]] && [[ "$(tr -d '[:space:]' <"$skill_scope_file")" == "project" ]]; then
       skill_line="${skill_line}- project skill source: $skill_source (install explicitly per project)"$'\n'
       continue
     fi

--- a/skills/loopx-benchmark/.loopx-skill-scope
+++ b/skills/loopx-benchmark/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/skills/loopx-doc-registry/.loopx-skill-scope
+++ b/skills/loopx-doc-registry/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/skills/loopx-pr-program/.loopx-skill-scope
+++ b/skills/loopx-pr-program/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/skills/loopx-pr-review/.loopx-skill-scope
+++ b/skills/loopx-pr-review/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/skills/loopx-project/.loopx-skill-scope
+++ b/skills/loopx-project/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/skills/loopx-self-repair/.loopx-skill-scope
+++ b/skills/loopx-self-repair/.loopx-skill-scope
@@ -1,0 +1,1 @@
+project

--- a/tests/test_ark_managed_agent_host.py
+++ b/tests/test_ark_managed_agent_host.py
@@ -323,6 +323,12 @@ def test_retire_duplicate_managed_skills_removes_only_loopx_managed_copies(
     agents_skills = tmp_path / ".agents" / "skills"
     _materialize_workflow_skills(codex_skills)
     _materialize_workflow_skills(agents_skills)
+    canonical_facade = codex_skills / "loopx-global-gates" / "SKILL.md"
+    canonical_facade.parent.mkdir(parents=True)
+    canonical_facade.write_text(
+        "<!-- loopx-managed-slash-command:v1 command=/loopx-global-gates -->\n",
+        encoding="utf-8",
+    )
     facade = agents_skills / "loopx-global-gates" / "SKILL.md"
     facade.parent.mkdir(parents=True)
     facade.write_text(

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import loopx.doctor as doctor
 from loopx import __version__
 from loopx.doctor import (
     REQUIRED_INSTALLED_SKILL_PHRASES,
@@ -324,6 +325,31 @@ def test_external_skill_fallback_requires_every_project_skill() -> None:
     assert external_skill_set_ready(
         skills, ("loopx-project", "loopx-pr-review")
     ) is False
+
+
+def test_collect_doctor_accepts_external_fixed_skill_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    _write_required_skills(home / ".agents" / "skills")
+    command = tmp_path / "bin" / "loopx"
+    command.parent.mkdir(parents=True)
+    command.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("CODEX_HOME", str(home / ".codex"))
+    monkeypatch.setattr(doctor, "DEFAULT_RUNTIME_ROOT", tmp_path / "runtime")
+    monkeypatch.setattr(
+        doctor,
+        "resolve_command_path",
+        lambda name: command if name == "loopx" else None,
+    )
+
+    payload = doctor.collect_doctor()
+
+    assert payload["skill_delivery"]["status"] == "ready"
+    assert payload["skill_delivery"]["owner"] == "external_skill_manager"
+    assert payload["install_freshness"]["externally_managed_skills"] is True
 
 
 def test_duplicate_skill_routes_fail_closed(tmp_path: Path) -> None:

--- a/tests/test_doctor_install_freshness.py
+++ b/tests/test_doctor_install_freshness.py
@@ -17,6 +17,7 @@ from loopx.doctor import (
     python_distribution_install,
     trusted_release_ref_for_root,
 )
+from loopx.skill_install_readback import external_skill_set_ready
 
 
 class _FakeDistributionFile:
@@ -307,6 +308,22 @@ def test_external_agents_skill_root_is_accepted_without_copying(tmp_path: Path) 
     expected_skip = "-SkipSkills" if os.name == "nt" else "LOOPX_INSTALL_SKILL=0"
     assert expected_skip in str(freshness["upgrade_command"])
     assert expected_skip in str(freshness["contributor_upgrade_command"])
+
+
+def test_external_skill_fallback_requires_every_project_skill() -> None:
+    skills = {
+        "loopx-project": {
+            "exists": True,
+            "required_phrases": True,
+            "managed_externally": True,
+            "route_conflict": False,
+        }
+    }
+
+    assert external_skill_set_ready(skills, ("loopx-project",)) is True
+    assert external_skill_set_ready(
+        skills, ("loopx-project", "loopx-pr-review")
+    ) is False
 
 
 def test_duplicate_skill_routes_fail_closed(tmp_path: Path) -> None:

--- a/tests/test_skill_delivery_parity.py
+++ b/tests/test_skill_delivery_parity.py
@@ -78,6 +78,9 @@ class TestPackagedSkills:
         skills_root = REPO_ROOT / "skills"
         for skill_id in PACKAGED_HOST_SKILL_IDS:
             assert (skills_root / skill_id / "SKILL.md").is_file(), skill_id
+            assert (skills_root / skill_id / ".loopx-skill-scope").read_text(
+                encoding="utf-8"
+            ).strip() == "project", skill_id
 
     def test_repo_has_seven_skills(self):
         assert len(REQUIRED_HOST_SKILL_IDS) == 7  # loopx + 6 packaged

--- a/tests/test_windows_install.py
+++ b/tests/test_windows_install.py
@@ -90,10 +90,6 @@ def test_windows_installer_promotes_release_and_runs_doctor(tmp_path: Path) -> N
         "loopx-global-gates",
         "loopx-global-todos",
         "loopx-global-risks",
-        "loop-global-summary",
-        "loop-global-gates",
-        "loop-global-todos",
-        "loop-global-risks",
     }
     assert expected_skills == {
         path.name for path in skills_dir.iterdir() if (path / "SKILL.md").is_file()


### PR DESCRIPTION
## Summary

Stacked on #4284, this follow-up completes the project-skill delivery contract for the six packaged LoopX workflow skills. The installer correctly requires `skills/<skill-id>/.loopx-skill-scope` to contain `project`, but six canonical skill directories were missing that marker and were therefore reported as `blocked` instead of installable.

- Add the required `project` scope marker to `loopx-benchmark`, `loopx-doc-registry`, `loopx-pr-program`, `loopx-pr-review`, `loopx-project`, and `loopx-self-repair.
- Extend packaged-skill parity coverage so a missing marker fails before release.
- No global skill root, authority, invocation, or permission behavior changes.

## Validation

- `python -m pytest tests/test_skill_delivery_parity.py tests/test_project_skill_cli.py -q` — 27 passed.
- Verified all eight project-managed LoopX skills report `status=current` after install/readback.
- `git diff --check` — passed.

Signed-off-by: huangruiteng <14976749+huangruiteng@users.noreply.github.com>
