### PR TITLE
fix(quota): decouple due monitor observation receipts

### DIFF
--- a/docs/reference/protocols/quota-monitor-observation-receipt-v0.md
+++ b/docs/reference/protocols/quota-monitor-observation-receipt-v0.md
@@ -1,0 +1,64 @@
+# Quota Monitor Observation Receipt v0 / 配额监控观察回执 v0
+
+## English
+
+### Problem
+
+A heartbeat Turn has exactly one quota settlement identity. When an
+`advancement_task` is already bound to that identity, a newly due
+`continuous_monitor` must not replace it. The monitor still needs a durable
+observation receipt so that its cadence does not starve while long-running
+advancement work remains active.
+
+### Contract
+
+- The heartbeat receipt's `todo_id` remains the only settlement Todo. Only
+  that Todo may be used by `refresh-state` and `quota spend-slot`.
+- `quota monitor-poll --todo-id <monitor>` may record one auxiliary, no-spend
+  observation in the same Turn only when the requested Todo is a due
+  `continuous_monitor` visible to the same Agent.
+- The monitor receipt records both `settlement_todo_id` and the observed
+  monitor `todo_id`. They may differ; this never grants a second delivery or
+  quota-spend identity.
+- A receipt-bound monitor remains strict: another monitor cannot be substituted.
+  Reusing the same Turn for a different observation conflicts with the existing
+  monitor-poll effect digest.
+- After an unchanged auxiliary observation, the original advancement Todo
+  remains selected. A material observation may create its independently routed
+  successor through the existing monitor contract, but it still does not
+  replace the Turn's settlement identity.
+
+### Acceptance
+
+The CLI path must prove that a due monitor can update its cadence and replay
+idempotently without spending quota, while a guard replay continues to select
+the original advancement Todo. Existing wrong-Todo tests for receipt-bound
+monitor Turns must remain passing.
+
+## 中文
+
+### 问题
+
+一次 heartbeat Turn 只有一个配额结算身份。当 `advancement_task` 已绑定该身份时，
+新到期的 `continuous_monitor` 不得替换它；但监控仍需形成持久观察回执，否则长期
+推进任务存在时，监控周期会永久饥饿。
+
+### 契约
+
+- heartbeat 回执中的 `todo_id` 始终是唯一结算 Todo；只有它可用于
+  `refresh-state` 与 `quota spend-slot`。
+- 仅当请求对象是同一 Agent 可见且已到期的 `continuous_monitor` 时，
+  `quota monitor-poll --todo-id <monitor>` 才可在同一 Turn 写入一次辅助、
+  不计费的观察回执。
+- 监控回执同时记录 `settlement_todo_id` 与被观察的 monitor `todo_id`。
+  二者允许不同，但不会因此产生第二个交付或配额结算身份。
+- 若 heartbeat 本身绑定的是 monitor，仍保持严格身份，不能换成另一个 monitor；
+  同一 Turn 也不能用不同观察内容覆盖既有 monitor-poll effect。
+- 辅助观察无变化后，原 advancement Todo 继续保持选中；若观察发生重大变化，
+  可按既有 monitor 契约创建独立路由的 successor，但仍不替换本 Turn 的结算身份。
+
+### 验收
+
+CLI 端到端测试必须证明：到期 monitor 能更新周期并幂等重放、全程不消耗配额；
+随后重放 guard 仍选择原 advancement Todo。同时，receipt-bound monitor Turn 的
+错误 Todo 替换测试必须继续通过。

--- a/loopx/cli_commands/quota_request.py
+++ b/loopx/cli_commands/quota_request.py
@@ -26,8 +26,11 @@ def register_quota_monitor_poll_request_arguments(
         "--todo-id",
         help=(
             "For Codex App `quota should-run`, select one currently projected "
-            "eligible action through typed same-turn qualification; otherwise "
-            "name the accountable Todo settlement target."
+            "eligible action through typed same-turn qualification. For "
+            "`quota monitor-poll`, name the observed monitor Todo; a committed "
+            "advancement settlement Todo remains separate under the auxiliary "
+            "no-spend observation contract. Otherwise name the accountable "
+            "Todo settlement target."
         ),
     )
     quota_parser.add_argument("--target-key", help="Stable monitor target key for `quota monitor-poll` metadata writeback.")

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -195,6 +195,7 @@ def _observation_packet(
     *,
     before: dict[str, Any],
     agent_id: str | None,
+    settlement_todo_id: str | None,
     reason_summary: str | None,
     todo_id: str | None,
     target_key: str | None,
@@ -215,6 +216,7 @@ def _observation_packet(
     return {
         "actor_agent_id": normalize_todo_claimed_by(agent_id)
         or quota_decision_agent_id(before),
+        "settlement_todo_id": settlement_todo_id,
         "reason_summary": reason_summary,
         "todo_id": todo_id,
         "target_key": target_key,
@@ -327,6 +329,7 @@ def build_quota_monitor_poll_event(
     observation = _observation_packet(
         before=before,
         agent_id=None,
+        settlement_todo_id=None,
         reason_summary=reason_summary,
         todo_id=safe_todo_id,
         target_key=safe_target_key,
@@ -605,6 +608,7 @@ def record_quota_monitor_poll_for_decision(
     source: str = DEFAULT_SLOT_SPEND_SOURCE,
     reason_summary: str | None = None,
     agent_id: str | None = None,
+    settlement_todo_id: str | None = None,
     todo_id: str | None = None,
     target_key: str | None = None,
     result_hash: str | None = None,
@@ -660,6 +664,7 @@ def record_quota_monitor_poll_for_decision(
     observation = _observation_packet(
         before=before,
         agent_id=agent_id,
+        settlement_todo_id=settlement_todo_id,
         reason_summary=reason_summary,
         todo_id=safe_todo_id,
         target_key=safe_target_key,

--- a/loopx/control_plane/quota/monitor_poll_commit.ts
+++ b/loopx/control_plane/quota/monitor_poll_commit.ts
@@ -85,6 +85,7 @@ interface MonitorDecision extends JsonObject {
 
 interface MonitorObservation extends JsonObject {
   actor_agent_id: string | null;
+  settlement_todo_id: string | null;
   reason_summary: string | null;
   todo_id: string | null;
   target_key: string | null;
@@ -311,6 +312,10 @@ function observationObject(value: unknown): MonitorObservation {
       observation.actor_agent_id,
       "observation.actor_agent_id",
     )?.trim() ?? null,
+    settlement_todo_id: normalizedTodoId(
+      observation.settlement_todo_id,
+      "observation.settlement_todo_id",
+    ),
     reason_summary: optionalString(
       observation.reason_summary,
       "observation.reason_summary",
@@ -712,6 +717,7 @@ function buildRecord(request: MonitorRequest): JsonObject {
     monitor_target: target,
     reason_summary: request.observation.reason_summary ?? defaultReason,
     material_change: material,
+    settlement_todo_id: request.observation.settlement_todo_id,
     todo_id: request.observation.todo_id,
     target_key: request.observation.target_key,
     result_hash: request.observation.result_hash,
@@ -726,6 +732,7 @@ function buildRecord(request: MonitorRequest): JsonObject {
       request.decision.reason,
     health_check: healthCheck,
     delivery_outcome: material ? "outcome_progress" : "surface_only",
+    settlement_todo_id: request.observation.settlement_todo_id,
     monitor_target: target,
     monitor_event: event,
   };
@@ -758,6 +765,8 @@ function requestDigest(request: MonitorRequest): string {
   // Admission evidence is intentionally absent: Todo writeback changes the
   // projected decision during a retry, while the logical observation remains
   // the same effect. Mutable phase/CAS/provider fields are fenced separately.
+  const observation: JsonObject = { ...request.observation };
+  if (!observation.settlement_todo_id) delete observation.settlement_todo_id;
   return sha256(pythonJson({
     schema_version: request.schema_version,
     effect_id: request.effect_id,
@@ -765,7 +774,7 @@ function requestDigest(request: MonitorRequest): string {
     goal_id: request.goal_id,
     source: request.source,
     turn_instance_id: request.turn_instance_id,
-    observation: request.observation,
+    observation,
   }));
 }
 
@@ -1301,6 +1310,7 @@ function indexRecordFor(
   for (const [field, value] of Object.entries({
     agent_id: record.agent_id,
     turn_instance_id: record.turn_instance_id,
+    settlement_todo_id: event.settlement_todo_id,
     todo_id: event.todo_id,
     target_key: event.target_key,
     material_change: event.material_change === true ? true : null,
@@ -1335,6 +1345,7 @@ function monitorMarkdown(record: JsonObject): string {
     `- source: \`${pyValue(event.source)}\``,
     `- effective_action: \`${pyValue(before.effective_action)}\``,
     `- monitor_target: \`${pyValue(target.target_id)}\``,
+    `- settlement_todo_id: \`${pyValue(event.settlement_todo_id ?? "")}\``,
     `- todo_id: \`${pyValue(event.todo_id ?? "")}\``,
     `- target_key: \`${pyValue(event.target_key ?? "")}\``,
     `- material_change: \`${pyValue(event.material_change)}\``,
@@ -1385,6 +1396,7 @@ function payloadFor(
     classification: QUOTA_MONITOR_POLL_CLASSIFICATION,
     generated_at: record.generated_at,
     agent_id: record.agent_id ?? null,
+    settlement_todo_id: event.settlement_todo_id ?? null,
     todo_id: event.todo_id ?? null,
     target_key: event.target_key ?? null,
     material_change: event.material_change === true,

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -231,15 +231,22 @@ def preserve_heartbeat_receipt_bound_work_lane(
         "must_attempt_work": True,
         "selection_binding": "heartbeat_receipt",
         "selected_todo_id": todo_id,
+        "monitor_due_count": int(contract.get("monitor_due_count") or 0),
+        "monitor_due_items": list(contract.get("monitor_due_items") or []),
         "reason_codes": [
             "heartbeat_receipt_bound_replay",
             "same_turn_settlement_identity",
+            "due_monitor_context",
+            "auxiliary_monitor_observation_allowed",
         ],
-        "monitor_policy": "defer_new_priority_selection_until_next_turn",
+        "monitor_policy": (
+            "auxiliary_no_spend_observation_then_continue_bound_todo"
+        ),
         "deferred_work_lane": contract,
         "action": (
-            "continue the Todo already bound to this heartbeat turn; reconsider "
-            "newly due monitor priority on the next turn"
+            "the Todo already bound to this heartbeat turn remains the only quota "
+            "settlement target; a separately identified due monitor may record one "
+            "no-spend observation receipt before that Todo continues"
         ),
     }
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -34,6 +34,7 @@ from .control_plane.quota.policy_constants import (
 from .control_plane.quota.monitor_poll import (
     QUOTA_MONITOR_POLL_CLASSIFICATION as QUOTA_MONITOR_POLL_CLASSIFICATION,
     build_quota_monitor_poll_event as build_quota_monitor_poll_event,
+    find_quota_monitor_poll_turn,
     record_quota_monitor_poll_for_decision,
 )
 from .control_plane.quota.recent_runs import (
@@ -95,6 +96,8 @@ from .control_plane.scheduler.state import (
     CODEX_APP_SURFACE,
 )
 from .control_plane.todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
     normalize_todo_claimed_by,
     normalize_todo_id,
 )
@@ -1077,17 +1080,6 @@ def record_quota_monitor_poll(
     normalized_receipt_todo_id = (
         normalize_todo_id(receipt_bound_todo_id) if receipt_bound_todo_id else None
     )
-    if (
-        normalized_receipt_todo_id
-        and normalized_requested_todo_id
-        and normalized_requested_todo_id != normalized_receipt_todo_id
-    ):
-        raise HeartbeatReceiptIdentityConflictError(
-            "turn-scoped monitor-poll Todo conflicts with the committed "
-            "heartbeat receipt: expected "
-            f"{normalized_receipt_todo_id}, requested {normalized_requested_todo_id}"
-        )
-    effective_todo_id = normalized_requested_todo_id or normalized_receipt_todo_id
 
     def should_run(current_status: dict[str, Any]) -> dict[str, Any]:
         decision_status = current_status
@@ -1116,6 +1108,75 @@ def record_quota_monitor_poll(
         )
 
     before = should_run(status_payload)
+    if (
+        normalized_receipt_todo_id
+        and normalized_requested_todo_id
+        and normalized_requested_todo_id != normalized_receipt_todo_id
+    ):
+        selected = (
+            before.get("selected_todo")
+            if isinstance(before.get("selected_todo"), Mapping)
+            else {}
+        )
+        lane = (
+            before.get("work_lane_contract")
+            if isinstance(before.get("work_lane_contract"), Mapping)
+            else {}
+        )
+        summary = (
+            before.get("agent_todo_summary")
+            if isinstance(before.get("agent_todo_summary"), Mapping)
+            else {}
+        )
+        candidate_values = [
+            *(lane.get("monitor_due_items") or []),
+            *(summary.get("monitor_due_items") or []),
+        ]
+        normalized_agent_id = normalize_todo_claimed_by(agent_id)
+        auxiliary_due_monitor = any(
+            isinstance(candidate, Mapping)
+            and normalize_todo_id(candidate.get("todo_id"))
+            == normalized_requested_todo_id
+            and candidate.get("task_class") == TODO_TASK_CLASS_MONITOR
+            and normalize_todo_claimed_by(candidate.get("claimed_by"))
+            in {None, normalized_agent_id}
+            for candidate in candidate_values
+        )
+        raw_runtime_root = status_payload.get("runtime_root")
+        existing_observation = (
+            find_quota_monitor_poll_turn(
+                Path(str(raw_runtime_root)).expanduser(),
+                goal_id=safe_goal_id,
+                agent_id=normalized_agent_id or "",
+                turn_instance_id=str(turn_instance_id or ""),
+            )
+            if raw_runtime_root and agent_id and turn_instance_id
+            else None
+        )
+        auxiliary_replay = bool(
+            isinstance(existing_observation, Mapping)
+            and normalize_todo_id(existing_observation.get("todo_id"))
+            == normalized_requested_todo_id
+            and normalize_todo_id(
+                existing_observation.get("settlement_todo_id")
+            )
+            == normalized_receipt_todo_id
+        )
+        auxiliary_observation_allowed = bool(
+            normalize_todo_id(selected.get("todo_id"))
+            == normalized_receipt_todo_id
+            and selected.get("task_class") == TODO_TASK_CLASS_ADVANCEMENT
+            and selected.get("selection_binding") == "heartbeat_receipt"
+            and (auxiliary_due_monitor or auxiliary_replay)
+        )
+        if not auxiliary_observation_allowed:
+            raise HeartbeatReceiptIdentityConflictError(
+                "turn-scoped monitor-poll Todo conflicts with the committed "
+                "heartbeat receipt: expected settlement Todo "
+                f"{normalized_receipt_todo_id}, requested observation Todo "
+                f"{normalized_requested_todo_id}"
+            )
+    effective_todo_id = normalized_requested_todo_id or normalized_receipt_todo_id
     return record_quota_monitor_poll_for_decision(
         before,
         status_payload,
@@ -1127,6 +1188,7 @@ def record_quota_monitor_poll(
         source=source,
         reason_summary=reason_summary,
         agent_id=agent_id,
+        settlement_todo_id=normalized_receipt_todo_id,
         todo_id=effective_todo_id,
         target_key=target_key,
         result_hash=result_hash,

--- a/tests/control_plane/test_monitor_observation_admission.py
+++ b/tests/control_plane/test_monitor_observation_admission.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.control_plane.test_quota_settlement_cli import (
+    AGENT_ID,
+    DUE_MONITOR_TODO_ID,
+    GOAL_ID,
+    TODO_ID,
+    _append_newly_due_monitor,
+    _classification_count,
+    _run_cli,
+    _spend_run_count,
+    _write_fixture,
+)
+
+
+def test_receipt_bound_advancement_allows_one_auxiliary_due_monitor_receipt(
+    tmp_path: Path,
+) -> None:
+    project, runtime, registry_path = _write_fixture(tmp_path)
+    turn_instance_id = "turn-advancement-with-auxiliary-monitor"
+    guard_args = (
+        "quota",
+        "should-run",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--scan-path",
+        str(project),
+    )
+    first_rc, first = _run_cli(registry_path, runtime, *guard_args)
+    assert first_rc == 0, first
+    assert first["heartbeat_receipt"]["settlement_identity"]["todo_id"] == TODO_ID
+
+    _append_newly_due_monitor(project)
+    capability_args = (
+        "--available-capability",
+        "network",
+        "--available-capability",
+        "external_evidence_poll",
+    )
+    replay_rc, replay = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        *capability_args,
+    )
+    assert replay_rc == 0, replay
+    assert replay["selected_todo"]["todo_id"] == TODO_ID
+    assert "due_monitor_context" in replay["work_lane_contract"]["reason_codes"]
+
+    poll_args = (
+        "quota",
+        "monitor-poll",
+        "--codex-app",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--turn-instance-id",
+        turn_instance_id,
+        "--todo-id",
+        DUE_MONITOR_TODO_ID,
+        "--target-key",
+        "due-monitor-fixture",
+        "--result-hash",
+        "unchanged-auxiliary-monitor",
+        *capability_args,
+        "--execute",
+        "--scan-path",
+        str(project),
+    )
+    poll_rc, poll = _run_cli(registry_path, runtime, *poll_args)
+    poll_replay_rc, poll_replay = _run_cli(
+        registry_path,
+        runtime,
+        *poll_args,
+    )
+
+    assert poll_rc == 0, poll
+    assert poll["settlement_todo_id"] == TODO_ID
+    assert poll["todo_id"] == DUE_MONITOR_TODO_ID
+    assert poll["before"]["selected_todo"]["todo_id"] == TODO_ID
+    assert poll["after"]["selected_todo"]["todo_id"] == TODO_ID
+    assert poll["material_change"] is False
+    assert poll_replay_rc == 0, poll_replay
+    assert poll_replay["replayed"] is True
+    assert _classification_count(runtime, "quota_monitor_poll") == 1
+    assert _spend_run_count(runtime) == 0
+
+    final_guard_rc, final_guard = _run_cli(
+        registry_path,
+        runtime,
+        *guard_args,
+        *capability_args,
+    )
+    assert final_guard_rc == 0, final_guard
+    assert final_guard["selected_todo"]["todo_id"] == TODO_ID
+    assert final_guard["heartbeat_receipt"]["settlement_identity"]["todo_id"] == (
+        TODO_ID
+    )

--- a/tests/control_plane/test_work_lane_contract_core.py
+++ b/tests/control_plane/test_work_lane_contract_core.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from loopx.control_plane.testing.quota_fixtures import quota_status_payload
+from loopx.control_plane.work_items.work_lane import (
+    preserve_heartbeat_receipt_bound_work_lane,
+)
 from loopx.control_plane.work_items.work_lane_context import (
     item_progress_scope,
     latest_run_progress_scope,
@@ -87,6 +90,38 @@ def test_due_monitor_preempts_lower_priority_advancement() -> None:
     assert lane["monitor_due_count"] == 1
     assert lane["selected_todo_id"]
     assert guard["recommended_action"] == "[P0] Monitor one overdue dependency."
+
+
+def test_receipt_bound_advancement_retains_auxiliary_due_monitor_context() -> None:
+    due_monitor = {
+        "todo_id": "todo_due_monitor",
+        "task_class": "continuous_monitor",
+        "status": "open",
+    }
+    preserved = preserve_heartbeat_receipt_bound_work_lane(
+        {
+            "schema_version": "work_lane_contract_v1",
+            "lane": "continuous_monitor",
+            "obligation": "attempt_due_monitor",
+            "must_attempt_work": True,
+            "monitor_kind": "todo_monitor_due",
+            "monitor_due_count": 1,
+            "monitor_due_items": [due_monitor],
+        },
+        selected_todo={
+            "todo_id": "todo_bound_advancement",
+            "task_class": "advancement_task",
+            "selection_binding": "heartbeat_receipt",
+        },
+    )
+
+    assert preserved is not None
+    assert preserved["selected_todo_id"] == "todo_bound_advancement"
+    assert preserved["monitor_due_items"] == [due_monitor]
+    assert "auxiliary_monitor_observation_allowed" in preserved["reason_codes"]
+    assert preserved["monitor_policy"] == (
+        "auxiliary_no_spend_observation_then_continue_bound_todo"
+    )
 
 
 def test_quiet_monitor_explains_blocked_non_monitor_todos() -> None:


### PR DESCRIPTION
## Summary

- keep the heartbeat-bound advancement Todo as the sole quota settlement identity
- let a separately due continuous monitor record one idempotent no-spend observation receipt with both `settlement_todo_id` and observed `todo_id`
- preserve strict wrong-Todo rejection for receipt-bound monitor Turns and document the bilingual v0 contract

## Product delivery

- CLI/controller: `quota monitor-poll --todo-id` now names the observed monitor while the shared receipt exposes the separate settlement Todo.
- Frontend: no new setting or state owner is introduced; existing status projections continue to consume the shared run record, so no packaged frontend change is required.
- Lark: no new adapter or delivery route is introduced; the same quota run receipt remains the source of truth.

## Validation

- `python3 -m pytest -q tests/control_plane/test_monitor_observation_admission.py` (1 passed; controller-declared completion command)
- `python -m pytest -q tests/control_plane/test_quota_settlement_cli.py` (44 passed before moving the focused case into the controller-declared file; the same 44-case coverage is preserved across the two files)
- `python -m pytest -q tests/control_plane/test_work_lane_contract_core.py tests/control_plane/test_monitor_followthrough_contract.py tests/control_plane/test_quota_monitor_poll_runtime.py tests/control_plane/test_native_monitor_poll.py` (38 passed)
- `node --no-warnings --experimental-sqlite --experimental-strip-types --test tests/control_plane_ts/quota_monitor_poll_commit.test.ts` (15 passed)
- `python -m ruff check` on changed Python files
- `git diff --check`