### PR TITLE
fix(lark): close manager failures with bounded receipts

### DIFF
--- a/loopx/extensions/lark/goal_topic_runtime.py
+++ b/loopx/extensions/lark/goal_topic_runtime.py
@@ -1076,6 +1076,21 @@ def process_lark_goal_topic_event(
             raise
         failure_code, failure_text = _manager_failure_reply(exc)
         answer_result = {"response_text": failure_text, "effect_receipt": exc.effect_receipt}
+    except Exception as exc:
+        # A synchronous manager route must leave a user-visible, bounded
+        # receipt even when the worker raises an untyped exception.  The
+        # exception itself may contain private provider details, so only its
+        # type is logged and the public reply uses the generic failure label.
+        if route.get("conversation_kind") != "manager":
+            raise
+        logging.getLogger(__name__).warning(
+            "Lark manager answer failed with %s", type(exc).__name__
+        )
+        failure_code, failure_text = _manager_failure_reply(exc)
+        answer_result = {
+            "response_text": failure_text,
+            "effect_receipt": _session_turn_effect(route),
+        }
     connector = route.get("connector")
     connector = connector if isinstance(connector, Mapping) else None
     effect_receipt: Mapping[str, Any] | None = None
@@ -1088,12 +1103,23 @@ def process_lark_goal_topic_event(
     else:
         reply_text = str(answer_result or "").strip()
     if not reply_text:
-        return {
-            "ok": False,
-            "status": "answer_empty",
-            "goal_id": route["goal_id"],
-            "inbox_config_ref": config_ref,
-        }
+        if route.get("conversation_kind") == "manager":
+            # Empty model output is a terminal, non-replayable failure for a
+            # manager request.  Reply through the same inbox path so the
+            # source is ACKed only after provider verification.
+            failure_code = "answer_empty"
+            reply_text = (
+                "已收到你的消息，但本次没有生成可发送的完整答复。"
+                "请求不会自动重放；请在 LoopX 管家会话查看状态或重新发起。"
+            )
+            effect_receipt = effect_receipt or _session_turn_effect(route)
+        else:
+            return {
+                "ok": False,
+                "status": "answer_empty",
+                "goal_id": route["goal_id"],
+                "inbox_config_ref": config_ref,
+            }
     if connector is not None:
         effect_decision = decide_external_event_ack(
             event_id=canonical["event_id"],

--- a/tests/extensions/test_lark_goal_topic_runtime.py
+++ b/tests/extensions/test_lark_goal_topic_runtime.py
@@ -1498,7 +1498,80 @@ def test_manager_terminal_failure_replies_once_before_ack(
         assert not result.get("source_acknowledged")
 
 
-@pytest.mark.parametrize("body", ["完整报告" * 400, "x" * 6001, "测" * 40000, "测" * 50000, r"private\nformat"], ids=["report", "long-ascii", "long-unicode", "oversize", "invalid-newlines"])
+@pytest.mark.parametrize("answer_value", ["raise", "empty"])
+def test_manager_untyped_or_empty_answer_gets_bounded_failure_receipt(
+    tmp_path, monkeypatch, answer_value,
+):
+    from loopx.extensions.lark import goal_topic_runtime as runtime
+
+    target_path, binding_path = tmp_path / "targets.json", tmp_path / "bindings.json"
+    _seed_legacy_topic(target_path, binding_path)
+    original_decide = runtime.decide_lark_topic_event
+
+    def manager_decision(**kw):
+        result = original_decide(**kw)
+        result["route"].update(
+            conversation_kind="manager", ingress_mode="session_queue",
+            event_id=kw["event"]["event_id"],
+            connector={"response_policy": "topic_reply"},
+        )
+        return result
+
+    monkeypatch.setattr(runtime, "decide_lark_topic_event", manager_decision)
+    monkeypatch.setattr(
+        runtime,
+        "ensure_lark_event_inbox_received_reaction",
+        lambda **kw: {"ok": True, "status": "already_received"},
+    )
+    state, answer_calls = {}, []
+
+    def answer(route, text):
+        answer_calls.append(text)
+        if answer_value == "raise":
+            raise ValueError("private provider detail")
+        return ""
+
+    kwargs = {
+        "target_payload": read_goal_channel_targets(target_path),
+        "binding_payloads": {"goal-alpha": read_goal_channel_binding(binding_path)},
+        "event": {
+            "event_id": "evt_incoming",
+            "message_id": "om_incoming",
+            "chat_id": "oc_public_fixture",
+            "root_id": "om_topic_alpha",
+            "create_time": "2026-08-14T21:00:00Z",
+            "content": "@linkmacbot report",
+            "mentioned": True,
+            "sender_type": "user",
+        },
+        "runtime_root": tmp_path / "runtime",
+        "answer": answer,
+        "reply_runner": _reply_runner(state),
+    }
+
+    result = runtime.process_lark_goal_topic_event(**kwargs)
+
+    assert result["ok"] is False
+    assert result["status"] == "processing_failed"
+    assert result["failure_reply_verified"] is True
+    assert result["source_acknowledged"] is True
+    assert "不会自动重放" in state["reply_text"]
+    assert "private provider detail" not in state["reply_text"]
+    assert len(answer_calls) == 1
+    pending = inspect_lark_event_inbox(
+        project=kwargs["runtime_root"],
+        config_path=Path(result["inbox_config_ref"]),
+    )
+    assert pending["items"] == []
+    assert runtime.process_lark_goal_topic_event(**kwargs)["status"] == "already_acknowledged"
+    assert len(answer_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "body",
+    ["完整报告" * 400, "x" * 6001, "测" * 40000, "测" * 50000, r"private\nformat"],
+    ids=["report", "long-ascii", "long-unicode", "oversize", "invalid-newlines"],
+)
 @pytest.mark.parametrize("reply_ok", [True, False])
 def test_manager_report_delivery_preserves_body_and_reports_format_failure(
     tmp_path, monkeypatch, body, reply_ok,


### PR DESCRIPTION
## Summary

- convert synchronous manager worker exceptions and empty answers into bounded public-safe Lark failure replies
- acknowledge the source only after the failure reply is provider-verified
- keep non-manager routes fail-closed and preserve idempotent replay without rerunning the request

## Product entry points

- Lark: changed; users receive a concrete terminal failure receipt instead of a stranded inbox item or silent empty answer
- CLI / managed Turn: unchanged; the existing session-turn receipt remains the source contract
- Frontend: no new control or state owner is needed; the existing manager Session remains the fallback location named by the Lark failure response

## Verification

- 62 passed: chat manager context, manager context roundtrip, Lark manager returns, and Lark Goal Topic runtime suites
- Ruff passed for the changed runtime and test files
- git diff --check passed
- rebased on latest origin/main at 0cbb8472

This runtime behavior change is review-required and must not be self-merged.