### PR TITLE
fix(todos): unify document ownership and recover canonical projections

### DIFF
--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.md
@@ -2772,6 +2772,15 @@ source paths, authorize monitor writeback, or change provider/promotion holds.
 
 **D1 — qualify permanent projection delivery; may overlap T1/T2.**
 
+The D1 document-ownership slice gives readers, editors and projection one visible-region
+and Todo-block boundary. It fixes fenced examples becoming real tasks, narrative after
+an archive end marker entering history, and sparse imported ordinals or archived
+priority labels blocking readback. Projection reuses durable atomic state publication;
+an equal-byte retry syncs file and directory before reporting `current`. Narrative and
+canonical records stay intact. This converges the retained Python presentation/legacy
+input adapter; it adds no RPC or business state machine and does not change TS authority
+transactions, provider defaults, SQLite D2 or D3 promotion requirements.
+
 T2 now commits a lease-free native Monitor observation and its independent
 successors in one canonical CAS/receipt; the route planner alone still grants
 no authority. The CLI delivers committed state through the existing journal/

--- a/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
+++ b/docs/architecture/rfcs/shared-goal-authority-state-provider-v0.zh-CN.md
@@ -2192,6 +2192,13 @@ Scoped fallback 的选择与门禁关系也已复用同一 TS decision owner，�
 
 **D1 — 资格化永久投影交付，可与 T1/T2 重叠推进。**
 
+D1 的文档归属切片把读取、编辑与投影放到同一可见区域／Todo 行解码边界，修复
+fenced 示例被当成真实任务、归档 end marker 后叙述进入历史、稀疏历史行号及归档
+优先级阻塞读回的问题。投影复用普通状态的耐久原子写入；相同字节的重试仍完成
+文件／目录同步，之后才报告 `current`。区域外正文和 canonical record 不被改写。
+这是永久 Python 展示／legacy 输入适配层的收敛：TS authority transaction、provider
+默认值、SQLite D2 与 D3 promotion 合同不变，不增加 RPC 或另一份业务状态机。
+
 能力缺口 consumer 在 legacy/canonical 输入上共用 TS requirement/resolution owner，
 包括 quota 的 Monitor 能力分流。删除 Python missing-set 与 owner/repair 决策 builder，
 保留来源适配和只读候选排序。这是披露修复优先级、空来源和 identity 修正的 T3 读取

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.md
@@ -531,6 +531,15 @@ delivery. This does not finish all T2 commands or authorize whole-Goal promotion
 
 **T3 — close remaining structured consumers, then remove their old reads.**
 
+The D1 document-ownership slice gives readers, editors and projection one visible-region
+and Todo-block boundary. It fixes fenced examples becoming real tasks, narrative after
+an archive end marker entering history, and sparse imported ordinals or archived
+priority labels blocking readback. Projection reuses durable atomic state publication;
+an equal-byte retry syncs file and directory before reporting `current`. Narrative and
+canonical records stay intact. This converges the retained Python presentation/legacy
+input adapter; it adds no RPC or business state machine and does not change TS authority
+transactions, provider defaults, SQLite D2 or D3 promotion requirements.
+
 Task-graph topology now shares `work_items/planning_relations.ts` with inventory
 and horizon. One pure TS request owns relationship discovery, deterministic
 bounded traversal, edge deduplication and missing/truncated completeness; the

--- a/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
+++ b/docs/architecture/rfcs/typescript-control-plane-migration-v0.zh-CN.md
@@ -408,6 +408,13 @@ promotion 已完成。
 
 **T3 — 闭合剩余 structured consumer，删除各自旧读路径。**
 
+D1 的文档归属切片把读取、编辑与投影放到同一可见区域／Todo 行解码边界，修复
+fenced 示例被当成真实任务、归档 end marker 后叙述进入历史、稀疏历史行号及归档
+优先级阻塞读回的问题。投影复用普通状态的耐久原子写入；相同字节的重试仍完成
+文件／目录同步，之后才报告 `current`。区域外正文和 canonical record 不被改写。
+这是永久 Python 展示／legacy 输入适配层的收敛：TS authority transaction、provider
+默认值、SQLite D2 与 D3 promotion 合同不变，不增加 RPC 或另一份业务状态机。
+
 Task graph topology 与 inventory/horizon 共用 `work_items/planning_relations.ts`。
 一轮纯 TS 请求拥有关系发现、稳定有界遍历、边去重与缺失/截断完整度；删除
 Python 的前驱索引、条件拆解和遍历。Python 保留 status 来源适配及节点、

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -128,8 +128,8 @@ canonical source can reconstruct it.
 
 The cutover is deliberately section-sized, not document-sized:
 
-- before promotion, Markdown remains the authority and existing writers are
-  unchanged;
+- before promotion, Markdown remains the authority and writes use its existing
+  transaction boundary;
 - after promotion, the versioned Todo records live in the canonical provider
   head and Markdown's Todo section is a compatibility/workbench projection;
 - other generated sections remain in Markdown until their canonical ownership
@@ -168,7 +168,29 @@ each Todo heading. The renderer, active Todo reader and section editor share
 that boundary contract. Future projections use those explicit bounds; orphan,
 nested, mismatched or missing markers, and non-generated content inside a marked
 region, fail closed. No ordinary Goal is rewritten or opted in by installation.
-Legacy unmarked readers and bootstrap output remain unchanged.
+Unmarked legacy readers and editors retain their heading aliases and multi-line
+Todo grammar, but now use the same visible-document boundary: fenced examples,
+leading frontmatter and multiline HTML comments cannot supply tasks or edit
+anchors. This intentionally changes legacy reads and writes that previously
+accepted example checkboxes. Marked archive regions end at their end marker;
+following narrative checkboxes are not historical decisions. Legacy heading
+substring aliases are input compatibility, not a new classification policy.
+
+Read/edit decoding now shares one Todo block codec. Projection assembly parses
+source and rendered document regions once each; marker diagnostics inspect only
+real Todo regions. A marker quoted in a code example is not delivery evidence.
+Imported `index` values still determine relative order, but the newly rendered
+section receives contiguous display ordinals. Canonical records and their
+section digests retain the imported values. Archive readback restores priority
+and title using the same existing text decoder as active records. Consequently,
+sparse historical ordinals and archived priority labels no longer strand
+projection recovery. These display corrections do not mutate provider state.
+
+中文：未晋升的旧格式也统一排除 fenced 示例、文首 frontmatter 和多行 HTML 注释中的
+假任务／编辑锚点；保留合法标题别名及多行任务文本。已标记归档区域在 end marker
+处结束，区域外的叙述清单不再进入历史。读取与编辑共用行解码，投影共用区域解析。
+历史行号只决定相对顺序，新展示使用连续行号；provider 中的旧行号、原始记录和
+摘要不变。归档读回复用既有优先级／标题解码，避免真实历史导致恢复永久 pending。
 
 Non-Todo byte preservation and canonical Todo parse/render parity are separate
 checks: the former compares untouched source slices, while the latter reads only
@@ -231,6 +253,17 @@ renderer/write failure leaves typed `pending` delivery
 evidence without reversing or hiding the canonical commit. A later successful
 mutation or `todo project-markdown --execute` replays the current head
 idempotently. This is projection recovery, not a second authority path.
+The ordinary state writer and projection writer share durable atomic publication.
+Missing-display recovery uses create-only publication and cannot overwrite a
+concurrently restored document. When bytes already match, execution still syncs
+the file and parent directory before reporting `current`: a previous failure
+may have occurred after rename but before directory durability. A failed barrier
+keeps delivery `pending` and does not acknowledge or repeat the business mutation.
+Preview remains read-only.
+
+中文：普通状态与投影共用原子落盘；缺失展示通过仅创建方式发布，避免覆盖并发恢复。
+字节相同的执行重试也重新完成文件和目录耐久化，之后才报告 `current`；失败继续
+保留“业务已提交、展示 pending”，不确认投影交付、不重执行业务。预览不写入。
 
 Supported non-Monitor Agent updates include action/domain/repository and required
 write scopes, required/target capabilities and Explore node references. These

--- a/loopx/control_plane/todos/active_state_editing.py
+++ b/loopx/control_plane/todos/active_state_editing.py
@@ -7,21 +7,19 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from ..goals.active_state_metadata import todo_role_for_heading
 from .contract import (
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
-    TODO_TASK_PATTERN,
     build_todo_id,
     normalize_todo_status,
     parse_todo_metadata_line,
     todo_done_for_status,
     todo_marker_for_status,
-    todo_status_from_marker,
 )
 from .text import normalize_new_todo
 from .todo_summary import normalize_todo_text
-from .machine_region import TODO_REGION_PREFIX, find_todo_regions
+from .machine_region import find_todo_source_regions, visible_markdown_lines
+from .todo_block_codec import decode_todo_blocks
 
 
 TODO_SECTION_HEADINGS = {
@@ -31,11 +29,11 @@ TODO_SECTION_HEADINGS = {
 COMPLETED_WORK_ARCHIVE_HEADING = "Completed Work Archive"
 
 
-def atomic_write_state_text(path: Path, text: str) -> None:
+def atomic_write_state_text(path: Path, text: str, *, create_only: bool = False) -> None:
     """Persist complete UTF-8 state while the caller holds its sibling lock."""
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    mode = stat.S_IMODE(path.stat().st_mode) if path.exists() else 0o600
+    mode = stat.S_IMODE(path.stat().st_mode) if not create_only and path.exists() else 0o600
     descriptor, temporary = tempfile.mkstemp(
         prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
     )
@@ -46,34 +44,40 @@ def atomic_write_state_text(path: Path, text: str) -> None:
             handle.write(text)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(temporary_path, path)
-        if os.name == "posix":
-            parent = os.open(path.parent, os.O_RDONLY)
-            try:
-                os.fsync(parent)
-            finally:
-                os.close(parent)
+        if create_only:
+            os.link(temporary_path, path)
+        else:
+            os.replace(temporary_path, path)
+        fsync_state_directory(path)
     finally:
         temporary_path.unlink(missing_ok=True)
 
 
+def fsync_state_directory(path: Path) -> None:
+    if os.name == "posix":
+        parent = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(parent)
+        finally:
+            os.close(parent)
+
+
+def verify_state_text_durable(path: Path, text: str) -> None:
+    """Re-establish durability after a previous publish may have failed at fsync.
+
+    Equality of visible bytes alone does not prove the directory entry persisted.
+    The caller holds the same document lock as the state writer.
+    """
+    with path.open("r+" if os.name == "nt" else "r", encoding="utf-8", newline="") as handle:
+        if handle.read() != text:
+            raise RuntimeError("Todo Markdown projection readback mismatch")
+        os.fsync(handle.fileno())
+    fsync_state_directory(path)
+
+
 def section_bounds(lines: list[str], role: str) -> tuple[int, int, str] | None:
-    if any(TODO_REGION_PREFIX in line for line in lines):
-        region = next((r for r in find_todo_regions(lines) if r.role == role), None)
-        return (region.start, region.body_end, region.heading) if region else None
-    for index, line in enumerate(lines):
-        if not line.startswith("## "):
-            continue
-        heading = line.lstrip("#").strip()
-        if todo_role_for_heading(heading) != role:
-            continue
-        end = len(lines)
-        for next_index in range(index + 1, len(lines)):
-            if lines[next_index].startswith("## "):
-                end = next_index
-                break
-        return index, end, heading
-    return None
+    region = next((region for region in find_todo_source_regions(lines) if region.role == role), None)
+    return (region.start, region.body_end, region.heading) if region else None
 
 
 def find_todo_block(
@@ -163,8 +167,8 @@ def set_todo_text(
 
 def heading_index(lines: list[str], heading: str) -> int | None:
     needle = f"## {heading}"
-    for index, line in enumerate(lines):
-        if line.strip() == needle:
+    for index in sorted(visible_markdown_lines(lines)):
+        if lines[index].strip() == needle:
             return index
     return None
 
@@ -202,15 +206,8 @@ def insert_new_section(lines: list[str], role: str, todo_line: str) -> None:
 
 
 def archive_section_bounds(lines: list[str]) -> tuple[int, int] | None:
-    start = heading_index(lines, COMPLETED_WORK_ARCHIVE_HEADING)
-    if start is None:
-        return None
-    end = len(lines)
-    for next_index in range(start + 1, len(lines)):
-        if lines[next_index].startswith("## "):
-            end = next_index
-            break
-    return start, end
+    region = next((region for region in find_todo_source_regions(lines) if region.role == "archive"), None)
+    return (region.start, region.body_end) if region else None
 
 
 def ensure_archive_section(lines: list[str]) -> tuple[int, int]:
@@ -254,42 +251,9 @@ def todo_blocks(
     role: str | None = None,
     source_section: str | None = None,
 ) -> list[dict[str, Any]]:
-    blocks: list[dict[str, Any]] = []
-    current: dict[str, Any] | None = None
-    todo_index = 0
-    for index in range(start + 1, end):
-        match = TODO_TASK_PATTERN.match(lines[index])
-        if match:
-            if current is not None:
-                current["end"] = index
-                ensure_block_identity(current, role=role, source_section=source_section)
-                blocks.append(current)
-            marker, text = match.groups()
-            todo_index += 1
-            status = todo_status_from_marker(marker)
-            current = {
-                "start": index,
-                "end": end,
-                "index": todo_index,
-                "done": todo_done_for_status(status),
-                "status": status,
-                "text": normalize_todo_text(text),
-            }
-            continue
-        if current is not None and lines[index].startswith((" ", "\t")):
-            metadata = parse_todo_metadata_line(lines[index])
-            if metadata:
-                current.update(metadata)
-                continue
-            continuation = lines[index].strip()
-            if continuation:
-                current["text"] = normalize_todo_text(
-                    f"{current.get('text', '')} {continuation}"
-                )
-    if current is not None:
-        current["end"] = end
-        ensure_block_identity(current, role=role, source_section=source_section)
-        blocks.append(current)
+    blocks = decode_todo_blocks(lines, start, end, visible=visible_markdown_lines(lines))
+    for block in blocks:
+        ensure_block_identity(block, role=role, source_section=source_section)
     return blocks
 
 

--- a/loopx/control_plane/todos/active_state_todo_parser.py
+++ b/loopx/control_plane/todos/active_state_todo_parser.py
@@ -5,24 +5,17 @@ from typing import Any
 
 from ...materials import extract_review_materials
 from ...orchestration import compact_orchestration_policy
-from ..goals.active_state_metadata import (
-    TODO_ARCHIVE_HEADER_MARKERS,
-    todo_role_for_heading,
-)
 from .contract import (
-    TODO_TASK_PATTERN,
     normalize_todo_id,
-    parse_todo_metadata_line,
-    todo_done_for_status,
-    todo_status_from_marker,
+    TODO_TASK_PATTERN,
 )
 from .standing_decision import build_standing_decision_authority
-from .machine_region import TODO_REGION_PREFIX, find_todo_regions
+from .machine_region import find_todo_source_regions, visible_markdown_lines
+from .todo_block_codec import decode_todo_blocks
 from .todo_summary import (
     MAX_STATUS_TODOS_PER_ROLE,
     compact_todo_group,
     count_advancement_todos,
-    normalize_todo_text,
 )
 
 
@@ -33,75 +26,29 @@ def parse_todo_source(
     state_path: Path | None = None,
 ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]], dict[str, str | None]]:
     """Decode active and archived source rows without inventing archive roles."""
-    role: str | None = None
     source_sections: dict[str, str | None] = {"user": None, "agent": None}
     items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
     archive_items: list[dict[str, Any]] = []
-    archive_mode = False
-    archive_source_section: str | None = None
-    current_todo: dict[str, Any] | None = None
-
     lines = state_text.splitlines()
-    regions = find_todo_regions(lines) if TODO_REGION_PREFIX in state_text else None
-    region_starts = {r.start for r in regions} if regions is not None else None
-    region_ends = {r.body_end for r in regions} if regions is not None else set()
-    for index, line in enumerate(lines):
-        if index in region_ends:
-            role = None
-            current_todo = None
-        if line.startswith("## "):
-            heading = line.lstrip("#").strip()
-            normalized_heading = heading.strip().lower()
-            archive_mode = any(
-                marker in normalized_heading for marker in TODO_ARCHIVE_HEADER_MARKERS
-            )
-            archive_source_section = heading if archive_mode else None
-            role = todo_role_for_heading(heading)
-            if role and region_starts is not None and index not in region_starts:
-                role = None
-            current_todo = None
-            if role and source_sections[role] is None:
-                source_sections[role] = heading
-            continue
-        if role is None and not archive_mode:
-            continue
-        match = TODO_TASK_PATTERN.match(line)
-        if match:
-            marker, text = match.groups()
-            status = todo_status_from_marker(marker)
-            target_items = archive_items if archive_mode else items[str(role)]
-            todo: dict[str, Any] = {
-                "index": len(target_items) + 1,
-                "done": todo_done_for_status(status),
-                "status": status,
-                "text": normalize_todo_text(text),
-            }
-            if archive_mode:
-                todo["archive_state"] = "archive"
-                todo["source_section"] = archive_source_section
-            else:
-                todo["archive_state"] = "active"
-                todo["source_section"] = source_sections[str(role)]
-                todo["role"] = role
+    visible = visible_markdown_lines(lines)
+    for region in find_todo_source_regions(lines, visible=visible):
+        archive = region.role == "archive"
+        target = archive_items if archive else items[region.role]
+        if not archive and source_sections[region.role] is None:
+            source_sections[region.role] = region.heading
+        for block in decode_todo_blocks(lines, region.start, region.body_end, visible=visible):
+            todo = {"archive_state": "archive" if archive else "active",
+                    "source_section": region.heading if archive else source_sections[region.role],
+                    **({} if archive else {"role": region.role}),
+                    **{key: value for key, value in block.items() if key not in {"start", "end"}},
+                    "index": len(target) + 1}
             if goal is not None:
-                materials = extract_review_materials(text, goal=goal, state_path=state_path)
+                match = TODO_TASK_PATTERN.match(lines[block["start"]])
+                assert match is not None  # The shared decoder only emits matched task lines.
+                materials = extract_review_materials(match.group(2), goal=goal, state_path=state_path)
                 if materials:
                     todo["review_materials"] = materials
-            target_items.append(todo)
-            current_todo = todo
-            continue
-        if current_todo is None or not line.startswith((" ", "\t")):
-            continue
-        metadata = parse_todo_metadata_line(line)
-        if metadata:
-            current_todo.update(metadata)
-            continue
-        continuation = line.strip()
-        if continuation:
-            current_todo["text"] = normalize_todo_text(
-                f"{current_todo.get('text', '')} {continuation}"
-            )
-
+            target.append(todo)
     return items, archive_items, source_sections
 
 

--- a/loopx/control_plane/todos/machine_region.py
+++ b/loopx/control_plane/todos/machine_region.py
@@ -11,6 +11,7 @@ import re
 from dataclasses import dataclass
 
 from .contract import TODO_TASK_PATTERN, parse_todo_metadata_line
+from ..goals.active_state_metadata import TODO_ARCHIVE_HEADER_MARKERS, todo_role_for_heading
 
 
 TODO_REGION_PREFIX = "<!-- loopx:todo-region-v0 "
@@ -43,14 +44,9 @@ def todo_region_marker(role: str, edge: str) -> str:
     return f"{TODO_REGION_PREFIX}role={role} {edge} -->"
 
 
-def find_todo_regions(lines: list[str]) -> list[TodoRegion]:
-    """Locate generated regions without consuming narrative or code examples.
-
-    Offsets are half-open line indexes. A marked region includes its heading
-    and both delimiters; body_end excludes the end marker for legacy editors.
-    The legacy import stops at the first non-generated line, not the next H2.
-    """
-    regions: list[TodoRegion] = []
+def visible_markdown_lines(lines: list[str]) -> frozenset[int]:
+    """Line ownership shared by Todo readers, editors and generated projections."""
+    visible: set[int] = set()
     fence: str | None = None
     in_comment = False
     index = 0
@@ -64,21 +60,28 @@ def find_todo_regions(lines: list[str]) -> list[TodoRegion]:
         if fence is not None:
             if re.fullmatch(r" {0,3}" + re.escape(fence[0]) + "{" + str(len(fence)) + r",}[ \t]*", line):
                 fence = None
-            index += 1
-            continue
-        if in_comment:
+        elif in_comment:
             in_comment = "-->" not in line
-            index += 1
-            continue
-        opening = _FENCE.fullmatch(line)
-        if opening:
+        elif opening := _FENCE.fullmatch(line):
             fence = opening.group(1)
-            index += 1
-            continue
-        if line.lstrip().startswith("<!--") and "-->" not in line:
+        elif line.lstrip().startswith("<!--") and "-->" not in line:
             in_comment = True
+        else:
+            visible.add(index)
+        index += 1
+    return frozenset(visible)
+
+
+def find_todo_regions(lines: list[str], *, visible: frozenset[int] | None = None) -> list[TodoRegion]:
+    """Find replaceable generated regions; never adopt surrounding narrative."""
+    visible = visible_markdown_lines(lines) if visible is None else visible
+    regions: list[TodoRegion] = []
+    index = 0
+    while index < len(lines):
+        if index not in visible:
             index += 1
             continue
+        line = lines[index].rstrip("\r\n")
         if TODO_REGION_PREFIX in line:
             raise ValueError("orphan or malformed Todo region marker")
         heading = line[3:].strip() if line.startswith("## ") else ""
@@ -97,7 +100,7 @@ def find_todo_regions(lines: list[str]) -> list[TodoRegion]:
                 break
             if TODO_REGION_PREFIX in content:
                 raise ValueError("nested, mismatched, or malformed Todo region marker")
-            generated = (
+            generated = index in visible and (
                 not content.strip()
                 or TODO_TASK_PATTERN.match(content) is not None
                 or parse_todo_metadata_line(content) is not None
@@ -114,4 +117,26 @@ def find_todo_regions(lines: list[str]) -> list[TodoRegion]:
         if marked:
             index += 1
         regions.append(TodoRegion(role, start, index, body_end, heading, marked))
+    return regions
+
+
+def find_todo_source_regions(lines: list[str], *, visible: frozenset[int] | None = None) -> list[TodoRegion]:
+    """Read/edit marked regions strictly; retain unmarked legacy heading aliases and continuations.
+
+    Existing heading-substring aliases are a legacy input compatibility contract,
+    not a classifier for generated ownership. They can retire with that importer.
+    """
+    visible = visible_markdown_lines(lines) if visible is None else visible
+    generated = find_todo_regions(lines, visible=visible)
+    if any(region.marked for region in generated):
+        return generated
+    headings = [index for index in sorted(visible) if lines[index].startswith("## ")]
+    regions: list[TodoRegion] = []
+    for position, start in enumerate(headings):
+        heading = lines[start][3:].strip()
+        role = "archive" if any(marker in heading.lower() for marker in TODO_ARCHIVE_HEADER_MARKERS) else todo_role_for_heading(heading)
+        if role is None:
+            continue
+        end = headings[position + 1] if position + 1 < len(headings) else len(lines)
+        regions.append(TodoRegion(role, start, end, end, heading, False))
     return regions

--- a/loopx/control_plane/todos/machine_section_projection.py
+++ b/loopx/control_plane/todos/machine_section_projection.py
@@ -30,7 +30,9 @@ from .active_state_editing import (
     archive_section_bounds,
     todo_blocks,
 )
-from .machine_region import find_todo_regions, todo_region_marker
+from .machine_region import todo_region_marker
+from .projection_document import TodoProjectionDocument
+from .todo_block_codec import decode_todo_blocks
 from .completion_validation_projection import (
     completion_validation_declaration,
     completion_validation_declaration_sha256,
@@ -47,7 +49,7 @@ from .contract import (
     require_todo_decision_scope,
     todo_marker_for_status,
 )
-from .todo_summary import canonical_todo_read_record
+from .todo_summary import canonical_todo_read_record, todo_priority_parts, normalize_todo_text
 
 
 TODO_SECTION_PROJECTION_SCHEMA_VERSION = "loopx_todo_section_projection_v0"
@@ -73,13 +75,6 @@ class TodoSectionProjectionResult:
     provider_revision: str
     todo_count: int
     section_record_sha256: dict[str, str]
-
-
-@dataclass(frozen=True)
-class _SectionSpan:
-    role: str
-    start: int
-    end: int
 
 
 def _sha256_text(value: str) -> str:
@@ -204,32 +199,6 @@ def _record_sort_key(record: Mapping[str, object]) -> tuple[int, str]:
     return index, str(record.get("todo_id") or "")
 
 
-def _section_spans(markdown: str) -> dict[str, _SectionSpan]:
-    lines = markdown.splitlines(keepends=True)
-    offsets = [0]
-    for line in lines:
-        offsets.append(offsets[-1] + len(line))
-    spans: dict[str, _SectionSpan] = {}
-    for region in find_todo_regions(lines):
-        if region.role in spans:
-            raise TodoSectionProjectionError(
-                f"active Markdown contains multiple {region.role} Todo sections"
-            )
-        spans[region.role] = _SectionSpan(region.role, offsets[region.start], offsets[region.end])
-    return spans
-
-
-def _narrative_segments(markdown: str) -> list[str]:
-    spans = sorted(_section_spans(markdown).values(), key=lambda span: span.start)
-    cursor = 0
-    parts: list[str] = []
-    for span in spans:
-        parts.append(markdown[cursor : span.start])
-        cursor = span.end
-    parts.append(markdown[cursor:])
-    return parts
-
-
 def _render_record(
     record: Mapping[str, object],
     *,
@@ -290,39 +259,6 @@ def _render_section(
     return newline.join(lines), digest
 
 
-def _replace_existing_sections(
-    markdown: str,
-    *,
-    rendered_sections: Mapping[str, str],
-) -> str:
-    spans = sorted(_section_spans(markdown).values(), key=lambda value: value.start)
-    if not spans:
-        raise TodoSectionProjectionError(
-            "active Markdown omits required Todo sections: no projection anchor"
-        )
-    replacements = {span.role: rendered_sections[span.role] for span in spans}
-    source_roles = set(replacements)
-    first_role = spans[0].role
-    last_role = spans[-1].role
-    prefix: list[str] = []
-    if "user" not in source_roles:
-        prefix.append(rendered_sections["user"])
-    if "agent" not in source_roles:
-        if "user" in source_roles:
-            replacements["user"] += rendered_sections["agent"]
-        else:
-            prefix.append(rendered_sections["agent"])
-    if "archive" in rendered_sections and "archive" not in source_roles:
-        replacements[last_role] += rendered_sections["archive"]
-    if prefix:
-        replacements[first_role] = "".join(prefix) + replacements[first_role]
-
-    result = markdown
-    for span in reversed(spans):
-        result = result[: span.start] + replacements[span.role] + result[span.end :]
-    return result
-
-
 def _parsed_active_records(markdown: str) -> list[dict[str, Any]]:
     fields = parse_active_state_todos(markdown, item_limit=None)
     records: list[dict[str, Any]] = []
@@ -351,6 +287,9 @@ def _parsed_archive_records(markdown: str) -> list[dict[str, Any]]:
             raise TodoSectionProjectionError(
                 f"archived Todo {item.get('todo_id')!r} omits its source role"
             )
+        priority, title = todo_priority_parts(str(item.get("text") or ""))
+        if priority:
+            item.update(priority=priority, title=normalize_todo_text(title))
         records.append(
             canonical_todo_read_record(
                 project_completion_validation_authority({
@@ -379,7 +318,8 @@ def _projection_record(
                 if record.get("archive_state") == "archive"
                 else TODO_SECTION_HEADINGS[str(record["role"])]
             ),
-            "index": record.get("index", display_index),
+            # Stored import ordinals determine ordering; the new display has its own contiguous ordinals.
+            "index": display_index,
         },
         reject_unknown=True,
     ))
@@ -401,18 +341,12 @@ _DERIVED_READ_MODEL_FIELDS = {
 
 
 def _private_validation_metadata(
-    markdown: str,
+    document: TodoProjectionDocument,
 ) -> dict[str, tuple[dict[str, Any], dict[str, object]]]:
-    lines = markdown.splitlines()
+    lines = [line.rstrip("\r\n") for line in document.lines]
     private: dict[str, tuple[dict[str, Any], dict[str, object]]] = {}
-    for region in find_todo_regions(lines):
-        for item in todo_blocks(
-            lines,
-            region.start,
-            region.body_end,
-            role=region.role if region.role in TODO_SECTION_HEADINGS else None,
-            source_section=region.heading,
-        ):
+    for region in document.regions:
+        for item in decode_todo_blocks(lines, region.start, region.body_end, visible=document.visible):
             todo_id = str(item.get("todo_id") or "")
             declaration = completion_validation_declaration(item)
             if not todo_id or declaration is None:
@@ -465,7 +399,11 @@ def render_canonical_todo_sections(
     if not re.fullmatch(r"[A-Za-z0-9_.:-]+", provider_revision):
         raise TodoSectionProjectionError("provider_revision must be a public-safe token")
     canonical = _canonical_records(records)
-    private_source = _private_validation_metadata(markdown)
+    try:
+        source_document = TodoProjectionDocument.parse(markdown)
+    except ValueError as error:
+        raise TodoSectionProjectionError(str(error)) from error
+    private_source = _private_validation_metadata(source_document)
     for todo_id, declaration in (private_validation_declarations or {}).items():
         external = _private_validation_entry(declaration)
         existing = private_source.get(todo_id)
@@ -501,7 +439,6 @@ def render_canonical_todo_sections(
                 f"Todo {todo_id!r} private validation declaration does not match authority"
             )
         private_validation[todo_id] = source[1]
-    source_spans = _section_spans(markdown)
     by_role = {
         role: sorted(
             [
@@ -529,7 +466,7 @@ def render_canonical_todo_sections(
             newline=newline,
             private_validation=private_validation,
         )
-    if archived or "archive" in source_spans:
+    if archived or "archive" in source_document.spans:
         rendered_sections["archive"], section_digests["archive"] = _render_section(
             role="archive",
             records=archived,
@@ -538,12 +475,13 @@ def render_canonical_todo_sections(
             private_validation=private_validation,
         )
 
-    rendered = _replace_existing_sections(
-        markdown,
-        rendered_sections=rendered_sections,
-    )
-    before_narrative = "".join(_narrative_segments(markdown))
-    after_narrative = "".join(_narrative_segments(rendered))
+    try:
+        rendered = source_document.replace(rendered_sections)
+        rendered_document = TodoProjectionDocument.parse(rendered)
+    except ValueError as error:
+        raise TodoSectionProjectionError(str(error)) from error
+    before_narrative = source_document.narrative
+    after_narrative = rendered_document.narrative
     if before_narrative != after_narrative:
         raise TodoSectionProjectionError("render changed Markdown outside Todo sections")
 
@@ -563,7 +501,7 @@ def render_canonical_todo_sections(
     )
     if _canonical_json(actual) != _canonical_json(expected):
         raise TodoSectionProjectionError("Todo section parse/render parity mismatch")
-    second = _replace_existing_sections(rendered, rendered_sections=rendered_sections)
+    second = rendered_document.replace(rendered_sections)
     if second != rendered:
         raise TodoSectionProjectionError("Todo section projection is not idempotent")
 
@@ -582,7 +520,13 @@ def render_canonical_todo_sections(
 def inspect_todo_section_projection(markdown: str) -> dict[str, object]:
     """Return compact marker diagnostics without treating Markdown as truth."""
 
-    markers = [match.groupdict() for match in _MARKER_PATTERN.finditer(markdown)]
+    document = TodoProjectionDocument.parse(markdown)
+    markers = []
+    for region in document.regions:
+        for line in document.lines[region.start:region.body_end]:
+            match = _MARKER_PATTERN.fullmatch(line.rstrip("\r\n"))
+            if match is not None and match["role"] == region.role:
+                markers.append(match.groupdict())
     return {
         "schema_version": TODO_SECTION_PROJECTION_SCHEMA_VERSION,
         "section_count": len(markers),

--- a/loopx/control_plane/todos/projection_document.py
+++ b/loopx/control_plane/todos/projection_document.py
@@ -1,0 +1,55 @@
+"""Parse replaceable Todo regions once, preserving every byte of surrounding prose."""
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .machine_region import TodoRegion, find_todo_regions, visible_markdown_lines
+
+
+@dataclass(frozen=True)
+class TodoProjectionDocument:
+    markdown: str
+    lines: list[str]
+    visible: frozenset[int]
+    regions: tuple[TodoRegion, ...]
+    spans: Mapping[str, tuple[int, int]]
+    narrative: str
+
+    @classmethod
+    def parse(cls, markdown: str) -> "TodoProjectionDocument":
+        lines = markdown.splitlines(keepends=True)
+        visible = visible_markdown_lines(lines)
+        regions = tuple(find_todo_regions(lines, visible=visible))
+        offsets = [0]
+        for line in lines:
+            offsets.append(offsets[-1] + len(line))
+        spans: dict[str, tuple[int, int]] = {}
+        narrative: list[str] = []
+        cursor = 0
+        for region in regions:
+            if region.role in spans:
+                raise ValueError(f"active Markdown contains multiple {region.role} Todo sections")
+            start, end = offsets[region.start], offsets[region.end]
+            spans[region.role] = start, end
+            narrative.append(markdown[cursor:start])
+            cursor = end
+        narrative.append(markdown[cursor:])
+        return cls(markdown, lines, visible, regions, spans, "".join(narrative))
+
+    def replace(self, sections: Mapping[str, str]) -> str:
+        if not self.spans:
+            raise ValueError("active Markdown omits required Todo sections: no projection anchor")
+        replacements = {role: sections[role] for role in self.spans}
+        roles = list(replacements)
+        prefix = sections["user"] if "user" not in replacements else ""
+        if "agent" not in replacements:
+            if "user" in replacements:
+                replacements["user"] += sections["agent"]
+            else:
+                prefix += sections["agent"]
+        if "archive" in sections and "archive" not in replacements:
+            replacements[roles[-1]] += sections["archive"]
+        replacements[roles[0]] = prefix + replacements[roles[0]]
+        result = self.markdown
+        for role, (start, end) in reversed(list(self.spans.items())):
+            result = result[:start] + replacements[role] + result[end:]
+        return result

--- a/loopx/control_plane/todos/provider_projection.py
+++ b/loopx/control_plane/todos/provider_projection.py
@@ -10,10 +10,7 @@ current head idempotently.
 
 from __future__ import annotations
 
-import os
 import json
-import stat
-import tempfile
 from enum import StrEnum
 from collections.abc import Mapping
 from pathlib import Path
@@ -31,6 +28,7 @@ from .machine_section_projection import (
     render_canonical_todo_sections,
 )
 from .completion_validation_store import load_completion_validation_declarations
+from .active_state_editing import atomic_write_state_text, verify_state_text_durable
 
 
 TODO_PROJECTION_DELIVERY_SCHEMA = "loopx_todo_projection_delivery_v0"
@@ -70,41 +68,6 @@ def projection_delivery_for_mutation(changed: bool) -> ProjectionDeliveryStatus:
 def _read_text_exact(path: Path) -> str:
     with path.open("r", encoding="utf-8", newline="") as handle:
         return handle.read()
-
-
-def _fsync_parent_directory(path: Path) -> None:
-    if os.name != "posix":  # pragma: no cover - Windows has no directory fsync
-        return
-    descriptor = os.open(path.parent, os.O_RDONLY)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
-
-
-def _atomic_write_text(path: Path, text: str, *, create_only: bool = False) -> None:
-    """Durably replace a compatibility projection without changing its mode."""
-
-    original_mode = 0o600 if create_only else stat.S_IMODE(path.stat().st_mode)
-    descriptor, temporary = tempfile.mkstemp(
-        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
-    )
-    temporary_path = Path(temporary)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
-            os.chmod(temporary_path, original_mode)
-            handle.write(text)
-            handle.flush()
-            os.fsync(handle.fileno())
-        if create_only:
-            # Publish a complete file without clobbering a concurrently restored
-            # document, even if that writer does not participate in our lock.
-            os.link(temporary_path, path)
-        else:
-            os.replace(temporary_path, path)
-        _fsync_parent_directory(path)
-    finally:
-        temporary_path.unlink(missing_ok=True)
 
 
 def project_current_canonical_todos(
@@ -189,11 +152,13 @@ def project_current_canonical_todos(
                 state_file=state_path,
             )
             if recovered_missing:
-                _atomic_write_text(state_path, projection.markdown, create_only=True)
+                atomic_write_state_text(state_path, projection.markdown, create_only=True)
             else:
-                _atomic_write_text(state_path, projection.markdown)
+                atomic_write_state_text(state_path, projection.markdown)
             if _read_text_exact(state_path) != projection.markdown:
                 raise RuntimeError("Todo Markdown projection readback mismatch")
+        elif execute:
+            verify_state_text_durable(state_path, projection.markdown)
 
     return {
         "schema_version": TODO_PROJECTION_DELIVERY_SCHEMA,

--- a/loopx/control_plane/todos/todo_block_codec.py
+++ b/loopx/control_plane/todos/todo_block_codec.py
@@ -1,0 +1,35 @@
+"""One legacy Markdown row decoder for reads and edits; no identity or authority writes."""
+from typing import Any
+
+from .contract import TODO_TASK_PATTERN, parse_todo_metadata_line, todo_done_for_status, todo_status_from_marker
+from .todo_summary import normalize_todo_text
+
+
+def decode_todo_blocks(
+    lines: list[str], start: int, end: int, *, visible: frozenset[int],
+) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    for index in range(start + 1, end):
+        if index not in visible:
+            if current is not None:
+                current["end"] = index
+                current = None
+            continue
+        match = TODO_TASK_PATTERN.match(lines[index])
+        if match:
+            if current is not None:
+                current["end"] = index
+            marker, text = match.groups()
+            status = todo_status_from_marker(marker)
+            current = {"start": index, "end": end, "index": len(blocks) + 1,
+                       "done": todo_done_for_status(status), "status": status,
+                       "text": normalize_todo_text(text)}
+            blocks.append(current)
+        elif current is not None and lines[index].startswith((" ", "\t")):
+            metadata = parse_todo_metadata_line(lines[index])
+            if metadata:
+                current.update(metadata)
+            elif continuation := lines[index].strip():
+                current["text"] = normalize_todo_text(f"{current['text']} {continuation}")
+    return blocks

--- a/tests/control_plane/test_archive_retry_delivery.py
+++ b/tests/control_plane/test_archive_retry_delivery.py
@@ -220,7 +220,7 @@ def test_pending_projection_and_preview_preserve_archive_retry(
         raise OSError("injected projection write failure")
 
     with monkeypatch.context() as patch:
-        patch.setattr(provider_projection, "_atomic_write_text", reject_projection)
+        patch.setattr(provider_projection, "atomic_write_state_text", reject_projection)
         committed = archive_completed_todos(
             registry_path=registry,
             goal_id="archive-goal",

--- a/tests/control_plane/test_local_coordination_authority.py
+++ b/tests/control_plane/test_local_coordination_authority.py
@@ -651,12 +651,12 @@ Continue.
     }
     initialize_canonical_authority(runtime_root, "goal-a", projection, state_path=state_file)
 
-    real_write = provider_projection._atomic_write_text
+    real_write = provider_projection.atomic_write_state_text
 
     def crash(*_args: object, **_kwargs: object) -> None:
         raise OSError("injected projection crash")
 
-    monkeypatch.setattr(provider_projection, "_atomic_write_text", crash)
+    monkeypatch.setattr(provider_projection, "atomic_write_state_text", crash)
     applied = add_goal_todo(
         registry_path=registry_path,
         goal_id="goal-a",
@@ -683,7 +683,7 @@ Continue.
     assert "validation_command_argv" not in canonical["todos"][0]
     assert state_file.read_text(encoding="utf-8") == source
 
-    monkeypatch.setattr(provider_projection, "_atomic_write_text", real_write)
+    monkeypatch.setattr(provider_projection, "atomic_write_state_text", real_write)
     replay = add_goal_todo(
         registry_path=registry_path,
         goal_id="goal-a",

--- a/tests/control_plane/test_todo_document_ownership.py
+++ b/tests/control_plane/test_todo_document_ownership.py
@@ -1,0 +1,107 @@
+"""Todo examples and narrative never become canonical work or writable regions."""
+from copy import deepcopy
+import json
+import re
+import subprocess
+import sys
+
+import pytest
+
+from loopx.control_plane.todos.active_state_editing import section_bounds, archive_section_bounds
+from loopx.control_plane.todos.active_state_todo_parser import parse_todo_source
+from loopx.control_plane.todos.machine_section_projection import render_canonical_todo_sections, inspect_todo_section_projection
+from test_todo_machine_section_projection import _records
+
+
+EXAMPLE = "## Agent Todo\n- [ ] Example task\n  <!-- loopx:todo todo_id=todo_example status=open -->\n\n## Completed Work Archive\n- [x] Example decision\n  <!-- loopx:todo todo_id=todo_example_decision role=user status=done -->\n"
+REAL = "## Agent Todo\n- [ ] Actual task\n  <!-- loopx:todo todo_id=todo_real status=open claimed_by=agent-a -->\n"
+
+
+def document(example, marked):
+    real = REAL
+    if marked:
+        real = real.replace("## Agent Todo\n", "## Agent Todo\n<!-- loopx:todo-region-v0 role=agent begin -->\n")
+        real += "<!-- loopx:todo-region-v0 role=agent end -->\n"
+    return "# Synthetic goal\n\n" + example + "\n" + real
+
+
+@pytest.mark.parametrize("marked", [False, True])
+@pytest.mark.parametrize("wrapper", ["```markdown\n{}\n```\n", "~~~~\n{}\n~~~~\n", "<!-- example\n{}\n-->\n"])
+def test_readers_and_editors_share_visible_region_ownership(marked, wrapper):
+    example = re.sub(r"  <!--.*?-->\n", "", EXAMPLE) if wrapper.startswith("<!--") else EXAMPLE
+    source = document(wrapper.format(example), marked)
+    active, archived, _ = parse_todo_source(source)
+    assert [row.get("todo_id") for row in active["agent"]] == ["todo_real"]
+    assert archived == []
+    bounds = section_bounds(source.splitlines(), "agent")
+    assert bounds is not None and bounds[0] == max(i for i, line in enumerate(source.splitlines()) if line == "## Agent Todo")
+    assert archive_section_bounds(source.splitlines()) is None
+
+
+def test_marked_archive_ends_before_unmanaged_narrative_tasks():
+    source = document("", True) + "\n## Completed Work Archive\n<!-- loopx:todo-region-v0 role=archive begin -->\n- [x] Actual historical task\n  <!-- loopx:todo todo_id=todo_history role=user status=done -->\n<!-- loopx:todo-region-v0 role=archive end -->\n\n- [x] Narrative checklist\n  <!-- loopx:todo todo_id=todo_not_history role=user status=done -->\n"
+    _, archive, _ = parse_todo_source(source)
+    assert [row["todo_id"] for row in archive] == ["todo_history"]
+
+
+def test_native_projection_preserves_the_deterministic_id_order_contract():
+    records = []
+    for todo_id in ["todo_zulu", "todo_alpha", "todo_middle"]:
+        row = deepcopy(_records()[0])
+        row.update(schema_version="todo_domain_record_v0", todo_id=todo_id)
+        row.pop("index")
+        row.pop("source_section")
+        records.append(row)
+    source = deepcopy(records)
+    rendered = render_canonical_todo_sections("## Agent Todo\n", records, provider_revision="test:1")
+    active, _, _ = parse_todo_source(rendered.markdown)
+    assert [row["todo_id"] for row in active["agent"]] == ["todo_alpha", "todo_middle", "todo_zulu"]
+    assert records == source
+
+
+def test_projection_diagnostics_ignore_markers_inside_examples():
+    marker = "<!-- loopx:todo-section-projection-v0 role=agent provider_revision=fake:1 records_sha256=" + "a" * 64 + " -->"
+    source = "```markdown\n" + marker + "\n```\n\n## Agent Todo\n"
+    rendered = render_canonical_todo_sections(source, _records(), provider_revision="actual:1")
+    inspected = inspect_todo_section_projection(rendered.markdown)
+    assert inspected["section_count"] == 2
+    assert {row["revision"] for row in inspected["sections"]} == {"actual:1"}
+
+
+def test_public_legacy_update_targets_real_section_and_preserves_example(tmp_path):
+    state, registry = tmp_path / "state.md", tmp_path / "registry.json"
+    example = "```markdown\n" + EXAMPLE + "```\n"
+    state.write_text(document(example, False))
+    registry.write_text(json.dumps({"common_runtime_root": str(tmp_path / "runtime"), "goals": [{
+        "id": "document-goal", "repo": str(tmp_path), "state_file": state.name,
+        "coordination": {"registered_agents": ["agent-a"]},
+    }]}))
+    def cli(todo_id):
+        return subprocess.run([sys.executable, "-m", "loopx.cli", "--registry", str(registry), "--format", "json",
+            "todo", "update", "--goal-id", "document-goal", "--role", "agent", "--agent-id", "agent-a",
+            "--todo-id", todo_id, "--text", "Updated actual task"], capture_output=True, text=True, timeout=90)
+    before = state.read_bytes()
+    rejected = cli("todo_example")
+    assert rejected.returncode == 1, rejected.stdout + rejected.stderr
+    assert state.read_bytes() == before
+    updated = cli("todo_real")
+    assert updated.returncode == 0, updated.stdout + updated.stderr
+    assert example in state.read_text()
+    assert "Updated actual task" in state.read_text()
+
+
+def test_archived_priority_and_sparse_imported_indexes_roundtrip_without_mutating_authority():
+    records = []
+    for todo_id, index in [("todo_later", 47), ("todo_earlier", 23)]:
+        row = deepcopy(_records()[0])
+        row.update(todo_id=todo_id, status="done", done=True, archive_state="archive",
+                   source_section="Completed Work Archive", index=index)
+        records.append(row)
+    before = deepcopy(records)
+    rendered = render_canonical_todo_sections("## Agent Todo\n", records, provider_revision="history:1")
+    _, archive, _ = parse_todo_source(rendered.markdown)
+    assert [row["todo_id"] for row in archive] == ["todo_earlier", "todo_later"]
+    assert [row["index"] for row in archive] == [1, 2]
+    assert all(row["text"].startswith("[P0]") for row in archive)
+    assert records == before
+    assert not render_canonical_todo_sections(rendered.markdown, records, provider_revision="history:1").changed

--- a/tests/control_plane/test_todo_machine_section_projection.py
+++ b/tests/control_plane/test_todo_machine_section_projection.py
@@ -16,7 +16,7 @@ from loopx.control_plane.todos.machine_section_projection import (
 )
 from loopx.cli import build_parser
 from loopx.cli_commands import todo as todo_command
-from loopx.control_plane.todos import provider_projection
+from loopx.control_plane.todos import provider_projection, active_state_editing
 from loopx.control_plane.coordination.local_authority import read_canonical_todos_if_promoted
 from loopx.control_plane.coordination.runtime_shadow import build_todo_runtime_shadow_projection
 from canonical_authority_fixture import initialize_canonical_authority
@@ -497,8 +497,8 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
     original_mode = stat.S_IMODE(state_path.stat().st_mode)
     parent_syncs: list[object] = []
     monkeypatch.setattr(
-        provider_projection,
-        "_fsync_parent_directory",
+        active_state_editing,
+        "fsync_state_directory",
         lambda path: parent_syncs.append(path),
     )
     monkeypatch.setattr(
@@ -521,14 +521,14 @@ def test_project_markdown_cli_publishes_with_atomic_replace(
         lambda **_kwargs: (object(), tmp_path, state_path),
     )
     replacements: list[tuple[object, object]] = []
-    real_replace = provider_projection.os.replace
+    real_replace = active_state_editing.os.replace
 
     def record_replace(source, target) -> None:
         if Path(target) == state_path:
             replacements.append((source, target))
         real_replace(source, target)
 
-    monkeypatch.setattr(provider_projection.os, "replace", record_replace)
+    monkeypatch.setattr(active_state_editing.os, "replace", record_replace)
 
     result = todo_command.handle_todo_command(
         build_parser().parse_args(
@@ -563,7 +563,7 @@ def test_atomic_projection_failure_preserves_original(monkeypatch, tmp_path, ope
     state_path = tmp_path / "ACTIVE_GOAL_STATE.md"
     state_path.write_bytes(b"original\r\n")
     opened = []
-    real_fdopen = provider_projection.os.fdopen
+    real_fdopen = active_state_editing.os.fdopen
 
     def capture_handle(*args, **kwargs):
         handle = real_fdopen(*args, **kwargs)
@@ -573,10 +573,10 @@ def test_atomic_projection_failure_preserves_original(monkeypatch, tmp_path, ope
     def fail(*_args, **_kwargs):
         raise OSError("injected pre-publication failure")
 
-    monkeypatch.setattr(provider_projection.os, "fdopen", capture_handle)
-    monkeypatch.setattr(provider_projection.os, operation, fail)
+    monkeypatch.setattr(active_state_editing.os, "fdopen", capture_handle)
+    monkeypatch.setattr(active_state_editing.os, operation, fail)
     with pytest.raises(OSError, match="injected pre-publication failure"):
-        provider_projection._atomic_write_text(state_path, "replacement\n")
+        active_state_editing.atomic_write_state_text(state_path, "replacement\n")
     assert state_path.read_bytes() == b"original\r\n"
     assert opened and all(handle.closed for handle in opened)
     assert list(tmp_path.iterdir()) == [state_path]

--- a/tests/control_plane/test_todo_projection_recovery.py
+++ b/tests/control_plane/test_todo_projection_recovery.py
@@ -18,7 +18,7 @@ from loopx.control_plane.coordination.coordination_state_contract import (
     TODO_DOMAIN_READ_RECORD_SCHEMA_VERSION, TODO_DOMAIN_RECORD_FIELDS,
 )
 from loopx.control_plane.coordination.local_authority_shadow_projection import canonical_bytes
-from loopx.control_plane.todos import provider_projection
+from loopx.control_plane.todos import provider_projection, active_state_editing
 from loopx.control_plane.todos.completion_validation_store import (
     persist_completion_validation_declaration,
 )
@@ -177,7 +177,7 @@ def test_concurrent_document_restoration_is_not_overwritten(canonical_display, m
         Path(destination).write_text("Another writer concurrently restored the generated document.\n")
         return real_link(source, destination)
 
-    monkeypatch.setattr(provider_projection.os, "link", restore_before_publish)
+    monkeypatch.setattr(active_state_editing.os, "link", restore_before_publish)
     with pytest.raises(FileExistsError):
         provider_projection.project_current_canonical_todos(
             registry_path=registry, runtime_root=runtime, goal_id="goal-a",
@@ -199,9 +199,9 @@ def test_interrupted_rebuild_is_safe_and_retryable(canonical_display, monkeypatc
 
     with monkeypatch.context() as patch:
         if failure_point == "directory_fsync":
-            patch.setattr(provider_projection, "_fsync_parent_directory", fail)
+            patch.setattr(active_state_editing, "fsync_state_directory", fail)
         else:
-            patch.setattr(provider_projection.os, failure_point, fail)
+            patch.setattr(active_state_editing.os, failure_point, fail)
         with pytest.raises(OSError, match="injected publication failure"):
             provider_projection.project_current_canonical_todos(
                 registry_path=registry, runtime_root=runtime, goal_id="goal-a",
@@ -237,8 +237,13 @@ def test_unpromoted_missing_document_is_not_regenerated(canonical_display):
     assert not state.exists()
 
 
-def test_production_scale_rebuild_retains_order_and_requires_private_declaration(tmp_path):
+@pytest.mark.parametrize("provider", ["file", "sqlite"])
+def test_production_scale_rebuild_retains_order_and_requires_private_declaration(tmp_path, monkeypatch, provider):
     # Reuse the shared RFC envelope, not a second large fixture or live data.
+    from canonical_authority_fixture import isolate_sqlite_runtime
+    from loopx.control_plane.todos.active_state_todo_parser import parse_todo_source
+    if provider == "sqlite":
+        isolate_sqlite_runtime(tmp_path, monkeypatch)
     script = (
         "import {productionScaleCoordinationFixture, PRODUCTION_SCALE_VALIDATION_DECLARATION} "
         "from './tests/control_plane_ts/production_scale_coordination_fixture.ts';"
@@ -256,7 +261,7 @@ def test_production_scale_rebuild_retains_order_and_requires_private_declaration
     registry.write_text(json.dumps({"common_runtime_root": str(runtime), "goals": [
         {"id": "goal-a", "repo": str(tmp_path), "state_file": state.name},
     ]}))
-    initialize_canonical_authority(runtime, "goal-a", projection, state_path=state)
+    initialize_canonical_authority(runtime, "goal-a", projection, state_path=state, provider=provider)
     before = _read(runtime)
     state.unlink()
     code, rejected = _run(registry, before["provider_revision"], "--execute")
@@ -279,3 +284,44 @@ def test_production_scale_rebuild_retains_order_and_requires_private_declaration
     assert _read(runtime) == before
     code, replay = _run(registry, before["provider_revision"], "--execute")
     assert code == 0 and replay["changed"] is False
+
+    example = (
+        "```markdown\n## Completed Work Archive\n- [x] Documentation example only\n"
+        "  <!-- loopx:todo todo_id=todo_example_only role=user status=done -->\n```\n\n"
+    )
+    state.write_text(example + state.read_text())
+    code, replay = _run(registry, before["provider_revision"], "--execute")
+    assert code == 0 and replay["status"] == "current"
+    assert state.read_text().startswith(example)
+    active, archived, _ = parse_todo_source(state.read_text())
+    parsed_ids = [row["todo_id"] for rows in (*active.values(), archived) for row in rows]
+    assert "todo_example_only" not in parsed_ids
+    assert len(parsed_ids) == 464
+    assert _read(runtime) == before
+
+
+def test_equal_display_does_not_acknowledge_an_unfinished_durability_barrier(canonical_display, monkeypatch):
+    registry, runtime, state = canonical_display
+    before = _read(runtime)
+    provider_projection.project_current_canonical_todos(
+        registry_path=registry, runtime_root=runtime, goal_id="goal-a",
+    )
+    original = state.read_bytes()
+    calls = []
+    def interrupted(_path):
+        calls.append("directory")
+        raise OSError("directory durability unavailable")
+    with monkeypatch.context() as patch:
+        patch.setattr(active_state_editing, "fsync_state_directory", interrupted)
+        payload = provider_projection.settle_canonical_todo_projection(
+            {"ok": True, "status": "replayed", "provider_revision": before["provider_revision"]},
+            registry_path=registry, runtime_root=runtime, goal_id="goal-a",
+        )
+    assert calls == ["directory"]
+    assert payload["ok"] is True and payload["status"] == "replayed"
+    assert payload["projection_delivery"] == "pending"
+    assert payload["projection_outbox"]["retry_business_mutation"] is False
+    assert state.read_bytes() == original and _read(runtime) == before
+    assert provider_projection.project_current_canonical_todos(
+        registry_path=registry, runtime_root=runtime, goal_id="goal-a",
+    )["status"] == "current"

--- a/tests/control_plane/test_todo_provider_projection.py
+++ b/tests/control_plane/test_todo_provider_projection.py
@@ -118,10 +118,10 @@ def test_settlement_preserves_commit_and_replays_after_projection_failure(
         "read_canonical_todos_if_promoted",
         lambda **_kwargs: _authority_read(),
     )
-    real_write = provider_projection._atomic_write_text
+    real_write = provider_projection.atomic_write_state_text
     monkeypatch.setattr(
         provider_projection,
-        "_atomic_write_text",
+        "atomic_write_state_text",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("crash")),
     )
 
@@ -150,7 +150,7 @@ def test_settlement_preserves_commit_and_replays_after_projection_failure(
     }
     assert state_file.read_text(encoding="utf-8") == SOURCE
 
-    monkeypatch.setattr(provider_projection, "_atomic_write_text", real_write)
+    monkeypatch.setattr(provider_projection, "atomic_write_state_text", real_write)
     replay = provider_projection.settle_canonical_todo_projection(
         {"status": "replayed", "changed": False},
         registry_path=registry,


### PR DESCRIPTION
## Problem and behavior

Todo readers, editors and generated projections disagreed about document ownership. An unpromoted CLI update could edit a task inside a fenced example; marked archive reads could absorb narrative after their end delimiter. Separately, sparse historical indices and archived priority/title fields could strand canonical projection recovery at parse/render parity validation.

This D1 slice shares visible Markdown regions and Todo block decoding, parses projection layout once per source/rendered document, and reuses the existing durable state writer. Imported indices still determine relative order, while display readback uses contiguous ordinals and restores archived priority/title. Provider records, digests and deterministic native ordering remain intact. Equal-byte execution now re-syncs file/directory before reporting `current`, so a retry cannot acknowledge an earlier incomplete durability barrier; business commits remain successful with typed pending delivery on failure.

**Intentional behavior change:** legacy reads/edits no longer treat fenced examples, leading frontmatter or multiline comments as tasks/anchors; narrative outside marked archive regions is not history. Valid legacy heading aliases and multiline task text remain supported. Preview is read-only, and missing-document recovery retains create-only concurrency protection.

## Scope and maintainability

- 7 product files: 232 additions / 297 deletions, net **65 fewer lines**. Remove duplicate row decoding, region traversal and atomic publication rather than adding another authority layer.
- 6 test files: add public CLI and semantic regressions; extend the existing 464-Todo synthetic fixture across File/SQLite with a false archive example.
- 5 protocol/RFC documents disclose behavior changes and record the D1 checkpoint. Two signed commits separate implementation/validation and documentation.
- This consolidates the retained Python presentation/legacy-input adapter. No TypeScript transaction, schema, RPC, capability descriptor or provider selection changes. SQLite D2 remains with #4224; this does not complete all D1 or authorize defaults/promotion.

The future-facing pass was applied at the document ownership and publication boundaries. No frontend companion is needed: no configuration/editor contract changes, and existing consumers retain the same structured response fields. CLI read/update/project readback and status/consumer regressions cover affected entry points.

## Validation

- 464 related Python tests passed, including CLI mutation, canonical planning/status, archive retry, recovery faults and File/SQLite fixture coverage.
- 1,291 TypeScript control-plane tests passed, zero skips, including 46 real PostgreSQL integration tests against an isolated PostgreSQL 16.15 server.
- TypeScript typecheck, changed-file Ruff/compile, diff hygiene, public-boundary scan and maintainability ratchet passed; no new exception.
- A read-only owner snapshot containing 474 Todos / 59 leases was copied into disposable runtimes. Actual File/SQLite CLI preview, execute, replay and missing-display recovery passed, with narrative and source snapshot unchanged. The old baseline failed this same historical projection readback.
- Existing three-arm archive rehearsal passed on baseline and candidate using File, SQLite and real PostgreSQL: 192 archived, 277 active Todos and 11 active leases afterward; provider heads/receipts, legacy active semantics and relative order match. No active Goal was promoted or mutated.

- Baseline `0cbb8472f` vs candidate public CLI: 8 cases match response/exit code/exact output bytes (only generated rollout event ID and timestamp excluded): preview, execute, current, missing preview/execute, stale revision, invalid UTF-8 and malformed region.
- 32 alternating actual CLI samples per arm, durability enabled, local macOS/Node 25.5.0/Python 3.13.13: baseline/candidate p50 **1264.76/1296.01 ms**, p95 **1781.01/2556.86 ms**, p99 **6346.98/5199.12 ms**. Tails are noisy; candidate p95 is higher. This is an efficiency warning, not evidence of a speedup or performance qualification.
- Exact quality receipt `cqr_782774c35049e96a8d49`: **valid/pass** for fingerprint `782774c35049e96a8d4956ce22fcd260e594520f8314d18a66c137c28f9f60c1`, 18 files; one allowed/applied safe-fix pass, 0 blockers / 1 warning / 0 advisories.

`canary premerge --from-git-diff --goal-id loopx-meta --timeout-seconds 600` passed on clean HEAD `444b91b34`: **4 direct checks + 18/18 selected checks**, zero failures/skips/manual holds, exact quality receipt enforced. Coverage includes Todo user/reward gates, quota wake/resume, interface budgets, maintainability, canary planning/execution and public boundaries; focused regressions and real-provider CLI checks above cover the changed document/durability semantics. The tail-latency warning remains recorded separately. This PR awaits review and CI; it has not been merged. Local snapshot contents, temporary probes and raw evidence are excluded from the branch. Cross-OS execution and long-duration SQLite qualification are not established by these local checks.
