### PR TITLE
fix(subagents): keep coordinators investigating alongside children

### DIFF
--- a/docs/integrations/codex-subagent-orchestration.md
+++ b/docs/integrations/codex-subagent-orchestration.md
@@ -40,6 +40,24 @@ Parallelize when it reduces uncertainty or latency:
 - run an independent review or validation pass;
 - inspect separate adapter, evidence, or boundary questions.
 
+The enabled capability also guides **coordinator participation** at its existing
+context phases. Before planning, reserve a distinct decision-relevant evidence
+question for the coordinator when useful independent work exists. Before
+launch, identify that question and its dependencies alongside the child briefs;
+continue it while children work. After results return, validate decisive sources,
+reconcile findings and revisit uncovered questions. Reviewing children is still
+necessary, but does not replace the coordinator's own parallel investigation.
+Wait when the remaining useful work depends on child results; do not invent
+work, require a minimum child count, or duplicate evidence to fill capacity.
+These are guidance-only instructions, not a new scheduler or completion gate.
+
+启用能力后，现有三个上下文阶段也引导主 Agent 参与研究：规划前保留一个
+独立、影响决策的证据问题；委派前说明自己的问题、依赖和子任务边界，并在
+子 Agent 工作期间推进；回收后核验原件、整合结果、重审尚未覆盖的问题。
+核验子任务不能替代主 Agent 自己的并行研究。剩余工作确实依赖子任务时可以
+等待，不要求凑满并发、重复取证或制造工作。这些是引导，不是新增调度器或
+完成门禁；等待某一候选也不意味着其他可执行研究必须停止。
+
 Keep tightly coupled decisions in one peer lane. Do not launch workers merely
 to make the activity graph look busy, and never let worker count override
 quota, user gates, write scope, or repository policy.

--- a/loopx/control_plane/subagent_context.ts
+++ b/loopx/control_plane/subagent_context.ts
@@ -4,22 +4,22 @@ import type { JsonObject } from "./effect_program.ts";
 import { jsonObject, requireJsonObject } from "./runtime_decode.ts";
 
 export const subagentContextProvider: AgentContextProvider = {
-  hookId: "multi_subagent.coordinator", capabilityId: "multi_subagent", revision: "v1",
+  hookId: "multi_subagent.coordinator", capabilityId: "multi_subagent", revision: "v2",
   phases: AGENT_CONTEXT_PHASES,
   produce(input, config) {
     const guidance = {
       before_plan: [
         "For read-heavy tasks, prefer parallel delegation of multiple fresh, independent evidence questions, including within one Todo, up to the configured child limit. Actively look for useful splits before keeping the research serial; avoid duplicate reads or concurrency for its own sake.",
         "For native child tools, read loopx agent-context with the current --goal-id and --agent-id at --phase before_delegate and --phase after_delegate_result. These read-only calls do not start turns or spend quota.",
-        "Keep useful work with the coordinator. Verify decisive sources, resolve disagreements and integrate results into the plan; child opinions are not independent evidence.",
+        "Reserve a distinct, decision-relevant evidence question for the coordinator to investigate while children work, when useful independent work exists. Integration and child review do not replace that investigation. Wait only when remaining useful work depends on child results; do not invent busywork.",
       ],
       before_delegate: [
-        "Give each child a bounded question, sources, read/write limits, expected evidence and stopping condition. Reuse prior findings; reserve integration for the coordinator.",
+        "Give each child a bounded question, sources, read/write limits, expected evidence and stopping condition. Identify the coordinator's concurrent question and dependencies; reuse prior findings and avoid duplicating the children's reads. If no independent work remains, explain the dependency rather than forcing a split.",
         "Explicitly pass the configured model and reasoning effort when the host supports them. Check host availability; never silently substitute. Preferences are not execution receipts.",
       ],
       after_delegate_result: [
         "Check returned sources, omissions and contradictions against the question. Missing or rejected receipts do not establish completed work.",
-        "Record accept/defer/reject with reasons and link accepted evidence to the plan and deliverable. Run the parent validation gate before writeback; do not merely concatenate child summaries.",
+        "Verify decisive sources and record accept/defer/reject with reasons; link accepted evidence to the plan and deliverable. Revisit uncovered questions using both coordinator and child findings. Waiting on one question need not block other useful research. Run parent validation before writeback; opinions are not independent evidence.",
       ],
     }[input.phase];
     const facts: JsonObject = {

--- a/tests/control_plane_ts/agent_context.test.ts
+++ b/tests/control_plane_ts/agent_context.test.ts
@@ -102,3 +102,20 @@ test("return phase projects reconciliation counts without copying raw child mate
   assert.deepEqual(facts.reconciliation_counts, { planned: 2, observed: 1, incomplete: 1 });
   assert.ok(!JSON.stringify(packet).includes("private original text"));
 });
+
+// Rich model identifiers and the complete participation guidance must survive
+// the actual provider budget, not disappear as an isolated provider failure.
+test("coordinator participation guidance survives all bounded lifecycle projections", () => {
+  for (const phase of AGENT_CONTEXT_PHASES) {
+    const packet = evaluateSubagentContext({ phase, scope, orchestration: {
+      ...policy, max_children: 4,
+      model_config: { model: "m".repeat(160), reasoning_effort: "max" },
+    } })!;
+    assert.deepEqual(packet.failures, []);
+    const [contribution] = packet.contributions as Record<string, any>[];
+    assert.equal(contribution.revision, "v2");
+    assert.equal(packet.authority, "guidance_only");
+    assert.ok(Buffer.byteLength(JSON.stringify(contribution)) <= 2048);
+    assert.ok(Buffer.byteLength(JSON.stringify(packet)) <= 3072);
+  }
+});


### PR DESCRIPTION
Enabled sub-agent guidance described coordinator work mostly as validation and integration, making it easy to delegate the investigation and then wait. The existing three lifecycle phases now guide the coordinator to retain a useful independent evidence question, work on it while children run, and revisit uncovered questions after reconciliation.

This remains guidance only: no minimum worker count, forced busywork, new fields, scheduler changes, or disabled-capability activation. Provider revision v2 identifies the changed content. The bounded provider is reused; no additional abstraction is needed.

Validation: 9 TypeScript context tests and 22 Python context/model-configuration tests passed, including disabled parity, managed/native transport, signed envelopes and the maximum-length model identifier within the unchanged context budget. Diff and the three-file public-boundary scan passed. The full operator registry check additionally reported pre-existing unrelated Goal metadata errors; it is not claimed as passing.

User entry points: managed Turn and native agent-context receive the same provider. Existing frontend settings already control enablement, capacity and model preference; this change introduces no setting or UI-owned state, and the existing configuration/roundtrip tests pass. No Lark mutation flow changes.

This PR only improves participation guidance; canonical configuration routing is a separate fix.

中文：通过现有规划、委派、回收三个阶段，引导主 Agent 在子任务运行期间推进独立证据问题，而不只负责汇总验收。没有新增强制并发、完成门禁或配置开关，关闭能力时保持不注入；配置写回来源问题单独修复。
