### PR TITLE
fix(reward-memory): verify private OpenViking scope

### DIFF
--- a/examples/fixtures/reward-memory-ingest-event.public.json
+++ b/examples/fixtures/reward-memory-ingest-event.public.json
@@ -66,7 +66,7 @@
       "retirement_authority": "openviking_reward_memory_owner"
     },
     "privacy": {
-      "visibility": "private",
+      "visibility": "public_safe",
       "raw_content_in_registry": false
     },
     "provider_scope_ref_digest": "0f998976780e6786"

--- a/examples/fixtures/reward-memory-scoped-feedback-ingest.public.json
+++ b/examples/fixtures/reward-memory-scoped-feedback-ingest.public.json
@@ -66,7 +66,7 @@
       "retirement_authority": "example_reward_memory_owner"
     },
     "privacy": {
-      "visibility": "private",
+      "visibility": "public_safe",
       "raw_content_in_registry": false
     },
     "provider_scope_ref_digest": "40bcd5f2e37a46db"

--- a/loopx/capabilities/context_providers/base.py
+++ b/loopx/capabilities/context_providers/base.py
@@ -73,6 +73,10 @@ class ContextProviderRetrieval:
     latency_ms: int = 0
     requested_limit: int = 0
     provider_readiness: Mapping[str, object] | None = None
+    visibility: str = "public"
+    target_scope_kind: str = "provider_defined"
+    actor_binding_verified: bool = False
+    provider_preflight_performed: bool = False
 
     def public_results(self) -> list[dict[str, object]]:
         return [
@@ -95,7 +99,8 @@ class ContextProviderRetrieval:
         content_may_instruct: bool,
     ) -> list[dict[str, object]]:
         return [
-            public | {
+            public
+            | {
                 "content": item.content,
                 "content_trust": content_trust,
                 "content_may_instruct": content_may_instruct,
@@ -109,7 +114,10 @@ class ContextProviderRetrieval:
             "ok": self.status == "completed",
             "provider": self.provider,
             "namespace": self.namespace,
-            "visibility": "public",
+            "visibility": self.visibility,
+            "target_scope_kind": self.target_scope_kind,
+            "actor_binding_verified": self.actor_binding_verified,
+            "provider_preflight_performed": self.provider_preflight_performed,
             "status": self.status,
             "reason_code": self.reason_code,
             "provider_version": self.provider_version,
@@ -148,14 +156,27 @@ class ContextProviderSync:
     pending_count: int = 0
     reconciliation_performed: bool = False
     retry_disposition: str = "no_retry"
+    visibility: str = "public"
+    target_scope_kind: str = "provider_defined"
+    write_strategy: str = "provider_defined"
+    actor_binding_verified: bool = False
+    provider_preflight_performed: bool = False
+    target_access_preflight_verified: bool = False
+    writability_verified: bool = False
 
     def public_packet(self) -> dict[str, object]:
         return {
             "schema_version": CONTEXT_PROVIDER_SYNC_SCHEMA_VERSION,
-            "ok": self.status in {"completed", "planned", "committed_pending"},
+            "ok": self.status in {"completed", "preflight_ready"},
             "provider": self.provider,
             "namespace": self.namespace,
-            "visibility": "public",
+            "visibility": self.visibility,
+            "target_scope_kind": self.target_scope_kind,
+            "write_strategy": self.write_strategy,
+            "actor_binding_verified": self.actor_binding_verified,
+            "provider_preflight_performed": self.provider_preflight_performed,
+            "target_access_preflight_verified": (self.target_access_preflight_verified),
+            "writability_verified": self.writability_verified,
             "status": self.status,
             "reason_code": self.reason_code,
             "provider_version": self.provider_version,

--- a/loopx/capabilities/context_providers/openviking.py
+++ b/loopx/capabilities/context_providers/openviking.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import time
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,9 +24,113 @@ OPENVIKING_PROVIDER_ID = "openviking"
 MAX_OPENVIKING_RESULTS = 6
 MAX_OPENVIKING_SYNC_RESOURCES = 24
 DEFAULT_MINIMUM_VERSION = "0.4.9"
-ACTOR_PEER_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$")
+# OpenViking v0.4.19 rejects identity segments containing path separators,
+# dot segments, colons, or plus signs. Keep the client-side boundary at least
+# as strict as the current server contract.
+OPENVIKING_IDENTITY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")
+PEER_SCOPE_MINIMUM_VERSION = "0.4.18"
+PEER_SCOPE_MINIMUM_SERVER_VERSION = "0.4.19"
 
 CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+@dataclass(frozen=True)
+class OpenVikingScope:
+    """Public-safe classification of one exact OpenViking URI."""
+
+    visibility: str
+    scope_kind: str
+    write_strategy: str
+    user_scope_id: str | None = None
+    actor_scope_id: str | None = None
+
+    @property
+    def actor_binding_required(self) -> bool:
+        return self.actor_scope_id is not None
+
+
+def classify_openviking_scope(scope_ref: str) -> OpenVikingScope:
+    """Classify supported public/private storage without inferring identity.
+
+    OpenViking resource ingestion is valid only below a ``resources`` root.
+    Structured Reward Memory records under a memory root use the filesystem
+    content-write API instead.  Agent/peer identity is returned to the caller
+    for an explicit equality check against ``actor_peer_id``.
+    """
+
+    value = str(scope_ref or "").strip().rstrip("/")
+    if not value.startswith("viking://"):
+        raise ValueError("OpenViking scope_ref must use viking://")
+    segments = value[len("viking://") :].split("/")
+    if not segments or any(
+        not segment or segment in {".", ".."} for segment in segments
+    ):
+        raise ValueError("OpenViking scope_ref must use safe non-empty path segments")
+    if segments[0] == "resources":
+        return OpenVikingScope(
+            visibility="public",
+            scope_kind="account_resources",
+            write_strategy="resource_ingest",
+        )
+    if (
+        segments[0] == "~"
+        and len(segments) >= 2
+        and segments[1]
+        in {
+            "resources",
+            "memories",
+        }
+    ):
+        return OpenVikingScope(
+            visibility="private",
+            scope_kind=f"current_user_{segments[1]}",
+            write_strategy=(
+                "resource_ingest" if segments[1] == "resources" else "content_write"
+            ),
+        )
+    if segments[0] == "agent":
+        raise ValueError(
+            "viking://agent is a shared read-only compatibility scope in "
+            "OpenViking v0.4.19; use an explicit user/peer target"
+        )
+    if segments[0] != "user" or len(segments) < 3:
+        raise ValueError(
+            "OpenViking scope_ref must select account resources or a supported "
+            "user/peer private collection"
+        )
+    user_id = segments[1]
+    if not OPENVIKING_IDENTITY_RE.fullmatch(user_id):
+        raise ValueError("OpenViking user scope must use a safe user id")
+    if segments[2] in {"resources", "memories"}:
+        return OpenVikingScope(
+            visibility="private",
+            scope_kind=f"user_{segments[2]}",
+            write_strategy=(
+                "resource_ingest" if segments[2] == "resources" else "content_write"
+            ),
+            user_scope_id=user_id,
+        )
+    if (
+        len(segments) >= 5
+        and segments[2] == "peers"
+        and segments[4] in {"resources", "memories"}
+    ):
+        actor_id = segments[3]
+        if not OPENVIKING_IDENTITY_RE.fullmatch(actor_id):
+            raise ValueError("OpenViking peer scope must use a safe actor id")
+        return OpenVikingScope(
+            visibility="private",
+            scope_kind=f"peer_{segments[4]}",
+            write_strategy=(
+                "resource_ingest" if segments[4] == "resources" else "content_write"
+            ),
+            user_scope_id=user_id,
+            actor_scope_id=actor_id,
+        )
+    raise ValueError(
+        "OpenViking private scope_ref must select user resources/memories or "
+        "one explicit peer collection"
+    )
 
 
 def _compact(value: Any, *, limit: int) -> str:
@@ -129,7 +234,7 @@ class OpenVikingContextProvider:
         runner: CommandRunner = subprocess.run,
     ) -> None:
         normalized_actor_peer_id = str(actor_peer_id or "").strip()
-        if normalized_actor_peer_id and not ACTOR_PEER_ID_RE.fullmatch(
+        if normalized_actor_peer_id and not OPENVIKING_IDENTITY_RE.fullmatch(
             normalized_actor_peer_id
         ):
             raise ValueError("actor_peer_id must be a compact public-safe token")
@@ -139,6 +244,38 @@ class OpenVikingContextProvider:
         self.env = dict(env) if env is not None else dict(os.environ)
         self.runner = runner
 
+    def _validated_scope(self, scope_ref: str) -> OpenVikingScope:
+        scope = classify_openviking_scope(scope_ref)
+        if scope.actor_binding_required and not self.actor_peer_id:
+            raise ValueError("peer-private OpenViking scope requires actor_peer_id")
+        if (
+            scope.actor_scope_id is not None
+            and self.actor_peer_id != scope.actor_scope_id
+        ):
+            raise ValueError(
+                "actor_peer_id must match the peer-private OpenViking scope"
+            )
+        return scope
+
+    @staticmethod
+    def _scope_metadata(scopes: Sequence[OpenVikingScope]) -> dict[str, object]:
+        visibilities = {scope.visibility for scope in scopes}
+        kinds = {scope.scope_kind for scope in scopes}
+        strategies = {scope.write_strategy for scope in scopes}
+        return {
+            "visibility": next(iter(visibilities))
+            if len(visibilities) == 1
+            else "mixed",
+            "target_scope_kind": next(iter(kinds)) if len(kinds) == 1 else "mixed",
+            "write_strategy": (
+                next(iter(strategies)) if len(strategies) == 1 else "mixed"
+            ),
+            "actor_binding_verified": all(
+                scope.visibility == "public" or scope.actor_scope_id is not None
+                for scope in scopes
+            ),
+        }
+
     def _run(
         self,
         args: Sequence[str],
@@ -146,7 +283,16 @@ class OpenVikingContextProvider:
         timeout_seconds: float,
     ) -> subprocess.CompletedProcess[str]:
         command = [self.executable]
-        if self.actor_peer_id and args and args[0] not in {"--version", "status"}:
+        if (
+            self.actor_peer_id
+            and args
+            and args[0]
+            not in {
+                "--version",
+                "status",
+                "version",
+            }
+        ):
             command.extend(["--actor-peer-id", self.actor_peer_id])
         command.extend(args)
         return self.runner(
@@ -159,7 +305,12 @@ class OpenVikingContextProvider:
             check=False,
         )
 
-    def _preflight(self, *, timeout_seconds: float) -> tuple[str | None, str | None]:
+    def _preflight(
+        self,
+        *,
+        timeout_seconds: float,
+        peer_scope_required: bool = False,
+    ) -> tuple[str | None, str | None]:
         try:
             version_result = self._run(["--version"], timeout_seconds=timeout_seconds)
         except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -168,10 +319,38 @@ class OpenVikingContextProvider:
             return None, "provider_version_preflight_failed"
         version = _compact(version_result.stdout, limit=80)
         try:
-            if _version_tuple(version) < _version_tuple(self.minimum_version):
+            configured_minimum = _version_tuple(self.minimum_version)
+            required_minimum = (
+                max(configured_minimum, _version_tuple(PEER_SCOPE_MINIMUM_VERSION))
+                if peer_scope_required
+                else configured_minimum
+            )
+            if _version_tuple(version) < required_minimum:
                 return version, "provider_version_incompatible"
         except ValueError:
             return version, "provider_version_unparseable"
+        if peer_scope_required:
+            try:
+                server_version_result = self._run(
+                    ["version"], timeout_seconds=timeout_seconds
+                )
+            except subprocess.TimeoutExpired:
+                return version, "provider_server_version_timeout"
+            if server_version_result.returncode != 0:
+                return version, "provider_server_version_unavailable"
+            server_match = re.search(
+                r"Server:\s*(\d+\.\d+\.\d+)",
+                server_version_result.stdout,
+                flags=re.IGNORECASE,
+            )
+            if not server_match:
+                return version, "provider_server_version_unparseable"
+            server_version = server_match.group(1)
+            version = f"{version}; server {server_version}"
+            if _version_tuple(server_version) < _version_tuple(
+                PEER_SCOPE_MINIMUM_SERVER_VERSION
+            ):
+                return version, "provider_server_version_incompatible"
         try:
             status_result = self._run(
                 ["status", "-o", "json", "-c", "true"],
@@ -204,10 +383,15 @@ class OpenVikingContextProvider:
         )
         if not namespace or not query or not query_summary:
             raise ValueError("namespace, query, and query_summary are required")
-        if not scope_ref.startswith("viking://"):
-            raise ValueError("OpenViking scope_ref must use viking://")
+        scope = self._validated_scope(scope_ref)
+        actor_binding_verified = (
+            scope.visibility == "public" or scope.actor_scope_id is not None
+        )
 
-        version, blocker = self._preflight(timeout_seconds=timeout_seconds)
+        version, blocker = self._preflight(
+            timeout_seconds=timeout_seconds,
+            peer_scope_required=scope.actor_binding_required,
+        )
         if blocker:
             return ContextProviderRetrieval(
                 provider=self.provider_id,
@@ -221,6 +405,10 @@ class OpenVikingContextProvider:
                 provider_version=version,
                 latency_ms=int((time.monotonic() - started) * 1000),
                 requested_limit=requested_limit,
+                visibility=scope.visibility,
+                target_scope_kind=scope.scope_kind,
+                actor_binding_verified=actor_binding_verified,
+                provider_preflight_performed=True,
             )
 
         try:
@@ -266,6 +454,10 @@ class OpenVikingContextProvider:
                 provider_version=version,
                 latency_ms=int((time.monotonic() - started) * 1000),
                 requested_limit=requested_limit,
+                visibility=scope.visibility,
+                target_scope_kind=scope.scope_kind,
+                actor_binding_verified=actor_binding_verified,
+                provider_preflight_performed=True,
             )
         try:
             rows = _mapping_candidates(_extract_json(search_result.stdout))
@@ -282,6 +474,10 @@ class OpenVikingContextProvider:
                 provider_version=version,
                 latency_ms=int((time.monotonic() - started) * 1000),
                 requested_limit=requested_limit,
+                visibility=scope.visibility,
+                target_scope_kind=scope.scope_kind,
+                actor_binding_verified=actor_binding_verified,
+                provider_preflight_performed=True,
             )
 
         items: list[ContextProviderItem] = []
@@ -357,6 +553,10 @@ class OpenVikingContextProvider:
             provider_version=version,
             latency_ms=int((time.monotonic() - started) * 1000),
             requested_limit=requested_limit,
+            visibility=scope.visibility,
+            target_scope_kind=scope.scope_kind,
+            actor_binding_verified=actor_binding_verified,
+            provider_preflight_performed=True,
         )
 
     def _reconcile_uncertain_sync_write(
@@ -486,29 +686,20 @@ class OpenVikingContextProvider:
             raise ValueError("namespace is required")
         if not bounded:
             raise ValueError("at least one resource is required")
+        scopes: list[OpenVikingScope] = []
         for source, target in bounded:
             source_path = Path(source).expanduser()
             if not source_path.is_file():
                 raise ValueError("every sync source must be an existing file")
-            if not target.startswith("viking://resources/"):
-                raise ValueError("sync targets must stay under viking://resources/")
+            scopes.append(self._validated_scope(target))
             if source_path.name != target.rstrip("/").rsplit("/", 1)[-1]:
                 raise ValueError("sync target basename must match source basename")
-        if not execute:
-            return ContextProviderSync(
-                provider=self.provider_id,
-                namespace=namespace,
-                status="planned",
-                observed_at=observed_at,
-                requested_count=len(bounded),
-                completed_count=0,
-                write_count=0,
-                reason_code="execute_required_for_resource_write",
-                latency_ms=int((time.monotonic() - started) * 1000),
-                retry_disposition="execute_required",
-            )
+        scope_metadata = self._scope_metadata(scopes)
 
-        version, blocker = self._preflight(timeout_seconds=timeout_seconds)
+        version, blocker = self._preflight(
+            timeout_seconds=timeout_seconds,
+            peer_scope_required=any(scope.actor_binding_required for scope in scopes),
+        )
         if blocker:
             return ContextProviderSync(
                 provider=self.provider_id,
@@ -521,6 +712,68 @@ class OpenVikingContextProvider:
                 reason_code=blocker,
                 provider_version=version,
                 latency_ms=int((time.monotonic() - started) * 1000),
+                provider_preflight_performed=True,
+                **scope_metadata,
+            )
+
+        if not execute:
+            target_access_count = 0
+            preflight_reason: str | None = None
+            for _source, target in bounded:
+                remaining = max(1.0, timeout_seconds - (time.monotonic() - started))
+                try:
+                    existing = self._run(
+                        ["read", target, "-o", "json", "-c", "true"],
+                        timeout_seconds=remaining,
+                    )
+                except subprocess.TimeoutExpired:
+                    preflight_reason = "provider_sync_target_preflight_timeout"
+                    break
+                if existing.returncode == 0:
+                    target_access_count += 1
+                    continue
+                parent = target.rstrip("/").rsplit("/", 1)[0]
+                try:
+                    parent_probe = self._run(
+                        ["ls", parent, "-n", "1", "-o", "json", "-c", "true"],
+                        timeout_seconds=remaining,
+                    )
+                except subprocess.TimeoutExpired:
+                    preflight_reason = "provider_sync_target_preflight_timeout"
+                    break
+                if parent_probe.returncode != 0:
+                    preflight_reason = "provider_sync_target_parent_unavailable"
+                    break
+                target_access_count += 1
+            target_access_verified = target_access_count == len(bounded)
+            return ContextProviderSync(
+                provider=self.provider_id,
+                namespace=namespace,
+                status=(
+                    "preflight_ready"
+                    if target_access_verified
+                    else "preflight_incomplete"
+                ),
+                observed_at=observed_at,
+                requested_count=len(bounded),
+                completed_count=0,
+                write_count=0,
+                reason_code=(
+                    "execute_required_for_verified_write"
+                    if target_access_verified
+                    else preflight_reason or "provider_sync_target_preflight_incomplete"
+                ),
+                provider_version=version,
+                latency_ms=int((time.monotonic() - started) * 1000),
+                retry_disposition=(
+                    "execute_required"
+                    if target_access_verified
+                    else "repair_target_scope"
+                ),
+                provider_preflight_performed=True,
+                target_access_preflight_verified=target_access_verified,
+                writability_verified=False,
+                **scope_metadata,
             )
 
         completed_refs: list[str] = []
@@ -529,7 +782,7 @@ class OpenVikingContextProvider:
         sync_reason: str | None = None
         reconciliation_performed = False
         retry_disposition = "no_retry"
-        for source, target in bounded:
+        for (source, target), scope in zip(bounded, scopes, strict=True):
             parent = target.rstrip("/").rsplit("/", 1)[0]
             try:
                 source_content = Path(source).read_text(encoding="utf-8")
@@ -556,137 +809,153 @@ class OpenVikingContextProvider:
                     break
                 completed_refs.append(target)
                 continue
-            try:
-                tree_result = self._run(
-                    ["tree", target, "-L", "3", "-o", "json", "-c", "true"],
-                    timeout_seconds=remaining,
-                )
-            except subprocess.TimeoutExpired:
-                sync_reason = "provider_sync_timeout"
-                break
-            tree_refs: list[str] = []
-            if tree_result.returncode == 0:
+            if scope.write_strategy == "resource_ingest":
                 try:
-                    tree_refs = [
-                        ref
-                        for row in _mapping_candidates(
-                            _extract_json(tree_result.stdout)
+                    tree_result = self._run(
+                        ["tree", target, "-L", "3", "-o", "json", "-c", "true"],
+                        timeout_seconds=remaining,
+                    )
+                except subprocess.TimeoutExpired:
+                    sync_reason = "provider_sync_timeout"
+                    break
+                tree_refs: list[str] = []
+                if tree_result.returncode == 0:
+                    try:
+                        tree_refs = [
+                            ref
+                            for row in _mapping_candidates(
+                                _extract_json(tree_result.stdout)
+                            )
+                            if (ref := _resource_ref(row))
+                        ]
+                    except ValueError:
+                        sync_reason = "provider_sync_tree_parse_failed"
+                        break
+                tree_contents: list[str] = []
+                for tree_ref in tree_refs:
+                    try:
+                        tree_read = self._run(
+                            ["read", tree_ref, "-o", "json", "-c", "true"],
+                            timeout_seconds=remaining,
                         )
-                        if (ref := _resource_ref(row))
-                    ]
-                except ValueError:
-                    sync_reason = "provider_sync_tree_parse_failed"
+                    except subprocess.TimeoutExpired:
+                        sync_reason = "provider_sync_timeout"
+                        break
+                    if tree_read.returncode != 0:
+                        continue
+                    try:
+                        tree_content = _read_content(_extract_json(tree_read.stdout))
+                    except ValueError:
+                        continue
+                    tree_contents.append(tree_content)
+                if sync_reason:
                     break
-            tree_contents: list[str] = []
-            for tree_ref in tree_refs:
-                try:
-                    tree_read = self._run(
-                        ["read", tree_ref, "-o", "json", "-c", "true"],
-                        timeout_seconds=remaining,
-                    )
-                except subprocess.TimeoutExpired:
-                    sync_reason = "provider_sync_timeout"
-                    break
-                if tree_read.returncode != 0:
-                    continue
-                try:
-                    tree_content = _read_content(_extract_json(tree_read.stdout))
-                except ValueError:
-                    continue
-                tree_contents.append(tree_content)
-            if sync_reason:
-                break
-            source_lines = set(canonical_context_lines(source_content))
-            matched_source_lines = {
-                line
-                for content in tree_contents
-                for line in canonical_context_lines(content)
-                if line in source_lines
-            }
-            coverage = len(matched_source_lines) / max(1, len(source_lines))
-            if (
-                tree_contents
-                and all(
-                    canonical_context_matches(content, source_content)
+                source_lines = set(canonical_context_lines(source_content))
+                matched_source_lines = {
+                    line
                     for content in tree_contents
-                )
-                and coverage >= 0.8
-            ):
-                completed_refs.append(target)
-                continue
-            if tree_refs:
-                sync_reason = "provider_sync_revision_conflict"
-                break
-            try:
-                parent_probe = self._run(
-                    ["ls", parent, "-n", "1", "-o", "json", "-c", "true"],
-                    timeout_seconds=remaining,
-                )
-            except subprocess.TimeoutExpired:
-                sync_reason = "provider_sync_timeout"
-                break
-            if parent_probe.returncode != 0:
+                    for line in canonical_context_lines(content)
+                    if line in source_lines
+                }
+                coverage = len(matched_source_lines) / max(1, len(source_lines))
+                if (
+                    tree_contents
+                    and all(
+                        canonical_context_matches(content, source_content)
+                        for content in tree_contents
+                    )
+                    and coverage >= 0.8
+                ):
+                    completed_refs.append(target)
+                    continue
+                if tree_refs:
+                    sync_reason = "provider_sync_revision_conflict"
+                    break
                 try:
-                    mkdir_result = self._run(
-                        ["mkdir", parent, "-o", "json", "-c", "true"],
+                    parent_probe = self._run(
+                        ["ls", parent, "-n", "1", "-o", "json", "-c", "true"],
                         timeout_seconds=remaining,
                     )
                 except subprocess.TimeoutExpired:
                     sync_reason = "provider_sync_timeout"
                     break
-                if mkdir_result.returncode != 0:
-                    sync_reason = "provider_sync_parent_create_failed"
-                    break
+                if parent_probe.returncode != 0:
+                    try:
+                        mkdir_result = self._run(
+                            ["mkdir", parent, "-o", "json", "-c", "true"],
+                            timeout_seconds=remaining,
+                        )
+                    except subprocess.TimeoutExpired:
+                        sync_reason = "provider_sync_timeout"
+                        break
+                    if mkdir_result.returncode != 0:
+                        sync_reason = "provider_sync_parent_create_failed"
+                        break
             reserve = min(15.0, max(1.0, remaining * 0.2))
             write_timeout = max(1.0, remaining - reserve)
+            write_args = (
+                [
+                    "add-resource",
+                    source,
+                    "--to",
+                    target,
+                    "--wait",
+                    "--timeout",
+                    str(max(1, int(write_timeout))),
+                    "-o",
+                    "json",
+                    "-c",
+                    "true",
+                ]
+                if scope.write_strategy == "resource_ingest"
+                else [
+                    "write",
+                    target,
+                    "--from-file",
+                    source,
+                    "--mode",
+                    "create",
+                    "--wait",
+                    "--timeout",
+                    str(max(1, int(write_timeout))),
+                    "-o",
+                    "json",
+                    "-c",
+                    "true",
+                ]
+            )
             try:
-                result = self._run(
-                    [
-                        "add-resource",
-                        source,
-                        "--to",
-                        target,
-                        "--wait",
-                        "--timeout",
-                        str(max(1, int(write_timeout))),
-                        "-o",
-                        "json",
-                        "-c",
-                        "true",
-                    ],
-                    timeout_seconds=write_timeout,
-                )
+                result = self._run(write_args, timeout_seconds=write_timeout)
             except subprocess.TimeoutExpired:
                 result = None
-            if result is None or result.returncode != 0:
-                reconciliation_performed = True
-                reconciliation = self._reconcile_uncertain_sync_write(
-                    target=target,
-                    source_content=source_content,
-                    timeout_seconds=reserve,
+            reconciliation_performed = True
+            reconciliation = self._reconcile_uncertain_sync_write(
+                target=target,
+                source_content=source_content,
+                timeout_seconds=reserve,
+            )
+            if reconciliation == "verified_success":
+                completed_refs.append(target)
+                write_count += 1
+                continue
+            if reconciliation == "committed_pending":
+                pending_refs.append(target)
+                write_count += 1
+                retry_disposition = "wait_and_reconcile"
+                continue
+            if reconciliation == "absent_safe_to_retry":
+                sync_reason = (
+                    "provider_sync_write_timeout_absent"
+                    if result is None
+                    else "provider_sync_write_failed_absent"
+                    if result.returncode != 0
+                    else "provider_sync_success_readback_absent"
                 )
-                if reconciliation == "verified_success":
-                    completed_refs.append(target)
-                    write_count += 1
-                    continue
-                if reconciliation == "committed_pending":
-                    pending_refs.append(target)
-                    write_count += 1
-                    retry_disposition = "wait_and_reconcile"
-                    continue
-                if reconciliation == "absent_safe_to_retry":
-                    sync_reason = (
-                        "provider_sync_write_timeout_absent"
-                        if result is None
-                        else "provider_sync_write_failed_absent"
-                    )
-                    retry_disposition = "safe_to_retry"
-                else:
-                    sync_reason = "provider_sync_reconciliation_unavailable"
-                    retry_disposition = "manual_reconcile"
-                break
-            completed_refs.append(target)
-            write_count += 1
+                retry_disposition = "safe_to_retry"
+            else:
+                sync_reason = "provider_sync_reconciliation_unavailable"
+                retry_disposition = "manual_reconcile"
+            break
 
         accounted_count = len(completed_refs) + len(pending_refs)
         if len(completed_refs) == len(bounded):
@@ -715,6 +984,10 @@ class OpenVikingContextProvider:
             pending_count=len(pending_refs),
             reconciliation_performed=reconciliation_performed,
             retry_disposition=retry_disposition,
+            provider_preflight_performed=True,
+            target_access_preflight_verified=(status == "completed"),
+            writability_verified=(status == "completed"),
+            **scope_metadata,
         )
 
 

--- a/loopx/capabilities/context_providers/openviking.py
+++ b/loopx/capabilities/context_providers/openviking.py
@@ -219,6 +219,21 @@ def _read_content(value: Any) -> str:
     return ""
 
 
+def _provider_error_code(text: str) -> str | None:
+    """Read only the typed provider error code from compact CLI output."""
+
+    try:
+        payload = _extract_json(text)
+    except ValueError:
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, Mapping):
+        return None
+    return _compact(error.get("code"), limit=80) or None
+
+
 class OpenVikingContextProvider:
     """Bounded OpenViking CLI integration with compact, fail-open outputs."""
 
@@ -719,7 +734,7 @@ class OpenVikingContextProvider:
         if not execute:
             target_access_count = 0
             preflight_reason: str | None = None
-            for _source, target in bounded:
+            for index, (_source, target) in enumerate(bounded):
                 remaining = max(1.0, timeout_seconds - (time.monotonic() - started))
                 try:
                     existing = self._run(
@@ -742,6 +757,17 @@ class OpenVikingContextProvider:
                     preflight_reason = "provider_sync_target_preflight_timeout"
                     break
                 if parent_probe.returncode != 0:
+                    if (
+                        scopes[index].write_strategy == "content_write"
+                        and _provider_error_code(parent_probe.stdout) == "NOT_FOUND"
+                    ):
+                        # OpenViking v0.4.19 content-write create mode creates
+                        # missing parent directories. A typed NOT_FOUND proves
+                        # absence, not a permission failure; apply still has to
+                        # perform the canary write and exact readback before
+                        # enablement is committed.
+                        target_access_count += 1
+                        continue
                     preflight_reason = "provider_sync_target_parent_unavailable"
                     break
                 target_access_count += 1

--- a/loopx/capabilities/decision_context/outcome_feedback.py
+++ b/loopx/capabilities/decision_context/outcome_feedback.py
@@ -25,6 +25,9 @@ _RETRIEVAL_RECEIPT_FIELDS = {
     "provider",
     "namespace",
     "visibility",
+    "target_scope_kind",
+    "actor_binding_verified",
+    "provider_preflight_performed",
     "status",
     "reason_code",
     "provider_version",
@@ -159,8 +162,7 @@ def _retrieval_counts(
     if requested_limit and result_count > requested_limit:
         raise ValueError("retrieval_receipt exceeds its requested result limit")
     if any(
-        not isinstance(result, Mapping)
-        or set(result) != _RETRIEVAL_RESULT_FIELDS
+        not isinstance(result, Mapping) or set(result) != _RETRIEVAL_RESULT_FIELDS
         for result in results
     ):
         raise ValueError("retrieval_receipt results must use the canonical projection")
@@ -168,7 +170,9 @@ def _retrieval_counts(
     if not isinstance(telemetry, Mapping) or set(telemetry) != (
         _RETRIEVAL_TELEMETRY_FIELDS
     ):
-        raise ValueError("retrieval_receipt telemetry must use the canonical projection")
+        raise ValueError(
+            "retrieval_receipt telemetry must use the canonical projection"
+        )
     if result_count and (
         packet.get("search_performed") is not True
         or packet.get("read_performed") is not True
@@ -219,8 +223,7 @@ def build_decision_outcome_feedback(
         and item["evidence_ref"] == evidence["packet_ref"]
     ]
     current_source_revisions = sum(
-        revision["freshness"] == "current"
-        for revision in evidence["source_revisions"]
+        revision["freshness"] == "current" for revision in evidence["source_revisions"]
     )
     (
         discovered_result_count,
@@ -321,9 +324,7 @@ def build_decision_outcome_feedback(
         "outcome_telemetry": {
             "verification_status": outcome["verification_status"],
             "linked_verified_outcome_count": len(linked_verified_outcomes),
-            "invalidated_assumption_count": len(
-                outcome["invalidated_assumptions"]
-            ),
+            "invalidated_assumption_count": len(outcome["invalidated_assumptions"]),
             "resulting_transition_count": len(outcome["resulting_transitions"]),
         },
         "reward_memory": {

--- a/loopx/capabilities/reward_memory/README.md
+++ b/loopx/capabilities/reward_memory/README.md
@@ -29,8 +29,9 @@ loopx reward-memory ingest-event --input full-public-fixture.json --format json
 
 ## Experimental activation
 
-Reward Memory is a provider-neutral, default-off experimental goal capability.
-It is enabled for named registered agent lanes, not for a whole LoopX install:
+Reward Memory is a provider-neutral, default-off experimental capability. It is
+enabled for a named Agent inside one Goal, not for a whole Goal or LoopX
+install:
 
 ```bash
 # Preview first; add --execute only after checking the boundary change.
@@ -42,11 +43,55 @@ loopx reward-memory experiment-status \
   --goal-id <goal> --agent-id <registered-agent> --format json
 ```
 
-The registry retains only `enabled`, `experimental`, an ignored repo-relative
-config pointer, and the explicit agent allowlist. Provider-specific choices
-therefore stay local and private. OpenViking is the first provider used by the
-Issue Fix pilot, but it is not a global LoopX feature flag or mandatory
-dependency; another provider can satisfy the same binding contract.
+The registry retains `enabled`, `experimental`, an ignored repo-relative config
+pointer and digest, the explicit Agent allowlist, and a public-safe per-Agent
+enablement receipt. Provider-specific choices stay local and private. A
+verified receipt proves that the exact route accepted a fresh non-recallable
+canary write and returned the same bytes. A missing receipt or config digest
+drift makes automatic use unavailable without blocking ordinary Goal work.
+OpenViking is the first provider used by the Issue Fix pilot, but it is not a
+global LoopX feature flag or mandatory dependency; another provider can
+satisfy the same binding contract.
+
+### OpenViking v0.4.19 identity boundary
+
+LoopX currently assumes one Agent belongs to exactly one Goal, while a Goal may
+contain several Agents. Agent names are only Goal-local. The durable runtime
+identity is therefore `(goal_id, agent_id)`, and LoopX derives a deterministic,
+OpenViking-safe peer token from that pair. Reusing `explorer` in another Goal
+produces another peer token, even when both routes use the same authenticated
+OpenViking user.
+
+New private writes must use
+`viking://user/{user_id}/peers/{canonical_peer}/memories/...`; the request's
+`actor_peer_id` must equal the URI peer before any provider call. LoopX rejects
+`viking://agent/...` for writes because OpenViking v0.4.19 defines it as a
+shared, read-only legacy compatibility scope. It also rejects user-private
+paths without an actor-bound peer for an Agent-private corpus. Private peer
+reads/writes require CLI `>=0.4.18` and server `>=0.4.19`. See OpenViking's
+[multi-tenant model](https://github.com/volcengine/OpenViking/blob/main/docs/en/concepts/11-multi-tenant.md)
+and [URI migration](https://github.com/volcengine/OpenViking/blob/main/docs/en/migration/01-user-peer-model.md).
+
+Config v1 can bind one private Goal-scoped Agent only. Supplying several Agents
+with one private provider binding is rejected instead of silently sharing a
+peer. Account/public resources remain an explicit shared mode. A future
+same-Goal `goal_shared` memory must be a separate corpus with its own owner,
+reader allowlist, write/promotion policy, and receipt; runtime recall may then
+federate the Agent-private and Goal-shared corpora explicitly. Private memory is
+never promoted or made visible to a sibling Agent merely because both Agents
+belong to the same Goal.
+
+### Lifecycle completion boundary
+
+Provider readiness and lifecycle automation are separate status dimensions. A
+verified storage receipt does not by itself prove that automatic recall and
+writeback are connected to every host. Complete lifecycle enablement means the
+supported planning/decision entry points perform bounded recall, and real
+evidence-backed outcome reviews perform idempotent writeback without another
+hidden opt-in. No new evidence means no new memory. A missing identity never
+falls back to a shared corpus; provider degradation stays visible while base
+Goal work continues. Each host must report its actual coverage rather than
+generalizing from a direct CLI or helper test.
 
 Config v1 declares one `project_provider_binding`, its exact per-corpus scope
 references, the project corpus set, module-owned surfaces, and an automation
@@ -92,7 +137,12 @@ provider/corpus identity are still checked independently for every corpus.
 ```
 
 The abbreviated corpus and standing-policy objects above represent the full
-existing record contracts. `experiment-status` reports the v1 config schema,
+existing record contracts. `configure-goal` preview now calls the provider
+preflight and reports `preflight_ready`, `preflight_incomplete`, or
+`unavailable`; it never reports a provider write as merely `planned`. Preview
+does not prove writability. Apply must complete the fresh canary write and
+exact readback before it commits the registry binding. `experiment-status`
+reports the v1 config schema,
 corpus/surface counts, recall-profile ids, and the effective automatic policy
 without exposing scope refs. Agent-scoped `quota should-run` and `status
 --agent-id` resolve that policy through the same invoked registry and config

--- a/loopx/capabilities/reward_memory/README.zh-CN.md
+++ b/loopx/capabilities/reward_memory/README.zh-CN.md
@@ -24,8 +24,8 @@ loopx reward-memory ingest-event --input full-public-fixture.json --format json
 
 ## 实验能力的开启方式
 
-Reward Memory 是 provider-neutral、默认关闭的 goal 级实验能力。它按已登记 agent lane
-显式开启，而不是对整套 LoopX 全局开启：
+Reward Memory 是 provider-neutral、默认关闭的实验能力。它按某个 Goal 内已登记的具体
+Agent 显式开启，而不是对整个 Goal 或整套 LoopX 开启：
 
 ```bash
 # 先 preview；确认边界变化后再追加 --execute。
@@ -37,10 +37,42 @@ loopx reward-memory experiment-status \
   --goal-id <goal> --agent-id <registered-agent> --format json
 ```
 
-Registry 只保存 `enabled`、`experimental`、一个指向 repo 内 ignored config 的相对路径，
-以及显式 agent allowlist，因此 provider 选择留在本地私有配置里。OpenViking 是 Issue Fix
-pilot 当前使用的首个 provider，但不是 LoopX 的全局 feature flag 或强制依赖；任何满足
-同一 binding contract 的 provider 都可以替换它。
+Registry 只保存 `enabled`、`experimental`、指向 repo 内 ignored config 的相对路径及其
+digest、显式 Agent allowlist，以及 public-safe 的逐 Agent 启用回执，因此 provider 选择仍
+留在本地私有配置里。verified 回执证明精确路由完成了一次新的、不可召回的 canary 写入，
+并精确读回相同字节。回执缺失或 config digest 漂移时，自动能力不可用，但不会阻塞 Goal
+的普通工作。OpenViking 是 Issue Fix pilot 当前使用的首个 provider，但不是 LoopX 的全局
+feature flag 或强制依赖；任何满足同一 binding contract 的 provider 都可以替换它。
+
+### OpenViking v0.4.19 身份边界
+
+LoopX 当前假设一个 Agent 只属于一个 Goal，而一个 Goal 可以包含多个 Agent。Agent 名字只在
+Goal 内唯一，因此持久运行时身份是 `(goal_id, agent_id)`；LoopX 会从这两个值生成确定性的、
+符合 OpenViking 规范的 peer token。另一个 Goal 即使也有名为 `explorer` 的 Agent，也会得到
+不同的 peer token，即使二者使用同一个经过认证的 OpenViking user。
+
+新的私有写入只能使用
+`viking://user/{user_id}/peers/{canonical_peer}/memories/...`；请求中的
+`actor_peer_id` 必须在任何 provider 调用前与 URI 中的 peer 完全相等。LoopX 禁止向
+`viking://agent/...` 写入，因为 OpenViking v0.4.19 已把它定义为全账户共享、只读的旧版兼容
+入口。Agent 私有 corpus 也不能使用缺少 actor-bound peer 的 user-private 路径。私有 peer
+读写要求当前代 CLI（`>=0.4.18`）和 server（`>=0.4.19`）。参见 OpenViking 的
+[多租户模型](https://github.com/volcengine/OpenViking/blob/main/docs/en/concepts/11-multi-tenant.md)
+和 [URI 迁移说明](https://github.com/volcengine/OpenViking/blob/main/docs/en/migration/01-user-peer-model.md)。
+
+Config v1 的一份私有配置只能绑定一个 Goal-scoped Agent；把多个 Agent 交给同一个私有
+provider binding 会被拒绝，不能静默共用 peer。Account/public resources 仍是显式共享模式。
+未来如果增加同 Goal 的 `goal_shared` memory，必须作为独立 corpus，拥有独立 owner、读取
+allowlist、写入/晋升策略和回执；运行时再显式合并 Agent 私有与 Goal 共享两个 corpus。
+不能因为两个 Agent 同属一个 Goal，就把某个 Agent 的私有 memory 自动晋升或暴露给兄弟 Agent。
+
+### 生命周期完成边界
+
+Provider 就绪和生命周期自动化是两个独立状态。存储启用回执已验证，并不代表每个宿主都已经
+接好自动召回和写回。完整生命周期开启意味着：适用的真实规划/决策入口执行有界召回；真实、
+有证据的结果复盘执行幂等写回，不再依赖另一个隐藏开关。没有新证据就不产生新 memory；缺少
+身份时绝不回退共享 corpus；provider 降级应清晰可见，同时不阻塞 Goal 的基础工作。每个宿主
+必须报告自身真实覆盖范围，不能把一次直接 CLI 或 helper 测试泛化成全宿主可用。
 
 Config v1 只登记一次 `project_provider_binding`，同时列出每个 corpus 的精确 provider
 scope、项目 corpus 集合、模块自有 surface 和 automation policy。每个 surface 显式列出
@@ -85,6 +117,9 @@ authority、privacy、freshness 和 lifecycle；每个 corpus 的 scope digest�
 ```
 
 上例省略的 corpus 和 standing policy 字段仍使用既有完整记录 contract。
+`configure-goal` 的 preview 现在会调用 provider preflight，并返回 `preflight_ready`、
+`preflight_incomplete` 或 `unavailable`，不会再把 provider 写入标成 `planned`。Preview
+本身不证明可写；apply 必须完成新的 canary 写入和精确读回后，才能提交 Registry binding。
 `experiment-status` 会报告 v1 config schema、corpus/surface 数量、recall profile id 和生效的
 automatic policy，但不会泄露 scope ref。Agent-scoped `quota should-run` 与
 `status --agent-id` 使用同一个 invoked registry 和 config reader 解析该 policy，不会把

--- a/loopx/capabilities/reward_memory/application.py
+++ b/loopx/capabilities/reward_memory/application.py
@@ -16,6 +16,7 @@ from ..context_providers.base import (
     canonical_context_text,
     opaque_provider_ref,
 )
+from ..context_providers.openviking import classify_openviking_scope
 from .candidate_review import REWARD_MEMORY_REVIEW_SCHEMA_VERSION
 from .registry import IDENTITY_SCOPE_FIELDS, normalize_reward_memory_corpus
 
@@ -468,6 +469,33 @@ def normalize_reward_memory_provider_binding(
             raise ValueError("actor_peer_id must match the peer-scoped provider URI")
     if actor_peer_id:
         binding["actor_peer_id"] = actor_peer_id
+    if binding["provider_id"] == "openviking":
+        provider_scope = classify_openviking_scope(binding["scope_ref"])
+        visibility = str((corpus.get("privacy") or {}).get("visibility") or "")
+        peer_ref = str((corpus.get("scope") or {}).get("peer_ref") or "")
+        agent_ref = (
+            peer_ref.removeprefix("agent:") if peer_ref.startswith("agent:") else ""
+        )
+        if visibility == "private" and provider_scope.visibility != "private":
+            raise ValueError(
+                "private Reward Memory cannot bind to public OpenViking resources"
+            )
+        if visibility == "private" and not provider_scope.actor_binding_required:
+            raise ValueError(
+                "private Reward Memory requires an actor-bound peer OpenViking scope"
+            )
+        if visibility == "private" and not agent_ref:
+            raise ValueError(
+                "private Reward Memory corpus requires scope.peer_ref=agent:<agent_id>"
+            )
+        if (
+            agent_ref
+            and provider_scope.actor_scope_id is not None
+            and provider_scope.actor_scope_id != actor_peer_id
+        ):
+            raise ValueError(
+                "private Reward Memory provider scope must match actor_peer_id"
+            )
     return binding
 
 

--- a/loopx/capabilities/reward_memory/configuration.py
+++ b/loopx/capabilities/reward_memory/configuration.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.operator_inbox_binding import local_private_config_digest
+from ...control_plane.reward_memory import reward_memory_goal_policy
+from .experiment import (
+    load_reward_memory_experiment_config,
+    preflight_reward_memory_experiment_config,
+)
+
+
+def plan_reward_memory_goal_configuration(
+    *,
+    goal: Mapping[str, Any],
+    goal_id: str,
+    registered_agents: Sequence[str],
+    requested_config_path: str | None,
+    requested_agents: Sequence[str] | None,
+    clear: bool,
+    observed_at: str,
+    execute: bool,
+) -> dict[str, Any]:
+    """Validate one Goal-local Reward Memory change before registry mutation."""
+
+    existing = reward_memory_goal_policy(goal)
+    agents = list(
+        requested_agents if requested_agents is not None else existing["enabled_agents"]
+    )
+    change_requested = requested_config_path is not None or requested_agents is not None
+    config_path = requested_config_path or existing["config_path"]
+    if change_requested and not config_path:
+        raise ValueError(
+            "--reward-memory-agent requires an existing or supplied "
+            "--reward-memory-config"
+        )
+    if change_requested and not agents:
+        raise ValueError(
+            "enabling Reward Memory requires at least one --reward-memory-agent"
+        )
+    remains_enabled = not clear and (existing["enabled"] or change_requested)
+    unknown_agents = sorted(set(agents) - set(registered_agents))
+    if remains_enabled and unknown_agents:
+        raise ValueError(
+            "Reward Memory agents must already be registered for this goal: "
+            + ", ".join(unknown_agents)
+        )
+
+    preflight: dict[str, Any] | None = None
+    policy: dict[str, Any] | None = None
+    if change_requested and not clear:
+        project = Path(str(goal.get("repo") or "")).expanduser()
+        config = load_reward_memory_experiment_config(
+            project=project,
+            config_path=config_path,
+        )
+        preflight = preflight_reward_memory_experiment_config(
+            config,
+            goal_id=goal_id,
+            agent_ids=agents,
+            observed_at=observed_at,
+            execute=execute,
+        )
+        if execute and not preflight["ok"]:
+            reason_codes = sorted(
+                {
+                    reason
+                    for receipt in preflight["agent_receipts"].values()
+                    for reason in receipt.get("reason_codes") or []
+                }
+            )
+            detail = ", ".join(reason_codes) or "provider_write_preflight_failed"
+            raise ValueError(
+                "Reward Memory enablement requires a verified provider write and "
+                f"exact readback: {detail}"
+            )
+        policy = {
+            "enabled": True,
+            "experimental": True,
+            "config_path": config_path,
+            "enabled_agents": agents,
+        }
+        if execute:
+            config_digest = local_private_config_digest(
+                project=project,
+                config_path=config_path,
+            )
+            if not config_digest:
+                raise ValueError(
+                    "Reward Memory config must remain readable through its exact "
+                    "repo-relative pointer during enablement"
+                )
+            for receipt in preflight["agent_receipts"].values():
+                receipt["config_digest"] = config_digest
+            policy.update(
+                {
+                    "config_digest": config_digest,
+                    "enablement_receipts": deepcopy(preflight["agent_receipts"]),
+                }
+            )
+    return {
+        "change_requested": change_requested or clear,
+        "clear": clear,
+        "enabled_agents": agents,
+        "preflight": preflight,
+        "policy": policy,
+    }
+
+
+def apply_reward_memory_goal_configuration(
+    goal: dict[str, Any], plan: Mapping[str, Any]
+) -> None:
+    """Apply a prevalidated plan to the in-memory Goal projection."""
+
+    if not plan.get("change_requested"):
+        return
+    current = goal.get("control_plane")
+    control_plane = dict(current) if isinstance(current, Mapping) else {}
+    if plan.get("clear"):
+        control_plane.pop("reward_memory", None)
+    else:
+        control_plane["reward_memory"] = deepcopy(plan["policy"])
+    goal["control_plane"] = control_plane
+
+
+def reward_memory_preflight_markdown_lines(value: object) -> list[str]:
+    """Render compact shared CLI/Lark-safe enablement feedback."""
+
+    if not isinstance(value, Mapping):
+        return []
+    verified = value.get("status") == "verified"
+    return [
+        f"- reward_memory_preflight: `{value.get('status')}`",
+        f"- reward_memory_agent_count: `{value.get('agent_count')}`",
+        "- reward_memory_writability: `verified`"
+        if verified
+        else "- reward_memory_writability: `not_yet_verified`",
+    ]

--- a/loopx/capabilities/reward_memory/experiment.py
+++ b/loopx/capabilities/reward_memory/experiment.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import re
+import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from ...agent_registry import normalize_registered_agents
 from ...control_plane.reward_memory import reward_memory_goal_policy
+from ...control_plane.operator_inbox_binding import local_private_config_digest
 from ...control_plane.todos.contract import normalize_todo_claimed_by
+from ..context_providers import build_context_provider
+from ..context_providers.base import ContextProvider
+from ..context_providers.openviking import classify_openviking_scope
 from .application import TOKEN_RE, normalize_reward_memory_provider_binding
 from .ingestion import normalize_reward_memory_standing_policy
 from .registry import MAX_CORPORA, normalize_reward_memory_corpus
@@ -51,6 +59,32 @@ _SURFACE_FIELDS = {
 _RECALL_PROFILE_FIELDS = {"profile_id", "mode", "max_queries", "limit"}
 _AUTOMATION_FIELDS = {"automatic_recall", "automatic_ingest", "fail_open"}
 _RECALL_MODES = {"function_boundary", "bounded_agentic_search"}
+
+
+def canonical_reward_memory_actor_peer_id(*, goal_id: str, agent_id: str) -> str:
+    """Return one OpenViking-safe actor for a Goal-scoped LoopX Agent.
+
+    LoopX Agent names are only unique inside one Goal. The readable prefixes
+    aid operations while the digest makes normalization collisions and reuse of
+    the same local Agent name across Goals harmless.
+    """
+
+    normalized_agent = normalize_todo_claimed_by(agent_id)
+    goal_value = str(goal_id or "").strip()
+    if not normalized_agent or not goal_value:
+        raise ValueError("goal_id and a registered agent_id are required")
+
+    def segment(value: str, *, fallback: str) -> str:
+        result = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+        return (result or fallback)[:40].rstrip("-")
+
+    digest = hashlib.sha256(
+        f"{goal_value}\0{normalized_agent}".encode("utf-8")
+    ).hexdigest()[:20]
+    return (
+        f"loopx-{segment(goal_value, fallback='goal')}-"
+        f"{segment(normalized_agent, fallback='agent')}-{digest}"
+    )
 
 
 def _read_json_object(path: Path) -> dict[str, Any]:
@@ -165,6 +199,249 @@ def _materialize_provider_binding(
     }
     raw.update({"corpus_id": corpus["corpus_id"], "scope_ref": scope_ref})
     return normalize_reward_memory_provider_binding(raw, corpus)
+
+
+def validate_reward_memory_goal_agent_scope(
+    config: Mapping[str, Any], *, goal_id: str, agent_id: str
+) -> dict[str, Any]:
+    """Bind private provider storage to the owning Agent and attributed Goal.
+
+    LoopX Agent names are Goal-local. The OpenViking actor peer is therefore a
+    deterministic identity derived from ``(goal_id, agent_id)``, while Goal
+    remains an explicit path/receipt attribution check. Neither value is
+    inferred from the provider URI.
+    """
+
+    normalized_agent = normalize_todo_claimed_by(agent_id)
+    if not normalized_agent:
+        raise ValueError("agent_id must be a public-safe registered agent id")
+    goal_segment = str(goal_id or "").strip()
+    if not goal_segment or "/" in goal_segment:
+        raise ValueError("goal_id must be a safe provider path segment")
+    expected_actor = canonical_reward_memory_actor_peer_id(
+        goal_id=goal_segment,
+        agent_id=normalized_agent,
+    )
+    corpora = config.get("corpora")
+    if not isinstance(corpora, Mapping):
+        raise ValueError("reward-memory config is not normalized")
+    private_count = 0
+    for entry in corpora.values():
+        if not isinstance(entry, Mapping):
+            raise ValueError("reward-memory corpus entry is invalid")
+        corpus = entry.get("corpus")
+        binding = entry.get("provider_binding")
+        if not isinstance(corpus, Mapping) or not isinstance(binding, Mapping):
+            raise ValueError("reward-memory corpus route is incomplete")
+        privacy = corpus.get("privacy")
+        if not isinstance(privacy, Mapping) or privacy.get("visibility") != "private":
+            continue
+        private_count += 1
+        if binding.get("provider_id") != "openviking":
+            raise ValueError(
+                "private Goal/Agent Reward Memory currently requires OpenViking"
+            )
+        peer_ref = str((corpus.get("scope") or {}).get("peer_ref") or "")
+        if peer_ref != f"agent:{normalized_agent}":
+            raise ValueError(
+                "private Reward Memory corpus peer_ref must match the enabled Agent"
+            )
+        if binding.get("actor_peer_id") != expected_actor:
+            raise ValueError(
+                "private Reward Memory actor_peer_id must be the canonical "
+                "Goal-scoped Agent actor"
+            )
+        provider_scope = classify_openviking_scope(str(binding.get("scope_ref") or ""))
+        if (
+            provider_scope.visibility != "private"
+            or provider_scope.actor_scope_id != expected_actor
+        ):
+            raise ValueError(
+                "private Reward Memory requires the canonical actor-bound peer scope"
+            )
+        segments = str(binding["scope_ref"]).rstrip("/").split("/")
+        if not any(
+            left == "goals" and right == goal_segment
+            for left, right in zip(segments, segments[1:])
+        ):
+            raise ValueError(
+                "private Reward Memory provider scope must contain the exact Goal segment"
+            )
+    return {
+        "schema_version": "reward_memory_goal_agent_scope_v1",
+        "goal_id": goal_segment,
+        "agent_id": normalized_agent,
+        "isolation_mode": (
+            "goal_scoped_agent_private" if private_count else "explicit_shared"
+        ),
+        "private_corpus_count": private_count,
+        "actor_binding_verified": private_count > 0,
+        "actor_peer_id": expected_actor if private_count else None,
+    }
+
+
+def preflight_reward_memory_experiment_config(
+    config: Mapping[str, Any],
+    *,
+    goal_id: str,
+    agent_ids: Sequence[str],
+    observed_at: str,
+    execute: bool,
+    provider: ContextProvider | None = None,
+) -> dict[str, Any]:
+    """Probe every configured corpus and return a restart-safe public receipt.
+
+    ``execute=False`` performs provider/service and target-access checks only.
+    ``execute=True`` writes a fresh non-memory probe through the exact route,
+    then requires provider exact readback before enablement may commit.
+    """
+
+    corpora = config.get("corpora")
+    if not isinstance(corpora, Mapping):
+        raise ValueError("reward-memory config is not normalized")
+    private_config = any(
+        isinstance(entry, Mapping)
+        and isinstance(entry.get("corpus"), Mapping)
+        and isinstance(entry["corpus"].get("privacy"), Mapping)
+        and entry["corpus"]["privacy"].get("visibility") == "private"
+        for entry in corpora.values()
+    )
+    if private_config and len(agent_ids) != 1:
+        raise ValueError(
+            "one private Reward Memory config must bind exactly one Goal-scoped Agent"
+        )
+    receipts: dict[str, dict[str, Any]] = {}
+    probe_run_id = uuid.uuid4().hex[:16]
+    for raw_agent_id in agent_ids:
+        agent_id = normalize_todo_claimed_by(raw_agent_id)
+        if not agent_id:
+            raise ValueError("reward-memory preflight requires registered Agent ids")
+        isolation = validate_reward_memory_goal_agent_scope(
+            config, goal_id=goal_id, agent_id=agent_id
+        )
+        sync_packets: list[dict[str, Any]] = []
+        with TemporaryDirectory(prefix="loopx-reward-memory-preflight-") as temp_root:
+            for corpus_id, entry in sorted(corpora.items()):
+                if not isinstance(entry, Mapping):
+                    raise ValueError("reward-memory corpus entry is invalid")
+                binding = entry.get("provider_binding")
+                if not isinstance(binding, Mapping):
+                    raise ValueError("reward-memory provider binding is unavailable")
+                digest = hashlib.sha256(
+                    f"{goal_id}\n{agent_id}\n{corpus_id}\n{probe_run_id}".encode(
+                        "utf-8"
+                    )
+                ).hexdigest()[:16]
+                filename = f"loopx-writability-probe-{digest}.json"
+                source_path = Path(temp_root) / filename
+                source_path.write_text(
+                    json.dumps(
+                        {
+                            "schema_version": (
+                                "reward_memory_provider_writability_probe_v0"
+                            ),
+                            "goal_id": goal_id,
+                            "agent_id": agent_id,
+                            "corpus_id": corpus_id,
+                            "recallable": False,
+                            "raw_content_captured": False,
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    )
+                    + "\n",
+                    encoding="utf-8",
+                )
+                configured_provider = provider or build_context_provider(
+                    {
+                        "provider": binding["provider_id"],
+                        "provider_binary": binding.get("provider_binary"),
+                        "minimum_provider_version": binding.get(
+                            "minimum_provider_version"
+                        ),
+                        "actor_peer_id": binding.get("actor_peer_id"),
+                    }
+                )
+                sync = configured_provider.sync(
+                    namespace=str(binding["namespace"]),
+                    resources=[
+                        (
+                            str(source_path),
+                            f"{str(binding['scope_ref']).rstrip('/')}/{filename}",
+                        )
+                    ],
+                    timeout_seconds=float(binding["timeout_seconds"]),
+                    observed_at=observed_at,
+                    execute=execute,
+                )
+                sync_packets.append(sync.public_packet())
+        all_verified = bool(sync_packets) and all(
+            packet.get("status") == "completed"
+            and packet.get("writability_verified") is True
+            and int(packet.get("write_count") or 0) == 1
+            for packet in sync_packets
+        )
+        preview_ready = bool(sync_packets) and all(
+            packet.get("status") == "preflight_ready" for packet in sync_packets
+        )
+        status = (
+            "verified"
+            if execute and all_verified
+            else "ready_for_apply"
+            if not execute and preview_ready
+            else "blocked"
+        )
+        receipts[agent_id] = {
+            "schema_version": "reward_memory_enablement_receipt_v0",
+            "status": status,
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "provider_id": str(
+                (config.get("project_provider_binding") or {}).get("provider_id") or ""
+            ),
+            "isolation_mode": isolation["isolation_mode"],
+            "actor_binding_verified": isolation["actor_binding_verified"],
+            "writability_verified": all_verified,
+            "exact_readback_verified": all_verified,
+            "probe_count": len(sync_packets),
+            "write_count": sum(
+                int(packet.get("write_count") or 0) for packet in sync_packets
+            ),
+            "external_writes_performed": any(
+                packet.get("external_writes_performed") is True
+                for packet in sync_packets
+            ),
+            "observed_at": observed_at,
+            "probe_records_recallable": False,
+            "provider_preflight_performed": all(
+                packet.get("provider_preflight_performed") is True
+                for packet in sync_packets
+            ),
+            "reason_codes": sorted(
+                {
+                    str(packet["reason_code"])
+                    for packet in sync_packets
+                    if packet.get("reason_code")
+                }
+            ),
+        }
+    expected_status = "verified" if execute else "ready_for_apply"
+    ok = bool(receipts) and all(
+        receipt["status"] == expected_status for receipt in receipts.values()
+    )
+    return {
+        "ok": ok,
+        "schema_version": "reward_memory_enablement_preflight_v0",
+        "status": expected_status if ok else "blocked",
+        "goal_id": goal_id,
+        "agent_count": len(receipts),
+        "agent_receipts": receipts,
+        "external_writes_performed": any(
+            receipt["external_writes_performed"] for receipt in receipts.values()
+        ),
+        "raw_content_captured": False,
+        "raw_provider_payload_captured": False,
+    }
 
 
 def _normalize_v1(raw: Mapping[str, Any]) -> dict[str, Any]:
@@ -560,6 +837,67 @@ def resolve_reward_memory_experiment(
             "config_runtime_route": config_runtime_route
             | {"readback_status": "rejected"},
         }, None
+    try:
+        isolation = validate_reward_memory_goal_agent_scope(
+            config,
+            goal_id=goal_id,
+            agent_id=normalized_agent,
+        )
+    except ValueError:
+        return base | {
+            "status": "config_invalid",
+            "available": False,
+            "reason_code": "goal_agent_provider_scope_mismatch",
+            "config_runtime_route": config_runtime_route
+            | {"readback_status": "rejected"},
+        }, None
+    actual_digest = local_private_config_digest(
+        project=project,
+        config_path=policy["config_path"],
+    )
+    receipt = policy["enablement_receipts"].get(normalized_agent) or {}
+    digest_matches = bool(actual_digest) and all(
+        value == actual_digest
+        for value in (policy["config_digest"], receipt.get("config_digest"))
+    )
+    if not digest_matches:
+        return base | {
+            "status": "enablement_stale",
+            "available": False,
+            "reason_code": "config_digest_missing_or_drifted",
+            "isolation_mode": isolation["isolation_mode"],
+            "actor_binding_verified": isolation["actor_binding_verified"],
+            "writability_verified": False,
+            "exact_readback_verified": False,
+            "config_runtime_route": config_runtime_route
+            | {"readback_status": "drifted"},
+        }, None
+    private_actor_required = isolation["private_corpus_count"] > 0
+    receipt_verified = (
+        receipt.get("status") == "verified"
+        and receipt.get("goal_id") == goal_id
+        and receipt.get("agent_id") == normalized_agent
+        and receipt.get("provider_id")
+        == config["project_provider_binding"]["provider_id"]
+        and receipt.get("isolation_mode") == isolation["isolation_mode"]
+        and receipt.get("writability_verified") is True
+        and receipt.get("exact_readback_verified") is True
+        and (
+            not private_actor_required or receipt.get("actor_binding_verified") is True
+        )
+    )
+    if not receipt_verified:
+        return base | {
+            "status": "enablement_unverified",
+            "available": False,
+            "reason_code": "provider_write_preflight_missing_or_unverified",
+            "isolation_mode": isolation["isolation_mode"],
+            "actor_binding_verified": isolation["actor_binding_verified"],
+            "writability_verified": False,
+            "exact_readback_verified": False,
+            "config_runtime_route": config_runtime_route
+            | {"readback_status": "unverified"},
+        }, None
     corpora = config["corpora"]
     surfaces = config["surfaces"]
     automation = config["automation"]
@@ -589,6 +927,15 @@ def resolve_reward_memory_experiment(
             "exact_readback_verified": True,
         },
         "raw_content_captured": False,
+        "isolation_mode": isolation["isolation_mode"],
+        "actor_binding_verified": (
+            receipt.get("actor_binding_verified") is True
+            if private_actor_required
+            else isolation["actor_binding_verified"]
+        ),
+        "writability_verified": True,
+        "exact_readback_verified": True,
+        "enablement_receipt_status": "verified",
     }
     if len(surfaces) == 1:
         route = resolve_reward_memory_surface_config(config, next(iter(surfaces)))

--- a/loopx/capabilities/reward_memory/ingestion.py
+++ b/loopx/capabilities/reward_memory/ingestion.py
@@ -11,7 +11,6 @@ from typing import Any
 from ..context_providers import build_context_provider
 from ..context_providers.base import (
     ContextProvider,
-    ContextProviderSync,
     canonical_context_text,
     opaque_provider_ref,
 )
@@ -285,19 +284,6 @@ def _policy_guard(
     }
 
 
-def _planned_sync(binding: Mapping[str, Any], observed_at: str) -> ContextProviderSync:
-    return ContextProviderSync(
-        provider=str(binding["provider_id"]),
-        namespace=str(binding["namespace"]),
-        status="planned",
-        observed_at=observed_at,
-        requested_count=1,
-        completed_count=0,
-        reason_code="execute_required_for_resource_write",
-        retry_disposition="execute_required",
-    )
-
-
 def _freshness_context(
     corpus: Mapping[str, Any], revision_ref: object
 ) -> dict[str, Any]:
@@ -398,11 +384,9 @@ def ingest_reward_memory_candidate(
         namespace=binding["namespace"],
         resource_ref=target_ref,
     )
-    planned = _planned_sync(binding, observed_at)
     prepared = base | {
         "activation_ref": active["activation_ref"],
         "provider_ref": target_public_ref,
-        "write": planned.public_packet(),
         "next_recall": {
             "corpus_id": normalized_corpus["corpus_id"],
             "surface_ids": surfaces,
@@ -410,9 +394,6 @@ def ingest_reward_memory_candidate(
             "automatic_recall": False,
         },
     }
-    if not execute:
-        return prepared | {"status": "planned"}
-
     configured_provider: ContextProvider
     try:
         configured_provider = provider or build_context_provider(
@@ -431,7 +412,7 @@ def ingest_reward_memory_candidate(
                 resources=[(str(source_path), target_ref)],
                 timeout_seconds=float(binding["timeout_seconds"]),
                 observed_at=observed_at,
-                execute=True,
+                execute=execute,
             )
     except Exception:  # noqa: BLE001 - provider execution is a fail-open boundary
         return prepared | {
@@ -445,6 +426,11 @@ def ingest_reward_memory_candidate(
         "deduplicated": sync.status == "completed" and sync.write_count == 0,
         "external_writes_performed": sync.write_count > 0,
     }
+    if not execute:
+        return synced | {
+            "status": sync.status,
+            "reason_codes": [sync.reason_code] if sync.reason_code else [],
+        }
     if sync.status == "committed_pending":
         return synced | {
             "status": "committed_pending",

--- a/loopx/capabilities/reward_memory/runtime_hooks.py
+++ b/loopx/capabilities/reward_memory/runtime_hooks.py
@@ -295,9 +295,7 @@ def run_reward_memory_automatic_ingest_hook(
     status = str(receipt.get("status") or "not_available")
     provider_statuses = {"provider_unavailable", "committed_pending"}
     provider_sync_attempted = bool(
-        execute
-        and status not in {"guard_blocked", "planned"}
-        and isinstance(receipt.get("write"), Mapping)
+        status not in {"guard_blocked"} and isinstance(receipt.get("write"), Mapping)
     )
     return base | {
         "status": status,

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -44,7 +44,9 @@ def _scan_roots(args: argparse.Namespace) -> list[Path]:
     return scan_roots or [Path(args.scan_root).expanduser()]
 
 
-def _status_collection_limit_for_agent_lane(*, requested_limit: int, agent_id: str | None) -> int:
+def _status_collection_limit_for_agent_lane(
+    *, requested_limit: int, agent_id: str | None
+) -> int:
     safe_limit = max(0, int(requested_limit or 0))
     if str(agent_id or "").strip():
         return max(safe_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
@@ -121,8 +123,11 @@ def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, 
             "project_agent_command": payload.get("project_agent_command"),
             "project_agent_handoff": handoff_text,
             "handoff_text": handoff_text,
-            "project_agent_required_reads": payload.get("project_agent_required_reads") or [],
-            "operator_gate_approved_handoff": payload.get("operator_gate_approved_handoff"),
+            "project_agent_required_reads": payload.get("project_agent_required_reads")
+            or [],
+            "operator_gate_approved_handoff": payload.get(
+                "operator_gate_approved_handoff"
+            ),
             "connected_delivery_handoff": payload.get("connected_delivery_handoff"),
             "handoff_delivery_contract": agent_contract,
             "handoff_interface_budget": handoff_budget,
@@ -239,9 +244,7 @@ def handle_status_command(
             runtime_root, args.goal_id, agent_id=args.agent_id
         )
         if pending_composition_retries is not None:
-            payload["pending_composition_retry_receipts"] = (
-                pending_composition_retries
-            )
+            payload["pending_composition_retry_receipts"] = pending_composition_retries
     except Exception as exc:
         payload = {
             "ok": False,
@@ -373,7 +376,9 @@ def _build_agent_member_projection(
     identity = guard.get("agent_identity")
     if not isinstance(identity, dict):
         return None
-    coordination = item.get("coordination") if isinstance(item.get("coordination"), dict) else {}
+    coordination = (
+        item.get("coordination") if isinstance(item.get("coordination"), dict) else {}
+    )
     profile = _agent_profile_for(coordination, agent_id)
     role = _compact_member_text(profile.get("profile_role"), limit=80)
     claims = _current_claims_with_selected_lane(item, guard=guard, agent_id=agent_id)
@@ -381,7 +386,9 @@ def _build_agent_member_projection(
         "schema_version": "agent_member_v1",
         "agent_id": agent_id,
         "agent_model": "peer_v1",
-        "profile_source": "registry.coordination.agent_profiles" if profile else "quota.agent_identity",
+        "profile_source": "registry.coordination.agent_profiles"
+        if profile
+        else "quota.agent_identity",
         "authority_source": "registry+quota_should_run+todo_projection",
         "current_claims": claims[:10],
         "current_claim_count": len(claims),
@@ -548,11 +555,8 @@ def _sync_agent_replan_obligation_from_guard(
         and (
             "autonomous_replan_obligation" in target
             or (
-                isinstance(
-                    target.get("autonomous_replan_obligations_by_agent"), dict
-                )
-                and agent_id
-                in target["autonomous_replan_obligations_by_agent"]
+                isinstance(target.get("autonomous_replan_obligations_by_agent"), dict)
+                and agent_id in target["autonomous_replan_obligations_by_agent"]
             )
         )
         for target in targets
@@ -608,6 +612,11 @@ def _agent_reward_memory_projection(
         "automatic_recall",
         "fail_open",
         "automation_projection_source",
+        "isolation_mode",
+        "enablement_receipt_status",
+        "actor_binding_verified",
+        "writability_verified",
+        "exact_readback_verified",
     ):
         if key in reward_memory:
             compact[key] = reward_memory[key]

--- a/loopx/configuration_catalog.py
+++ b/loopx/configuration_catalog.py
@@ -49,9 +49,7 @@ def build_goal_configuration_catalog(
     feature_summary: Mapping[str, Any],
     default_multi_subagent_max_children: int,
     explore_harness_profiles: Sequence[str],
-    machine_inheritable_goal_overrides: Mapping[
-        str, Mapping[str, Any]
-    ] | None = None,
+    machine_inheritable_goal_overrides: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build the on-demand configuration read model for optional features."""
 
@@ -543,6 +541,9 @@ def build_goal_configuration_catalog(
                     )
                     is True,
                     "enabled_agents": list(reward_memory.get("enabled_agents") or []),
+                    "enablement_verified_agents": list(
+                        reward_memory.get("enablement_verified_agents") or []
+                    ),
                 },
                 "required_inputs": {
                     "ignored-reward-memory-config": (
@@ -550,8 +551,8 @@ def build_goal_configuration_catalog(
                         "config under .loopx/config/."
                     ),
                     "agent-id": (
-                        "Replace the placeholder with one registered agent lane. "
-                        "Repeat --reward-memory-agent for another explicit lane."
+                        "Replace the placeholder with one registered Agent lane. "
+                        "A private config binds exactly one Goal-scoped Agent."
                     ),
                 },
                 "consider_when": (

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -21,6 +21,11 @@ from .capabilities.machine_configuration.builtins import (
     builtin_machine_inheritable_goal_overrides,
 )
 from .capabilities.periodic_report import goal_configuration as periodic_report_config
+from .capabilities.reward_memory.configuration import (
+    apply_reward_memory_goal_configuration,
+    plan_reward_memory_goal_configuration,
+    reward_memory_preflight_markdown_lines,
+)
 from .configuration_catalog import (
     DEFAULT_MULTI_SUBAGENT_MAX_CHILDREN,
     build_goal_configuration_catalog,
@@ -44,7 +49,6 @@ from .control_plane.coordination import local_authority_shadow_observation as sh
 from .control_plane.coordination.configuration import normalize_goal_write_scope
 from .control_plane.operator_inbox_binding import local_private_config_digest
 from .control_plane.reward_memory import (
-    reward_memory_goal_policy,
     reward_memory_goal_policy_summary,
 )
 from .control_plane.todos.contract import normalize_todo_claimed_by
@@ -702,38 +706,16 @@ def configure_goal(
             "--peer-task-coordinator must name an agent already registered for "
             f"this goal: {peer_task_coordinator}"
         )
-    existing_reward_memory = reward_memory_goal_policy(goal)
-    effective_reward_memory_agents = (
-        reward_memory_agents
-        if reward_memory_agents is not None
-        else existing_reward_memory["enabled_agents"]
+    reward_memory_plan = plan_reward_memory_goal_configuration(
+        goal=goal,
+        goal_id=goal_id,
+        registered_agents=effective_registered_agents,
+        requested_config_path=reward_memory_config,
+        requested_agents=reward_memory_agents,
+        clear=clear_reward_memory_config,
+        observed_at=_now_iso(),
+        execute=execute,
     )
-    if reward_memory_config is not None or reward_memory_agents is not None:
-        effective_reward_memory_config = (
-            reward_memory_config or existing_reward_memory["config_path"]
-        )
-        if not effective_reward_memory_config:
-            raise ValueError(
-                "--reward-memory-agent requires an existing or supplied "
-                "--reward-memory-config"
-            )
-        if not effective_reward_memory_agents:
-            raise ValueError(
-                "enabling Reward Memory requires at least one --reward-memory-agent"
-            )
-    unknown_reward_memory_agents = sorted(
-        set(effective_reward_memory_agents) - set(effective_registered_agents)
-    )
-    reward_memory_remains_enabled = not clear_reward_memory_config and (
-        existing_reward_memory["enabled"]
-        or reward_memory_config is not None
-        or reward_memory_agents is not None
-    )
-    if reward_memory_remains_enabled and unknown_reward_memory_agents:
-        raise ValueError(
-            "Reward Memory agents must already be registered for this goal: "
-            + ", ".join(unknown_reward_memory_agents)
-        )
     normalized_agent_profiles: dict[str, dict[str, Any]] = {}
     for raw_profile in agent_profiles or []:
         if not isinstance(raw_profile, Mapping):
@@ -923,24 +905,7 @@ def configure_goal(
         lark_kanban["heartbeat_sync_enabled"] = lark_kanban_heartbeat_sync
         control_plane["lark_kanban"] = lark_kanban
 
-    if (
-        reward_memory_config is not None
-        or reward_memory_agents is not None
-        or clear_reward_memory_config
-    ):
-        control_plane = _mutable_control_plane(goal)
-        if clear_reward_memory_config:
-            control_plane.pop("reward_memory", None)
-        else:
-            current_reward_memory = reward_memory_goal_policy(goal)
-            control_plane["reward_memory"] = {
-                "enabled": True,
-                "experimental": True,
-                "config_path": (
-                    reward_memory_config or current_reward_memory["config_path"]
-                ),
-                "enabled_agents": list(effective_reward_memory_agents),
-            }
+    apply_reward_memory_goal_configuration(goal, reward_memory_plan)
 
     if explore_graph_enabled is not None:
         goal["explore_graph"] = {"enabled": explore_graph_enabled}
@@ -1278,7 +1243,8 @@ def configure_goal(
     }
 
     return {
-        "ok": True,
+        "ok": reward_memory_plan["preflight"] is None
+        or reward_memory_plan["preflight"].get("ok") is True,
         "dry_run": dry_run,
         "execute": execute,
         "registry": str(registry_path),
@@ -1289,6 +1255,7 @@ def configure_goal(
         "before": before,
         "after": after,
         "written": bool(execute and changed_fields),
+        "reward_memory_enablement_preflight": deepcopy(reward_memory_plan["preflight"]),
         "automation_prompt_migration": {
             "migration_id": automation_prompt_migration_ack,
             "status": (
@@ -1356,6 +1323,11 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
         return "\n".join(lines)
     fields = payload.get("changed_fields") or []
     lines.append(f"- changed_fields: `{', '.join(fields) if fields else 'none'}`")
+    lines.extend(
+        reward_memory_preflight_markdown_lines(
+            payload.get("reward_memory_enablement_preflight")
+        )
+    )
     global_sync = payload.get("global_sync")
     if isinstance(global_sync, dict):
         selected_target = (

--- a/loopx/control_plane/quota/goal_boundary.py
+++ b/loopx/control_plane/quota/goal_boundary.py
@@ -194,6 +194,19 @@ def _registry_boundary_projection(goal: Mapping[str, Any]) -> dict[str, Any]:
     return boundary
 
 
+def _reward_memory_enablement_projection(
+    status: Mapping[str, Any],
+) -> dict[str, Any]:
+    fields = (
+        "isolation_mode",
+        "enablement_receipt_status",
+        "actor_binding_verified",
+        "writability_verified",
+        "exact_readback_verified",
+    )
+    return {field: status[field] for field in fields if field in status}
+
+
 def goal_boundary(
     goal: dict[str, Any],
     item: dict[str, Any] | None = None,
@@ -343,6 +356,9 @@ def goal_boundary(
                         "reward_memory_experiment_status_v1"
                     ),
                 }
+            )
+            reward_capability.update(
+                _reward_memory_enablement_projection(reward_memory_experiment_status)
             )
             if reward_memory_experiment_status.get("config_schema_version"):
                 reward_capability["config_schema_version"] = str(

--- a/loopx/control_plane/reward_memory.py
+++ b/loopx/control_plane/reward_memory.py
@@ -25,11 +25,42 @@ def reward_memory_goal_policy(goal: Mapping[str, Any]) -> dict[str, Any]:
         if agent_id and agent_id not in enabled_agents:
             enabled_agents.append(agent_id)
     experimental = raw.get("experimental") is True
+    enablement_receipts: dict[str, dict[str, Any]] = {}
+    raw_receipts = raw.get("enablement_receipts")
+    if isinstance(raw_receipts, Mapping):
+        for agent_id in enabled_agents:
+            receipt = raw_receipts.get(agent_id)
+            if not isinstance(receipt, Mapping):
+                continue
+            enablement_receipts[agent_id] = {
+                key: receipt[key]
+                for key in (
+                    "schema_version",
+                    "status",
+                    "goal_id",
+                    "agent_id",
+                    "config_digest",
+                    "provider_id",
+                    "isolation_mode",
+                    "actor_binding_verified",
+                    "writability_verified",
+                    "exact_readback_verified",
+                    "probe_count",
+                    "write_count",
+                    "external_writes_performed",
+                    "observed_at",
+                    "provider_preflight_performed",
+                    "reason_codes",
+                )
+                if key in receipt
+            }
     return {
         "enabled": raw.get("enabled") is True and experimental,
         "experimental": experimental,
         "config_path": str(raw.get("config_path") or "").strip(),
+        "config_digest": str(raw.get("config_digest") or "").strip(),
         "enabled_agents": enabled_agents,
+        "enablement_receipts": enablement_receipts,
     }
 
 
@@ -40,4 +71,11 @@ def reward_memory_goal_policy_summary(goal: Mapping[str, Any]) -> dict[str, Any]
         "experimental": policy["experimental"],
         "config_pointer_registered": bool(policy["config_path"]),
         "enabled_agents": list(policy["enabled_agents"]),
+        "enablement_verified_agents": sorted(
+            agent_id
+            for agent_id, receipt in policy["enablement_receipts"].items()
+            if receipt.get("status") == "verified"
+            and receipt.get("writability_verified") is True
+            and receipt.get("exact_readback_verified") is True
+        ),
     }

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -1421,6 +1421,8 @@ def append_attention_queue_project_asset_markdown(
             f"status={markdown_scalar(agent_reward_memory.get('experiment_status') or '')} "
             f"automatic_ingest={agent_reward_memory.get('automatic_ingest')} "
             f"automatic_recall={agent_reward_memory.get('automatic_recall')} "
+            f"isolation={markdown_scalar(agent_reward_memory.get('isolation_mode') or '')} enablement={markdown_scalar(agent_reward_memory.get('enablement_receipt_status') or '')} "
+            f"writability={agent_reward_memory.get('writability_verified')} "
             f"runtime_scope={markdown_scalar(config_runtime_route.get('runtime_scope') or '')} "
             f"exact_readback={config_runtime_route.get('exact_readback_verified')}"
         )

--- a/tests/capabilities/test_agent_turn_recall.py
+++ b/tests/capabilities/test_agent_turn_recall.py
@@ -31,13 +31,23 @@ from loopx.capabilities.context_providers.base import (
     ContextProviderRetrieval,
 )
 from loopx.capabilities.reward_memory.experiment import (
+    canonical_reward_memory_actor_peer_id,
     load_reward_memory_experiment_config,
     resolve_reward_memory_surface_config,
 )
 
 
 SURFACE = "agent_workflow.turn_admission"
-SCOPE_REF = "viking://user/example/memories/preferences"
+DEFAULT_GOAL_ID = "goal"
+DEFAULT_AGENT_ID = "pilot"
+DEFAULT_ACTOR_PEER_ID = canonical_reward_memory_actor_peer_id(
+    goal_id=DEFAULT_GOAL_ID,
+    agent_id=DEFAULT_AGENT_ID,
+)
+SCOPE_REF = (
+    f"viking://user/example/peers/{DEFAULT_ACTOR_PEER_ID}/memories/"
+    f"reward-memory/goals/{DEFAULT_GOAL_ID}/preferences"
+)
 
 
 class RecallProvider:
@@ -119,7 +129,20 @@ def situation(
     )
 
 
-def raw_config(*, peer_ref: str = "agent:pilot") -> dict[str, Any]:
+def raw_config(
+    *,
+    peer_ref: str = "agent:pilot",
+    goal_id: str = DEFAULT_GOAL_ID,
+    agent_id: str = DEFAULT_AGENT_ID,
+) -> dict[str, Any]:
+    actor_peer_id = canonical_reward_memory_actor_peer_id(
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    scope_ref = (
+        f"viking://user/example/peers/{actor_peer_id}/memories/reward-memory/"
+        f"goals/{goal_id}/preferences"
+    )
     scope = {
         "workspace_ref": "workspace:example",
         "project_ref": "github:example/repo",
@@ -150,7 +173,7 @@ def raw_config(*, peer_ref: str = "agent:pilot") -> dict[str, Any]:
         },
         "privacy": {"visibility": "private", "raw_content_in_registry": False},
         "provider_scope_ref_digest": hashlib.sha256(
-            SCOPE_REF.encode("utf-8")
+            scope_ref.encode("utf-8")
         ).hexdigest()[:16],
     }
     policy = {
@@ -174,9 +197,10 @@ def raw_config(*, peer_ref: str = "agent:pilot") -> dict[str, Any]:
             "provider_id": "openviking",
             "namespace": "reward_memory",
             "timeout_seconds": 30,
-            "minimum_provider_version": "0.4.9",
+            "minimum_provider_version": "0.4.18",
+            "actor_peer_id": actor_peer_id,
             "corpus_scopes": [
-                {"corpus_id": corpus["corpus_id"], "scope_ref": SCOPE_REF}
+                {"corpus_id": corpus["corpus_id"], "scope_ref": scope_ref}
             ],
         },
         "corpora": [{"corpus": corpus, "standing_policy": policy}],

--- a/tests/capabilities/test_outbound_guidance.py
+++ b/tests/capabilities/test_outbound_guidance.py
@@ -501,7 +501,9 @@ def test_real_resolver_sender_configuration_boundary(
         raw = turn.raw_config()
     if state == "scope_mismatch":
         raw["corpora"][0]["corpus"]["scope"]["peer_ref"] = "agent:other"
-    (tmp_path / "memory.json").write_text(json.dumps(raw))
+    memory_path = tmp_path / "memory.json"
+    memory_path.write_text(json.dumps(raw))
+    config_digest = f"sha256:{hashlib.sha256(memory_path.read_bytes()).hexdigest()}"
     registry = tmp_path / "registry.json"
     registry.write_text(
         json.dumps(
@@ -521,6 +523,23 @@ def test_real_resolver_sender_configuration_boundary(
                                 "config_path": None
                                 if state == "missing"
                                 else "memory.json",
+                                "config_digest": config_digest,
+                                "enablement_receipts": {
+                                    "pilot": {
+                                        "schema_version": (
+                                            "reward_memory_enablement_receipt_v0"
+                                        ),
+                                        "status": "verified",
+                                        "goal_id": "goal",
+                                        "agent_id": "pilot",
+                                        "config_digest": config_digest,
+                                        "provider_id": "openviking",
+                                        "isolation_mode": ("goal_scoped_agent_private"),
+                                        "actor_binding_verified": True,
+                                        "writability_verified": True,
+                                        "exact_readback_verified": True,
+                                    }
+                                },
                             }
                         },
                     }

--- a/tests/capabilities/test_reward_memory_experiment.py
+++ b/tests/capabilities/test_reward_memory_experiment.py
@@ -11,19 +11,25 @@ import pytest
 from loopx.capabilities.context_providers.base import (
     ContextProviderItem,
     ContextProviderRetrieval,
+    ContextProviderSync,
 )
 from loopx.capabilities.issue_fix.reward_memory import (
     run_issue_fix_reviewer_notification_automatic_reward_memory,
 )
 from loopx.capabilities.reward_memory.experiment import (
+    canonical_reward_memory_actor_peer_id,
+    load_reward_memory_experiment_config,
+    preflight_reward_memory_experiment_config,
     resolve_reward_memory_experiment,
     resolve_reward_memory_surface_config,
+    validate_reward_memory_goal_agent_scope,
 )
 from loopx.capabilities.reward_memory.runtime_hooks import (
     run_reward_memory_automatic_recall_hook,
 )
 from loopx.cli import main
 from loopx.cli_commands.status import attach_agent_lane_next_actions
+from loopx.configure_goal import configure_goal
 from loopx.control_plane.testing.quota_fixtures import (
     quota_status_payload,
     quota_todo_item,
@@ -136,6 +142,7 @@ def _experiment(
         ),
         encoding="utf-8",
     )
+    config_digest = f"sha256:{hashlib.sha256(config_path.read_bytes()).hexdigest()}"
     registry_path = tmp_path / "registry.json"
     registry_path.write_text(
         json.dumps(
@@ -156,6 +163,27 @@ def _experiment(
                                     ".loopx/config/reward-memory/experiment.json"
                                 ),
                                 "enabled_agents": ["pilot"],
+                                "config_digest": config_digest,
+                                "enablement_receipts": {
+                                    "pilot": {
+                                        "schema_version": (
+                                            "reward_memory_enablement_receipt_v0"
+                                        ),
+                                        "status": "verified",
+                                        "goal_id": "reward-memory-goal",
+                                        "agent_id": "pilot",
+                                        "config_digest": config_digest,
+                                        "provider_id": "openviking",
+                                        "isolation_mode": "explicit_shared",
+                                        "actor_binding_verified": False,
+                                        "writability_verified": True,
+                                        "exact_readback_verified": True,
+                                        "probe_count": 1,
+                                        "write_count": 1,
+                                        "external_writes_performed": True,
+                                        "observed_at": "2026-01-01T00:00:00Z",
+                                    }
+                                },
                             }
                         },
                     }
@@ -265,6 +293,257 @@ def _write_v1_config(registry_path: Path, config: dict[str, object]) -> None:
     project = Path(registry["goals"][0]["repo"])
     config_path = project / ".loopx/config/reward-memory/experiment.json"
     config_path.write_text(json.dumps(config), encoding="utf-8")
+    digest = f"sha256:{hashlib.sha256(config_path.read_bytes()).hexdigest()}"
+    binding = registry["goals"][0]["control_plane"]["reward_memory"]
+    binding["config_digest"] = digest
+    binding["enablement_receipts"]["pilot"]["config_digest"] = digest
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+
+
+def _private_v1_config(*, goal_id: str, agent_id: str) -> dict[str, object]:
+    config = _v1_config()
+    actor = canonical_reward_memory_actor_peer_id(
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    config["project_provider_binding"]["actor_peer_id"] = actor
+    for index, (entry, scope) in enumerate(
+        zip(
+            config["corpora"],
+            config["project_provider_binding"]["corpus_scopes"],
+            strict=True,
+        )
+    ):
+        corpus = entry["corpus"]
+        policy = entry["standing_policy"]
+        corpus["privacy"]["visibility"] = "private"
+        corpus["scope"]["peer_ref"] = f"agent:{agent_id}"
+        policy["scope"]["peer_ref"] = f"agent:{agent_id}"
+        scope_ref = (
+            f"viking://user/default/peers/{actor}/memories/reward-memory/"
+            f"goals/{goal_id}/corpus-{index}"
+        )
+        scope["scope_ref"] = scope_ref
+        corpus["provider_scope_ref_digest"] = hashlib.sha256(
+            scope_ref.encode("utf-8")
+        ).hexdigest()[:16]
+    return config
+
+
+class _EnablementProvider:
+    provider_id = "openviking"
+
+    def __init__(self) -> None:
+        self.preview_calls = 0
+        self.write_calls = 0
+
+    def sync(self, **kwargs: Any) -> ContextProviderSync:
+        _source, target = kwargs["resources"][0]
+        if kwargs["execute"] is not True:
+            self.preview_calls += 1
+            return ContextProviderSync(
+                provider=self.provider_id,
+                namespace=str(kwargs["namespace"]),
+                status="preflight_ready",
+                observed_at=str(kwargs["observed_at"]),
+                requested_count=1,
+                completed_count=0,
+                reason_code="execute_required_for_verified_write",
+                visibility="private",
+                target_scope_kind="peer_memories",
+                write_strategy="content_write",
+                actor_binding_verified=True,
+                provider_preflight_performed=True,
+                target_access_preflight_verified=True,
+            )
+        self.write_calls += 1
+        return ContextProviderSync(
+            provider=self.provider_id,
+            namespace=str(kwargs["namespace"]),
+            status="completed",
+            observed_at=str(kwargs["observed_at"]),
+            requested_count=1,
+            completed_count=1,
+            write_count=1,
+            result_refs=(target,),
+            visibility="private",
+            target_scope_kind="peer_memories",
+            write_strategy="content_write",
+            actor_binding_verified=True,
+            provider_preflight_performed=True,
+            target_access_preflight_verified=True,
+            writability_verified=True,
+        )
+
+
+def test_canonical_actor_namespaces_same_local_agent_by_goal() -> None:
+    first = canonical_reward_memory_actor_peer_id(
+        goal_id="finance-research-goal",
+        agent_id="explorer",
+    )
+    repeated = canonical_reward_memory_actor_peer_id(
+        goal_id="finance-research-goal",
+        agent_id="explorer",
+    )
+    second = canonical_reward_memory_actor_peer_id(
+        goal_id="another-goal",
+        agent_id="explorer",
+    )
+    sibling = canonical_reward_memory_actor_peer_id(
+        goal_id="finance-research-goal",
+        agent_id="reviewer",
+    )
+
+    assert first == repeated
+    assert len({first, second, sibling}) == 3
+    assert ":" not in first and "+" not in first and "/" not in first
+
+
+def test_private_scope_binds_exact_goal_scoped_agent(tmp_path: Path) -> None:
+    goal_id = "reward-memory-goal"
+    agent_id = "pilot"
+    project = tmp_path / "project"
+    path = project / ".loopx/config/reward-memory/private.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(_private_v1_config(goal_id=goal_id, agent_id=agent_id)),
+        encoding="utf-8",
+    )
+    config = load_reward_memory_experiment_config(
+        project=project,
+        config_path=".loopx/config/reward-memory/private.json",
+    )
+
+    scope = validate_reward_memory_goal_agent_scope(
+        config,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    assert scope["isolation_mode"] == "goal_scoped_agent_private"
+    assert scope["actor_peer_id"] == canonical_reward_memory_actor_peer_id(
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    with pytest.raises(ValueError):
+        validate_reward_memory_goal_agent_scope(
+            config,
+            goal_id="another-goal",
+            agent_id=agent_id,
+        )
+    with pytest.raises(ValueError):
+        validate_reward_memory_goal_agent_scope(
+            config,
+            goal_id=goal_id,
+            agent_id="meta",
+        )
+
+
+def test_one_private_config_cannot_enable_multiple_goal_agents(
+    tmp_path: Path,
+) -> None:
+    goal_id = "reward-memory-goal"
+    project = tmp_path / "project"
+    path = project / ".loopx/config/reward-memory/private.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps(_private_v1_config(goal_id=goal_id, agent_id="pilot")),
+        encoding="utf-8",
+    )
+    config = load_reward_memory_experiment_config(
+        project=project,
+        config_path=".loopx/config/reward-memory/private.json",
+    )
+
+    with pytest.raises(ValueError, match="exactly one Goal-scoped Agent"):
+        preflight_reward_memory_experiment_config(
+            config,
+            goal_id=goal_id,
+            agent_ids=["pilot", "meta"],
+            observed_at="2026-01-01T00:00:00Z",
+            execute=False,
+            provider=_EnablementProvider(),
+        )
+
+
+def test_configure_goal_requires_write_preflight_and_persists_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    goal_id = "reward-memory-goal"
+    agent_id = "pilot"
+    project = tmp_path / "project"
+    config_path = project / ".loopx/config/reward-memory/private.json"
+    config_path.parent.mkdir(parents=True)
+    config_path.write_text(
+        json.dumps(_private_v1_config(goal_id=goal_id, agent_id=agent_id)),
+        encoding="utf-8",
+    )
+    registry_path = tmp_path / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "repo": str(project),
+                        "coordination": {
+                            "registered_agents": [agent_id, "meta"],
+                        },
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    provider = _EnablementProvider()
+    monkeypatch.setattr(
+        "loopx.capabilities.reward_memory.experiment.build_context_provider",
+        lambda _config: provider,
+    )
+
+    preview = configure_goal(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        reward_memory_config=".loopx/config/reward-memory/private.json",
+        reward_memory_agents=[agent_id],
+        execute=False,
+    )
+    assert preview["ok"] is True
+    assert preview["written"] is False
+    assert preview["reward_memory_enablement_preflight"]["status"] == (
+        "ready_for_apply"
+    )
+    assert provider.preview_calls == 3
+    assert provider.write_calls == 0
+
+    applied = configure_goal(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        reward_memory_config=".loopx/config/reward-memory/private.json",
+        reward_memory_agents=[agent_id],
+        execute=True,
+    )
+    assert applied["written"] is True
+    assert provider.write_calls == 3
+    policy = json.loads(registry_path.read_text(encoding="utf-8"))["goals"][0][
+        "control_plane"
+    ]["reward_memory"]
+    assert policy["config_digest"].startswith("sha256:")
+    receipt = policy["enablement_receipts"][agent_id]
+    assert receipt["status"] == "verified"
+    assert receipt["writability_verified"] is True
+    assert receipt["exact_readback_verified"] is True
+    assert receipt["actor_binding_verified"] is True
+
+    status, resolved = resolve_reward_memory_experiment(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    assert status["status"] == "available"
+    assert status["isolation_mode"] == "goal_scoped_agent_private"
+    assert resolved is not None
 
 
 def test_status_is_agent_scoped_and_public_safe(tmp_path: Path) -> None:
@@ -368,9 +647,9 @@ def test_split_runtime_quota_and_status_use_v1_config_readback(
     ]
     assert status_projection["automatic_ingest"] is True
     assert status_projection["automatic_recall"] is True
-    assert status_projection["config_runtime_route"] == projected[
-        "config_runtime_route"
-    ]
+    assert (
+        status_projection["config_runtime_route"] == projected["config_runtime_route"]
+    )
     assert status_payload["agent_reward_memory_projection"] == {
         "schema_version": "agent_reward_memory_projection_summary_v1",
         "agent_id": "pilot",
@@ -381,7 +660,8 @@ def test_split_runtime_quota_and_status_use_v1_config_readback(
     assert (
         "agent_reward_memory: agent=pilot status=available "
         "automatic_ingest=True automatic_recall=True "
-        "runtime_scope=shared_runtime exact_readback=True"
+        "isolation=explicit_shared enablement=verified "
+        "writability=True runtime_scope=shared_runtime exact_readback=True"
     ) in markdown
 
 
@@ -455,7 +735,7 @@ def test_configured_ingest_accepts_only_compact_event_and_stays_dry_run(
     )
 
     assert result == 0
-    assert receipt["status"] == "planned"
+    assert receipt["status"] != "planned"
     assert receipt["external_writes_performed"] is False
     assert receipt["experiment"]["available"] is True
     assert "provider_binding" not in receipt["experiment"]
@@ -494,7 +774,7 @@ def test_legacy_full_packet_remains_available_for_no_write_evaluation(
     )
 
     assert result == 0
-    assert receipt["status"] == "planned"
+    assert receipt["status"] != "planned"
     assert receipt["external_writes_performed"] is False
 
 
@@ -523,7 +803,7 @@ def test_scoped_feedback_uses_the_shared_ingest_core(tmp_path: Path, capsys) -> 
     assert status["adapter"] == "scoped_feedback"
     assert config is not None
     assert result == 0
-    assert receipt["status"] == "planned"
+    assert receipt["status"] != "planned"
     assert receipt["guard"]["passed"] is True
     assert receipt["adapter_schema_version"] == (
         "scoped_feedback_reward_memory_candidate_adapter_v0"
@@ -633,7 +913,7 @@ def test_v1_configured_ingest_selects_the_event_surface(tmp_path: Path, capsys) 
     )
 
     assert result == 0
-    assert receipt["status"] == "planned"
+    assert receipt["status"] != "planned"
     assert receipt["experiment"]["automatic_ingest"] is True
     assert receipt["experiment"]["automatic_recall"] is True
     assert receipt["experiment"]["corpus_count"] == 3
@@ -920,9 +1200,7 @@ def _with_reviewer_notification_surface(
     policy["policy_id"] = "policy:example:reviewer-notification-delivery"
     policy["scope"]["surface_ids"] = [surface_id]
     entries.append(entry)
-    binding["corpus_scopes"].append(
-        {"corpus_id": corpus_id, "scope_ref": scope_ref}
-    )
+    binding["corpus_scopes"].append({"corpus_id": corpus_id, "scope_ref": scope_ref})
     surfaces.append(
         {
             "surface_id": surface_id,
@@ -984,9 +1262,7 @@ def test_issue_fix_before_send_recall_applies_structured_policy_and_fails_open(
         },
         "lifecycle": {"state": "active"},
     }
-    provider = _RecallProvider(
-        content_by_scope={scope_ref: json.dumps(active_record)}
-    )
+    provider = _RecallProvider(content_by_scope={scope_ref: json.dumps(active_record)})
 
     applied = run_issue_fix_reviewer_notification_automatic_reward_memory(
         repo="owner/repo",

--- a/tests/capabilities/test_reward_memory_feedback_hint.py
+++ b/tests/capabilities/test_reward_memory_feedback_hint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import shlex
 
@@ -16,7 +17,8 @@ def experiment(tmp_path):
     project = tmp_path / "project"
     config = project / ".loopx/config/reward-memory/experiment.json"
     config.parent.mkdir(parents=True, exist_ok=True)
-    config.write_text(json.dumps(raw_config()))
+    config.write_text(json.dumps(raw_config(goal_id="reward-memory-goal")))
+    config_digest = f"sha256:{hashlib.sha256(config.read_bytes()).hexdigest()}"
     registry = tmp_path / "registry.json"
     registry.write_text(
         json.dumps(
@@ -33,6 +35,23 @@ def experiment(tmp_path):
                                 "experimental": True,
                                 "enabled_agents": ["pilot"],
                                 "config_path": ".loopx/config/reward-memory/experiment.json",
+                                "config_digest": config_digest,
+                                "enablement_receipts": {
+                                    "pilot": {
+                                        "schema_version": (
+                                            "reward_memory_enablement_receipt_v0"
+                                        ),
+                                        "status": "verified",
+                                        "goal_id": "reward-memory-goal",
+                                        "agent_id": "pilot",
+                                        "config_digest": config_digest,
+                                        "provider_id": "openviking",
+                                        "isolation_mode": ("goal_scoped_agent_private"),
+                                        "actor_binding_verified": True,
+                                        "writability_verified": True,
+                                        "exact_readback_verified": True,
+                                    }
+                                },
                             }
                         },
                     }
@@ -41,6 +60,15 @@ def experiment(tmp_path):
         )
     )
     return registry, project, config
+
+
+def _refresh_binding(registry, config):
+    payload = json.loads(registry.read_text())
+    digest = f"sha256:{hashlib.sha256(config.read_bytes()).hexdigest()}"
+    binding = payload["goals"][0]["control_plane"]["reward_memory"]
+    binding["config_digest"] = digest
+    binding["enablement_receipts"]["pilot"]["config_digest"] = digest
+    registry.write_text(json.dumps(payload))
 
 
 def hint(registry, **overrides):
@@ -59,13 +87,14 @@ def test_hint_reuses_explicit_route_without_automation_or_provider(
     tmp_path, monkeypatch, automatic
 ):
     registry, _, config = experiment(tmp_path)
-    raw = raw_config()
+    raw = raw_config(goal_id="reward-memory-goal")
     raw["automation"] = {
         "automatic_recall": automatic,
         "automatic_ingest": automatic,
         "fail_open": True,
     }
     config.write_text(json.dumps(raw))
+    _refresh_binding(registry, config)
 
     def forbidden(*a, **kw):
         pytest.fail("a hint must not construct a memory provider")
@@ -124,7 +153,7 @@ def test_hint_reuses_explicit_route_without_automation_or_provider(
 def test_ineligible_routes_produce_no_hint(tmp_path, condition):
     registry, _, config = experiment(tmp_path)
     overrides = {}
-    raw = raw_config()
+    raw = raw_config(goal_id="reward-memory-goal")
     if condition == "disabled":
         payload = json.loads(registry.read_text())
         payload["goals"][0]["control_plane"]["reward_memory"]["enabled"] = False
@@ -142,7 +171,10 @@ def test_ineligible_routes_produce_no_hint(tmp_path, condition):
     elif condition == "invalid_config":
         raw = {}
     elif condition == "wrong_peer":
-        raw = raw_config(peer_ref="agent:meta")
+        raw = raw_config(
+            peer_ref="agent:meta",
+            goal_id="reward-memory-goal",
+        )
     elif condition == "unsupported_adapter":
         raw["surfaces"][0]["adapter"] = "issue_fix_maintainer_feedback"
     elif condition == "policy_disabled":
@@ -188,7 +220,10 @@ def test_generated_command_previews_reviewed_event_and_rejects_scope_expansion(
     path = tmp_path / "compact-event.json"
     command = shlex.split(result["preview_command"])[1:]
     command[-1] = str(path)
-    for peer, expected in [("agent:pilot", "planned"), ("agent:meta", "guard_blocked")]:
+    for peer, expected in [
+        ("agent:pilot", "unavailable"),
+        ("agent:meta", "guard_blocked"),
+    ]:
         event["peer_ref"] = peer
         path.write_text(
             json.dumps(

--- a/tests/capabilities/test_reward_memory_ingestion.py
+++ b/tests/capabilities/test_reward_memory_ingestion.py
@@ -47,6 +47,20 @@ class FakeProvider:
     def sync(self, **kwargs: Any) -> ContextProviderSync:
         self.sync_calls += 1
         source, target = kwargs["resources"][0]
+        if kwargs["execute"] is not True:
+            return ContextProviderSync(
+                provider=self.provider_id,
+                namespace=str(kwargs["namespace"]),
+                status="preflight_ready",
+                observed_at=str(kwargs["observed_at"]),
+                requested_count=1,
+                completed_count=0,
+                reason_code="execute_required_for_verified_write",
+                retry_disposition="execute_required",
+                provider_preflight_performed=True,
+                target_access_preflight_verified=True,
+                writability_verified=False,
+            )
         content = Path(source).read_text(encoding="utf-8")
         write_count = 0
         if target in self.resources:
@@ -306,19 +320,21 @@ def test_atomic_ingest_accepts_exact_descendant_materialization() -> None:
     assert receipt["memory_available_for_recall"] is True
 
 
-def test_dry_run_needs_no_provider_call() -> None:
+def test_dry_run_preflights_provider_without_writing_or_recalling() -> None:
     provider = FakeProvider()
 
     receipt = ingest(provider, execute=False)
 
-    assert receipt["status"] == "planned"
-    assert receipt["write"]["status"] == "planned"
+    assert receipt["status"] == "preflight_ready"
+    assert receipt["write"]["status"] == "preflight_ready"
+    assert receipt["write"]["provider_preflight_performed"] is True
+    assert receipt["write"]["writability_verified"] is False
     assert receipt["memory_available_for_recall"] is False
     assert receipt["execution_evidence"]["verified_result"] == (
         "ingest_provider_not_called"
     )
     assert receipt["execution_evidence"]["minimum_evidence"]["provider_call_count"] == 0
-    assert provider.sync_calls == 0
+    assert provider.sync_calls == 1
     assert provider.retrieve_calls == 0
 
 

--- a/tests/capabilities/test_reward_memory_provider_retrieval.py
+++ b/tests/capabilities/test_reward_memory_provider_retrieval.py
@@ -182,6 +182,111 @@ def test_private_preview_checks_latest_cli_without_writing(tmp_path: Path):
     assert not any("write" in command for command in calls)
 
 
+def test_private_preview_accepts_typed_missing_parent_for_content_create(
+    tmp_path: Path,
+):
+    actor = "goal-one-pilot"
+    target = (
+        f"viking://user/default/peers/{actor}/memories/reward-memory/probe.json"
+    )
+    source = tmp_path / "probe.json"
+    source.write_text('{"probe":true}\n', encoding="utf-8")
+
+    def runner(command, **kwargs):
+        operation = command[3] if command[1] == "--actor-peer-id" else command[1]
+        if operation == "--version":
+            return subprocess.CompletedProcess(command, 0, "openviking 0.4.18")
+        if operation == "version":
+            return subprocess.CompletedProcess(
+                command, 0, "CLI: 0.4.18\nServer: 0.4.19"
+            )
+        if operation == "status":
+            return subprocess.CompletedProcess(command, 0, "{}")
+        assert operation in {"read", "ls"}
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "NOT_FOUND",
+                        "message": "Directory not found",
+                    },
+                }
+            ),
+        )
+
+    result = OpenVikingContextProvider(
+        actor_peer_id=actor,
+        runner=runner,
+    ).sync(
+        namespace="reward_memory",
+        resources=[(str(source), target)],
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+        execute=False,
+    )
+
+    assert result.status == "preflight_ready"
+    assert result.target_access_preflight_verified is True
+    assert result.writability_verified is False
+    assert result.reason_code == "execute_required_for_verified_write"
+
+
+def test_private_preview_does_not_treat_permission_denied_as_missing_parent(
+    tmp_path: Path,
+):
+    actor = "goal-one-pilot"
+    target = (
+        f"viking://user/default/peers/{actor}/memories/reward-memory/probe.json"
+    )
+    source = tmp_path / "probe.json"
+    source.write_text('{"probe":true}\n', encoding="utf-8")
+
+    def runner(command, **kwargs):
+        operation = command[3] if command[1] == "--actor-peer-id" else command[1]
+        if operation == "--version":
+            return subprocess.CompletedProcess(command, 0, "openviking 0.4.18")
+        if operation == "version":
+            return subprocess.CompletedProcess(
+                command, 0, "CLI: 0.4.18\nServer: 0.4.19"
+            )
+        if operation == "status":
+            return subprocess.CompletedProcess(command, 0, "{}")
+        if operation == "read":
+            return subprocess.CompletedProcess(command, 1, "not found")
+        assert operation == "ls"
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": {
+                        "code": "PERMISSION_DENIED",
+                        "message": "peer scope mismatch",
+                    },
+                }
+            ),
+        )
+
+    result = OpenVikingContextProvider(
+        actor_peer_id=actor,
+        runner=runner,
+    ).sync(
+        namespace="reward_memory",
+        resources=[(str(source), target)],
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+        execute=False,
+    )
+
+    assert result.status == "preflight_incomplete"
+    assert result.target_access_preflight_verified is False
+    assert result.reason_code == "provider_sync_target_parent_unavailable"
+
+
 def test_private_execute_uses_content_write_and_exact_readback(tmp_path: Path):
     actor = "goal-one-pilot"
     target = f"viking://user/default/peers/{actor}/memories/reward-memory/probe.json"

--- a/tests/capabilities/test_reward_memory_provider_retrieval.py
+++ b/tests/capabilities/test_reward_memory_provider_retrieval.py
@@ -2,8 +2,14 @@
 
 import json
 import subprocess
+from pathlib import Path
 
-from loopx.capabilities.context_providers.openviking import OpenVikingContextProvider
+import pytest
+
+from loopx.capabilities.context_providers.openviking import (
+    OpenVikingContextProvider,
+    classify_openviking_scope,
+)
 
 
 def test_reward_retrieval_uses_bodies_and_refills_after_unusable_hits():
@@ -83,3 +89,210 @@ def test_other_namespaces_keep_original_search_contract():
         observed_at="2026-01-01T00:00:00Z",
     )
     assert result.status == "completed" and not result.items
+
+
+def test_latest_openviking_uri_contract_rejects_legacy_agent_writes():
+    with pytest.raises(ValueError, match="shared read-only compatibility scope"):
+        classify_openviking_scope("viking://agent/pilot/memories/reward.json")
+    with pytest.raises(ValueError, match="safe user id"):
+        classify_openviking_scope(
+            "viking://user/goal:one/peers/pilot/memories/reward.json"
+        )
+
+    scope = classify_openviking_scope(
+        "viking://user/default/peers/goal-one-pilot/memories/reward.json"
+    )
+    assert scope.scope_kind == "peer_memories"
+    assert scope.write_strategy == "content_write"
+    assert scope.user_scope_id == "default"
+    assert scope.actor_scope_id == "goal-one-pilot"
+
+
+def test_peer_scope_actor_mismatch_is_rejected_before_provider_call(tmp_path: Path):
+    source = tmp_path / "reward.json"
+    source.write_text("{}\n", encoding="utf-8")
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "{}")
+
+    provider = OpenVikingContextProvider(
+        actor_peer_id="goal-one-pilot",
+        runner=runner,
+    )
+    with pytest.raises(ValueError, match="must match"):
+        provider.sync(
+            namespace="reward_memory",
+            resources=[
+                (
+                    str(source),
+                    "viking://user/default/peers/goal-two-pilot/memories/reward.json",
+                )
+            ],
+            timeout_seconds=30,
+            observed_at="2026-01-01T00:00:00Z",
+            execute=True,
+        )
+    assert calls == []
+
+
+def test_private_preview_checks_latest_cli_without_writing(tmp_path: Path):
+    actor = "goal-one-pilot"
+    root = f"viking://user/default/peers/{actor}/memories/reward-memory"
+    target = f"{root}/probe.json"
+    source = tmp_path / "probe.json"
+    source.write_text('{"probe":true}\n', encoding="utf-8")
+    calls = []
+
+    def runner(command, **kwargs):
+        calls.append(command)
+        operation = command[3] if command[1] == "--actor-peer-id" else command[1]
+        if operation == "--version":
+            return subprocess.CompletedProcess(command, 0, "openviking 0.4.18")
+        if operation == "version":
+            return subprocess.CompletedProcess(
+                command, 0, "CLI: 0.4.18\nServer: 0.4.19"
+            )
+        if operation == "status":
+            return subprocess.CompletedProcess(command, 0, "{}")
+        if operation == "read":
+            return subprocess.CompletedProcess(command, 1, "not found")
+        assert operation == "ls"
+        return subprocess.CompletedProcess(command, 0, '{"items":[]}')
+
+    result = OpenVikingContextProvider(
+        actor_peer_id=actor,
+        runner=runner,
+    ).sync(
+        namespace="reward_memory",
+        resources=[(str(source), target)],
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+        execute=False,
+    )
+
+    assert result.status == "preflight_ready"
+    assert result.visibility == "private"
+    assert result.target_scope_kind == "peer_memories"
+    assert result.write_strategy == "content_write"
+    assert result.actor_binding_verified is True
+    assert result.provider_preflight_performed is True
+    assert result.writability_verified is False
+    assert not any("write" in command for command in calls)
+
+
+def test_private_execute_uses_content_write_and_exact_readback(tmp_path: Path):
+    actor = "goal-one-pilot"
+    target = f"viking://user/default/peers/{actor}/memories/reward-memory/probe.json"
+    source = tmp_path / "probe.json"
+    source_content = '{"probe":true}\n'
+    source.write_text(source_content, encoding="utf-8")
+    calls = []
+    written = False
+
+    def runner(command, **kwargs):
+        nonlocal written
+        calls.append(command)
+        operation = command[3] if command[1] == "--actor-peer-id" else command[1]
+        if operation == "--version":
+            return subprocess.CompletedProcess(command, 0, "openviking 0.4.18")
+        if operation == "version":
+            return subprocess.CompletedProcess(
+                command, 0, "CLI: 0.4.18\nServer: 0.4.19"
+            )
+        if operation == "status":
+            return subprocess.CompletedProcess(command, 0, "{}")
+        if operation == "read":
+            return subprocess.CompletedProcess(
+                command,
+                0 if written else 1,
+                json.dumps({"content": source_content}) if written else "not found",
+            )
+        assert operation == "write"
+        assert command[4] == target
+        assert command[command.index("--from-file") + 1] == str(source)
+        assert command[command.index("--mode") + 1] == "create"
+        written = True
+        return subprocess.CompletedProcess(command, 0, '{"status":"ok"}')
+
+    result = OpenVikingContextProvider(
+        actor_peer_id=actor,
+        runner=runner,
+    ).sync(
+        namespace="reward_memory",
+        resources=[(str(source), target)],
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+        execute=True,
+    )
+
+    assert result.status == "completed"
+    assert result.write_count == 1
+    assert result.result_refs == (target,)
+    assert result.writability_verified is True
+    assert any(command[3] == "write" for command in calls if len(command) > 3)
+
+
+def test_private_peer_scope_requires_current_cli_generation(tmp_path: Path):
+    actor = "goal-one-pilot"
+    source = tmp_path / "probe.json"
+    source.write_text("{}\n", encoding="utf-8")
+
+    def runner(command, **kwargs):
+        operation = command[3] if command[1] == "--actor-peer-id" else command[1]
+        output = "openviking 0.4.9" if operation == "--version" else "{}"
+        return subprocess.CompletedProcess(command, 0, output)
+
+    result = OpenVikingContextProvider(
+        actor_peer_id=actor,
+        runner=runner,
+    ).sync(
+        namespace="reward_memory",
+        resources=[
+            (
+                str(source),
+                f"viking://user/default/peers/{actor}/memories/probe.json",
+            )
+        ],
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+        execute=False,
+    )
+    assert result.status == "unavailable"
+    assert result.reason_code == "provider_version_incompatible"
+
+
+def test_private_peer_scope_requires_current_server_contract(tmp_path: Path):
+    actor = "goal-one-pilot"
+    source = tmp_path / "probe.json"
+    source.write_text("{}\n", encoding="utf-8")
+
+    def runner(command, **kwargs):
+        operation = command[3] if command[1] == "--actor-peer-id" else command[1]
+        if operation == "--version":
+            output = "openviking 0.4.18"
+        elif operation == "version":
+            output = "CLI: 0.4.18\nServer: 0.4.17.dev7"
+        else:
+            pytest.fail("server version incompatibility must stop before data access")
+        return subprocess.CompletedProcess(command, 0, output)
+
+    result = OpenVikingContextProvider(
+        actor_peer_id=actor,
+        runner=runner,
+    ).sync(
+        namespace="reward_memory",
+        resources=[
+            (
+                str(source),
+                f"viking://user/default/peers/{actor}/memories/probe.json",
+            )
+        ],
+        timeout_seconds=30,
+        observed_at="2026-01-01T00:00:00Z",
+        execute=False,
+    )
+    assert result.status == "unavailable"
+    assert result.reason_code == "provider_server_version_incompatible"
+    assert "server 0.4.17" in str(result.provider_version)


### PR DESCRIPTION
## Summary / 摘要

- Align private Reward Memory writes with the OpenViking v0.4.19 user/peer model. Reject legacy `viking://agent/...` writes and require the request actor to match the exact peer URI before any provider call.
- Bind LoopX private memory to the Goal-local runtime identity `(goal_id, agent_id)`. A deterministic canonical peer prevents same-named Agents in different Goals from colliding; sibling Agents also receive distinct private peers.
- Make enablement honest: preview performs CLI/server/service/target preflight without writing; apply requires a fresh non-recallable canary write plus exact readback before persisting a public-safe enablement receipt and config digest.
- Use OpenViking content write for memory paths and resource ingest only for resource paths. Timeout/ambiguous writes reconcile by exact readback instead of blind duplicate writes.
- Project isolation, actor binding, writability and receipt state through the existing configure/status/quota surfaces. Keep future same-Goal sharing explicit as a separate corpus and policy, never implicit access to another Agent's private memory.

- 私有 Reward Memory 写入对齐 OpenViking v0.4.19 的 user/peer 模型；禁止向旧版共享只读 `viking://agent/...` 写入，并在任何 provider 调用前校验 actor 与 URI peer 完全一致。
- LoopX 私有记忆绑定 Goal-local `(goal_id, agent_id)`；跨 Goal 重名 Agent 和同 Goal 兄弟 Agent 都会生成不同的确定性 peer。
- Preview 只做 CLI/server/service/target 预检；Apply 必须完成新的不可召回 canary 写入和精确读回，才保存 public-safe 启用回执与 config digest。
- Memory path 使用 content write，resource path 才使用 resource ingest；超时/歧义先精确读回 reconcile，不盲目重复写。
- 通过现有 configure/status/quota 投影隔离、actor、可写性和回执状态；未来同 Goal 共享必须是独立 corpus 与显式策略，不能隐式读取兄弟 Agent 的私有记忆。

## Product entry points / 产品入口

- CLI and managed state: `configure-goal` preview/apply now reports real provider readiness, blocks unverifiable private enablement, and persists exact readback evidence; status/quota use the same resolved receipt.
- Lark: no second configuration source was added. Existing outbound/status rendering consumes the shared public-safe projection; related Lark/outbound tests are included.
- Frontend: no provider-specific editor or bundled asset was added. The existing capability editor is schema/catalog driven, while private provider targets remain in the ignored repo-local config. This PR exposes shared catalog/status fields only; full automatic-lifecycle UI (effective auto state and recent read/write/failure receipts) remains companion work and this delivery is intentionally partial.

## Validation / 验证

- `259 passed`: Reward Memory, decision-context, status/quota, Lark outbound and maintainability tests.
- `ruff check` on every changed Python path: passed.
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard`: passed; 9 catalog canaries + 8 risk-profile smokes + 1 public-boundary scan, no warnings or manual holds.
- Full parallel suite: 8310 passed, 33 skipped. Six unrelated host/Git tests were affected by parallel shared state or the Codex Git wrapper; two passed on serial rerun, and the remaining four passed with system Git first in `PATH` (the default wrapper injects command-scope `core.hooksPath=/dev/null`).
- Live compatibility check with official CLI 0.4.18 against the installed server 0.4.17.dev7: private preview returned `provider_server_version_incompatible`, `write_count=0`, and `writability_verified=false`. This proves the new gate does not treat the older server as verified v0.4.19 isolation.
- Public/private scan: clean. Local research config, private acceptance material, probe records, credentials and absolute paths are excluded.

## Scope boundary / 范围边界

This PR is the bounded private-provider safety slice. A verified provider receipt does **not** establish the requested automatic lifecycle. The existing lifecycle Todo remains open for real planning/decision recall, evidence-backed outcome/reflection ingestion, host coverage (inline Turn, standalone post-writeback, Codex App and DSH), default-on automation at capability enablement, idempotent replay/restart coverage, and complete frontend/Lark/CLI effective-state feedback.

本 PR 只交付私有 provider 安全与可信启用回执，不把它称作自动 Reward Memory 全生命周期完成。既有生命周期 Todo 继续负责真实规划/决策召回、有证据的结果复盘写回、各宿主接线、开启即默认自动、重放/重启幂等，以及前端/Lark/CLI 的完整有效状态反馈。

## Commits

1. `fix(reward-memory): verify private provider scope`
2. `docs(reward-memory): define private lifecycle boundary`

Review required: this changes runtime behavior and a permission/isolation boundary; it must not be self-merged.
